### PR TITLE
Update Ninject container configuration

### DIFF
--- a/doc/source/configuration/containers/ninject.rst
+++ b/doc/source/configuration/containers/ninject.rst
@@ -28,11 +28,11 @@ container. The two bus interfaces, ``IBus`` and ``IBusControl``, are included.
 
             sbc.ReceiveEndpoint("customer_update_queue", ec =>
             {
-                ec.LoadFrom(container);
+                ec.LoadFrom(kernel);
             })
         });
         
-        container.Configure(cfg =>
+        kernel.Configure(cfg =>
         {
             For<IBusControl>()
                 .Use(busControl);
@@ -45,7 +45,7 @@ container. The two bus interfaces, ``IBus`` and ``IBusControl``, are included.
 .. note::
 
     The behavior with Ninject is slightly different, in that the current AppDomain types are checked against the
-    container and any consumer types are registered, they are resolved from the container. The unit tests pass, and
+    container and if any consumer types are registered, they are resolved from the container. The unit tests pass, and
     it works, but just be aware that container metadata is not being used to support this feature. There is some history
     on this, found at the `Ninject issue`_.
 

--- a/doc/source/configuration/containers/ninject.rst
+++ b/doc/source/configuration/containers/ninject.rst
@@ -21,12 +21,12 @@ container. The two bus interfaces, ``IBus`` and ``IBusControl``, are included.
         
         // just register all the consumers using Ninject.Extensions.Conventions
         kernel.Bind(x =>
-            {
-                x.FromThisAssembly()
+        {
+            x.FromThisAssembly()
                 .SelectAllClasses()
                 .InheritedFrom<IConsumer>()
                 .BindToSelf();
-            });
+        });
             
         var busControl = Bus.Factory.CreateUsingRabbitMq(cfg =>
         {

--- a/doc/source/configuration/containers/ninject.rst
+++ b/doc/source/configuration/containers/ninject.rst
@@ -32,15 +32,10 @@ container. The two bus interfaces, ``IBus`` and ``IBusControl``, are included.
             })
         });
         
-        kernel.Configure(cfg =>
-        {
-            For<IBusControl>()
-                .Use(busControl);
-            Forward<IBus, IBusControl>();
-        });
-
-        busControl.Start();
-    }
+        kernel.Bind<IBus>()
+            .ToProvider(new CallbackProvider<IBus>(x => x.Kernel.Get<IBusControl>()));
+                busControl.Start();
+        }
 
 .. note::
 

--- a/doc/source/configuration/containers/ninject.rst
+++ b/doc/source/configuration/containers/ninject.rst
@@ -34,8 +34,9 @@ container. The two bus interfaces, ``IBus`` and ``IBusControl``, are included.
         
         kernel.Bind<IBus>()
             .ToProvider(new CallbackProvider<IBus>(x => x.Kernel.Get<IBusControl>()));
-                busControl.Start();
-        }
+        
+        busControl.Start();
+    }
 
 .. note::
 

--- a/doc/source/configuration/containers/ninject.rst
+++ b/doc/source/configuration/containers/ninject.rst
@@ -16,7 +16,17 @@ container. The two bus interfaces, ``IBus`` and ``IBusControl``, are included.
     {
         var kernel = new StandardKernel();
 
+        // register a specific consumer
         kernel.Bind<UpdateCustomerAddressConsumer>().ToSelf();
+        
+        // just register all the consumers using Ninject.Extensions.Conventions
+        kernel.Bind(x =>
+            {
+                x.FromThisAssembly()
+                .SelectAllClasses()
+                .InheritedFrom<IConsumer>()
+                .BindToSelf();
+            });
             
         var busControl = Bus.Factory.CreateUsingRabbitMq(cfg =>
         {


### PR DESCRIPTION
As a side note. I can not find any example of this using this syntax in Ninject:

```
kernel.Configure(cfg =>
{
    For<IBusControl>()
      .Use(busControl);
    Forward<IBus, IBusControl>();
});
```

Do you know where I can find documentation on this?
