### PR TITLE
Added propagation of exceptions from response handlers to encapsulating Task

### DIFF
--- a/src/MassTransit/RequestResponse/TaskRequest.cs
+++ b/src/MassTransit/RequestResponse/TaskRequest.cs
@@ -175,7 +175,13 @@ namespace MassTransit.RequestResponse
         {
             foreach (TaskResponseHandler handler in _responseHandlers)
             {
-                handler.Task.ContinueWith(_ => { _source.TrySetResult(_message); });
+                handler.Task.ContinueWith(x =>
+                    {
+                        if (x.IsFaulted)
+                            _source.TrySetException(x.Exception);
+                        else
+                            _source.TrySetResult(_message);
+                    });
             }
 
             return bus.InboundPipeline


### PR DESCRIPTION
This results in the Task returned from ITaskRequest.Task to get status Faulted and that in turn allows for handling of the thrown Exception.

I'm not sure if this is going to have any side effects. I'll try to add a test for it but maybe anyone of you could already have a look to see if this is something that's useful.

Thanks!
