### PR TITLE
Fix Host crash when scanning native dlls

### DIFF
--- a/src/MassTransit.Host/AssemblyScanner.cs
+++ b/src/MassTransit.Host/AssemblyScanner.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Host
 {
@@ -64,7 +64,8 @@ namespace MassTransit.Host
                     .ToList();
 
                 var registrations = assemblies
-                    .Select(Assembly.ReflectionOnlyLoadFrom)
+                    .Select(ReflectionOnlyLoadAssembly)
+                    .Where(x => x != null)
                     .SelectMany(TrySelectAllTypes)
                     .Where(x => IsSupportedType(x.Item2))
                     .GroupBy(x => x.Item1)
@@ -107,6 +108,19 @@ namespace MassTransit.Host
             finally
             {
                 AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve -= CurrentDomain_ReflectionOnlyAssemblyResolve;
+            }
+        }
+
+        Assembly ReflectionOnlyLoadAssembly(string assemblyFile)
+        {
+            try
+            {
+                return Assembly.ReflectionOnlyLoadFrom(assemblyFile);
+            }
+            catch (BadImageFormatException e)
+            {
+                _log.Debug("Could not scan contents of assembly " + assemblyFile, e);
+                return null;
             }
         }
 


### PR DESCRIPTION
If there are native dlls that come with some nuget packages (e.g. https://www.nuget.org/packages/Microsoft.SqlServer.Types/) then the scanner will throw an exception and crash.