### PR TITLE
Fix typos in docs and add Azure Service Bus configuration example

### DIFF
--- a/doc/source/configuration/bus_configuration.rst
+++ b/doc/source/configuration/bus_configuration.rst
@@ -47,7 +47,7 @@ require any configuration, because it's, well, in memory.
     });
 
 
-For RabbitMQ, a URI specifying the host (and virtual host, default is /) should be specified, along
+For RabbitMQ, a URI specifying the host (and virtual host, default is /) should be provided, along
 with additional configuration for the username/password, as well as options on the transport.
 
 .. sourcecode:: csharp
@@ -58,6 +58,19 @@ with additional configuration for the username/password, as well as options on t
         {
             h.Username("guest");
             h.Password("guest");
+        });
+    });
+
+For Azure Service Bus, a URI specifying the namespace should be provided, along with the
+``TokenProvider`` for a token with **manage** permissions.
+
+.. sourcecode:: csharp
+
+    var busControl = Bus.Factory.CreateUsingAzureServiceBus(cfg =>
+    {
+        var host = cfg.Host(new Uri("sb://my-namespace.servicebus.windows.net/"), h =>
+        {
+            h.TokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider("KeyName", "keyvalue");
         });
     });
 

--- a/doc/source/configuration/gotchas.rst
+++ b/doc/source/configuration/gotchas.rst
@@ -1,4 +1,4 @@
-Common gotcha's
+Common gotchas
 ===============
 
 Trying to share a queue

--- a/doc/source/middleware/circuit_breaker.rst
+++ b/doc/source/middleware/circuit_breaker.rst
@@ -1,11 +1,11 @@
 Using the circuit breaker
 =========================
 
-A circuit breaker is used to protect resources (remote, local, or otherwise) from being overload when
+A circuit breaker is used to protect resources (remote, local, or otherwise) from being overloaded when
 in a failure state. For example, a remote web site may be unavailable and calling that web site in a
 message consumer takes 30-60 seconds to time out. By continuing to call the failing service, the service
 may be unable to recover. A circuit breaker detects the repeated failures and trips, preventing further
-calls to the service giving it time to recover. Once the reset interval expires, calls are slowed allowed
+calls to the service and giving it time to recover. Once the reset interval expires, calls are slowly allowed
 back to the service. If it is still failing, the breaker remains open, and the timeout interval resets.
 Once the service returns to healthy, calls flow normally as the breaker closes.
 

--- a/doc/source/middleware/custom.rst
+++ b/doc/source/middleware/custom.rst
@@ -90,7 +90,7 @@ entirely asynchronous, and expect that asynchronous operations will be performed
             }
             catch (Exception ex)
             {
-                ::Interlocked.Increment(ref _exceptionCount);
+                Interlocked.Increment(ref _exceptionCount);
 
                 await Console.Out.WriteLineAsync($"An exception occurred: {ex.Message}");
 

--- a/doc/source/middleware/rate_limiter.rst
+++ b/doc/source/middleware/rate_limiter.rst
@@ -27,7 +27,7 @@ To add a rate limiter to a receive endpoint:
 
         cfg.ReceiveEndpoint(host, "customer_update_queue", e =>
         {
-            e.UseRateLimit(1000, TimeSpan.FromSeconds(5));;
+            e.UseRateLimit(1000, TimeSpan.FromSeconds(5));
 
             e.Consumer(() => new UpdateCustomerAddressConsumer(sessionFactory));
         });

--- a/doc/source/overview/publishing.rst
+++ b/doc/source/overview/publishing.rst
@@ -32,7 +32,7 @@ This approach was `based on an article`_ on how to maximize routing performance 
 
 .. _based on an article: http://spring.io/blog/2011/04/01/routing-topologies-for-performance-and-scalability-with-rabbitmq/
 
-This dynamic, type-based routing model has provided very powerful in many large applications. The ability to add
+This dynamic, type-based routing model has proved very powerful in many large applications. The ability to add
 new consumers to an existing message publisher is a great way to manage dependencies and keep projects from becoming tightly
 coupled.
 

--- a/doc/source/usage/messages.rst
+++ b/doc/source/usage/messages.rst
@@ -7,10 +7,10 @@ use read-only properties and no behavior.
 
 .. note::
 
-	It is strongly suggested that interfaces be used for message contracts, based
+	It is strongly suggested to use interfaces for message contracts, based
 	on experience over several years with varying levels of developer experience.
 	MassTransit will create dynamic interface implementations for the messages,
-	ensuring a clean separate of the message contract from the consumer.
+	ensuring a clean separation of the message contract from the consumer.
 
 An example message to update a customer address is shown below.
 


### PR DESCRIPTION
- Add an example of configuring an Azure Service Bus
- Fix typos and passive voice in docs