### PR TITLE
Removed Sql2008 database connection setup, should just use the config.

### DIFF
--- a/src/MassTransit.RuntimeServices/SubscriptionServiceRegistry.cs
+++ b/src/MassTransit.RuntimeServices/SubscriptionServiceRegistry.cs
@@ -63,12 +63,6 @@ namespace MassTransit.RuntimeServices
 					{
 						m.FluentMappings.Add<SubscriptionSagaMap>();
 						m.FluentMappings.Add<SubscriptionClientSagaMap>();
-					}).Database(()=>
-					{
-					    return MsSqlConfiguration.MsSql2008.ConnectionString(cfg =>
-					    {
-                            cfg.FromConnectionStringWithKey("MassTransit");
-					    });
 					})
 				//.ExposeConfiguration(BuildSchema)
 				.BuildSessionFactory();


### PR DESCRIPTION
This caught me out when I was trying to get the RunTime services to use SQLCE 4
