### PR TITLE
Fix NullReferenceException when using the NLogLogger default constructor

### DIFF
--- a/src/Loggers/MassTransit.NLogIntegration/Logging/NLogLogger.cs
+++ b/src/Loggers/MassTransit.NLogIntegration/Logging/NLogLogger.cs
@@ -30,9 +30,10 @@ namespace MassTransit.NLogIntegration.Logging
             _logs = new ConcurrentDictionary<string, NLogLog>();
         }
 
-        public NLogLogger()
+        public NLogLogger() 
         {
             _logFactory = LogManager.GetLogger;
+            _logs = new ConcurrentDictionary<string, NLogLog>();
         }
 
         public ILog Get(string name)


### PR DESCRIPTION
Fixes MassTransit#352

I have tested this change and it has resolve the issue.