### PR TITLE
Support for removing a completed simple saga from a repository

### DIFF
--- a/src/MassTransit.TestFramework/ExtensionMethodsForSagas.cs
+++ b/src/MassTransit.TestFramework/ExtensionMethodsForSagas.cs
@@ -38,26 +38,49 @@ namespace MassTransit.TestFramework
 			return ShouldContainSaga(repository, sagaId, Timeout);
 		}
 
-		public static TSaga ShouldContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
-			where TSaga : class, ISaga
-		{
-			DateTime giveUpAt = DateTime.Now + timeout;
+        public static TSaga ShouldContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
+            DateTime giveUpAt = DateTime.Now + timeout;
 
-			while (DateTime.Now < giveUpAt)
-			{
-				TSaga saga = repository.Where(x => x.CorrelationId == sagaId).FirstOrDefault();
-				if (saga != null)
-				{
-					return saga;
-				}
+            while (DateTime.Now < giveUpAt)
+            {
+                TSaga saga = repository.Where(x => x.CorrelationId == sagaId).FirstOrDefault();
+                if (saga != null)
+                {
+                    return saga;
+                }
 
-				Thread.Sleep(100);
-			}
+                Thread.Sleep(100);
+            }
 
-			return null;
-		}
+            return null;
+        }
 
-		public static TSaga ShouldContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Expression<Func<TSaga, bool>> filter)
+	    public static void ShouldNotContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Guid sagaId)
+	        where TSaga : class, ISaga
+	    {
+            ShouldNotContainSaga(repository,sagaId,Timeout);
+	    }
+
+	    public static void ShouldNotContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
+            DateTime giveUpAt = DateTime.Now + timeout;
+
+            while (DateTime.Now < giveUpAt)
+            {
+                TSaga saga = repository.Where(x => x.CorrelationId == sagaId).FirstOrDefault();
+                if (saga != null)
+                {
+                    Assert.Fail("The saga " + typeof(TSaga).Name + " still exists in the repository");
+                }
+
+                Thread.Sleep(100);
+            }
+        }
+
+        public static TSaga ShouldContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Expression<Func<TSaga, bool>> filter)
 			where TSaga : class, ISaga
 		{
 			return ShouldContainSaga(repository, filter, Timeout);

--- a/src/MassTransit.Tests/Saga/InitiateSaga_Specs.cs
+++ b/src/MassTransit.Tests/Saga/InitiateSaga_Specs.cs
@@ -63,7 +63,7 @@ namespace MassTransit.Tests.Saga
 
 			var saga = _repository.ShouldContainSaga(_sagaId);
 
-			saga.Completed.ShouldBeTrue();
+			saga.IsCompleted.ShouldBeTrue();
 		}
 
 		[Test]
@@ -79,7 +79,19 @@ namespace MassTransit.Tests.Saga
 
 			saga.Observed.ShouldBeTrue();
 		}
-	}
+
+        [Test]
+        public void The_saga_should_be_removed_from_repository_when_completed()
+        {
+            LocalBus.InboundPipeline.Dispatch(new InitiateSimpleSaga(_sagaId));
+            
+            var saga = _repository.ShouldContainSaga(_sagaId);
+
+            LocalBus.InboundPipeline.Dispatch(new CompleteSimpleSaga(_sagaId));
+            
+            _repository.ShouldNotContainSaga(_sagaId);
+        }
+    }
 
 	[TestFixture]
 	public class When_an_existing_saga_receives_an_initiating_message :

--- a/src/MassTransit.Tests/Saga/SimpleSaga.cs
+++ b/src/MassTransit.Tests/Saga/SimpleSaga.cs
@@ -20,7 +20,7 @@ namespace MassTransit.Tests.Saga
 		InitiatedBy<InitiateSimpleSaga>,
 		Orchestrates<CompleteSimpleSaga>,
 		Observes<ObservableSagaMessage,SimpleSaga>,
