### PR TITLE
Fixing cancelled recurring schedules

### DIFF
--- a/src/MassTransit.QuartzIntegration/CancelScheduledMessageConsumer.cs
+++ b/src/MassTransit.QuartzIntegration/CancelScheduledMessageConsumer.cs
@@ -51,7 +51,16 @@ namespace MassTransit.QuartzIntegration
 
         public Task Consume(ConsumeContext<CancelScheduledRecurringMessage> context)
         {
-            bool unscheduledJob = _scheduler.UnscheduleJob(new TriggerKey(context.Message.ScheduleId, context.Message.ScheduleGroup));
+            string prependedValue = "Recurring.Trigger.";
+
+            string scheduleId = context.Message.ScheduleId;
+
+            if (!scheduleId.StartsWith(prependedValue))
+            {
+                scheduleId = string.Concat(prependedValue, scheduleId);
+            }
+
+            bool unscheduledJob = _scheduler.UnscheduleJob(new TriggerKey(scheduleId, context.Message.ScheduleGroup));
 
             if (_log.IsDebugEnabled)
             {


### PR DESCRIPTION
This is so that you can cancel a recurring schedule with the schedule id you used to create the recurring schedule.  

If someone had used a work around where they prepended the schedule id with "Recurring.Trigger." it will still work as I checked for that scenario before prepending in the consumer.

I added a test to confirm that it works also.