### PR TITLE
Update link to CI artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Next, run the following command to enable the rabbitmq management plugin:
 
 Download from NuGet 'MassTransit' [Search NuGet for MassTransit](http://nuget.org/packages?q=masstransit)
 
-Download the continuously integrated Binaries from [TeamCity](http://teamcity.codebetter.com/viewType.html?buildTypeId=bt8&tab=buildTypeStatusDiv).
+Download the continuously integrated Nuget packages from [AppVeyor](https://ci.appveyor.com/project/phatboyg/masstransit/build/artifacts).
 
 ### Supported transports
 


### PR DESCRIPTION
Noticed that the readme page links to some TeamCity builds that don't seem to be used anymore.  It looks like you've transitioned to AppVeyor, so updated the link to point to that instead.