### PR TITLE
Fixes polymorphism when using the binary serializer

### DIFF
--- a/src/MassTransit/Serialization/StaticConsumeContext.cs
+++ b/src/MassTransit/Serialization/StaticConsumeContext.cs
@@ -48,8 +48,21 @@ namespace MassTransit.Serialization
             _messageTypes = new Dictionary<Type, object>();
             _message = message;
             _binaryHeaders = headers;
+            _supportedTypes = GetSupportedMessageTypes().ToArray();
+        }
 
-            _supportedTypes = new[] {GetHeaderString(BinaryMessageSerializer.MessageTypeKey)};
+        private IEnumerable<string> GetSupportedMessageTypes()
+        {
+            yield return GetHeaderString(BinaryMessageSerializer.MessageTypeKey);
+            var header = GetHeaderString(BinaryMessageSerializer.PolymorphicMessageTypesKey);
+            if (header != null)
+            {
+                var additionalMessageUrns = header.Split(';');
+                foreach (var additionalMessageUrn in additionalMessageUrns)
+                {
+                    yield return additionalMessageUrn;
+                }
+            }
         }
 
         public override Guid? MessageId => _messageId.HasValue ? _messageId : (_messageId = GetHeaderGuid(BinaryMessageSerializer.MessageIdKey));


### PR DESCRIPTION
### Binary serializer and polymorphic consumers

#### Scenario

Given two bus instances *source* and *destination* where:

* *source* is configured to use the binary serializer
* *destination* is configured to use the json serializer but also with `SupportBinaryMessageDeserializer` on the receive side
* one or more consumers in *destination* consume messages produced by *source*  by their base types
* consumers on *destination* don't receive any message

See also the test 

`Should_be_able_to_consume_messages_polymorphically_if_the_receiving_bus_support_the_binary_serializer`

in src\MassTransit.Tests\BinarySerializer_Specs.cs

#### Issue

The serialization/deserialization implementation in `StaticConsumeContext`/`BinaryMessageSerializer` consider only  the concrete type that is being sent/published.

> I added another header (`PolymorphicMessageTypesKey`) that holds the additional types required to support polymorphism. This should be the safest route  in regard to retro compatibility. If this is not required then the existing header (`MessageTypeKey`) can be used instead.


