### PR TITLE
Azure sb default batch interval

### DIFF
--- a/src/MassTransit.AzureServiceBusTransport/Configuration/AzureServiceBusHostConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/AzureServiceBusHostConfigurator.cs
@@ -82,8 +82,8 @@ namespace MassTransit.AzureServiceBusTransport.Configuration
                 RetryMaxBackoff = TimeSpan.FromSeconds(20);
                 RetryLimit = 10;
                 TransportType = TransportType.Amqp;
-                AmqpTransportSettings = new AmqpTransportSettings() { BatchFlushInterval = TimeSpan.FromMilliseconds(50), };
-                NetMessagingTransportSettings = new NetMessagingTransportSettings() { BatchFlushInterval = TimeSpan.FromMilliseconds(50), };
+                AmqpTransportSettings = new AmqpTransportSettings();
+                NetMessagingTransportSettings = new NetMessagingTransportSettings();
             }
 
             public Uri ServiceUri { get; private set; }

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusAmqpTransportSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusAmqpTransportSettings.cs
@@ -27,6 +27,14 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
     public interface ServiceBusAmqpTransportSettings :
         ISettings
     {
+        /// <summary>
+        /// Sets the batch flush interval to use with the messaging factory, default is 20ms.
+        /// </summary>
+        /// <remarks>
+        /// Currently the Microsoft ServiceBus client defaults to 20ms. For more inforamtion
+        /// regarding batching and performance see: 
+        /// https://azure.microsoft.com/en-us/blog/new-article-best-practices-for-performance-improvements-using-service-bus-brokered-messaging/
+        /// </remarks>
         TimeSpan? BatchFlushInterval { get; }
         bool? EnableLinkRedirect { get; }
         int? MaxFrameSize { get; }

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusNetMessagingTransportSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusNetMessagingTransportSettings.cs
@@ -27,6 +27,14 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
     public interface ServiceBusNetMessagingTransportSettings :
         ISettings
     {
+        /// <summary>
+        /// Sets the batch flush interval to use with the messaging factory, default is 20ms.
+        /// </summary>
+        /// <remarks>
+        /// Currently the Microsoft ServiceBus client defaults to 20ms. For more inforamtion
+        /// regarding batching and performance see: 
+        /// https://azure.microsoft.com/en-us/blog/new-article-best-practices-for-performance-improvements-using-service-bus-brokered-messaging/
+        /// </remarks>
         TimeSpan? BatchFlushInterval { get; }
         bool? EnableRedirect { get; }
         TimeSpan? LeaseTimeout { get; }

--- a/src/MassTransit.AzureServiceBusTransport/IServiceBusHostConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/IServiceBusHostConfigurator.cs
@@ -48,10 +48,15 @@ namespace MassTransit.AzureServiceBusTransport
         /// Sets the messaging protocol to use with the messaging factory, defaults to AMQP.
         /// </summary>
         TransportType TransportType { set; }
-        
+
         /// <summary>
-        /// Sets the batch flush interval to use with the messaging factory.
+        /// Sets the batch flush interval to use with the messaging factory, default is 20ms. 
         /// </summary>
+        /// <remarks>
+        /// Currently the Microsoft ServiceBus client defaults to 20ms. For more inforamtion
+        /// regarding batching and performance see: 
+        /// https://azure.microsoft.com/en-us/blog/new-article-best-practices-for-performance-improvements-using-service-bus-brokered-messaging/
+        /// </remarks>
         TimeSpan BatchFlushInterval { set; }
     }
 }

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusHost.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusHost.cs
@@ -126,10 +126,7 @@ namespace MassTransit.AzureServiceBusTransport
                 TokenProvider = _settings.TokenProvider,
                 OperationTimeout = _settings.OperationTimeout,
                 TransportType = TransportType.NetMessaging,
-                NetMessagingTransportSettings = new NetMessagingTransportSettings
-                {
-                    BatchFlushInterval = TimeSpan.FromMilliseconds(50)
-                }
+                NetMessagingTransportSettings = _settings.NetMessagingTransportSettings
             };
 
             return CreateFactory(mfs);


### PR DESCRIPTION
Left the batch intervals as the transport setting defaults, and added links to more information for tuning the Azure SB client. Also the ServiceBusHost wasnt using settings provided by the configurator interface when CreateNetMessagingFactory() was called to create the Session Messaging Factory.