### PR TITLE
Add DebuggerDisplay to TaskSupervisor

### DIFF
--- a/src/MassTransit/Util/TaskParticipant.cs
+++ b/src/MassTransit/Util/TaskParticipant.cs
@@ -13,10 +13,12 @@
 namespace MassTransit.Util
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
 
 
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     class TaskParticipant :
         ITaskParticipant
     {
@@ -75,7 +77,12 @@ namespace MassTransit.Util
 
         public override string ToString()
         {
-            return $"Scope: {_tag}";
+            return $"Participant: {_tag}";
+        }
+
+        string DebuggerDisplay()
+        {
+            return $"Participant: {_tag}";
         }
     }
 }

--- a/src/MassTransit/Util/TaskScope.cs
+++ b/src/MassTransit/Util/TaskScope.cs
@@ -13,11 +13,13 @@
 namespace MassTransit.Util
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
 
 
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     class TaskScope :
         ITaskScope
     {
@@ -105,6 +107,11 @@ namespace MassTransit.Util
         }
 
         public override string ToString()
+        {
+            return $"Scope: {_supervisor.Tag}";
+        }
+
+        string DebuggerDisplay()
         {
             return $"Scope: {_supervisor.Tag}";
         }

--- a/src/MassTransit/Util/TaskSupervisor.cs
+++ b/src/MassTransit/Util/TaskSupervisor.cs
@@ -14,6 +14,7 @@ namespace MassTransit.Util
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -23,6 +24,7 @@ namespace MassTransit.Util
     /// <summary>
     /// An asynchronous signaling component
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     public class TaskSupervisor :
         ITaskSupervisor
     {
@@ -179,6 +181,11 @@ namespace MassTransit.Util
         public override string ToString()
         {
             return $"Supervisor: {_tag}";
+        }
+
+        string DebuggerDisplay()
+        {
+            return $"Supervisor: {_tag} - Participants: {_participants.Count}";
         }
     }
 }


### PR DESCRIPTION
- TaskScope
- TaskParticipant

The goal was to add some debugging support to these three classes. This first pass is just the obvious stuff, but I'd be interested to hear if there is anything else that could be exposed to assist with debug time views.