### PR TITLE
ISO Formatted Date Strings unit test

### DIFF
--- a/src/MassTransit.Tests/Serialization/DateTime_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/DateTime_Specs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+﻿// Copyright 2007-2011 Chris Patterson, Dru Sellers, Travis Smith, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 // this file except in compliance with the License. You may obtain a copy of the 
@@ -33,7 +33,6 @@ namespace MassTransit.Tests.Serialization
                             {
                                 Local = new DateTime(2001, 9, 11, 8, 46, 30, DateTimeKind.Local),
                                 Universal = new DateTime(2001, 9, 11, 9, 3, 2, DateTimeKind.Local).ToUniversalTime(),
-                                IsoFormatDate = "1994-11-05T13:15:30Z"
                             };
                         x.Send(_sent);
 
@@ -64,17 +63,10 @@ namespace MassTransit.Tests.Serialization
             _sent.Universal.ShouldEqual(_received.Universal);
         }
 
-        [Then]
-        public void Should_recieve_the_ISO_formatted_date_string_as_an_ISO_formatted_date_string()
-        {
-            _sent.IsoFormatDate.ShouldEqual(_received.IsoFormatDate);
-        }
-
         class A
         {
             public DateTime Local { get; set; }
             public DateTime Universal { get; set; }
-            public String IsoFormatDate { get; set; }
         }
     }
 }

--- a/src/MassTransit.Tests/Serialization/DateTime_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/DateTime_Specs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2007-2011 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 // this file except in compliance with the License. You may obtain a copy of the 
@@ -33,6 +33,7 @@ namespace MassTransit.Tests.Serialization
                             {
                                 Local = new DateTime(2001, 9, 11, 8, 46, 30, DateTimeKind.Local),
                                 Universal = new DateTime(2001, 9, 11, 9, 3, 2, DateTimeKind.Local).ToUniversalTime(),
+                                IsoFormatDate = "1994-11-05T13:15:30Z"
                             };
                         x.Send(_sent);
 
@@ -63,10 +64,17 @@ namespace MassTransit.Tests.Serialization
             _sent.Universal.ShouldEqual(_received.Universal);
         }
 
+        [Then]
+        public void Should_recieve_the_ISO_formatted_date_string_as_an_ISO_formatted_date_string()
+        {
+            _sent.IsoFormatDate.ShouldEqual(_received.IsoFormatDate);
+        }
+
         class A
         {
             public DateTime Local { get; set; }
             public DateTime Universal { get; set; }
+            public String IsoFormatDate { get; set; }
         }
     }
 }

--- a/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
@@ -566,6 +566,26 @@ namespace MassTransit.Tests.Serialization
     public class IsoDateAsString
     {
         public String IsoDate { get; set; }
+
+        public bool Equals(IsoDateAsString other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(other.IsoDate, IsoDate);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(IsoDateAsString)) return false;
+            return Equals((IsoDateAsString)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (IsoDate != null ? IsoDate.GetHashCode() : 0);
+        }
     }
 
         [Serializable]

--- a/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
@@ -549,6 +549,23 @@ namespace MassTransit.Tests.Serialization
 
             TestSerialization(message);
         }
+
+        [Test]
+        public void A_string_with_iso_date_should_be_properly_serialized()
+        {
+            IsoDateAsString message = new IsoDateAsString
+                {
+                    IsoDate = "1994-11-05T13:15:30Z"
+                };
+
+            TestSerialization(message);
+        }
+    }
+
+    [Serializable]
+    public class IsoDateAsString
+    {
+        public String IsoDate { get; set; }
     }
 
         [Serializable]


### PR DESCRIPTION
Seems to be an issue with them. Gets converted to a datetime. 

See http://stackoverflow.com/questions/18355009/masstransit-is-messing-with-my-string-data/18358202. 

* [x] Test Fails
* [ ] Test Passes