### PR TITLE
Moving namespace so it's more discoverable

### DIFF
--- a/src/Transports/MassTransit.Transports.Msmq/Configuration/SubscriptionClientConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/Configuration/SubscriptionClientConfiguratorExtensions.cs
@@ -10,7 +10,7 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
-namespace MassTransit.Transports.Msmq.Configuration
+namespace MassTransit
 {
     using System;
     using Exceptions;


### PR DESCRIPTION
UseSubscriptionService should be discoverable, per this thread: https://groups.google.com/forum/#!msg/masstransit-discuss/GS7w_bywSaU/nTUpDkVqpQoJ
