### PR TITLE
Allow SSL client certificate to use used as login identity

### DIFF
--- a/src/MassTransit.RabbitMqTransport.Tests/HostConfigurator_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/HostConfigurator_Specs.cs
@@ -44,5 +44,28 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             configurator.Settings.SslProtocol.ShouldBe(SslProtocols.Tls);
         }
+
+        [Test, Description("Default SSL settings should not use client certificate as authentication identity")]
+        public void Should_set_client_certificate_as_authentication_identity_as_false_by_default()
+        {
+            var configurator = new RabbitMqHostConfigurator(new Uri("rabbitmq://localhost"));
+
+            configurator.UseSsl(sslConfigurator => { });
+
+            configurator.Settings.UseClientCertificateAsAuthenticationIdentity.ShouldBeFalse();
+        }
+
+        [TestCase(true), TestCase(false), Description("SSL settings should set use client certificate as authentication identity as specified by configuration")]
+        public void Should_set_client_certificate_as_authentication_identity_when_configured(bool valueToSet)
+        {
+            var configurator = new RabbitMqHostConfigurator(new Uri("rabbitmq://localhost"));
+
+            configurator.UseSsl(sslConfigurator =>
+            {
+                sslConfigurator.UseCertificateAsAuthenticationIdentity = valueToSet;
+            });
+
+            configurator.Settings.UseClientCertificateAsAuthenticationIdentity.ShouldBe(valueToSet);
+        }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -33,5 +33,6 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         public string ClientCertificatePath { get; set; }
         public string ClientCertificatePassphrase { get; set; }
         public X509Certificate ClientCertificate { get; set; }
+        public bool UseClientCertificateAsAuthenticationIdentity { get; set; }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/IRabbitMqSslConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/IRabbitMqSslConfigurator.cs
@@ -38,5 +38,6 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         /// </summary>
         X509Certificate Certificate { get; set; }
         void AllowPolicyErrors(SslPolicyErrors policyErrors);
+        bool UseCertificateAsAuthenticationIdentity { get; set; }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
@@ -53,6 +53,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
             _settings.ClientCertificatePassphrase = configurator.CertificatePassphrase;
             _settings.ClientCertificatePath = configurator.CertificatePath;
             _settings.ClientCertificate = configurator.Certificate;
+            _settings.UseClientCertificateAsAuthenticationIdentity = configurator.UseCertificateAsAuthenticationIdentity;
             _settings.AcceptablePolicyErrors = configurator.AcceptablePolicyErrors;
             _settings.SslServerName = configurator.ServerName ?? _settings.Host;
             _settings.SslProtocol = configurator.Protocol;

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqSslConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqSslConfigurator.cs
@@ -27,6 +27,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
             CertificatePath = settings.ClientCertificatePath;
             CertificatePassphrase = settings.ClientCertificatePassphrase;
             Certificate = settings.ClientCertificate;
+            UseCertificateAsAuthenticationIdentity = settings.UseClientCertificateAsAuthenticationIdentity;
             ServerName = settings.SslServerName;
             Protocol = settings.SslProtocol;
             _acceptablePolicyErrors = settings.AcceptablePolicyErrors | SslPolicyErrors.RemoteCertificateChainErrors;
@@ -49,6 +50,8 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         public string ServerName { get; set; }
 
         public SslProtocols Protocol { get; set; }
+
+        public bool UseCertificateAsAuthenticationIdentity { get; set; }
 
         /// <summary>
         /// Configures the rabbit mq client connection for Sll properties.

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
@@ -74,6 +74,7 @@ namespace MassTransit.RabbitMqTransport.Hosting
             public string ClientCertificatePath => null;
             public string ClientCertificatePassphrase => null;
             public X509Certificate ClientCertificate => null;
+            public bool UseClientCertificateAsAuthenticationIdentity => false;
         }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -17,7 +17,6 @@ namespace MassTransit.RabbitMqTransport
     using System.Globalization;
     using System.Net;
     using System.Net.Security;
-    using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -332,6 +331,21 @@ namespace MassTransit.RabbitMqTransport
                 RequestedHeartbeat = settings.Heartbeat
             };
 
+            if (settings.UseClientCertificateAsAuthenticationIdentity)
+            {
+                factory.AuthMechanisms.Clear();
+                factory.AuthMechanisms.Add(new ExternalMechanismFactory());
+                factory.UserName = "";
+                factory.Password = "";
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(settings.Username))
+                    factory.UserName = settings.Username;
+                if (!string.IsNullOrWhiteSpace(settings.Password))
+                    factory.Password = settings.Password;
+            }
+
             factory.Ssl.Enabled = settings.Ssl;
             factory.Ssl.Version = settings.SslProtocol;
             factory.Ssl.AcceptablePolicyErrors = settings.AcceptablePolicyErrors;
@@ -343,11 +357,6 @@ namespace MassTransit.RabbitMqTransport
 
             if (string.IsNullOrEmpty(settings.ClientCertificatePath))
             {
-                if (!string.IsNullOrWhiteSpace(settings.Username))
-                    factory.UserName = settings.Username;
-                if (!string.IsNullOrWhiteSpace(settings.Password))
-                    factory.Password = settings.Password;
-
                 factory.Ssl.CertPath = "";
                 factory.Ssl.CertPassphrase = "";
             }
@@ -356,7 +365,7 @@ namespace MassTransit.RabbitMqTransport
                 factory.Ssl.CertPath = settings.ClientCertificatePath;
                 factory.Ssl.CertPassphrase = settings.ClientCertificatePassphrase;
             }
-
+            
             factory.ClientProperties = factory.ClientProperties ?? new Dictionary<string, object>();
 
             HostInfo hostInfo = HostMetadataCache.Host;

--- a/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
@@ -87,5 +87,13 @@ namespace MassTransit.RabbitMqTransport
         /// A certificate to use for client certificate authentication, if not set then the <see cref="ClientCertificatePath"/> and <see cref="ClientCertificatePassphrase"/> will be used
         /// </summary>
         X509Certificate ClientCertificate { get; }
+
+        /// <summary>
+        /// Whether the client certificate should be used for logging in to RabbitMQ, ignoring any username and password set
+        /// </summary>
+        /// <remarks>
+        /// RabbitMQ must be configured correctly for this to work, including enabling the rabbitmq_auth_mechanism_ssl plugin
+        /// </remarks>
+        bool UseClientCertificateAsAuthenticationIdentity { get; }
     }
 }


### PR DESCRIPTION
Follow up to #458

This change removes the need to specify a username and password as part of the set-up of RabbitMQ configuration, instead the SSL client certificate can be used (if RabbitMQ has been configured to allow it).  Having this in place means that no username or passwords need to be stored in the app's configuration file.

Sample usage:

```c#
IBusControl bus = MassTransit.Bus.Factory.CreateUsingRabbitMq(x =>
{
  IRabbitMqHost host = x.Host(_hostAddress, h =>
  {
    h.UseSsl(ssl =>
    {
      ssl.Certificate = LoadCertificate(); //read from some location such as Windows cert store
      ssl.UseCertificateAsAuthenticationIdentity = true;  //<-- new configuration option here
    });
  });
}
```

Note that this provides an either/or authentication scenario - a client system may use username and password **or** a client certificate, there is no support for fall-back if the client certificate authentication fails.

I have tested this locally and it works, through the Rabbit Web UI I can see the connection being created with my client certificate's username (my local RabbitMQ is configured to allow the CN of my client certificate)