### PR TITLE
Removing reference to binary downloads

### DIFF
--- a/doc/source/installation/install.rst
+++ b/doc/source/installation/install.rst
@@ -11,20 +11,6 @@ NuGet.::
 
 However, the NuGet packages don't contain the MassTransit.RuntimeServices executable and database SQL scripts.  The RuntimeServices system routes messages to multiple subscribers via the Subscription Service.  If you plan to use the "UseSubscriptionService" feature, then you'll need to get compile that from source.
 
-Raw Binaries
-''''''''''''
-
-If you are a fan of getting the binaries you can get released builds from
-
-http://github.com/masstransit/MassTransit/downloads
-
-Then you will need to add references to 
-=======================================
-
- * MassTransit.dll
- * MassTransit.<Transport>.dll (Either MSMQ or RabbitMQ)
- * MassTransit.<ContainerSupport>.dll (If you are so inclined)
-
 
 Compiling From Source
 '''''''''''''''''''''


### PR DESCRIPTION
Removing reference to binary downloads in the installation documentation because they are no longer published.
