### PR TITLE
Start hosted service specifications in parallel.

### DIFF
--- a/src/MassTransit.Host/MassTransitHostService.cs
+++ b/src/MassTransit.Host/MassTransitHostService.cs
@@ -66,14 +66,17 @@ namespace MassTransit.Host
 
                 List<ServiceControl> services = bootstrappers.Select(x => x.CreateService()).ToList();
 
-                foreach (ServiceControl serviceControl in services)
+                Parallel.ForEach(services, serviceControl =>
                 {
                     hostControl.RequestAdditionalTime(TimeSpan.FromMinutes(1));
 
                     StartService(hostControl, serviceControl);
 
-                    started.Add(serviceControl);
-                }
+                    lock (started)
+                    {
+                        started.Add(serviceControl);
+                    }
+                });
 
                 _services = started;
 


### PR DESCRIPTION
I have test this in a staging environment and have reduced service startup time from around 1:40 to 30 seconds with 4 services specifications that were being loaded in series to being loaded in parallel.

Most object instances appear to be scoped in AutoFac to not cause any threading issues on startup.