### PR TITLE
Added persistence support for Sagas in Entity Framework

### DIFF
--- a/src/MassTransit.sln
+++ b/src/MassTransit.sln
@@ -82,6 +82,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Futures", "Mass
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Futures.Tests", "MassTransit.Futures.Tests\MassTransit.Futures.Tests.csproj", "{941A22AD-C791-4111-9B67-CD576977C95A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.EntityFrameworkIntegration", "Persistence\MassTransit.EntityFrameworkIntegration\MassTransit.EntityFrameworkIntegration.csproj", "{442E2B78-0237-458D-B32B-CEC94413F44D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.EntityFrameworkIntegration.Tests", "Persistence\MassTransit.EntityFrameworkIntegration.Tests\MassTransit.EntityFrameworkIntegration.Tests.csproj", "{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -333,6 +337,30 @@ Global
 		{941A22AD-C791-4111-9B67-CD576977C95A}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{941A22AD-C791-4111-9B67-CD576977C95A}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
 		{941A22AD-C791-4111-9B67-CD576977C95A}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Debug|x86.Build.0 = Debug|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Release|x86.ActiveCfg = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.Release|x86.Build.0 = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{442E2B78-0237-458D-B32B-CEC94413F44D}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Debug|x86.Build.0 = Debug|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Release|x86.ActiveCfg = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.Release|x86.Build.0 = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -359,6 +387,8 @@ Global
 		{2F7DB49B-B650-4B57-BB9D-5D1B913CCACC} = {FDC1A760-D4E5-44F4-B0D9-C19F2E14253A}
 		{CC243B02-0542-48CB-B175-C8035075E376} = {FDC1A760-D4E5-44F4-B0D9-C19F2E14253A}
 		{989BA511-C126-4C88-A74B-BAD83DF2291B} = {FDC1A760-D4E5-44F4-B0D9-C19F2E14253A}
+		{442E2B78-0237-458D-B32B-CEC94413F44D} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
+		{B6EA7211-7706-4EB1-B91C-B4C959F0CB29} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/App.config
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/App.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v12.0"/>
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+    </providers>
+  </entityFramework>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/ContextSetup.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/ContextSetup.cs
@@ -1,0 +1,15 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Tests
+{
+    using Log4NetIntegration.Logging;
+    using NUnit.Framework;
+
+    [SetUpFixture]
+    public class ContextSetup
+    {
+        [SetUp]
+        public void Before_any()
+        {
+            Log4NetLogger.Use("test.log4net.xml");
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/DbQuery.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/DbQuery.cs
@@ -1,0 +1,40 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Tests
+{
+    using System.Data.SqlClient;
+
+    public class DbQuery
+    {
+        readonly string _connectionString;
+
+        public DbQuery(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public object ExecuteScalar(string sql)
+        {
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+
+                using (var cmd = new SqlCommand(sql, conn))
+                {
+                    return cmd.ExecuteScalar();
+                }
+            }
+        }
+
+        public int ExecuteCommand(string sql)
+        {
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+
+                using (var cmd = new SqlCommand(sql, conn))
+                {
+                    return cmd.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/MassTransit.EntityFrameworkIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/MassTransit.EntityFrameworkIntegration.Tests.csproj
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B6EA7211-7706-4EB1-B91C-B4C959F0CB29}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MassTransit.EntityFrameworkIntegration.Tests</RootNamespace>
+    <AssemblyName>MassTransit.EntityFrameworkIntegration.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mehdime.Entity, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mehdime.Entity.1.0.0\lib\Mehdime.Entity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NewId, Version=2.1.3.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\NewId.2.1.3\lib\net45\NewId.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Shouldly, Version=2.5.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.2.5.0\lib\net40\Shouldly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ContextSetup.cs" />
+    <Compile Include="DbQuery.cs" />
+    <Compile Include="SagaDbContextFactoryProvider.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SagaLocator_Specs.cs" />
+    <Compile Include="SimpleSagaEntity.cs" />
+    <Compile Include="SimpleSagaMap.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj">
+      <Project>{8d2be372-a756-4676-b2ea-ed7846809bfe}</Project>
+      <Name>MassTransit.Log4NetIntegration</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MassTransit.EntityFrameworkIntegration\MassTransit.EntityFrameworkIntegration.csproj">
+      <Project>{442e2b78-0237-458d-b32b-cec94413f44d}</Project>
+      <Name>MassTransit.EntityFrameworkIntegration</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\MassTransit.TestFramework\MassTransit.TestFramework.csproj">
+      <Project>{3c4b5f1a-69ad-415e-9f40-a7fdbd7a3012}</Project>
+      <Name>MassTransit.TestFramework</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\MassTransit.Tests\MassTransit.Tests.csproj">
+      <Project>{76646b96-936b-4d31-a053-35cd630e3c68}</Project>
+      <Name>MassTransit.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\MassTransit\MassTransit.csproj">
+      <Project>{6efd69fc-cbcc-4f85-aee0-efba73f4d273}</Project>
+      <Name>MassTransit</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="test.log4net.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/Properties/AssemblyInfo.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MassTransit.EntityFrameworkIntegration.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MassTransit.EntityFrameworkIntegration.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b6ea7211-7706-4eb1-b91c-b4c959f0cb29")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SagaDbContextFactoryProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SagaDbContextFactoryProvider.cs
@@ -1,0 +1,70 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Tests
+{
+    using System;
+    using System.Data.Entity;
+    using System.Data.SqlClient;
+    using Mehdime.Entity;
+
+    public class SagaDbContextFactoryProvider :
+        IDbContextFactory
+    {
+        /// <summary>
+        /// This is a list of the connection strings that we will attempt to find what LocalDb versions
+        /// are on the local pc which we can run the unit tests against
+        /// </summary>
+        private readonly string[] _possibleLocalDbConnectionStrings = new[]
+        {
+            @"Data Source=(LocalDb)\MSSQLLocalDB;Integrated Security=True;Initial Catalog=MassTransitUnitTests_v12_2015;",  // the localdb installed with VS 2015
+            @"Data Source=(LocalDb)\ProjectsV12;Integrated Security=True;Initial Catalog=MassTransitUnitTests_v12;",        // the localdb with VS 2013
+            @"Data Source=(LocalDb)\v11.0;Integrated Security=True;Initial Catalog=MassTransitUnitTests_v11;"               // the older version of localdb
+        };
+
+        private static object _lockConnectionString = new object();
+        private static string _connectionString;
+
+        public TDbContext CreateDbContext<TDbContext>() where TDbContext : DbContext
+        {
+            TrySetLocalDbConnectionString();
+
+            return new SagaDbContext<SimpleSagaEntity, SimpleSagaMap>(_connectionString) as TDbContext;
+        }
+
+        /// <summary>
+        /// Loops through the array of potential localdb connection strings to find one that we can use for the unit tests
+        /// </summary>
+        private void TrySetLocalDbConnectionString()
+        {
+            if (string.IsNullOrWhiteSpace(_connectionString))
+            {
+                lock (_lockConnectionString)
+                {
+                    if (string.IsNullOrWhiteSpace(_connectionString))
+                    {
+                        // Lets find a localdb that we can use for our unit test
+                        foreach (var connectionString in _possibleLocalDbConnectionStrings)
+                        {
+                            try
+                            {
+                                using (var connection = new SqlConnection(connectionString))
+                                {
+                                    // It worked, we can save this as our connection string
+                                    _connectionString = connectionString;
+                                    break;
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                // Swallow
+                            }
+                        }
+
+                        // If we looped through all possible localdb connection strings and didn't find one, we fail.
+                        if (string.IsNullOrWhiteSpace(_connectionString))
+                            throw new InvalidOperationException(
+                                "Couldn't connect to any of the LocalDB Databases. You might have a version installed that is not in the list. Please check the list and modify as necessary");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SagaLocator_Specs.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SagaLocator_Specs.cs
@@ -1,0 +1,76 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Tests
+{
+    using System;
+    using MassTransit.Saga;
+    using MassTransit.Tests.Saga.Messages;
+    using NUnit.Framework;
+    using Saga;
+    using Shouldly;
+    using TestFramework;
+    using Mehdime.Entity;
+
+
+    [TestFixture, Category("Integration")]
+    public class Locating_an_existing_ef_saga :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async void A_correlated_message_should_find_the_correct_saga()
+        {
+            Guid sagaId = NewId.NextGuid();
+            var message = new InitiateSimpleSaga(sagaId);
+
+            await InputQueueSendEndpoint.Send(message);
+
+            Guid? foundId = await _sagaRepository.Value.ShouldContainSaga(message.CorrelationId, TestTimeout);
+
+            foundId.HasValue.ShouldBe(true);
+
+            var nextMessage = new CompleteSimpleSaga { CorrelationId = sagaId };
+
+            await InputQueueSendEndpoint.Send(nextMessage);
+
+            foundId = await _sagaRepository.Value.ShouldContainSaga(x => x.CorrelationId == sagaId && x.Completed, TestTimeout);
+
+            foundId.HasValue.ShouldBe(true);
+        }
+
+        [Test]
+        public async void An_initiating_message_should_start_the_saga()
+        {
+            Guid sagaId = NewId.NextGuid();
+            var message = new InitiateSimpleSaga(sagaId);
+
+            await InputQueueSendEndpoint.Send(message);
+
+            Guid? foundId = await _sagaRepository.Value.ShouldContainSaga(message.CorrelationId, TestTimeout);
+
+            foundId.HasValue.ShouldBe(true);
+        }
+
+        readonly IDbContextScopeFactory _dbContextScopeFactory;
+        readonly Lazy<ISagaRepository<SimpleSagaEntity>> _sagaRepository;
+
+        public Locating_an_existing_ef_saga()
+        {
+            _dbContextScopeFactory = new DbContextScopeFactory(new SagaDbContextFactoryProvider());
+            _sagaRepository = new Lazy<ISagaRepository<SimpleSagaEntity>>(() => new EfSagaRepository<SimpleSagaEntity>(_dbContextScopeFactory));
+        }
+
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+        }
+
+        [TestFixtureTearDown]
+        public void Teardown()
+        {
+        }
+
+        protected override void ConfigureInputQueueEndpoint(IReceiveEndpointConfigurator configurator)
+        {
+            configurator.Saga(_sagaRepository.Value);
+        }
+
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SimpleSagaEntity.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SimpleSagaEntity.cs
@@ -1,0 +1,56 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Tests
+{
+    using System;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+    using MassTransit.Saga;
+    using MassTransit.Tests.Saga.Messages;
+
+    /// <summary>
+    /// Nearly a complete copy from MassTransit.Tests.Saga.SimpleSaga, but had to use SimpleSagaEntity with the setter available
+    /// </summary>
+    public class SimpleSagaEntity :
+        SagaEntity,
+        InitiatedBy<InitiateSimpleSaga>,
+        Orchestrates<CompleteSimpleSaga>,
+        Observes<ObservableSagaMessage, SimpleSagaEntity>,
+        ISaga
+    {
+        public SimpleSagaEntity()
+        {
+        }
+
+        public SimpleSagaEntity(Guid correlationId)
+        {
+            CorrelationId = correlationId;
+        }
+
+        public bool Completed { get; private set; }
+        public bool Initiated { get; private set; }
+        public bool Observed { get; private set; }
+        public string Name { get; private set; }
+
+        public async Task Consume(ConsumeContext<InitiateSimpleSaga> context)
+        {
+            Initiated = true;
+            Name = context.Message.Name;
+        }
+
+        public new Guid CorrelationId { get; set; }
+
+        public async Task Consume(ConsumeContext<ObservableSagaMessage> message)
+        {
+            Observed = true;
+        }
+
+        public Expression<Func<SimpleSagaEntity, ObservableSagaMessage, bool>> CorrelationExpression
+        {
+            get { return (saga, message) => saga.Name == message.Name; }
+        }
+
+        public async Task Consume(ConsumeContext<CompleteSimpleSaga> message)
+        {
+            Completed = true;
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SimpleSagaMap.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SimpleSagaMap.cs
@@ -1,0 +1,15 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Tests
+{
+    public class SimpleSagaMap :
+        SagaClassMapping<SimpleSagaEntity>
+    {
+        public SimpleSagaMap()
+        {
+            Property(x => x.Name)
+                .HasMaxLength(40);
+            Property(x => x.Initiated);
+            Property(x => x.Observed);
+            Property(x => x.Completed);
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/packages.config
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.0.0" targetFramework="net45" />
+  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="Mehdime.Entity" version="1.0.0" targetFramework="net45" />
+  <package id="NewId" version="2.1.3" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Shouldly" version="2.5.0" targetFramework="net45" />
+</packages>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/test.log4net.xml
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/test.log4net.xml
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net" />
+  </configSections>
+  <log4net>
+    <root>
+      <level value="ALL" />
+      <appender-ref ref="LogFileAppender" />
+      <appender-ref ref="console" />
+    </root>
+
+    <logger name="MassTransit">
+      <level value="DEBUG" />
+    </logger>
+
+    <logger name="MassTransit.Messages" additivity="false">
+      <level value="DEBUG" />
+      <appender-ref ref="MessageLogAppender" />
+    </logger>
+
+    <appender name="console" type="log4net.Appender.ConsoleAppender, log4net">
+      <layout type="log4net.Layout.PatternLayout,log4net">
+        <param name="ConversionPattern" value="%d [%t] %-5p %c - %m%n" />
+      </layout>
+    </appender>
+    <appender name="LogFileAppender"
+          type="log4net.Appender.RollingFileAppender" >
+      <param name="File"
+           value="C:\LogFiles\MassTransit.ServiceBus.Tests.log" />
+      <param name="AppendToFile"
+           value="true" />
+      <rollingStyle value="Size" />
+      <maxSizeRollBackups value="4" />
+      <maximumFileSize value="10MB" />
+      <staticLogFileName value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+        <param name="ConversionPattern"
+             value="%-5p %d{yyyy-MM-dd hh:mm:ss} - %m%n" />
+      </layout>
+    </appender>
+    <appender name="MessageLogAppender"
+          type="log4net.Appender.RollingFileAppender" >
+      <param name="File"
+           value="C:\LogFiles\MassTransit.ServiceBus.Tests.Messages.log" />
+      <param name="AppendToFile"
+           value="true" />
+      <rollingStyle value="Size" />
+      <maxSizeRollBackups value="4" />
+      <maximumFileSize value="10MB" />
+      <staticLogFileName value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+        <param name="ConversionPattern"
+             value="%-5p %d{yyyy-MM-dd hh:mm:ss} - %m%n" />
+      </layout>
+    </appender>
+  </log4net>
+</configuration>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{442E2B78-0237-458D-B32B-CEC94413F44D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MassTransit.EntityFrameworkIntegration</RootNamespace>
+    <AssemblyName>MassTransit.EntityFrameworkIntegration</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mehdime.Entity, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mehdime.Entity.1.0.0\lib\Mehdime.Entity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SagaClassMapping.cs" />
+    <Compile Include="SagaDbContext.cs" />
+    <Compile Include="SagaEntity.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Saga\EfSagaConsumeContext.cs" />
+    <Compile Include="Saga\EfSagaRepository.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MassTransit\MassTransit.csproj">
+      <Project>{6efd69fc-cbcc-4f85-aee0-efba73f4d273}</Project>
+      <Name>MassTransit</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/Properties/AssemblyInfo.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MassTransit.EntityFrameworkIntegration")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MassTransit.EntityFrameworkIntegration")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("442e2b78-0237-458d-b32b-cec94413f44d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/EfSagaConsumeContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/EfSagaConsumeContext.cs
@@ -1,0 +1,229 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Saga
+{
+    using System.Data.Entity;
+    using MassTransit.Pipeline;
+    using Mehdime.Entity;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Context;
+    using Logging;
+    using MassTransit.Saga;
+    using Util;
+
+
+    public class EfSagaConsumeContext<TSaga, TMessage> :
+        SagaConsumeContext<TSaga, TMessage>
+        where TMessage : class
+        where TSaga : class, ISaga
+    {
+        static readonly ILog _log = Logger.Get<EfSagaRepository<TSaga>>();
+        readonly ConsumeContext<TMessage> _context;
+        readonly TSaga _instance;
+        readonly IDbContextScopeFactory _dbContextScopeFactory;
+        bool _completed;
+        readonly PayloadCache _payloadCache;
+
+        public EfSagaConsumeContext(IDbContextScopeFactory dbContextScopeFactory, ConsumeContext<TMessage> context, TSaga instance)
+        {
+            _context = context;
+            _instance = instance;
+            _dbContextScopeFactory = dbContextScopeFactory;
+
+            _payloadCache = new PayloadCache();
+        }
+
+        Task ConsumeContext.CompleteTask => _context.CompleteTask;
+        IEnumerable<string> ConsumeContext.SupportedMessageTypes => _context.SupportedMessageTypes;
+
+        Task IPublishEndpoint.Publish<T>(T message, CancellationToken cancellationToken)
+        {
+            return _context.Publish(message, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish<T>(T message, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken)
+        {
+            return _context.Publish(message, publishPipe, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish<T>(T message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken)
+        {
+            return _context.Publish(message, publishPipe, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish(object message, CancellationToken cancellationToken)
+        {
+            return _context.Publish(message, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish(object message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken)
+        {
+            return _context.Publish(message, publishPipe, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish(object message, Type messageType, CancellationToken cancellationToken)
+        {
+            return _context.Publish(message, messageType, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish(object message, Type messageType, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken)
+        {
+            return _context.Publish(message, messageType, publishPipe, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish<T>(object values, CancellationToken cancellationToken)
+        {
+            return _context.Publish<T>(values, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish<T>(object values, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken)
+        {
+            return _context.Publish(values, publishPipe, cancellationToken);
+        }
+
+        Task IPublishEndpoint.Publish<T>(object values, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken)
+        {
+            return _context.Publish<T>(values, publishPipe, cancellationToken);
+        }
+
+        bool PipeContext.HasPayloadType(Type contextType)
+        {
+            return _payloadCache.HasPayloadType(contextType) || _context.HasPayloadType(contextType);
+        }
+
+        bool PipeContext.TryGetPayload<TPayload>(out TPayload context)
+        {
+            if (_payloadCache.TryGetPayload(out context))
+                return true;
+
+            return _context.TryGetPayload(out context);
+        }
+
+        TPayload PipeContext.GetOrAddPayload<TPayload>(PayloadFactory<TPayload> payloadFactory)
+        {
+            TPayload payload;
+            if (_payloadCache.TryGetPayload(out payload))
+                return payload;
+
+            if (_context.TryGetPayload(out payload))
+                return payload;
+
+            return _payloadCache.GetOrAddPayload(payloadFactory);
+        }
+
+        Guid? MessageContext.MessageId => _context.MessageId;
+        Guid? MessageContext.RequestId => _context.RequestId;
+        Guid? MessageContext.CorrelationId => _instance.CorrelationId;
+        DateTime? MessageContext.ExpirationTime => _context.ExpirationTime;
+        Uri MessageContext.SourceAddress => _context.SourceAddress;
+        Uri MessageContext.DestinationAddress => _context.DestinationAddress;
+        Uri MessageContext.ResponseAddress => _context.ResponseAddress;
+        Uri MessageContext.FaultAddress => _context.FaultAddress;
+        Headers MessageContext.Headers => _context.Headers;
+
+        SagaConsumeContext<TSaga, T> SagaConsumeContext<TSaga>.PopContext<T>()
+        {
+            return (SagaConsumeContext<TSaga, T>)this;
+        }
+
+        async Task SagaConsumeContext<TSaga>.SetCompleted()
+        {
+            using (var dbContextScope = _dbContextScopeFactory.Create())
+            {
+                var dbContext = dbContextScope.DbContexts.Get<DbContext>();
+
+                dbContext.Set<TSaga>().Remove(_instance);
+
+                _completed = true;
+                if (_log.IsDebugEnabled)
+                {
+                    _log.DebugFormat("SAGA:{0}:{1} Removed {2}", TypeMetadataCache<TSaga>.ShortName, TypeMetadataCache<TMessage>.ShortName,
+                        _instance.CorrelationId);
+                }
+
+                await dbContextScope.SaveChangesAsync();
+            }
+        }
+
+        public bool IsCompleted
+        {
+            get { return _completed; }
+        }
+
+        public CancellationToken CancellationToken
+        {
+            get { return _context.CancellationToken; }
+        }
+
+        public ReceiveContext ReceiveContext
+        {
+            get { return _context.ReceiveContext; }
+        }
+
+        public bool HasMessageType(Type messageType)
+        {
+            return _context.HasMessageType(messageType);
+        }
+
+        public bool TryGetMessage<T>(out ConsumeContext<T> consumeContext)
+            where T : class
+        {
+            return _context.TryGetMessage(out consumeContext);
+        }
+
+        public Task RespondAsync<T>(T message)
+            where T : class
+        {
+            return _context.RespondAsync(message);
+        }
+
+        Task ConsumeContext.RespondAsync<T>(T message, IPipe<SendContext<T>> sendPipe)
+        {
+            return _context.RespondAsync(message, sendPipe);
+        }
+
+        public void Respond<T>(T message)
+            where T : class
+        {
+            _context.Respond(message);
+        }
+
+        public Task<ISendEndpoint> GetSendEndpoint(Uri address)
+        {
+            return _context.GetSendEndpoint(address);
+        }
+
+        Task ConsumeContext.NotifyConsumed<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType)
+        {
+            return _context.NotifyConsumed(context, duration, consumerType);
+        }
+
+        public Task NotifyFaulted<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception)
+            where T : class
+        {
+            return _context.NotifyFaulted(context, duration, consumerType, exception);
+        }
+
+        TMessage ConsumeContext<TMessage>.Message => _context.Message;
+
+        Task ConsumeContext<TMessage>.NotifyConsumed(TimeSpan duration, string consumerType)
+        {
+            return _context.NotifyConsumed(duration, consumerType);
+        }
+
+        Task ConsumeContext<TMessage>.NotifyFaulted(TimeSpan duration, string consumerType, Exception exception)
+        {
+            return NotifyFaulted(_context, duration, consumerType, exception);
+        }
+
+        public TSaga Saga => _instance;
+
+        ConnectHandle IPublishObserverConnector.ConnectPublishObserver(IPublishObserver observer)
+        {
+            return _context.ConnectPublishObserver(observer);
+        }
+    }
+}
+
+

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/EfSagaRepository.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/EfSagaRepository.cs
@@ -1,0 +1,209 @@
+﻿namespace MassTransit.EntityFrameworkIntegration.Saga
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Entity;
+    using System.Data.Entity.Core.Metadata.Edm;
+    using System.Data.Entity.Infrastructure;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using MassTransit.Logging;
+    using MassTransit.Saga;
+    using MassTransit.Pipeline;
+    using MassTransit.Util;
+    using Mehdime.Entity;
+
+    public class EfSagaRepository<TSaga> :
+        ISagaRepository<TSaga>,
+        IQuerySagaRepository<TSaga>
+        where TSaga : class, ISaga
+    {
+        private static readonly ILog _log = Logger.Get<EfSagaRepository<TSaga>>();
+
+        private readonly IDbContextScopeFactory _dbContextScopeFactory;
+
+        public EfSagaRepository(IDbContextScopeFactory dbContextScopeFactory)
+        {
+            _dbContextScopeFactory = dbContextScopeFactory;
+        }
+
+        public async Task<IEnumerable<Guid>> Find(ISagaQuery<TSaga> query)
+        {
+            using (var dbContextScope = _dbContextScopeFactory.Create())
+            {
+                var dbContext = dbContextScope.DbContexts.Get<DbContext>();
+
+                return await dbContext.Set<TSaga>()
+                    .Where(query.FilterExpression)
+                    .Select(x => x.CorrelationId)
+                    .ToListAsync();
+            }
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            ProbeContext scope = context.CreateScope("sagaRepository");
+            using (var dbContextScope = _dbContextScopeFactory.Create())
+            {
+                var dbContext = dbContextScope.DbContexts.Get<DbContext>();
+
+                var objectContext = ((IObjectContextAdapter)dbContext).ObjectContext;
+                var workspace = objectContext.MetadataWorkspace;
+
+                scope.Set(new
+                {
+                    Persistence = "entityframework",
+                    Entities = workspace.GetItems<EntityType>(DataSpace.SSpace).Select(x => x.Name),
+                });
+            }
+        }
+
+        public async Task Send<T>(ConsumeContext<T> context, ISagaPolicy<TSaga, T> policy,
+            IPipe<SagaConsumeContext<TSaga, T>> next) where T : class
+        {
+            if (!context.CorrelationId.HasValue)
+                throw new SagaException("The CorrelationId was not specified", typeof(TSaga), typeof(T));
+
+            Guid sagaId = context.CorrelationId.Value;
+
+            using (var dbContextScope = _dbContextScopeFactory.Create())
+            {
+                var dbContext = dbContextScope.DbContexts.Get<DbContext>();
+
+
+                var sagaInstance = dbContext.Set<TSaga>().SingleOrDefault(x => x.CorrelationId == sagaId);
+
+                if (sagaInstance == null)
+                {
+                    var missingSagaPipe = new MissingPipe<T>(_dbContextScopeFactory, next);
+
+                    await policy.Missing(context, missingSagaPipe);
+                }
+                else
+                {
+                    if (_log.IsDebugEnabled)
+                        _log.DebugFormat("SAGA:{0}:{1} Used {2}", TypeMetadataCache<TSaga>.ShortName, sagaInstance.CorrelationId, TypeMetadataCache<T>.ShortName);
+
+                    var sagaConsumeContext = new EfSagaConsumeContext<TSaga, T>(_dbContextScopeFactory, context, sagaInstance);
+
+                    await policy.Existing(sagaConsumeContext, next);
+                }
+
+                await dbContextScope.SaveChangesAsync();
+            }
+        }
+
+        public async Task SendQuery<T>(SagaQueryConsumeContext<TSaga, T> context, ISagaPolicy<TSaga, T> policy,
+            IPipe<SagaConsumeContext<TSaga, T>> next) where T : class
+        {
+            using (var dbContextScope = _dbContextScopeFactory.Create())
+            {
+                try
+                {
+                    var dbContext = dbContextScope.DbContexts.Get<DbContext>();
+
+                    var sagaInstances = await dbContext.Set<TSaga>().Where(context.Query.FilterExpression).ToListAsync();
+
+                    if (sagaInstances.Count == 0)
+                    {
+                        var missingSagaPipe = new MissingPipe<T>(_dbContextScopeFactory, next);
+                        await policy.Missing(context, missingSagaPipe);
+                    }
+                    else
+                    {
+                        await
+                            Task.WhenAll(
+                                sagaInstances.Select(instance => SendToInstance(context, policy, instance, next)));
+                    }
+
+                    await dbContextScope.SaveChangesAsync();
+                }
+                catch (SagaException sex)
+                {
+                    if (_log.IsErrorEnabled)
+                        _log.Error("Saga Exception Occurred", sex);
+                }
+                catch (Exception ex)
+                {
+                    if (_log.IsErrorEnabled)
+                        _log.Error(
+                            string.Format("SAGA:{0} Exception {1}", TypeMetadataCache<TSaga>.ShortName,
+                                TypeMetadataCache<T>.ShortName), ex);
+
+                    throw new SagaException(ex.Message, typeof(TSaga), typeof(T), Guid.Empty, ex);
+                }
+            }
+        }
+
+        async Task SendToInstance<T>(SagaQueryConsumeContext<TSaga, T> context, ISagaPolicy<TSaga, T> policy, TSaga instance,
+            IPipe<SagaConsumeContext<TSaga, T>> next)
+            where T : class
+        {
+            try
+            {
+                if (_log.IsDebugEnabled)
+                    _log.DebugFormat("SAGA:{0}:{1} Used {2}", TypeMetadataCache<TSaga>.ShortName, instance.CorrelationId, TypeMetadataCache<T>.ShortName);
+
+                var sagaConsumeContext = new EfSagaConsumeContext<TSaga, T>(_dbContextScopeFactory, context, instance);
+
+                await policy.Existing(sagaConsumeContext, next);
+            }
+            catch (SagaException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new SagaException(ex.Message, typeof(TSaga), typeof(T), instance.CorrelationId, ex);
+            }
+        }
+
+        /// <summary>
+        /// Once the message pipe has processed the saga instance, add it to the saga repository
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        class MissingPipe<TMessage> :
+            IPipe<SagaConsumeContext<TSaga, TMessage>>
+            where TMessage : class
+        {
+            readonly IPipe<SagaConsumeContext<TSaga, TMessage>> _next;
+            readonly IDbContextScopeFactory _dbContextScopeFactory;
+
+            public MissingPipe(IDbContextScopeFactory dbContextScopeFactory, IPipe<SagaConsumeContext<TSaga, TMessage>> next)
+            {
+                _dbContextScopeFactory = dbContextScopeFactory;
+                _next = next;
+            }
+
+            async void IProbeSite.Probe(ProbeContext context)
+            {
+                _next.Probe(context);
+            }
+
+            public async Task Send(SagaConsumeContext<TSaga, TMessage> context)
+            {
+                using (var dbContextScope = _dbContextScopeFactory.Create())
+                {
+                    var dbContext = dbContextScope.DbContexts.Get<DbContext>();
+
+                    if (_log.IsDebugEnabled)
+                    {
+                        _log.DebugFormat("SAGA:{0}:{1} Added {2}", TypeMetadataCache<TSaga>.ShortName,
+                            context.Saga.CorrelationId,
+                            TypeMetadataCache<TMessage>.ShortName);
+                    }
+
+                    var proxy = new EfSagaConsumeContext<TSaga, TMessage>(_dbContextScopeFactory, context, context.Saga);
+
+                    await _next.Send(proxy);
+
+                    if (!proxy.IsCompleted)
+                        dbContext.Set<TSaga>().Add(context.Saga);
+
+                    await dbContextScope.SaveChangesAsync();
+                }
+            }
+        }
+    }
+}
+

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaClassMapping.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaClassMapping.cs
@@ -1,0 +1,18 @@
+﻿namespace MassTransit.EntityFrameworkIntegration
+{
+    using System.ComponentModel.DataAnnotations.Schema;
+    using System.Data.Entity.ModelConfiguration;
+
+    public abstract class SagaClassMapping<T> :
+        EntityTypeConfiguration<T>
+        where T : SagaEntity
+    {
+        protected SagaClassMapping()
+        {
+            HasKey(t => t.CorrelationId);
+
+            Property(t => t.CorrelationId)
+                .HasDatabaseGeneratedOption(DatabaseGeneratedOption.None);
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaDbContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaDbContext.cs
@@ -1,0 +1,46 @@
+﻿namespace MassTransit.EntityFrameworkIntegration
+{
+    using System.Data.Entity;
+    using System.Data.Common;
+    using System.Data.Entity.Core.Objects;
+    using System.Data.Entity.Infrastructure;
+    using MassTransit.Saga;
+
+    public class SagaDbContext<TSaga, TSagaClassMapping> : DbContext
+        where TSaga : SagaEntity, ISaga
+        where TSagaClassMapping : SagaClassMapping<TSaga>, new()
+    {
+        #region Constructors
+        protected SagaDbContext() { }
+
+        protected SagaDbContext(DbCompiledModel model)
+            : base(model)
+        { }
+
+        public SagaDbContext(string nameOrConnectionString)
+            : base(nameOrConnectionString)
+        { }
+
+        public SagaDbContext(DbConnection existingConnection, bool contextOwnsConnection)
+            : base(existingConnection, contextOwnsConnection)
+        { }
+
+        public SagaDbContext(ObjectContext objectContext, bool dbContextOwnsObjectContext)
+            : base(objectContext, dbContextOwnsObjectContext)
+        { }
+
+        public SagaDbContext(string nameOrConnectionString, DbCompiledModel model)
+            : base(nameOrConnectionString, model)
+        { }
+
+        public SagaDbContext(DbConnection existingConnection, DbCompiledModel model, bool contextOwnsConnection)
+            : base(existingConnection, model, contextOwnsConnection)
+        { }
+        #endregion
+
+        protected override void OnModelCreating(DbModelBuilder modelBuilder)
+        {
+            modelBuilder.Configurations.Add(new TSagaClassMapping());
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaEntity.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaEntity.cs
@@ -1,0 +1,10 @@
+﻿namespace MassTransit.EntityFrameworkIntegration
+{
+    using System;
+
+    public abstract class SagaEntity : CorrelatedBy<Guid>
+    {
+        // EF Mapping requires property to have a setter
+        public Guid CorrelationId { get; protected set; }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/packages.config
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.0.0" targetFramework="net45" />
+  <package id="Mehdime.Entity" version="1.0.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Hello, I've added support for Entity Framework, and structured it similar to the NHibernate. The same unit tests that MassTransit.NHibernateIntegration.Tests were implemented for EntityFramework and passed.

I added some comments to the commits to help explain some decisions that were made.

Also one library you'll notice that I used was Mehdime.Entity. I've used it before in production code and it has worked great.

If you look at the `EfSagaRepository.cs` for example, you'll notice that EF doesn't have the NHibernate SessionFactory.
Instead you'll see:
```csharp
using (var dbContextScope = _dbContextScopeFactory.Create())
```
Basically it lets you get the benefits of a scoped connection (doesn't create a new db connection if called within a parent scope), similar to NHibernate SessionFactory, but it still retains the EF's Unit of Work pattern. So when I tried to wrap my head around the NHibernate implementation, I didn't see it necessary to start a transaction scope in the EntityFramework implementation. But I might have misunderstood some of the usages of pipelineing/policies in the saga, and so it still might be necessary to add the transaction scope (which can easily be added).

I'd recommend reading about [DbContextScope here](http://mehdi.me/ambient-dbcontext-in-ef6/) and it will help clear up some questions about it, and versus NHibernate's SessionFactory.