-		ISaga
+		ISimpleSaga
 	{
 		public SimpleSaga()
 		{
@@ -31,10 +31,10 @@ namespace MassTransit.Tests.Saga
 			CorrelationId = correlationId;
 		}
 
-		public bool Completed { get; private set; }
 		public bool Initiated { get; private set; }
 		public bool Observed { get; private set; }
 		public string Name { get; private set; }
+        public bool IsCompleted { get; private set; }
 
 		public Guid Id
 		{
@@ -63,7 +63,7 @@ namespace MassTransit.Tests.Saga
 
 		public void Consume(CompleteSimpleSaga message)
 		{
-			Completed = true;
+			IsCompleted = true;
 		}
 
 		public Expression<Func<SimpleSaga, ObservableSagaMessage, bool>> GetBindExpression()

--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -116,6 +116,7 @@
     <Compile Include="NewId\NewIdFormatters\ZBase32Formatter.cs" />
     <Compile Include="NewId\NewIdParsers\Base32Parser.cs" />
     <Compile Include="NewId\NewIdParsers\ZBase32Parser.cs" />
+    <Compile Include="Saga\DefaultSagaPolicySettings.cs" />
     <Compile Include="Subscriptions\Coordinator\InMemorySubscriptionStorage.cs" />
     <Compile Include="Configuration\Configuration\InterceptingConsumerFactory.cs" />
     <Compile Include="Configuration\EndpointConfigurators\DefaultMessageTrackerEndpointFactoryConfigurator.cs" />

--- a/src/MassTransit/Saga/DefaultSagaPolicySettings.cs
+++ b/src/MassTransit/Saga/DefaultSagaPolicySettings.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2007-2012 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Saga
+{
+    using System;
+    using System.Linq.Expressions;
+
+    public static class DefaultSagaPolicySettings<TSaga> where TSaga : class, ISaga
+    {
+        public static readonly Expression<Func<TSaga, bool>> ShouldBeRemovedExpression = saga => saga is ISimpleSaga && ((ISimpleSaga)saga).IsCompleted;
+    }
+}

--- a/src/MassTransit/Saga/ISaga.cs
+++ b/src/MassTransit/Saga/ISaga.cs
@@ -23,4 +23,12 @@ namespace MassTransit.Saga
     {
 		IServiceBus Bus { set; get; }
     }
+
+    /// <summary>
+    /// Defines a saga that asserts whether it is completed or not.
+    /// </summary>
+    public interface ISimpleSaga : ISaga
+    {
+        bool IsCompleted { get; }
+    }
 }

--- a/src/MassTransit/Saga/SubscriptionConnectors/InitiatedBySagaSubscriptionConnector.cs
+++ b/src/MassTransit/Saga/SubscriptionConnectors/InitiatedBySagaSubscriptionConnector.cs
@@ -22,7 +22,7 @@ namespace MassTransit.Saga.SubscriptionConnectors
 		where TMessage : class, CorrelatedBy<Guid>
 	{
 		public InitiatedBySagaSubscriptionConnector(ISagaRepository<TSaga> sagaRepository)
-			: base(sagaRepository, new InitiatingSagaPolicy<TSaga, TMessage>(x => x.CorrelationId, x => false))
+            : base(sagaRepository, new InitiatingSagaPolicy<TSaga, TMessage>(x => x.CorrelationId, DefaultSagaPolicySettings<TSaga>.ShouldBeRemovedExpression))
 		{
 		}
 

--- a/src/MassTransit/Saga/SubscriptionConnectors/ObservesSagaSubscriptionConnector.cs
+++ b/src/MassTransit/Saga/SubscriptionConnectors/ObservesSagaSubscriptionConnector.cs
@@ -26,7 +26,7 @@ namespace MassTransit.Saga.SubscriptionConnectors
 		readonly Expression<Func<TSaga, TMessage, bool>> _selector;
 
 		public ObservesSagaSubscriptionConnector(ISagaRepository<TSaga> sagaRepository)
-			: base(sagaRepository, new ExistingOrIgnoreSagaPolicy<TSaga, TMessage>(x => false))
+            : base(sagaRepository, new ExistingOrIgnoreSagaPolicy<TSaga, TMessage>(DefaultSagaPolicySettings<TSaga>.ShouldBeRemovedExpression))
 		{
 			var instance = (Observes<TMessage, TSaga>) FastActivator<TSaga>.Create(Guid.Empty);
 

--- a/src/MassTransit/Saga/SubscriptionConnectors/OrchestratesSagaSubscriptionConnector.cs
+++ b/src/MassTransit/Saga/SubscriptionConnectors/OrchestratesSagaSubscriptionConnector.cs
@@ -22,7 +22,7 @@ namespace MassTransit.Saga.SubscriptionConnectors
 		where TMessage : class, CorrelatedBy<Guid>
 	{
 		public OrchestratesSagaSubscriptionConnector(ISagaRepository<TSaga> sagaRepository)
-			: base(sagaRepository, new ExistingOrIgnoreSagaPolicy<TSaga, TMessage>(x => false))
+            : base(sagaRepository, new ExistingOrIgnoreSagaPolicy<TSaga, TMessage>(DefaultSagaPolicySettings<TSaga>.ShouldBeRemovedExpression))
 		{
 		}
 

--- a/src/SolutionVersion.cs
+++ b/src/SolutionVersion.cs
@@ -8,7 +8,6 @@ using System.Security;
 [assembly: AssemblyVersion("2.7.0")]
 [assembly: AssemblyFileVersion("2.7.1")]
 
-[assembly: AssemblyInformationalVersion("2.7.1.e229db")]
+[assembly: AssemblyInformationalVersion("2.7.1.1e69c3")]
 [assembly: ComVisibleAttribute(false)]
 [assembly: CLSCompliantAttribute(false)]
-


### PR DESCRIPTION
added new interface ISimpleSaga. that exposes a 'IsCompleted' property
that asserts that the saga is completed and should be removed from the
repository.

changed default 'ShouldBeRemoved' expression used by subscription connectors to an expression that checks the IsCompleted property in case the saga is ISimpleSaga.
