### PR TITLE
Typo fix in installation instructions page

### DIFF
--- a/doc/source/installation/index.rst
+++ b/doc/source/installation/index.rst
@@ -2,7 +2,7 @@ MassTransit Installation
 """"""""""""""""""""""""
 
 This section of the online docs will explain how to get MassTransit into
-your project. It will also show you were to get help, how to report bugs, etc.
+your project. It will also show you where to get help, how to report bugs, etc.
 Hopefully, you will find it useful as you explore the MassTransit framework.
 
 .. toctree::


### PR DESCRIPTION
This is just correcting "were" to "where", that's all.