### PR TITLE
Added autofac registration extension method for registering all consumers found through scanning assemblies/

### DIFF
--- a/src/Containers/MassTransit.AutoFacIntegration/MassTransit.AutoFacIntegration.csproj
+++ b/src/Containers/MassTransit.AutoFacIntegration/MassTransit.AutoFacIntegration.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AutofacSagaRepository.cs" />
     <Compile Include="ConsumerConfiguratorCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RegistrationExtensions.cs" />
     <Compile Include="SagaConfiguratorCache.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Containers/MassTransit.AutoFacIntegration/RegistrationExtensions.cs
+++ b/src/Containers/MassTransit.AutoFacIntegration/RegistrationExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AutofacIntegration
+{
+    using System.Reflection;
+    using Autofac.Builder;
+    using Autofac.Features.Scanning;
+    using Autofac;
+
+    /// <summary>
+    /// Extends <see cref="ContainerBuilder"/> with methods to support MassTransit.
+    /// </summary>
+    public static class RegistrationExtensions
+    {
+        /// <summary>
+        /// Register types that implement <see cref="IConsumer"/> in the provided assemblies.
+        /// </summary>
+        /// <param name="builder">The container builder.</param>
+        /// <param name="consumerAssemblies">Assemblies to scan for consumers.</param>
+        /// <returns>Registration builder allowing the consumer components to be customised.</returns>
+        public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
+            RegisterConsumers(this ContainerBuilder builder, params Assembly[] consumerAssemblies)
+        {
+            return builder.RegisterAssemblyTypes(consumerAssemblies)
+                .Where(t => typeof(IConsumer).IsAssignableFrom(t));
+        }
+    }
+}

--- a/src/Containers/MassTransit.Containers.Tests/AutofacRegistrationExtension_Specs.cs
+++ b/src/Containers/MassTransit.Containers.Tests/AutofacRegistrationExtension_Specs.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Containers.Tests
+{
+    using System.Threading.Tasks;
+    using Autofac;
+    using AutofacIntegration;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    public class AutofacContainer_RegistrationExtension
+    {
+        [Test]
+        public void Registration_extension_method_for_consumers()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterConsumers(System.Reflection.Assembly.GetExecutingAssembly());
+
+            var container = builder.Build();
+
+            Assert.That(container.IsRegistered<TestConsumer>(), Is.True);
+        }
+    }
+
+    public class TestConsumer : IConsumer
+    { }
+}

--- a/src/Containers/MassTransit.Containers.Tests/MassTransit.Containers.Tests.csproj
+++ b/src/Containers/MassTransit.Containers.Tests/MassTransit.Containers.Tests.csproj
@@ -93,6 +93,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutofacRegistrationExtension_Specs.cs" />
     <Compile Include="AutofacRegistration_Specs.cs" />
     <Compile Include="CastleWindsor_Specs.cs" />
     <Compile Include="Ninject_Specs.cs" />


### PR DESCRIPTION
Simple extension method for registration scanning of the marker interface IConsumer