### PR TITLE
Update BinaryMessageSerializer.cs

### DIFF
--- a/src/MassTransit/Serialization/BinaryMessageSerializer.cs
+++ b/src/MassTransit/Serialization/BinaryMessageSerializer.cs
@@ -66,7 +66,7 @@ namespace MassTransit.Serialization
             catch
             {
                 throw new ConventionException(
-                    $"The message '{TypeMetadataCache<T>.ShortName}' fail to be serialized. Check if all inner objects are serializable.");
+                    $"The message '{TypeMetadataCache<T>.ShortName}' failed to be serialized. Check if all inner objects are serializable.");
             }
 
             context.ContentType = BinaryContentType;

--- a/src/MassTransit/Serialization/BinaryMessageSerializer.cs
+++ b/src/MassTransit/Serialization/BinaryMessageSerializer.cs
@@ -59,7 +59,15 @@ namespace MassTransit.Serialization
                     $"Whoa, slow down buddy. The message '{TypeMetadataCache<T>.ShortName}' must be marked with the 'Serializable' attribute!");
             }
 
-            _formatter.Serialize(stream, context.Message, GetHeaders<T>(context));
+            try
+            {
+                _formatter.Serialize(stream, context.Message, GetHeaders<T>(context));
+            }
+            catch
+            {
+                throw new ConventionException(
+                    $"The message '{TypeMetadataCache<T>.ShortName}' fail to be serialized. Check if all inner objects are serializable.");
+            }
 
             context.ContentType = BinaryContentType;
         }


### PR DESCRIPTION
We found an issue in one of our projects where we have a message that returns an Exception object as member, when the Exception has a inner member like in some Entity Framework exception that is not serializable it crash Masstransit because _formatter.Serialize keeps raising an exception and the message is never ACK to RabbitMQ then consumer keeps receiving the same message in an endless loop, creating dozen of requests per second and no message in _error queue.
Check IsSerializable doesn't produce the desired results if an inner member doesn't have IsSerializable.