### PR TITLE
Updated Reactive Extensions references to 3.0.

### DIFF
--- a/src/.nuget/NuGet.targets
+++ b/src/.nuget/NuGet.targets
@@ -113,7 +113,7 @@
 
                     Log.LogMessage("Downloading latest version of NuGet.exe...");
                     WebClient webClient = new WebClient();
-                    webClient.DownloadFile("https://nuget.org/nuget.exe", OutputFilename);
+                    webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", OutputFilename);
 
                     return true;
                 }

--- a/src/MassTransit.Reactive.Tests/MassTransit.Reactive.Tests.csproj
+++ b/src/MassTransit.Reactive.Tests/MassTransit.Reactive.Tests.csproj
@@ -44,15 +44,17 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Reactive.Core">
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.0.0\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.0.0\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.3.0.0\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/MassTransit.Reactive.Tests/packages.config
+++ b/src/MassTransit.Reactive.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.4.1" targetFramework="net452" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
+  <package id="System.Reactive.Core" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Interfaces" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Linq" version="3.0.0" targetFramework="net452" />
 </packages>

--- a/src/MassTransit.Reactive/MassTransit.Reactive.csproj
+++ b/src/MassTransit.Reactive/MassTransit.Reactive.csproj
@@ -68,15 +68,17 @@
     <Reference Include="System" />
     <Reference Include="System.Core">
     </Reference>
-    <Reference Include="System.Reactive.Core">
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Core.3.0.0\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.0.0\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.Linq.3.0.0\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MassTransit.Reactive/packages.config
+++ b/src/MassTransit.Reactive/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
+  <package id="System.Reactive.Core" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Interfaces" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Linq" version="3.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This commit resolves #607 

I had to change NuGet.exe download URL to latest version, since new rx packages
cannot be installed with the old one.
Existing URL [https://nuget.org/nuget.exe] points to 2.8 but rx 3.0 requires >=2.12. 

Also, not sure if this dependency update is a as breaking change or not, since new assemblies have new strong key. 