### PR TITLE
Bugfix/service settings compatibility with isettingsprovider

### DIFF
--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusAmqpTransportSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusAmqpTransportSettings.cs
@@ -1,0 +1,35 @@
+// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+namespace MassTransit.AzureServiceBusTransport.Hosting
+{
+    using System;
+    using MassTransit.Hosting;
+
+
+    /// <summary>
+    /// Represents the Advanced Message Queuing Protocol transport settings.
+    /// </summary>
+    /// <remarks>
+    /// All properties are nullable so that default values are not overwritten unless
+    /// a configuraiton value is provided.
+    /// </remarks>
+    public interface ServiceBusAmqpTransportSettings :
+        ISettings
+    {
+        TimeSpan? BatchFlushInterval { get; }
+        bool? EnableLinkRedirect { get; }
+        int? MaxFrameSize { get; }
+        bool? UseSslStreamSecurity { get; }
+    }
+}

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusNetMessagingTransportSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusNetMessagingTransportSettings.cs
@@ -1,0 +1,34 @@
+// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+namespace MassTransit.AzureServiceBusTransport.Hosting
+{
+    using System;
+    using MassTransit.Hosting;
+
+
+    /// <summary>
+    /// Represents.NET messaging transport settings.
+    /// </summary>
+    /// <remarks>
+    /// All properties are nullable so that default values are not overwritten unless
+    /// a configuraiton value is provided.
+    /// </remarks>
+    public interface ServiceBusNetMessagingTransportSettings :
+        ISettings
+    {
+        TimeSpan? BatchFlushInterval { get; }
+        bool? EnableRedirect { get; }
+        TimeSpan? LeaseTimeout { get; }
+    }
+}

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusSettings.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Hosting
 {
@@ -16,7 +16,6 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
     using MassTransit.Hosting;
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
-    using Microsoft.ServiceBus.Messaging.Amqp;
 
 
     public interface ServiceBusSettings :
@@ -35,7 +34,5 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
         TimeSpan? RetryMaxBackoff { get; }
         int? RetryLimit { get; }
         TransportType TransportType { get; }
-        NetMessagingTransportSettings NetMessagingTransportSettings { get; }
-        AmqpTransportSettings AmqpTransportSettings { get; }
     }
 }

--- a/src/MassTransit.AzureServiceBusTransport/MassTransit.AzureServiceBusTransport.csproj
+++ b/src/MassTransit.AzureServiceBusTransport/MassTransit.AzureServiceBusTransport.csproj
@@ -74,7 +74,9 @@
     <Compile Include="Configuration\ServiceBusMessageSchedulerSpecification.cs" />
     <Compile Include="Contexts\ServiceBusMessageSchedulerContext.cs" />
     <Compile Include="Defaults.cs" />
+    <Compile Include="Hosting\ServiceBusAmqpTransportSettings.cs" />
     <Compile Include="Hosting\ServiceBusHostBusFactory.cs" />
+    <Compile Include="Hosting\ServiceBusNetMessagingTransportSettings.cs" />
     <Compile Include="Hosting\ServiceBusServiceConfigurator.cs" />
     <Compile Include="Hosting\ServiceBusSettings.cs" />
     <Compile Include="IQueueConfigurator.cs" />

