### PR TITLE
Fix path for Log4Net file loading

### DIFF
--- a/src/Loggers/MassTransit.Log4NetIntegration/Logging/Log4NetLogger.cs
+++ b/src/Loggers/MassTransit.Log4NetIntegration/Logging/Log4NetLogger.cs
@@ -10,6 +10,8 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
+using System;
+
 namespace MassTransit.Log4NetIntegration.Logging
 {
     using System.IO;
@@ -34,6 +36,7 @@ namespace MassTransit.Log4NetIntegration.Logging
         {
             Logger.UseLogger(new Log4NetLogger());
 
+            file = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, file);
             var configFile = new FileInfo(file);
             XmlConfigurator.Configure(configFile);
         }


### PR DESCRIPTION
When running as a windows service the Log4Net logger should load the config file from AppDomain.CurrentDomain.BaseDirectory and not from a Windows system directory.

As discussed on the mailing list http://groups.google.com/group/masstransit-discuss/browse_thread/thread/82c1034ebb38cc0f
