### PR TITLE
Fixed binary serialization issues when dealing with faults

### DIFF
--- a/src/MassTransit.Tests/BinarySerializer_Specs.cs
+++ b/src/MassTransit.Tests/BinarySerializer_Specs.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Tests
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using TestFramework;
+    using Util;
+    
+
+
+    [TestFixture]
+    public class When_using_the_binary_serializer :
+        InMemoryTestFixture
+    {
+        readonly TaskCompletionSource<Fault<A>> _faultTaskTcs = new TaskCompletionSource<Fault<A>>();
+
+        protected override void ConfigureBus(IInMemoryBusFactoryConfigurator configurator)
+        {
+            configurator.UseBinarySerializer();
+            base.ConfigureBus(configurator);
+        }
+        protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            base.ConfigureInputQueueEndpoint(configurator);
+
+            #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+            configurator.Handler<A>(async m =>
+            {
+                throw new System.Exception("Booom!");
+            });
+
+            configurator.Handler<Fault<A>>(async m =>
+            {
+                _faultTaskTcs.TrySetResult(m.Message);
+            });
+
+            #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        }
+
+
+        [System.Serializable]
+        class A
+        {
+        }
+
+
+
+        [Test]
+        public async Task Should_be_possibile_to_send_and_consume_faults()
+        {
+            await Bus.Publish(new A());
+            var faultTask = _faultTaskTcs.Task;
+            var completedTask = await Task.WhenAny(faultTask, Task.Delay(2000));
+            Assert.AreEqual(faultTask, completedTask);
+        }
+    }
+}

--- a/src/MassTransit.Tests/MassTransit.Tests.csproj
+++ b/src/MassTransit.Tests/MassTransit.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="InterfaceSubscription_Specs.cs" />
     <Compile Include="MessageContext_Specs.cs" />
     <Compile Include="Messages\PartialSerializationTestMessage.cs" />
+    <Compile Include="BinarySerializer_Specs.cs" />
     <Compile Include="MixedConsumer_Specs.cs" />
     <Compile Include="MultiTestConsumer_Specs.cs" />
     <Compile Include="ObjectToDictionary_Specs.cs" />

--- a/src/MassTransit/Events/FaultEvent.cs
+++ b/src/MassTransit/Events/FaultEvent.cs
@@ -15,7 +15,7 @@ namespace MassTransit.Events
     using System;
     using System.Linq;
 
-
+    [Serializable]
     public class FaultEvent<T> :
         Fault<T>
     {

--- a/src/MassTransit/Events/FaultExceptionInfo.cs
+++ b/src/MassTransit/Events/FaultExceptionInfo.cs
@@ -16,7 +16,7 @@ namespace MassTransit.Events
     using Internals.Extensions;
     using Util;
 
-
+    [Serializable]
     public class FaultExceptionInfo :
         ExceptionInfo
     {

--- a/src/MassTransit/Serialization/StaticConsumeContext.cs
+++ b/src/MassTransit/Serialization/StaticConsumeContext.cs
@@ -213,7 +213,7 @@ namespace MassTransit.Serialization
         public Task NotifyFaulted<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception)
             where T : class
         {
-            Task faultTask = GenerateFault(context, exception);
+            Task faultTask = GenerateFault(context.Message, exception);
 
             _pendingTasks.Add(faultTask);
 


### PR DESCRIPTION
* The `ConsumeContext.NotifyFaulted` implementation in `StaticConsumeContext` was calling `GenerateFault` passing the context instance instead of the message. Since `GeneratingFault` is a generic method no error was reported by the compiler. Instead a serialization exception was thrown at run-time.
* The `FaultEvent` and `FaultExceptionInfo` need to be serializable to work when the bus is configured to use binary serialization. Since interfaces are used (`IFault` and `ExceptionInfo`) in the surface API model, this probably need some additional analysis because it impose additional implicit requirements on alternative implementations (they need to be serializable).