### PR TITLE
Updated the HealthService and TimeoutService to use the control bus

### DIFF
--- a/src/MassTransit.Tests/Services/HealthMonitoring/HealthServiceTestFixture.cs
+++ b/src/MassTransit.Tests/Services/HealthMonitoring/HealthServiceTestFixture.cs
@@ -47,11 +47,11 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 
 			Thread.Sleep(500);
 
-			LocalBus.ShouldHaveRemoteSubscriptionFor<EndpointCameOnline>();
-			LocalBus.ShouldHaveRemoteSubscriptionFor<Heartbeat>();
-			LocalBus.ShouldHaveRemoteSubscriptionFor<EndpointWentOffline>();
-			LocalBus.ShouldHaveRemoteSubscriptionFor<TimeoutExpired>();
-			LocalBus.ShouldHaveRemoteSubscriptionFor<PingEndpointResponse>();
+			LocalBus.ControlBus.ShouldHaveRemoteSubscriptionFor<EndpointCameOnline>();
+			LocalBus.ControlBus.ShouldHaveRemoteSubscriptionFor<Heartbeat>();
+			LocalBus.ControlBus.ShouldHaveRemoteSubscriptionFor<EndpointWentOffline>();
+			LocalBus.ControlBus.ShouldHaveRemoteSubscriptionFor<TimeoutExpired>();
+			LocalBus.ControlBus.ShouldHaveRemoteSubscriptionFor<PingEndpointResponse>();
 		}
 
 		public ISagaRepository<HealthSaga> HealthSagaRepository

--- a/src/MassTransit.Tests/Services/HealthMonitoring/HealthService_Specs.cs
+++ b/src/MassTransit.Tests/Services/HealthMonitoring/HealthService_Specs.cs
@@ -29,7 +29,7 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 			MakeSagaSuspect();
 
 			HealthSaga saga = GetSaga();
-			LocalBus.Publish(new TimeoutExpired { CorrelationId = saga.CorrelationId, Tag = 2 });
+			LocalBus.ControlBus.Publish(new TimeoutExpired { CorrelationId = saga.CorrelationId, Tag = 2 });
 
 			saga.ShouldNotBeNull();
 			saga.ShouldBeInState(HealthSaga.Down);
@@ -38,14 +38,14 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 
 		public void MakeSagaSuspect()
 		{
-			LocalBus.Publish(new EndpointCameOnline(Guid.NewGuid(), LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri,
+			LocalBus.ControlBus.Publish(new EndpointCameOnline(Guid.NewGuid(), LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri,
 				0));
 
 			HealthSaga saga = GetSaga();
 			saga.ShouldNotBeNull();
 			saga.ShouldBeInState(HealthSaga.Healthy);
 
-			LocalBus.Publish(new TimeoutExpired {CorrelationId = saga.CorrelationId, Tag = 1});
+			LocalBus.ControlBus.Publish(new TimeoutExpired {CorrelationId = saga.CorrelationId, Tag = 1});
 
 			saga.ShouldBeInState(HealthSaga.Suspect);
 		}
@@ -71,7 +71,7 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 			MakeSagaSuspect();
 
 			HealthSaga saga = GetSaga();
-			LocalBus.Publish(new Heartbeat(saga.CorrelationId, LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri, 0));
+			LocalBus.ControlBus.Publish(new Heartbeat(saga.CorrelationId, LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri, 0));
 
 			saga.ShouldNotBeNull();
 			saga.ShouldBeInState(HealthSaga.Healthy);
@@ -83,7 +83,7 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 			MakeSagaSuspect();
 
 			HealthSaga saga = GetSaga();
-			LocalBus.Publish(new TimeoutExpired {CorrelationId = saga.CorrelationId, Tag = 2});
+			LocalBus.ControlBus.Publish(new TimeoutExpired {CorrelationId = saga.CorrelationId, Tag = 2});
 
 			saga.ShouldNotBeNull();
 			saga.ShouldBeInState(HealthSaga.Down);
@@ -95,7 +95,7 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 			MakeSagaSuspect();
 
 			HealthSaga saga = GetSaga();
-			LocalBus.Publish(new PingEndpointResponse(saga.CorrelationId, LocalBus.ControlBus.Endpoint.Address.Uri,
+			LocalBus.ControlBus.Publish(new PingEndpointResponse(saga.CorrelationId, LocalBus.ControlBus.Endpoint.Address.Uri,
 				LocalBus.Endpoint.Address.Uri, 0));
 
 			saga.ShouldNotBeNull();
@@ -108,7 +108,7 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 			MakeSagaDown();
 
 			HealthSaga saga = GetSaga();
-			LocalBus.Publish(new Heartbeat(saga.CorrelationId, LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri, 0));
+			LocalBus.ControlBus.Publish(new Heartbeat(saga.CorrelationId, LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri, 0));
 
 			saga.ShouldNotBeNull();
 			saga.ShouldBeInState(HealthSaga.Healthy);
@@ -123,7 +123,7 @@ namespace MassTransit.Tests.Services.HealthMonitoring
 		[Test]
 		public void Should_publish_heartbeats_to_the_service()
 		{
-			LocalBus.Publish(new EndpointCameOnline(Guid.NewGuid(), LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri,
+			LocalBus.ControlBus.Publish(new EndpointCameOnline(Guid.NewGuid(), LocalBus.ControlBus.Endpoint.Address.Uri, LocalBus.Endpoint.Address.Uri,
 				0));
 
 			HealthSaga saga = GetSaga();

--- a/src/MassTransit/Services/HealthMonitoring/HealthService.cs
+++ b/src/MassTransit/Services/HealthMonitoring/HealthService.cs
@@ -59,8 +59,8 @@ namespace MassTransit.Services.HealthMonitoring
         {
             _log.Info("Health Service Starting");
 
-            _unsubscribeToken += _bus.SubscribeInstance(this);
-            _unsubscribeToken += _bus.SubscribeSaga(_healthSagas);
+            _unsubscribeToken += _bus.ControlBus.SubscribeInstance(this);
+            _unsubscribeToken += _bus.ControlBus.SubscribeSaga(_healthSagas);
 
             _log.Info("Health Service Started");
         }

--- a/src/MassTransit/Services/Timeout/TimeoutService.cs
+++ b/src/MassTransit/Services/Timeout/TimeoutService.cs
@@ -86,8 +86,8 @@ namespace MassTransit.Services.Timeout
 			if (_log.IsInfoEnabled)
 				_log.Info("Timeout Service Starting");
 
-			_unsubscribeToken = _bus.SubscribeInstance(this);
-			_unsubscribeToken += _bus.SubscribeSaga(_repository);
+			_unsubscribeToken = _bus.ControlBus.SubscribeInstance(this);
+			_unsubscribeToken += _bus.ControlBus.SubscribeSaga(_repository);
 
 			_fiber.Add(CheckExistingTimeouts);
 
@@ -139,7 +139,7 @@ namespace MassTransit.Services.Timeout
 		{
 			try
 			{
-				_bus.Publish(new TimeoutExpired {CorrelationId = id, Tag = tag});
+				_bus.ControlBus.Publish(new TimeoutExpired {CorrelationId = id, Tag = tag});
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Attempting to get the Health and Timeout services communicating correctly by registering them entirely on the control bus.

I outlined the issue I'm seeing [in this thread](https://groups.google.com/d/topic/masstransit-discuss/ci9Fx7uDp9s/discussion) and the feedback I got implied both services should be running on the control bus.
