### PR TITLE
Make ReceiveFaultEvent serializable

### DIFF
--- a/src/MassTransit/Events/ReceiveFaultEvent.cs
+++ b/src/MassTransit/Events/ReceiveFaultEvent.cs
@@ -15,7 +15,7 @@ namespace MassTransit.Events
     using System;
     using System.Linq;
 
-
+    [Serializable]
     public class ReceiveFaultEvent :
         ReceiveFault
     {


### PR DESCRIPTION
When trying to use the Binary Serializer, I noticed that ReceiveFault messages were throwing errors inside MassTransit because the type wasn't Serializable.