### PR TITLE
Updated build script to run MongoDbIntegration tests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -271,6 +271,7 @@ Target "Default" (fun _ ->
 "Clean"
   ==> "RestorePackages"
   ==> "Build"
+  ==> "UnitTests"
   ==> "Package"
   ==> "Default"
 

--- a/build.fsx
+++ b/build.fsx
@@ -109,7 +109,8 @@ Target "Build" (fun _ ->
 )
 
 let testDlls = [ "./src/MassTransit.Tests/bin/Release/MassTransit.Tests.dll"
-                 "./src/MassTransit.AutomatonymousIntegration.Tests/bin/Release/MassTransit.AutomatonymousIntegration.Tests.dll" ]
+                 "./src/MassTransit.AutomatonymousIntegration.Tests/bin/Release/MassTransit.AutomatonymousIntegration.Tests.dll"
+                 "./src/Persistence/MassTransit.MongoDbIntegration.Tests/bin/Release/MassTransit.MongoDbIntegration.Tests.dll" ]
 
 Target "UnitTests" (fun _ ->
     testDlls


### PR DESCRIPTION
This change is dependent on the AppVeyor build configuration being updated to include `mongodb` as a service, as in the docs https://www.appveyor.com/docs/services-databases#mongodb

Thanks