### PR TITLE
Race Condition in OutboundRabbitMqTransport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    albacore (0.3.6)
-      rubyzip (< 1.0.0)
+    albacore (1.0.0)
+      nokogiri (~> 1.5)
+      rake (~> 10.0)
+      rubyzip (~> 1.0)
+    mini_portile (0.6.1)
+    nokogiri (1.6.4.1)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.4.1-x86-mingw32)
+      mini_portile (~> 0.6.0)
     rake (10.1.1)
-    rubyzip (0.9.9)
+    rubyzip (1.1.6)
     semver2 (3.3.3)
 
 PLATFORMS
@@ -12,6 +19,6 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  albacore (~> 0.3.5)
+  albacore (~> 1.0.0)
   rake
   semver2

--- a/src/MassTransit/RequestResponse/RequestImpl.cs
+++ b/src/MassTransit/RequestResponse/RequestImpl.cs
@@ -220,8 +220,7 @@ namespace MassTransit.RequestResponse
             {
                 _completed = true;
 
-                if (_complete != null)
-                    _complete.Set();
+                CompleteEvent.Set();
             }
 
             lock (_completionCallbacks)

--- a/src/SolutionVersion.cs
+++ b/src/SolutionVersion.cs
@@ -6,8 +6,8 @@ using System.Security;
 [assembly: AssemblyProduct("MassTransit")]
 [assembly: AssemblyCopyright("Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al. - All rights reserved.")]
 [assembly: AssemblyVersion("2.9.0")]
-[assembly: AssemblyFileVersion("2.9.7")]
+[assembly: AssemblyFileVersion("2.9.8")]
 
-[assembly: AssemblyInformationalVersion("2.9.7.f3285e")]
+[assembly: AssemblyInformationalVersion("2.9.8.aff1d0")]
 [assembly: ComVisibleAttribute(false)]
 [assembly: CLSCompliantAttribute(true)]


### PR DESCRIPTION
OutboundRabbitMqTransport.AddProducerBinding() was not synchronized at all, so if one thread sets the variable _producer, the next thread will read it assuming it is completely initialized. But the code line _connectionHandler.AddBinding(_producer) is probably not yet executed.

In RequestImpl.NotifyComplete() the bug happens as follows: Thread A runs in the method Wait() to line 103, obtaining the lock. It sees _completed as false, and releases the lock thereafter. Thread B reached the lock in NotifyComplete(), line 219, while Thread A had this lock obtained. It will now run into the locked section, sets _completed to true, and will find that _complete is null, because Thread A was not fast enough to to reach the statement CompleteEvent.WaitOne(...) in line 105. Thus, Thread B will not call _complete.Set(), and thus Thread A will wait forever.

We found these two bugs while stress-testing our new application which uses MassTransit. It would be nice if the fixes could find their way into the product.