### PR TITLE
Configurable SSL protocol [RabbitMQ transport].

### DIFF
--- a/src/MassTransit.RabbitMqTransport.Tests/HostConfigurator_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/HostConfigurator_Specs.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.RabbitMqTransport.Tests
+{
+    using System;
+    using System.Security.Authentication;
+    using Configuration.Configurators;
+    using NUnit.Framework;
+    using Shouldly;
+
+
+    [TestFixture]
+    public class HostConfigurator_Specs
+    {
+        [Test]
+        public void Should_set_assigned_ssl_protocol()
+        {
+            var configurator = new RabbitMqHostConfigurator(new Uri("rabbitmq://localhost"));
+
+            configurator.UseSsl(sslConfigurator =>
+            {
+                sslConfigurator.Protocol = SslProtocols.Tls12;
+            });
+
+            configurator.Settings.SslProtocol.ShouldBe(SslProtocols.Tls12);
+        }
+
+        [Test, Description("Default ssl protocol should be tls 1.0 for back compatibility reason")]
+        public void Should_set_tls10_protocol_by_default()
+        {
+            var configurator = new RabbitMqHostConfigurator(new Uri("rabbitmq://localhost"));
+
+            configurator.UseSsl(sslConfigurator => { });
+
+            configurator.Settings.SslProtocol.ShouldBe(SslProtocols.Tls);
+        }
+    }
+}

--- a/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
+++ b/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="FailedConnection_Specs.cs" />
     <Compile Include="HammerTime_Specs.cs" />
     <Compile Include="HeaderObject_Specs.cs" />
+    <Compile Include="HostConfigurator_Specs.cs" />
     <Compile Include="LocalBusName_Specs.cs" />
     <Compile Include="Performance_Specs.cs" />
     <Compile Include="PriorityQueue_Specs.cs" />

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.RabbitMqTransport.Configuration.Configurators
 {
     using System.Net.Security;
+    using System.Security.Authentication;
 
 
     class ConfigurationHostSettings :
@@ -25,6 +26,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         public string Password { get; set; }
         public ushort Heartbeat { get; set; }
         public bool Ssl { get; set; }
+        public SslProtocols SslProtocol { get; set; } = SslProtocols.Tls;
         public string SslServerName { get; set; }
         public SslPolicyErrors AcceptablePolicyErrors { get; set; }
         public string ClientCertificatePath { get; set; }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/IRabbitMqSslConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/IRabbitMqSslConfigurator.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.RabbitMqTransport.Configuration.Configurators
 {
     using System.Net.Security;
+    using System.Security.Authentication;
 
 
     /// <summary>
@@ -21,6 +22,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
     /// </summary>
     public interface IRabbitMqSslConfigurator
     {
+        SslProtocols Protocol { get; set; }
         string ServerName { get; set; }
         string CertificatePath { get; set; }
         string CertificatePassphrase { get; set; }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
@@ -54,6 +54,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
             _settings.ClientCertificatePath = configurator.CertificatePath;
             _settings.AcceptablePolicyErrors = configurator.AcceptablePolicyErrors;
             _settings.SslServerName = configurator.ServerName ?? _settings.Host;
+            _settings.SslProtocol = configurator.Protocol;
         }
 
         public void Heartbeat(ushort requestedHeartbeat)

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqSslConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqSslConfigurator.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.RabbitMqTransport.Configuration.Configurators
 {
     using System.Net.Security;
+    using System.Security.Authentication;
 
 
     public class RabbitMqSslConfigurator :
@@ -25,10 +26,12 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
             CertificatePath = settings.ClientCertificatePath;
             CertificatePassphrase = settings.ClientCertificatePassphrase;
             ServerName = settings.SslServerName;
+            Protocol = settings.SslProtocol;
             _acceptablePolicyErrors = settings.AcceptablePolicyErrors | SslPolicyErrors.RemoteCertificateChainErrors;
         }
 
         public SslPolicyErrors AcceptablePolicyErrors => _acceptablePolicyErrors;
+
 
         public string CertificatePath { get; set; }
 
@@ -40,6 +43,8 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         public string CertificatePassphrase { get; set; }
 
         public string ServerName { get; set; }
+
+        public SslProtocols Protocol { get; set; }
 
         /// <summary>
         /// Configures the rabbit mq client connection for Sll properties.

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.RabbitMqTransport.Hosting
 {
     using System.Net.Security;
+    using System.Security.Authentication;
     using Logging;
     using MassTransit.Hosting;
 
@@ -66,6 +67,7 @@ namespace MassTransit.RabbitMqTransport.Hosting
             public string Password => _settings.Password ?? "guest";
             public ushort Heartbeat => _settings.Heartbeat ?? 0;
             public bool Ssl => false;
+            public SslProtocols SslProtocol => SslProtocols.None;
             public string SslServerName => null;
             public SslPolicyErrors AcceptablePolicyErrors => SslPolicyErrors.None;
             public string ClientCertificatePath => null;

--- a/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -332,7 +332,7 @@ namespace MassTransit.RabbitMqTransport
             };
 
             factory.Ssl.Enabled = settings.Ssl;
-            factory.Ssl.Version = SslProtocols.Tls;
+            factory.Ssl.Version = settings.SslProtocol;
             factory.Ssl.AcceptablePolicyErrors = settings.AcceptablePolicyErrors;
             factory.Ssl.ServerName = settings.SslServerName;
             if (string.IsNullOrWhiteSpace(factory.Ssl.ServerName))

--- a/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.RabbitMqTransport
 {
     using System.Net.Security;
+    using System.Security.Authentication;
 
 
     /// <summary>
@@ -55,6 +56,11 @@ namespace MassTransit.RabbitMqTransport
         /// True if SSL is required
         /// </summary>
         bool Ssl { get; }
+
+        /// <summary>
+        /// SSL protocol, Tls11 or Tls12 are recommended
+        /// </summary>
+        SslProtocols SslProtocol { get; }
 
         /// <summary>
         /// The server name specified on the certificate for the RabbitMQ server

--- a/src/MassTransit.sln.DotSettings
+++ b/src/MassTransit.sln.DotSettings
@@ -187,6 +187,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR &#xD
 CONDITIONS OF ANY KIND, either express or implied. See the License for the &#xD;
 specific language governing permissions and limitations under the License.</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Interfaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="_" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/Environment/Editor/MatchingBraceHighlighting/Position/@EntryValue">BOTH_SIDES</s:String>
 	<s:String x:Key="/Default/Environment/Editor/MatchingBraceHighlighting/Style/@EntryValue">OUTLINE</s:String>


### PR DESCRIPTION
According to RabbitMQ SSL doco(https://www.rabbitmq.com/ssl.html), TLS 1.0 is not recommended, so I made hard coded value configurable. 