### PR TITLE
Added implementation and test for not updating completed sagas

### DIFF
--- a/src/Persistence/MassTransit.MongoDbIntegration.Tests/MassTransit.MongoDbIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.MongoDbIntegration.Tests/MassTransit.MongoDbIntegration.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Saga\MongoDbSagaRepositoryTestsForSendingWhenCorrelationIdNull.cs" />
     <Compile Include="Saga\MongoDbSagaRepositoryTestsForSendingWhenInstanceNotFound.cs" />
     <Compile Include="Saga\MongoDbSagaRepositoryTestsForSendingWhenInstanceNotReturnedFromPolicy.cs" />
+    <Compile Include="Saga\MongoDbSagaRepositoryTestsForSendingWhenPolicyReturnsCompletedInstance.cs" />
     <Compile Include="Saga\MongoDbSagaRepositoryTestsForSendingWhenPolicyReturnsInstance.cs" />
     <Compile Include="Saga\MongoDbSagaRepositoryTestsForSendQuery.cs" />
     <Compile Include="Saga\MongoDbSagaRepositoryTestsForSendQueryWhenSagaNotFound.cs" />

--- a/src/Persistence/MassTransit.MongoDbIntegration.Tests/Saga/MongoDbSagaRepositoryTestsForSendingWhenPolicyReturnsCompletedInstance.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration.Tests/Saga/MongoDbSagaRepositoryTestsForSendingWhenPolicyReturnsCompletedInstance.cs
@@ -1,0 +1,62 @@
+namespace MassTransit.MongoDbIntegration.Tests.Saga
+{
+    using System;
+    using System.Threading;
+    using MassTransit.Saga;
+    using MongoDbIntegration.Saga;
+    using MongoDbIntegration.Saga.Context;
+    using MongoDB.Driver;
+    using Moq;
+    using NUnit.Framework;
+    using Util;
+
+
+    [TestFixture]
+    public class MongoDbSagaRepositoryTestsForSendingWhenPolicyReturnsCompletedInstance
+    {
+        [Test]
+        public void ThenTheCompletedSagaIsNotUpdated()
+        {
+            var actual = TaskUtil.Await(() => SagaRepository.GetSaga(_correlationId));
+
+            Assert.That(actual.Version, Is.EqualTo(_simpleSaga.Version));
+        }
+
+        SimpleSaga _simpleSaga;
+        CancellationToken _cancellationToken;
+        Guid _correlationId;
+
+        [TestFixtureSetUp]
+        public void GivenAMongoDbSagaRespository_WhenSendingCompletedInstance()
+        {
+            _correlationId = Guid.NewGuid();
+            _cancellationToken = new CancellationToken();
+
+            var context = new Mock<ConsumeContext<CompleteSimpleSaga>>();
+            context.Setup(x => x.CorrelationId).Returns(_correlationId);
+            context.Setup(m => m.CancellationToken).Returns(_cancellationToken);
+
+            _simpleSaga = new SimpleSaga
+            {
+                CorrelationId = _correlationId,
+                Version = 5
+            };
+            TaskUtil.Await(() => _simpleSaga.Consume(It.IsAny<ConsumeContext<CompleteSimpleSaga>>()));
+            TaskUtil.Await(() => SagaRepository.InsertSaga(_simpleSaga));
+
+            var sagaConsumeContext = new Mock<SagaConsumeContext<SimpleSaga, CompleteSimpleSaga>>();
+            sagaConsumeContext.SetupGet(x => x.IsCompleted).Returns(true);
+            var mongoDbSagaConsumeContextFactory = new Mock<IMongoDbSagaConsumeContextFactory>();
+            mongoDbSagaConsumeContextFactory.Setup(x => x.Create(It.IsAny<IMongoCollection<SimpleSaga>>(), context.Object, It.IsAny<SimpleSaga>(), true)).Returns(sagaConsumeContext.Object);
+            var repository = new MongoDbSagaRepository<SimpleSaga>(SagaRepository.Instance, mongoDbSagaConsumeContextFactory.Object);
+
+            TaskUtil.Await(() => repository.Send(context.Object, Mock.Of<ISagaPolicy<SimpleSaga, CompleteSimpleSaga>>(), null));
+        }
+
+        [TestFixtureTearDown]
+        public void Kill()
+        {
+            TaskUtil.Await(() => SagaRepository.DeleteSaga(_correlationId));
+        }
+    }
+}

--- a/src/Persistence/MassTransit.MongoDbIntegration/Saga/MongoDbSagaRepository.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/Saga/MongoDbSagaRepository.cs
@@ -154,7 +154,8 @@ namespace MassTransit.MongoDbIntegration.Saga
 
                 await policy.Existing(sagaConsumeContext, next).ConfigureAwait(false);
 
-                await UpdateMongoDbSaga(context, instance).ConfigureAwait(false);
+                if (!sagaConsumeContext.IsCompleted)
+                    await UpdateMongoDbSaga(context, instance).ConfigureAwait(false);
             }
             catch (SagaException)
             {


### PR DESCRIPTION
As per issue #539.

When a MongoDb saga is finalized it is deleted from the collection. This PR changes functionality to only update the data store if the saga is not complete (else there will be no saga to update and an exception will be thrown).