### PR TITLE
Fix a memory leak when a consumer throws an exception. 

### DIFF
--- a/src/MassTransit/Transports/Endpoint.cs
+++ b/src/MassTransit/Transports/Endpoint.cs
@@ -202,7 +202,7 @@ namespace MassTransit.Transports
                                     if (_log.IsErrorEnabled)
                                         _log.Error("An exception was thrown by a message consumer", ex);
 
-                                    _tracker.IncrementRetryCount(receiveContext.MessageId, ex);
+                                    _tracker.MessageWasReceivedSuccessfully(receiveContext.MessageId);
                                     MoveMessageToErrorTransport(receiveContext);
                                 }
 


### PR DESCRIPTION
The MessageRetryTracker was holding onto the thrown Exception and the original message.