--- a/src/MassTransit.Tests/DictionaryToObject_Specs.cs
+++ b/src/MassTransit.Tests/DictionaryToObject_Specs.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright 2007-2014 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests
 {
+    using System;
     using System.Collections.Generic;
     using Internals.Mapping;
     using Internals.Reflection;
@@ -33,6 +34,20 @@ namespace MassTransit.Tests
         {
             Assert.IsTrue(_values.LongValue.HasValue);
             Assert.AreEqual(123, _values.LongValue.Value);
+        }
+
+        [Test]
+        public void Should_include_nullable_timespan()
+        {
+            Assert.IsTrue(_values.TimeSpanValue.HasValue);
+            Assert.AreEqual(TimeSpan.FromSeconds(5), _values.TimeSpanValue.Value);
+        }
+
+        [Test]
+        public void Should_include_nullable_timespan_as_string()
+        {
+            Assert.IsTrue(_values.TimeSpanValueAsString.HasValue);
+            Assert.AreEqual(TimeSpan.FromMilliseconds(20), _values.TimeSpanValueAsString.Value);
         }
 
         [Test]
@@ -117,6 +132,8 @@ namespace MassTransit.Tests
                 {"IntValue", 27},
                 {"StringValue", "Hello"},
                 {"LongValue", (long?)123},
+                {"TimeSpanValue", TimeSpan.FromSeconds(5)},
+                {"TimeSpanValueAsString", "00:00:00.0200000"},
                 {"ValueType", ValueType.Integer},
                 {"ValueTypeAsInt", 2},
                 {"ValueTypeAsString", "String"},
@@ -179,6 +196,8 @@ namespace MassTransit.Tests
             int IntValue { get; }
             string StringValue { get; }
             long? LongValue { get; }
+            TimeSpan? TimeSpanValue { get; }
+            TimeSpan? TimeSpanValueAsString { get; }
             ValueType ValueType { get; }
             ValueType ValueTypeAsInt { get; }
             ValueType ValueTypeAsString { get; }

--- a/src/MassTransit/Internals/Mapping/NullableValueObjectMapper.cs
+++ b/src/MassTransit/Internals/Mapping/NullableValueObjectMapper.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.Internals.Mapping
 {
     using System;
+    using System.ComponentModel;
     using Reflection;
 
 
@@ -32,9 +33,14 @@ namespace MassTransit.Internals.Mapping
             object value;
             if (valueProvider.TryGetValue(_property.Property.Name, out value))
             {
-                TValue? nullableValue = value as TValue?;
-                if (!nullableValue.HasValue)
-                    nullableValue = (TValue)Convert.ChangeType(value, typeof(TValue));
+                TValue? nullableValue = null;
+                if (value != null)
+                {
+                    var converter = TypeDescriptor.GetConverter(typeof(TValue));
+                    nullableValue = converter.CanConvertFrom(value.GetType())
+                        ? (TValue)converter.ConvertFrom(value)
+                        : default(TValue?);
+                }
 
                 _property.Set(obj, nullableValue);
             }

--- a/src/MassTransit/Internals/Mapping/NullableValueObjectMapper.cs
+++ b/src/MassTransit/Internals/Mapping/NullableValueObjectMapper.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Internals.Mapping
 {
@@ -33,13 +33,13 @@ namespace MassTransit.Internals.Mapping
             object value;
             if (valueProvider.TryGetValue(_property.Property.Name, out value))
             {
-                TValue? nullableValue = null;
-                if (value != null)
+                TValue? nullableValue = value as TValue?;
+                if (!nullableValue.HasValue)
                 {
                     var converter = TypeDescriptor.GetConverter(typeof(TValue));
                     nullableValue = converter.CanConvertFrom(value.GetType())
-                        ? (TValue)converter.ConvertFrom(value)
-                        : default(TValue?);
+                        ? (TValue?)converter.ConvertFrom(value)
+                        : null;
                 }
 
                 _property.Set(obj, nullableValue);


### PR DESCRIPTION
Settings when using Masstransit.Host work by adding the following to app.config. I note that there is now an inconstancy where AzureServiceBusHostConfigurator defaults all flush intervals to 50ms, where Microsoft default is 20ms. I have left the default value (currently 20ms) as the flush interval unless a config value is provided. 

Is there a reason that MassTransit is defaulting the flush interval in the AzureServiceBusHostConfigurator to 50ms?

```
    <add key="ServiceBusNetMessagingTransportBatchFlushInterval" value="00:00:00.02"/>
    <add key="ServiceBusNetMessagingTransportEnableRedirect" value="False"/>
    <add key="ServiceBusNetMessagingTransportLeaseTimeout" value="00:10:00"/>

    <add key="ServiceBusAmqpTransportBatchFlushInterval" value="00:00:00.02"/>
    <add key="ServiceBusAmqpTransportEnableLinkRedirect" value="False"/>
    <add key="ServiceBusAmqpTransportMaxFrameSize" value="131072"/>
    <add key="ServiceBusAmqpTransportUseSslStreamSecurity" value="False"/>
```