### PR TITLE
FaultExceptionInfo and non-serializable Exceptions

### DIFF
--- a/src/MassTransit.Tests/MassTransit.Tests.csproj
+++ b/src/MassTransit.Tests/MassTransit.Tests.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Serialization\IEnumerable_Specs.cs" />
     <Compile Include="Serialization\MessageDataSerialization_Specs.cs" />
     <Compile Include="Serialization\PolymorphicProperty_Specs.cs" />
+    <Compile Include="Serialization\ReceiveFault_Serialization_Specs.cs" />
     <Compile Include="Serialization\SerializationException_Specs.cs" />
     <Compile Include="InMemoryTest_Specs.cs" />
     <Compile Include="Serialization\TypeHandling_Specs.cs" />

--- a/src/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MassTransit.Tests.Serialization {
+    using Events;
+    using MassTransit.Serialization;
+    using NUnit.Framework;
+    using Shouldly;
+    using Util;
+
+
+    [TestFixture(typeof(XmlMessageSerializer))]
+    [TestFixture(typeof(JsonMessageSerializer))]
+    [TestFixture(typeof(BsonMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(BinaryMessageSerializer))]
+    public class ReceiveFault_Serialization_Specs :
+        SerializationTest {
+        public ReceiveFault_Serialization_Specs(Type serializerType)
+            : base(serializerType) {
+        }
+
+        public class NonSerializableException : Exception
+        {
+
+        }
+
+        [Test]
+        public void Should_serialize_fault_from_serializable_exception() {
+
+            Exception ex = null;
+            try {
+                throw new Exception("Boom");
+            }
+            catch (Exception e) {
+                ex = new AggregateException(e);
+            }
+            var fault = new ReceiveFaultEvent(HostMetadataCache.Host, ex, "Foo", Guid.Empty);
+
+
+            TestCanSerialize(fault);
+        }
+
+        [Test]
+        public void Should_serialize_fault_from_non_serializable_exception()
+        {
+
+            Exception ex = null;
+            try
+            {
+                throw new NonSerializableException();
+            }
+            catch (Exception e)
+            {
+                ex = new AggregateException(e);
+            }
+            var fault = new ReceiveFaultEvent(HostMetadataCache.Host, ex, "Foo", Guid.Empty);
+
+
+            TestCanSerialize(fault);
+        }
+
+        void TestCanSerialize(ReceiveFaultEvent fault) {
+            var bytes = Serialize(fault);
+            bytes.Length.ShouldBeGreaterThan(0);
+        }
+    }
+}

--- a/src/MassTransit/Events/FaultExceptionInfo.cs
+++ b/src/MassTransit/Events/FaultExceptionInfo.cs
@@ -20,29 +20,25 @@ namespace MassTransit.Events
     public class FaultExceptionInfo :
         ExceptionInfo
     {
-        readonly Exception _exception;
 
-        public FaultExceptionInfo(Exception exception)
-        {
-            _exception = exception;
+        public FaultExceptionInfo(Exception exception) {
+            ExceptionType = exception.GetType().GetTypeName();
+            InnerException = exception.InnerException != null
+                ? new FaultExceptionInfo(exception.InnerException)
+                : null;
+            StackTrace = ExceptionUtil.GetStackTrace(exception);
+            Message = exception.Message;
+            Source = exception.Source;
         }
 
-        public string ExceptionType => _exception.GetType().GetTypeName();
+        public string ExceptionType { get; private set; }
 
-        public ExceptionInfo InnerException
-        {
-            get
-            {
-                if (_exception.InnerException != null)
-                    return new FaultExceptionInfo(_exception.InnerException);
-                return null;
-            }
-        }
+        public ExceptionInfo InnerException { get; private set;}
 
-        public string StackTrace => ExceptionUtil.GetStackTrace(_exception);
 
-        public string Message => _exception.Message;
+        public string StackTrace { get; private set; }
 
-        public string Source => _exception.Source;
+        public string Message { get; private set; }
+        public string Source { get; private set; }
     }
 }


### PR DESCRIPTION
When using the Binary Serializer, I've noticed that if we try to send a ReceiveFaultEvent that wraps a non-serializable exception (esp. if the exception itself is a third-party exception, e.g. with exceptions from the AWS SDK) that the Binary Serializer throws an error because the FaultExceptionInfo class holds on to the exception object itself as a private field.