### PR TITLE
Add Quartz Trigger Fire Times to Payload Message Headers

### DIFF
--- a/src/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
+++ b/src/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
@@ -57,9 +57,31 @@ namespace MassTransit.QuartzIntegration.Tests
             Assert.AreEqual(countBeforeCancel, _count, "Expected to see the count matches.");
         }
 
+        [Test, Explicit]
+        public async void Should_contain_additional_headers_that_provide_time_domain_context()
+        {
+            var scheduleId = Guid.NewGuid().ToString();
+
+            await QuartzEndpoint.ScheduleSend(InputQueueAddress, DateTime.UtcNow + TimeSpan.FromSeconds(10), new Done { Name = "Joe" });
+            var scheduledRecurringMessage = await QuartzEndpoint.ScheduleRecurringSend(InputQueueAddress, new MySchedule(), new Interval { Name = "Joe" });
+
+            await _done;
+
+            Assert.Greater(_count, 0, "Expected to see at least one interval");
+
+
+            //This test framework does not receive the message headers they are always null
+            // I was able to validate they are being added in the MassTransit.QuartzIntegration.MasstransitJobFactory
+            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("ScheduledFireTimeUtc", null));
+            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("FireTimeUtc", null));
+            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("NextFireTimeUtc", null));
+            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("PrevFireTimeUtc", null));
+        }
+
         Task<ConsumeContext<Done>> _done;
         Task<ConsumeContext<DoneAgain>> _doneAgain;
         int _count;
+        ConsumeContext<Interval> _lastInterval;
 
         protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
@@ -67,6 +89,7 @@ namespace MassTransit.QuartzIntegration.Tests
             configurator.Handler<Interval>(async context =>
             {
                 Interlocked.Increment(ref _count);
+                _lastInterval = context;
             });
 
             _done = Handled<Done>(configurator);

--- a/src/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
+++ b/src/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
@@ -70,12 +70,10 @@ namespace MassTransit.QuartzIntegration.Tests
             Assert.Greater(_count, 0, "Expected to see at least one interval");
 
 
-            //This test framework does not receive the message headers they are always null
-            // I was able to validate they are being added in the MassTransit.QuartzIntegration.MasstransitJobFactory
-            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("ScheduledFireTimeUtc", null));
-            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("FireTimeUtc", null));
-            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("NextFireTimeUtc", null));
-            //Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("PrevFireTimeUtc", null));
+            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("ScheduledFireTimeUtc", null));
+            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("FireTimeUtc", null));
+            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("NextFireTimeUtc", null));
+            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>("PrevFireTimeUtc", null));
         }
 
         Task<ConsumeContext<Done>> _done;

--- a/src/MassTransit.QuartzIntegration/MassTransitJobFactory.cs
+++ b/src/MassTransit.QuartzIntegration/MassTransitJobFactory.cs
@@ -86,6 +86,7 @@ namespace MassTransit.QuartzIntegration
                 jobData.PutAll(scheduler.Context);
                 jobData.PutAll(bundle.JobDetail.JobDataMap);
                 jobData.PutAll(bundle.Trigger.JobDataMap);
+                jobData.Put("HeadersAsJson", CreateFireTimeHeaders(bundle));
 
                 SetObjectProperties(job, jobData);
 
@@ -148,6 +149,23 @@ namespace MassTransit.QuartzIntegration
             NewExpression @new = Expression.New(constructorInfo, bus);
 
             return Expression.Lambda<Func<IBus, T>>(@new, bus).Compile();
+        }
+
+        /// <summary>
+        /// Some additional properties from the TriggerFiredBundle
+        /// </summary>
+        /// <param name="bundle"></param>
+        public string CreateFireTimeHeaders(TriggerFiredBundle bundle)
+        {
+            var timeHeaders = new Dictionary<string, DateTimeOffset?>();
+            timeHeaders.Add("ScheduledFireTimeUtc", bundle.ScheduledFireTimeUtc);
+            timeHeaders.Add("FireTimeUtc", bundle.FireTimeUtc);
+            timeHeaders.Add("NextFireTimeUtc", bundle.NextFireTimeUtc);
+            timeHeaders.Add("PrevFireTimeUtc", bundle.PrevFireTimeUtc);
+
+            return JsonConvert.SerializeObject(timeHeaders);
+
+
         }
     }
 }


### PR DESCRIPTION
Many times dealing with scheduled messages and recurring messages.
It's important to have some time context with a message to help decide if it should be consumed.

I have added the trigger fire times from quartz to the payload.

ScheduledFireTimeUtc
FireTimeUtc
NextFireTimeUtc
PrevFireTimeUtc



