### PR TITLE
ArgumentException in InMemoryTransport.DispatchMessage when invoked…

### DIFF
--- a/src/MassTransit.Tests/InMemoryTest_Specs.cs
+++ b/src/MassTransit.Tests/InMemoryTest_Specs.cs
@@ -78,4 +78,47 @@ namespace MassTransit.Tests
             _receivedA = Handled<A>(configurator);
         }
     }
+
+    [TestFixture]
+    public class Publishing_a_message_on_the_bus_using_the_InMemoryTransport
+        : AsyncTestFixture
+    {
+        class TestMessage
+        { }
+
+        [Test, Explicit]
+        public async Task Throw_an_an_uncatchable_ArgumentException()
+        {
+            var busControl = MassTransit.Bus.Factory.CreateUsingInMemory(x => { });
+
+            await busControl.StartAsync();
+
+            await busControl.Publish(new TestMessage());
+
+            await Task.Delay(5000);
+
+            await busControl.StopAsync();
+
+        }
+
+        [Test, Explicit]
+        public async Task Should_not_move_the_message_to_the_dead_letter_queue()
+        {
+
+            var busControl = MassTransit.Bus.Factory.CreateUsingInMemory(x =>
+            {
+                x.ReceiveEndpoint("recv_queue", q => q.Handler<TestMessage>(async m => { }));
+            });
+
+            await busControl.StartAsync();
+
+            await busControl.Publish(new TestMessage());
+
+            await Task.Delay(5000);
+
+            await busControl.StopAsync();
+
+        }
+    }
+
 }


### PR DESCRIPTION
… by `InMemoryTransport.Move`.

It's not a very big problem since it's only in the InMemoryTransport, but something is weird so though i let you know.

Also this is more a repro that a real pull request, since it does not really add/fix anything, but i think it's easier to analyze this way.

## The issue

Looking at `InMemoryTransport.DispatchMessage` i am not really sure what the correct behavior should be. 
It complains that `_receivePipe` is null, but `_receivePipe` is initialized only by calling `IReceiveTransport.Start` and that is never called when retrieving the `ISendTransport` for the dead letter queue.

> This can be observed by running the `Publishing_a_message_on_the_bus_using_the_InMemoryTransport.Throw_an_an_uncatchable_ArgumentException`.

Additionally it's not clear why the message is moved to the dead letter queue even if an handler is
present.

> This can be observed by running the `Publishing_a_message_on_the_bus_using_the_InMemoryTransport.Should_not_move_the_message_to_the_dead_letter_queue`.

Note that the tests don't have any assertions, because i did not find a way to get hold of anything useful to demostrate the problem and i didn't want to make too many changes to the code without really understanding what's going on.

The only way to really observe the problem is by debugging the tests.
Also, watching the visual studio output windows will show 

```
Exception thrown: 'System.ArgumentException' in MassTransit.dll` 
```

after the message is published in both tests.

A proposed solution is available in *InMemoryTransport.cs* (commented out and marked with **L.P.**) but i am not sure if it is really a good solution :)