### PR TITLE
Source changes to allow disposing of the bus, but remaining subscribed to messages.

### DIFF
--- a/src/MassTransit/Services/Subscriptions/Server/Messages/DuplicateSubscriptionClientRemoved.cs
+++ b/src/MassTransit/Services/Subscriptions/Server/Messages/DuplicateSubscriptionClientRemoved.cs
@@ -1,0 +1,25 @@
+// Copyright 2007-2008 The Apache Software Foundation.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Services.Subscriptions.Server.Messages
+{
+	using System;
+
+	[Serializable]
+	public class DuplicateSubscriptionClientRemoved :
+		CorrelatedBy<Guid>
+	{
+		public Guid CorrelationId { get; set; }
+		public Uri ControlUri { get; set; }
+		public Uri DataUri { get; set; }
+	}
+}

--- a/src/MassTransit/Services/Subscriptions/Server/SubscriptionClientSaga.cs
+++ b/src/MassTransit/Services/Subscriptions/Server/SubscriptionClientSaga.cs
@@ -26,13 +26,13 @@ namespace MassTransit.Services.Subscriptions.Server
 		{
 			Define(() =>
 				{
-				    Correlate(ClientRemoved)
+					Correlate(ClientRemoved)
 						.By((saga, message) => saga.CorrelationId == message.CorrelationId && saga.CurrentState == Active);
 
 					Correlate(DuplicateClientAdded)
 						.By((saga, message) => saga.ControlUri == message.ControlUri &&
-						                       saga.CorrelationId != message.ClientId &&
-						                       saga.CurrentState == Active);
+											   saga.CorrelationId != message.ClientId &&
+											   saga.CurrentState == Active);
 
 					Initially(
 						When(ClientAdded)
@@ -46,12 +46,12 @@ namespace MassTransit.Services.Subscriptions.Server
 							.TransitionTo(Active));
 
 					During(Active,
-					       When(ClientRemoved)
-					       	.Then((saga, message) => saga.NotifySubscriptionClientRemoved())
-					       	.Complete(),
-					       When(DuplicateClientAdded)
-					       	.Then((saga, message) => saga.NotifySubscriptionClientRemoved())
-					       	.Complete());
+						   When(ClientRemoved)
+							.Then((saga, message) => saga.NotifySubscriptionClientRemoved())
+							.Complete(),
+						   When(DuplicateClientAdded)
+							.Then((saga, message) => saga.NotifyDuplicateSubscriptionClientRemoved())
+							.Complete());
 				});
 		}
 
@@ -98,6 +98,18 @@ namespace MassTransit.Services.Subscriptions.Server
 					ControlUri = ControlUri,
 					DataUri = DataUri,
 				};
+
+			Bus.Publish(message);
+		}
+
+		private void NotifyDuplicateSubscriptionClientRemoved()
+		{
+			var message = new DuplicateSubscriptionClientRemoved
+			{
+				CorrelationId = CorrelationId,
+				ControlUri = ControlUri,
+				DataUri = DataUri,
+			};
 
 			Bus.Publish(message);
 		}


### PR DESCRIPTION
Please note that DuplicateSubscriptionClientRemoved.cs file needs to be added to the solution (master is in VS 2008, unfortunately I don’t have that installed)

This should be a fix for the problem discussed at: http://groups.google.com/group/masstransit-discuss/browse_thread/thread/6fa25ea7a2113ea7
As far as I can tell this should fix the problem, I've tested it with the RC01 build compiled with .net 4.0.

SubscriptionClientSaga will now publish DuplicateSubscriptionClientRemoved instead of SubscriptionClientRemoved message when a duplicate is removed.

SubscriptionSaga will now remove subscriptions only when a duplicate subscription is detected or a duplicate client is subscribing
