### PR TITLE
Fix formatting in "RabbitMQ configuration options" section of the docs

### DIFF
--- a/doc/source/configuration/transports/rabbitmq.rst
+++ b/doc/source/configuration/transports/rabbitmq.rst
@@ -19,43 +19,42 @@ This is the recommended approach for configuring MassTransit for use with Rabbit
     });
 
 
+Routing topology
+----------------
 
- Routing topology
- ----------------
+About the RabbitMQ routing topology in place with MassTransit.
 
- About the RabbitMQ routing topology in place with MassTransit.
-
-  - networks are segregated by vhosts
-  - we generate an exchange for each queue so that we can do direct sends to the queue. it is bound as a fanout exchange
-  - for each message published we generate series of exchanges that go from concrete class to each of its subclass / interfaces these are linked together from most specific to least specific. This way if you subscribe to the base interface you get all the messages. or you can be more selective. all exchanges in this situation are bound as fanouts.
-  - the subscriber declares his own queue and his queue exchange - he then also declares/binds his exchange to each of the message type exchanges desired
-  - the publisher discovers all of the exchanges needed for a given message, binds them all up and then pushes the message into the most specific queue letting RabbitMQ do the fanout for him. (One publish, multiple receivers!)
-  - control queues are exclusive and auto-delete - they go away when you go away and are not shared.
-  - we also lose the routing keys. WIN!
+- networks are segregated by vhosts
+- we generate an exchange for each queue so that we can do direct sends to the queue. it is bound as a fanout exchange
+- for each message published we generate series of exchanges that go from concrete class to each of its subclass / interfaces these are linked together from most specific to least specific. This way if you subscribe to the base interface you get all the messages. or you can be more selective. all exchanges in this situation are bound as fanouts.
+- the subscriber declares his own queue and his queue exchange - he then also declares/binds his exchange to each of the message type exchanges desired
+- the publisher discovers all of the exchanges needed for a given message, binds them all up and then pushes the message into the most specific queue letting RabbitMQ do the fanout for him. (One publish, multiple receivers!)
+- control queues are exclusive and auto-delete - they go away when you go away and are not shared.
+- we also lose the routing keys. WIN!
 
 
- RabbitMQ with SSL
- -----------------
+RabbitMQ with SSL
+-----------------
 
- .. sourceode:: csharp
+.. sourcecode:: csharp
 
-  ServiceBusFactory.New(c =>
-      {
-          c.ReceiveFrom(inputAddress);
-          c.UseRabbitMqRouting();
-          c.UseRabbitMq(r =>
-              {
-                  r.ConfigureHost(inputAddress, h =>
-                      {
-                          h.UseSsl(s =>
-                              {
-                                  s.SetServerName(System.Net.Dns.GetHostName());
-                                  s.SetCertificatePath("client.p12");
-                                  s.SetCertificatePassphrase("Passw0rd");
-                              });
-                      });
-              });
-      });
+    ServiceBusFactory.New(c =>
+    {
+        c.ReceiveFrom(inputAddress);
+        c.UseRabbitMqRouting();
+        c.UseRabbitMq(r =>
+        {
+            r.ConfigureHost(inputAddress, h =>
+            {
+                h.UseSsl(s =>
+                {
+                    s.SetServerName(System.Net.Dns.GetHostName());
+                    s.SetCertificatePath("client.p12");
+                    s.SetCertificatePassphrase("Passw0rd");
+                });
+            });
+        });
+    });
 
 You will need to configure RabbitMQ to support SSL also http://www.rabbitmq.com/ssl.html.
 


### PR DESCRIPTION
It's not being rendered properly because of the leading spaces in each line after the first code sample, I've just cleaned it up.