### PR TITLE
Initialize MassTransit logger with TopShelf during host startup

### DIFF
--- a/src/MassTransit.Host/Program.cs
+++ b/src/MassTransit.Host/Program.cs
@@ -15,6 +15,7 @@ namespace MassTransit.Host
     using System;
     using System.IO;
     using log4net.Config;
+    using Log4NetIntegration.Logging;
     using Topshelf;
     using Topshelf.Logging;
 
@@ -44,6 +45,7 @@ namespace MassTransit.Host
                 XmlConfigurator.ConfigureAndWatch(configFile);
 
             Log4NetLogWriterFactory.Use();
+            Log4NetLogger.Use();
         }
     }
 }


### PR DESCRIPTION
If using a logger during service initialization, it will get a handle to a trace logger before a service configurator can configure it. Also since the log4net is setup and configured for topshelf, it would make sense to have MassTransit configured to use log4net at the same time.