### PR TITLE
Marked MassTransit.Distributor.Messages as Serializable

### DIFF
--- a/src/MassTransit/Distributor/Messages/ConfigureWorker.cs
+++ b/src/MassTransit/Distributor/Messages/ConfigureWorker.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Distributor.Messages
 {
+	using System;
+
+	[Serializable]
 	public class ConfigureWorker
 	{
         public int InProgressLimit { get; set; }

--- a/src/MassTransit/Distributor/Messages/Distributed.cs
+++ b/src/MassTransit/Distributor/Messages/Distributed.cs
@@ -20,6 +20,7 @@ namespace MassTransit.Distributor.Messages
     ///   want it getting downgraded to a consumer of TMessage.
     /// </summary>
     /// <typeparam name = "TMessage">The message type being distributed</typeparam>
+	[Serializable]
     public class Distributed<TMessage> :
         CorrelatedBy<Guid>
     {

--- a/src/MassTransit/Distributor/Messages/PingWorker.cs
+++ b/src/MassTransit/Distributor/Messages/PingWorker.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Distributor.Messages
 {
+	using System;
+
+	[Serializable]
     public class PingWorker
     {
     }

--- a/src/MassTransit/Distributor/Messages/WakeUpWorker.cs
+++ b/src/MassTransit/Distributor/Messages/WakeUpWorker.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Distributor.Messages
 {
+	using System;
+
+	[Serializable]
 	public class WakeUpWorker
 	{
 	}

--- a/src/MassTransit/Distributor/Messages/WorkerAvailable.cs
+++ b/src/MassTransit/Distributor/Messages/WorkerAvailable.cs
@@ -19,6 +19,7 @@ namespace MassTransit.Distributor.Messages
     /// Published by workers that can process a message of type T
     /// </summary>
     /// <typeparam name="T">The type of message that can be processed.</typeparam>
+	[Serializable]
     public class WorkerAvailable<T> :
         Workload<T>,
         IWorkerAvailable


### PR DESCRIPTION
If someone ever wants to use Distributor and binary serialization, messages from MassTransit.Distributor.Messages should be marked as Serializable.
