### PR TITLE
Preventing inheriting from Consumes

### DIFF
--- a/src/MassTransit/Consumes.cs
+++ b/src/MassTransit/Consumes.cs
@@ -21,7 +21,7 @@ namespace MassTransit
 	/// </summary>
 	/// <typeparam name="TMessage">The message type to consume.</typeparam>
 	[UsedImplicitly]
-	public class Consumes<TMessage>
+	public static class Consumes<TMessage>
 		where TMessage : class
 	{
 		static readonly Selected _null;


### PR DESCRIPTION
I ran into this trap yesterday. When you subscribe consumer like this:

```
Bus.Instance.SubscribeConsumer<SampleConsumer>()
```

compiler warns that SampleConsumer should inherit from IConsumer somehow, but when you use IoC, nobody gives you a hint:

```
sbc.Subscribe(s => s.LoadFrom(c.Resolve<ILifetimeScope>()));
```
