### PR TITLE
Request to merge client certificate authentication support for RabbitMQ

### DIFF
--- a/src/Transports/MassTransit.Transports.RabbitMq.Tests/RabbitMqSsl_Specs.cs
+++ b/src/Transports/MassTransit.Transports.RabbitMq.Tests/RabbitMqSsl_Specs.cs
@@ -14,6 +14,7 @@ namespace MassTransit.Transports.RabbitMq.Tests
 {
     using System;
     using System.Net;
+    using System.Security.Cryptography.X509Certificates;
     using Magnum.TestFramework;
     using NUnit.Framework;
     using RabbitMQ.Client;
@@ -45,6 +46,28 @@ namespace MassTransit.Transports.RabbitMq.Tests
                                 });
                         });
                 });
+        }
+
+        [When]
+        public void Connecting_to_a_rabbit_mq_server_using_ssl_and_with_an_explicitly_loaded_client_certificate()
+        {
+            var inputAddress = new Uri("rabbitmq://localhost:5671/test_queue");
+            var cert = new X509Certificate2("client.p12", "Passw0rd", X509KeyStorageFlags.MachineKeySet);
+            _bus = ServiceBusFactory.New(c =>
+            {
+                c.ReceiveFrom(inputAddress);
+                c.UseRabbitMq(r =>
+                {
+                    r.ConfigureHost(inputAddress, h =>
+                    {
+                        h.UseSsl(s =>
+                        {
+                            s.SetServerName(Dns.GetHostName());
+                            s.SetCertificates(cert);
+                        });
+                    });
+                });
+            });
         }
 
         [When]

--- a/src/Transports/MassTransit.Transports.RabbitMq/Configuration/Configurators/SslConnectionFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.Transports.RabbitMq/Configuration/Configurators/SslConnectionFactoryConfigurator.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.Transports.RabbitMq.Configuration.Configurators
 {
     using System.Net.Security;
+    using System.Security.Cryptography.X509Certificates;
     using RabbitMQ.Client;
 
 
@@ -25,6 +26,7 @@ namespace MassTransit.Transports.RabbitMq.Configuration.Configurators
         void SetServerName(string serverName);
         void SetCertificatePath(string certificatePath);
         void SetCertificatePassphrase(string passphrase);
+        void SetCertificates(params X509Certificate[] certificates);
         void SetAcceptablePolicyErrors(SslPolicyErrors policyErrors);
         void SetClientCertificateRequired(bool clientCertificateRequired);
         void SetAuthMechanisms(params AuthMechanismFactory[] factories);


### PR DESCRIPTION
This pull request adds 2 features:
1) allow for setting the AuthMechanisms on the ConnectionFactory to enable client-certificate authentication
2) Allow for explicitly setting the client certificate used because my InfoSec team gets all worked up when we store certificates on disk.

The tests for #1 will break unless the server is configured for authentication through client certificates as per this blog entry:
http://blog.johnruiz.com/2011/12/establishing-ssl-connection-to-rabbitmq.html

Additionally the server will need a user created with the DN or CN of the certificate depending on the server config.
