### PR TITLE
RabbitMQ Cluster Support

### DIFF
--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -46,5 +46,6 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
         public X509Certificate ClientCertificate { get; set; }
         public bool UseClientCertificateAsAuthenticationIdentity { get; set; }
         public IMessageNameFormatter MessageNameFormatter { get; set; }
+        public string[] ClusterMembers { get; set; }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqClusterConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqClusterConfigurator.cs
@@ -1,0 +1,39 @@
+﻿namespace MassTransit.RabbitMqTransport.Configuration.Configurators
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class RabbitMqClusterConfigurator : IRabbitMqClusterConfigurator
+    {
+        private List<string> _clusterMembers;
+
+        public RabbitMqClusterConfigurator()
+        {
+            _clusterMembers = new List<string>();
+        }
+
+        public string[] ClusterMembers
+        {
+            get
+            {
+                return _clusterMembers.ToArray();
+            }
+            set
+            {
+                _clusterMembers = value.ToList();
+            }
+        }
+
+        public void Node(string clusterNodeHostname)
+        {
+            if (string.IsNullOrWhiteSpace(clusterNodeHostname))
+            {
+                throw new ArgumentException("Cluster node hostname cannot be empty.");
+            }
+            _clusterMembers.Add(clusterNodeHostname);
+        }
+    }
+}

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
@@ -18,7 +18,7 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
     public class RabbitMqHostConfigurator :
         IRabbitMqHostConfigurator
     {
-        static readonly char[] _pathSeparator = {'/'};
+        static readonly char[] _pathSeparator = { '/' };
         readonly ConfigurationHostSettings _settings;
 
         public RabbitMqHostConfigurator(Uri hostAddress)
@@ -85,5 +85,13 @@ namespace MassTransit.RabbitMqTransport.Configuration.Configurators
 
             throw new FormatException("The host path must be empty or contain a single virtual host name");
         }
+
+        public void UseCluster(Action<IRabbitMqClusterConfigurator> configureCluster)
+        {
+            var configurator = new RabbitMqClusterConfigurator();
+            configureCluster(configurator);
+            _settings.ClusterMembers = configurator.ClusterMembers;
+        }
+
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqClusterConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqClusterConfigurator.cs
@@ -1,0 +1,9 @@
+﻿namespace MassTransit.RabbitMqTransport.Configuration
+{
+    public interface IRabbitMqClusterConfigurator
+    {
+        string[] ClusterMembers { get; set; }
+
+        void Node(string clusterNodeHostname);
+    }
+}

--- a/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqHostConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqHostConfigurator.cs
@@ -43,5 +43,11 @@ namespace MassTransit.RabbitMqTransport.Configuration
         /// </summary>
         /// <param name="password"></param>
         void Password(string password);
+
+        /// <summary>
+        /// Configure a RabbitMQ High-Availability cluster which will cycle hosts when connections are interrupted.
+        /// </summary>
+        /// <param name="configureCluster">The cluster configuration</param>
+        void UseCluster(Action<IRabbitMqClusterConfigurator> configureCluster);
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
@@ -77,6 +77,7 @@ namespace MassTransit.RabbitMqTransport.Hosting
             public X509Certificate ClientCertificate => null;
             public bool UseClientCertificateAsAuthenticationIdentity => false;
             public IMessageNameFormatter MessageNameFormatter => new RabbitMqMessageNameFormatter();
+            public string[] ClusterMembers => null;
         }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Integration/RabbitMqConnectionCache.cs
