### PR TITLE
Support for single SSL client certificate provided by client

### DIFF
--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -14,6 +14,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
 {
     using System.Net.Security;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
 
 
     class ConfigurationHostSettings :
@@ -31,5 +32,6 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         public SslPolicyErrors AcceptablePolicyErrors { get; set; }
         public string ClientCertificatePath { get; set; }
         public string ClientCertificatePassphrase { get; set; }
+        public X509Certificate ClientCertificate { get; set; }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/IRabbitMqSslConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/IRabbitMqSslConfigurator.cs
@@ -14,6 +14,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
 {
     using System.Net.Security;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
 
 
     /// <summary>
@@ -24,8 +25,18 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
     {
         SslProtocols Protocol { get; set; }
         string ServerName { get; set; }
+        /// <summary>
+        /// The path to a file containing a certificate to use for client authentication, not required if <see cref="Certificate"/> is populated
+        /// </summary>
         string CertificatePath { get; set; }
+        /// <summary>
+        /// The password for the certificate file at <see cref="CertificatePath"/>
+        /// </summary>
         string CertificatePassphrase { get; set; }
+        /// <summary>
+        /// A certficate instance to use for client authentication, if provided then <see cref="CertificatePath"/> and <see cref="CertificatePassphrase"/> are not required
+        /// </summary>
+        X509Certificate Certificate { get; set; }
         void AllowPolicyErrors(SslPolicyErrors policyErrors);
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
@@ -52,6 +52,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
             _settings.Ssl = true;
             _settings.ClientCertificatePassphrase = configurator.CertificatePassphrase;
             _settings.ClientCertificatePath = configurator.CertificatePath;
+            _settings.ClientCertificate = configurator.Certificate;
             _settings.AcceptablePolicyErrors = configurator.AcceptablePolicyErrors;
             _settings.SslServerName = configurator.ServerName ?? _settings.Host;
             _settings.SslProtocol = configurator.Protocol;

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqSslConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqSslConfigurator.cs
@@ -14,6 +14,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
 {
     using System.Net.Security;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
 
 
     public class RabbitMqSslConfigurator :
@@ -25,6 +26,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         {
             CertificatePath = settings.ClientCertificatePath;
             CertificatePassphrase = settings.ClientCertificatePassphrase;
+            Certificate = settings.ClientCertificate;
             ServerName = settings.SslServerName;
             Protocol = settings.SslProtocol;
             _acceptablePolicyErrors = settings.AcceptablePolicyErrors | SslPolicyErrors.RemoteCertificateChainErrors;
@@ -41,6 +43,8 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         }
 
         public string CertificatePassphrase { get; set; }
+
+        public X509Certificate Certificate { get; set; }
 
         public string ServerName { get; set; }
 

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
@@ -14,6 +14,7 @@ namespace MassTransit.RabbitMqTransport.Hosting
 {
     using System.Net.Security;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
     using Logging;
     using MassTransit.Hosting;
 
@@ -72,6 +73,7 @@ namespace MassTransit.RabbitMqTransport.Hosting
             public SslPolicyErrors AcceptablePolicyErrors => SslPolicyErrors.None;
             public string ClientCertificatePath => null;
             public string ClientCertificatePassphrase => null;
+            public X509Certificate ClientCertificate => null;
         }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -18,6 +18,7 @@ namespace MassTransit.RabbitMqTransport
     using System.Net;
     using System.Net.Security;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
     using System.Text;
     using System.Text.RegularExpressions;
     using Configuration;
@@ -335,6 +336,8 @@ namespace MassTransit.RabbitMqTransport
             factory.Ssl.Version = settings.SslProtocol;
             factory.Ssl.AcceptablePolicyErrors = settings.AcceptablePolicyErrors;
             factory.Ssl.ServerName = settings.SslServerName;
+            factory.Ssl.Certs = settings.ClientCertificate == null ? null : new X509Certificate2Collection {settings.ClientCertificate};
+            
             if (string.IsNullOrWhiteSpace(factory.Ssl.ServerName))
                 factory.Ssl.AcceptablePolicyErrors |= SslPolicyErrors.RemoteCertificateNameMismatch;
 
@@ -347,7 +350,6 @@ namespace MassTransit.RabbitMqTransport
 
                 factory.Ssl.CertPath = "";
                 factory.Ssl.CertPassphrase = "";
-                factory.Ssl.Certs = null;
             }
             else
             {

--- a/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
@@ -14,6 +14,7 @@ namespace MassTransit.RabbitMqTransport
 {
     using System.Net.Security;
     using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
 
 
     /// <summary>
@@ -78,8 +79,13 @@ namespace MassTransit.RabbitMqTransport
         string ClientCertificatePath { get; }
 
         /// <summary>
-        /// The passphrase for the client certificate 
+        /// The passphrase for the client certificate found using the <see cref="ClientCertificatePath"/>, not required if <see cref="ClientCertificate"/> is populated
         /// </summary>
         string ClientCertificatePassphrase { get; }
+
+        /// <summary>
+        /// A certificate to use for client certificate authentication, if not set then the <see cref="ClientCertificatePath"/> and <see cref="ClientCertificatePassphrase"/> will be used
+        /// </summary>
+        X509Certificate ClientCertificate { get; }
     }
 }


### PR DESCRIPTION
Resolves #457 using single certificate

Opted for a single certificate approach as the collection would have required also passing a delegate around for client certificate selection which may have been messy

Tested locally using a RabbitMQ instance configured for SSL, cannot create or amend unit tests in the test suite for this though