### PR TITLE
Fixed Ninject version error with the nuget package

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -605,7 +605,7 @@ task :all_nuspecs => [:mt_nuspec, :mtl4n_nuspec, :mtnlog_nuspec, :mtsm_nuspec, :
     nuspec.license_url = "http://www.apache.org/licenses/LICENSE-2.0"
     nuspec.require_license_acceptance
     nuspec.dependency "MassTransit", NUGET_VERSION
-    nuspec.dependency "Ninject", "3.3.2.0"
+    nuspec.dependency "Ninject", "3.2.2.0"
     nuspec.output_file = 'nuspecs/MassTransit.Ninject.nuspec'
 
 	add_files props[:stage], "#{File.join('Containers', 'MassTransit.NinjectIntegration.{dll,pdb,xml}')}", nuspec


### PR DESCRIPTION
The MassTransit.NinjectIntegration nuget package on nuget.org has a dependency on a version of Ninject which doesnt exist.  It looks like someone fat-fingered the version in the rake file.  This fixes it.
