### PR TITLE
Fix path for Log4Net config file loading

### DIFF
--- a/src/Loggers/MassTransit.Log4NetIntegration/Logging/Log4NetLogger.cs
+++ b/src/Loggers/MassTransit.Log4NetIntegration/Logging/Log4NetLogger.cs
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Log4NetIntegration.Logging
 {
+    using System;
     using System.IO;
     using MassTransit.Logging;
     using log4net;
@@ -34,6 +35,7 @@ namespace MassTransit.Log4NetIntegration.Logging
         {
             Logger.UseLogger(new Log4NetLogger());
 
+            file = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, file);
             var configFile = new FileInfo(file);
             XmlConfigurator.Configure(configFile);
         }


### PR DESCRIPTION
The Log4Net config file should be picked up from the base directory of the current app domain so that when running as a windows service MT will load the log4net config file from the app directory and not a Windows
system folder.

As discussed on the mailing list http://groups.google.com/group/masstransit-discuss/browse_thread/thread/82c1034ebb38cc0f
