### PR TITLE
Added the ability to F5 start the RapidTransit.Sample project 

### DIFF
--- a/src/RapidTransit/RapidTransit.Sample/RapidTransit.Sample.csproj
+++ b/src/RapidTransit/RapidTransit.Sample/RapidTransit.Sample.csproj
@@ -58,6 +58,10 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <StartAction>Program</StartAction>
+    <StartProgram>$(ProjectDir)$(OutputPath)MassTransit.Host.exe</StartProgram>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
If you add the RapidTransit.Sample project to the solution, I have added the ability to start the sample project in the VS debugger.