+++ b/src/MassTransit.RabbitMqTransport/Integration/RabbitMqConnectionCache.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.RabbitMqTransport.Integration
 {
     using System;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Contexts;
@@ -89,7 +90,16 @@ namespace MassTransit.RabbitMqTransport.Integration
                 if (_log.IsDebugEnabled)
                     _log.DebugFormat("Connecting: {0}", _connectionFactory.ToDebugString());
 
-                var connection = _connectionFactory.CreateConnection();
+                IConnection connection = null;
+                if (_connectionFactory.HostnameSelector != null && _settings.ClusterMembers.Any())
+                {
+                    connection = _connectionFactory.CreateConnection(_settings.ClusterMembers);
+                }
+                else
+                {
+                    connection = _connectionFactory.CreateConnection();
+                }
+
 
                 if (_log.IsDebugEnabled)
                 {

--- a/src/MassTransit.RabbitMqTransport/Integration/RabbitMqConnectionCache.cs
+++ b/src/MassTransit.RabbitMqTransport/Integration/RabbitMqConnectionCache.cs
@@ -91,7 +91,7 @@ namespace MassTransit.RabbitMqTransport.Integration
                     _log.DebugFormat("Connecting: {0}", _connectionFactory.ToDebugString());
 
                 IConnection connection = null;
-                if (_connectionFactory.HostnameSelector != null && _settings.ClusterMembers.Any())
+                if (_connectionFactory.HostnameSelector != null && _settings.ClusterMembers != null && _settings.ClusterMembers.Any())
                 {
                     connection = _connectionFactory.CreateConnection(_settings.ClusterMembers);
                 }

--- a/src/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
+++ b/src/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
@@ -71,12 +71,14 @@
     <Compile Include="Configuration\Builders\RabbitMqBusBuilder.cs" />
     <Compile Include="Configuration\Builders\RabbitMqReceiveEndpointBuilder.cs" />
     <Compile Include="Configuration\Configurators\ConfigurationHostSettings.cs" />
+    <Compile Include="Configuration\Configurators\RabbitMqClusterConfigurator.cs" />
     <Compile Include="Configuration\Configurators\RabbitMqHostConfigurator.cs" />
     <Compile Include="Configuration\DelayedExchangeMessageSchedulerSpecification.cs" />
     <Compile Include="Configuration\DelayedExchangeRedeliveryPipeSpecification.cs" />
     <Compile Include="Configuration\IExchangeBindingConfigurator.cs" />
     <Compile Include="Configuration\IExchangeConfigurator.cs" />
     <Compile Include="Configuration\IQueueConfigurator.cs" />
+    <Compile Include="Configuration\IRabbitMqClusterConfigurator.cs" />
     <Compile Include="Configuration\RabbitMqConsumerPipeSpecification.cs" />
     <Compile Include="Configuration\ConsumerPipeConfiguratorExtensions.cs" />
     <Compile Include="Contexts\DelayedExchangeMessageRedeliveryContext.cs" />

--- a/src/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
+++ b/src/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
@@ -144,6 +144,7 @@
     <Compile Include="RabbitMqSendContextExtensions.cs" />
     <Compile Include="RabbitMqSendEndpointProvider.cs" />
     <Compile Include="RabbitMqSendTransportProvider.cs" />
+    <Compile Include="RabbitMqSequentialHostnameSelector.cs" />
     <Compile Include="ReceiveSettings.cs" />
     <Compile Include="RabbitMqReceiveTransport.cs" />
     <Compile Include="RabbitMqSendContext.cs" />

--- a/src/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs
+++ b/src/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs
@@ -175,6 +175,7 @@ namespace MassTransit.RabbitMqTransport.Pipeline
             {
                 await _receiveObserver.ReceiveFault(context, ex).ConfigureAwait(false);
 
+                //NOTE: If this exceptions, the application will crash
                 _model.BasicNack(deliveryTag, false, true);
             }
             finally

--- a/src/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs
+++ b/src/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs
@@ -174,9 +174,15 @@ namespace MassTransit.RabbitMqTransport.Pipeline
             catch (Exception ex)
             {
                 await _receiveObserver.ReceiveFault(context, ex).ConfigureAwait(false);
-
-                //NOTE: If this exceptions, the application will crash
-                _model.BasicNack(deliveryTag, false, true);
+                try
+                {
+                    _model.BasicNack(deliveryTag, false, true);
+                }
+                catch (Exception ackEx)
+                {
+                    if (_log.IsErrorEnabled)
+                        _log.ErrorFormat("An error occurred trying to NACK a message with delivery tag {0}: {1}", deliveryTag, ackEx.ToString());
+                }
             }
             finally
             {

--- a/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.RabbitMqTransport
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Net;

--- a/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -344,6 +344,13 @@ namespace MassTransit.RabbitMqTransport
                 RequestedHeartbeat = settings.Heartbeat
             };
 
+            if (settings.ClusterMembers != null && settings.ClusterMembers.Any())
+            {
+                factory.HostName = null;
+                factory.HostnameSelector = new RabbitMqSequentialHostnameSelector();
+                factory.AutomaticRecoveryEnabled = true;
+            }
+            
             if (settings.UseClientCertificateAsAuthenticationIdentity)
             {
                 factory.AuthMechanisms.Clear();

--- a/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqHostSettings.cs
@@ -101,5 +101,10 @@ namespace MassTransit.RabbitMqTransport
         /// The message name formatter for the publisher
         /// </summary>
         IMessageNameFormatter MessageNameFormatter { get; }
+          
+        /// <summary>
+        /// When using a RabbitMQ cluster, this contains the host names which make up the cluster. In the event of a connection failure, the next host in the array will be connected to.
+        /// </summary>
+        string[] ClusterMembers { get; } 
     }
 }

--- a/src/MassTransit.RabbitMqTransport/RabbitMqSequentialHostnameSelector.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqSequentialHostnameSelector.cs
@@ -1,0 +1,49 @@
+﻿namespace MassTransit.RabbitMqTransport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Logging;
+    using RabbitMQ.Client;
+
+    /// <summary>
+    /// Creates an IHostnameSelector which sequentially chooses the next host name from the provided list based on index
+    /// </summary>
+    public class RabbitMqSequentialHostnameSelector : IHostnameSelector
+    {
+        static readonly ILog _log = Logger.Get<RabbitMqSequentialHostnameSelector>();
+
+        private int _nextHostIndex;
+
+        public RabbitMqSequentialHostnameSelector()
+        {
+            _nextHostIndex = 0;
+        }
+
+        public string NextFrom(IList<string> options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException("options");
+            }
+            if (!options.Any())
+            {
+                throw new ArgumentException("There must be at least one host to use a hostname selector.", "options");
+            }
+
+            //Clamp host index
+            if (_nextHostIndex >= options.Count())
+            {
+                _nextHostIndex = 0;
+            }
+
+            string host = options[_nextHostIndex];
+            if (_log.IsDebugEnabled)
+            {
+                _log.Debug($"Using new hostname from pool; {host}");
+            }
+            _nextHostIndex++;
+            return host;
+        }
+    }
+}


### PR DESCRIPTION
Updates RabbitMq configuration to expose clustering options. The list of cluster nodes provided by the user is then passed to the RabbitMq driver which fails over, based on the selected IHostnameSelector instance.

#563 