### PR TITLE
Windsor: Only get Handlers which have been specifically registered to Windsor

### DIFF
--- a/src/Containers/MassTransit.Containers.Tests/CastleWindsor_Specs.cs
+++ b/src/Containers/MassTransit.Containers.Tests/CastleWindsor_Specs.cs
@@ -39,13 +39,15 @@ namespace MassTransit.Containers.Tests
             _container = new WindsorContainer();
             _container.Register(
                 Component.For<SimpleConsumer>()
-                         .LifestyleTransient(),
+                         .LifestyleTransient()
+                         .Forward<IConsumer>(),
                 Component.For<ISimpleConsumerDependency>()
                          .ImplementedBy<SimpleConsumerDependency>()
                          .LifestyleTransient(),
                 Component.For<AnotherMessageConsumer>()
                          .ImplementedBy<AnotherMessageConsumerImpl>()
-                         .LifestyleTransient());
+                         .LifestyleTransient()
+                         .Forward<IConsumer>());
         }
 
         [Finally]
@@ -71,10 +73,10 @@ namespace MassTransit.Containers.Tests
         {
             _container = new WindsorContainer();
             _container.Register(
-                Component.For<SimpleSaga>(),
+                Component.For<SimpleSaga>().Forward<ISaga>(),
                 Component.For(typeof(ISagaRepository<>))
                          .ImplementedBy(typeof(InMemorySagaRepository<>))
-                         .LifeStyle.Singleton);
+                         .LifestyleSingleton());
         }
 
         [Finally]
@@ -100,10 +102,10 @@ namespace MassTransit.Containers.Tests
         {
             _container = new WindsorContainer();
             _container.Register(
-                Component.For<DummySaga>(),
+                Component.For<DummySaga>().Forward<ISaga>(),
                 Component.For(typeof(ISagaRepository<>))
                          .ImplementedBy(typeof(InMemorySagaRepository<>))
-                         .LifeStyle.Singleton);
+                         .LifestyleSingleton());
         }
 
         [Finally]
@@ -171,7 +173,8 @@ namespace MassTransit.Containers.Tests
             _container = new WindsorContainer();
             _container.Register(
                 Component.For<CheckScopeConsumer>()
-                         .LifestyleScoped<MessageScope>(),
+                         .LifestyleScoped<MessageScope>()
+                         .Forward<IConsumer>(),
                 Component.For<IDepedency>()
                          .ImplementedBy<Depedency>()
                          .LifestyleScoped<MessageScope>());

--- a/src/Containers/MassTransit.WindsorIntegration/WindsorContainerExtensions.cs
+++ b/src/Containers/MassTransit.WindsorIntegration/WindsorContainerExtensions.cs
@@ -121,7 +121,7 @@ namespace MassTransit
         static IList<Type> FindTypes<T>(IWindsorContainer container, Func<Type, bool> filter)
         {
             return container.Kernel
-                            .GetAssignableHandlers(typeof(T))
+                            .GetHandlers(typeof(T))
                             .Select(h => h.ComponentModel.Implementation)
                             .Where(filter)
                             .ToList();


### PR DESCRIPTION
Replacing #223

WindsorContainerExtensions was pulling IContainers and ISaga Types from Windsor using GetAssignableHandlers() instead of GetHandlers(). GetAssignableHandlers() brute forces every Windsor registration to determine if a specified service is implemented. GetHandlers() only pulls back handlers which were specifically registered as implementations of the given service.

Since Windsor grants robust access to determining which services are bound to a registration, this does not remove any functionality. It does require the user to specifically assign IConsumer or ISaga as services which their Consumes or Sagas implement.
