### PR TITLE
Use FormatterAssemblyStyle.Simple for binary deserialization.

### DIFF
--- a/src/MassTransit/Serialization/BinaryMessageSerializer.cs
+++ b/src/MassTransit/Serialization/BinaryMessageSerializer.cs
@@ -16,6 +16,7 @@ namespace MassTransit.Serialization
     using System.Collections.Generic;
     using System.IO;
     using System.Runtime.Remoting.Messaging;
+    using System.Runtime.Serialization.Formatters;
     using System.Runtime.Serialization.Formatters.Binary;
     using Logging;
     using Util;
@@ -42,7 +43,7 @@ namespace MassTransit.Serialization
         const string RetryCountKey = "RetryCount";
         const string SourceAddressKey = "SourceAddress";
 
-        static readonly BinaryFormatter _formatter = new BinaryFormatter();
+        static readonly BinaryFormatter _formatter = new BinaryFormatter { AssemblyFormat = FormatterAssemblyStyle.Simple };
         static readonly ILog _log = Logger.Get(typeof (BinaryMessageSerializer));
 
         public string ContentType


### PR DESCRIPTION
FormatterAssemblyStyle.Simple lets deserialization ignore assembly verison of the serialized type.  This prevents binary-serialized messages from breaking between MT release versions.

https://groups.google.com/d/msg/masstransit-discuss/MnS4WkY2-aY/vVDstA0_BikJ
