### PR TITLE
Checking job exists so exception doesn't get thrown

### DIFF
--- a/src/MassTransit.QuartzIntegration/ScheduleMessageConsumer.cs
+++ b/src/MassTransit.QuartzIntegration/ScheduleMessageConsumer.cs
@@ -56,7 +56,10 @@ namespace MassTransit.QuartzIntegration
                 .WithIdentity(new TriggerKey(correlationId))
                 .Build();
 
-            _scheduler.ScheduleJob(jobDetail, trigger);
+            if (_scheduler.CheckExists(trigger.Key))
+                _scheduler.RescheduleJob(trigger.Key, trigger);
+            else
+                _scheduler.ScheduleJob(jobDetail, trigger);
         }
 
         public async Task Consume(ConsumeContext<ScheduleRecurringMessage> context)


### PR DESCRIPTION
You have this rescheduling logic for recurring jobs, but not for single jobs. We have a situation where we have single jobs that can be retried manually. The correlation id happens to be the same and if we want to happen to redeliver again, an exception gets thrown by Quartz because the job already exists. I didn't see any harm in making both job types function the same.