### PR TITLE
AutoFac container: expose the service registration to MassTransit

### DIFF
--- a/src/Containers/MassTransit.AutoFacIntegration/AutofacExtensions.cs
+++ b/src/Containers/MassTransit.AutoFacIntegration/AutofacExtensions.cs
@@ -71,7 +71,7 @@ namespace MassTransit
             return scope.ComponentRegistry.Registrations
                 .SelectMany(r => r.Services.OfType<IServiceWithType>(), (r, s) => new {r, s})
                 .Where(rs => rs.s.ServiceType.Implements<T>())
-                .Select(rs => rs.r.Activator.LimitType)
+                .Select(rs => rs.s.ServiceType)
                 .Where(filter)
                 .ToList();
         }

--- a/src/MassTransit.sln.DotSettings
+++ b/src/MassTransit.sln.DotSettings
@@ -14,4 +14,6 @@ License at &#xD;
 Unless required by applicable law or agreed to in writing, software distributed&#xD;
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR &#xD;
 CONDITIONS OF ANY KIND, either express or implied. See the License for the &#xD;
-specific language governing permissions and limitations under the License.</s:String></wpf:ResourceDictionary>
+specific language governing permissions and limitations under the License.</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
I'm having a problem using AutoFac with MassTransit because the component's instance type is exposed to MassTransit instead of the service type. This causes problems when registering components with interceptors because the component's instance type is a generated proxy type, while the service type is the unintercepted type. MassTransit will try to resolve the proxied type, which results in an activation error.

<!---
@huboard:{"order":93.75}
-->
