### PR TITLE
Add EF Optimistic Concurrency Alternative to using Database Locking f…

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
@@ -141,10 +141,14 @@
     <Compile Include="SingleConnectionSessionFactory.cs" />
     <Compile Include="SqlLiteSessionFactoryProvider.cs" />
     <Compile Include="StateMachineTestFixture.cs" />
+    <Compile Include="Storage2Spec_Types.cs" />
     <Compile Include="TestExtensions.cs" />
     <Compile Include="Testing_Specs.cs" />
     <Compile Include="UncorrelatedMessage_Specs.cs" />
     <Compile Include="StorageSpec_Types.cs" />
+    <Compile Include="UsingEntityFrameworkConcurrencyFail_Specs.cs" />
+    <Compile Include="UsingEntityFrameworkConcurrencyPessimistic_Specs.cs" />
+    <Compile Include="UsingEntityFrameworkConcurrencyOptimistic_Specs.cs" />
     <Compile Include="UsingEntityFramework_Specs.cs" />
     <Compile Include="UsingNHibernate_Specs.cs" />
   </ItemGroup>

--- a/src/MassTransit.AutomatonymousIntegration.Tests/Storage2Spec_Types.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/Storage2Spec_Types.cs
@@ -1,0 +1,117 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AutomatonymousIntegration.Tests
+{
+    using System;
+    using Automatonymous;
+    using Saga;
+
+    public class RehersalBegins
+    {
+        public Guid CorrelationId { get; set; }
+    }
+
+    public class Bass
+    {
+        public Guid CorrelationId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Baritone
+    {
+        public Guid CorrelationId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Tenor
+    {
+        public Guid CorrelationId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Countertenor
+    {
+        public Guid CorrelationId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class ChoirState :
+        SagaStateMachineInstance
+    {
+        protected ChoirState()
+        {
+        }
+
+        public ChoirState(Guid correlationId)
+        {
+            CorrelationId = correlationId;
+        }
+
+        public string CurrentState { get; set; }
+        public int Harmony { get; set; }
+        public Guid CorrelationId { get; set; }
+        public byte[] RowVersion { get; set; }
+        public string BassName { get; set; }
+        public string BaritoneName { get; set; }
+        public string TenorName { get; set; }
+        public string CountertenorName { get; set; }
+    }
+
+
+    public class ChoirStateMachine :
+        MassTransitStateMachine<ChoirState>
+    {
+        public ChoirStateMachine()
+        {
+            InstanceState(x => x.CurrentState);
+
+            Event(() => RehersalStarts, x => x.CorrelateById(context => context.Message.CorrelationId));
+            Event(() => BassStarts, x => x.CorrelateById(context => context.Message.CorrelationId));
+            Event(() => BaritoneStarts, x => x.CorrelateById(context => context.Message.CorrelationId));
+            Event(() => TenorStarts, x => x.CorrelateById(context => context.Message.CorrelationId));
+            Event(() => CountertenorStarts, x => x.CorrelateById(context => context.Message.CorrelationId));
+            CompositeEvent(() => AllSinging, x => x.Harmony, BassStarts, BaritoneStarts, TenorStarts, CountertenorStarts);
+
+            Initially(
+                When(RehersalStarts)
+                    .Then(context => Console.WriteLine("Rehersal Started!!"))
+                    .TransitionTo(Warmup));
+
+            During(Warmup,
+                When(BassStarts)
+                    .Then(context => Console.WriteLine("Bass Started!!"))
+                    .Then(context => context.Instance.BassName = context.Data.Name),
+                When(BaritoneStarts)
+                    .Then(context => Console.WriteLine("Baritone Started!!"))
+                    .Then(context => context.Instance.BaritoneName = context.Data.Name),
+                When(TenorStarts)
+                    .Then(context => Console.WriteLine("Tenor Started!!"))
+                    .Then(context => context.Instance.TenorName = context.Data.Name),
+                When(CountertenorStarts)
+                    .Then(context => Console.WriteLine("CounterTenor Started!!"))
+                    .Then(context => context.Instance.CountertenorName = context.Data.Name),
+                When(AllSinging)
+                    .Then(context => Console.WriteLine("Harmony Reached!!"))
+                    .TransitionTo(Harmony));
+        }
+
+        public Event<RehersalBegins> RehersalStarts { get; private set; }
+        public Event<Bass> BassStarts { get; private set; }
+        public Event<Baritone> BaritoneStarts { get; private set; }
+        public Event<Tenor> TenorStarts { get; private set; }
+        public Event<Countertenor> CountertenorStarts { get; private set; }
+        public Event AllSinging { get; private set; }
+        public State Warmup { get; private set; }
+        public State Harmony { get; private set; }
+    }
+}

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AutomatonymousIntegration.Tests
+{
+    using Automatonymous;
+    using EntityFrameworkIntegration;
+    using EntityFrameworkIntegration.Saga;
+    using NUnit.Framework;
+    using Saga;
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Entity;
+    using System.Threading.Tasks;
+    using TestFramework;
+
+    [TestFixture]
+    public class When_using_EntityFrameworkConcurrencyFail :
+        InMemoryTestFixture
+    {
+        ChoirStateMachine _machine;
+        readonly SagaDbContextFactory _sagaDbContextFactory;
+        readonly Lazy<ISagaRepository<ChoirState>> _repository;
+
+        protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _machine = new ChoirStateMachine();
+
+            configurator.StateMachineSaga(_machine, _repository.Value);
+
+            configurator.TransportConcurrencyLimit = 16;
+        }
+
+        public When_using_EntityFrameworkConcurrencyFail()
+        {
+            _sagaDbContextFactory =
+                () => new SagaDbContext<ChoirState, EntityFrameworkChoirStateMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString());
+            _repository = new Lazy<ISagaRepository<ChoirState>>(() => new EntityFrameworkSagaRepository<ChoirState>(_sagaDbContextFactory, optimistic: true));
+        }
+
+        async Task<ChoirState> GetSaga(Guid id)
+        {
+            using (var dbContext = _sagaDbContextFactory())
+            {
+                return await dbContext.Set<ChoirState>().SingleOrDefaultAsync(x => x.CorrelationId == id);
+            }
+        }
+
+        [Test]
+        public async Task Should_not_capture_all_events_many_sagas()
+        {
+            var tasks = new List<Task>();
+
+            Guid[] sagaIds = new Guid[20];
+            for (int i = 0; i < 20; i++)
+            {
+                Guid correlationId = NewId.NextGuid();
+
+                await InputQueueSendEndpoint.Send(new RehersalBegins { CorrelationId = correlationId });
+
+                sagaIds[i] = correlationId;
+            }
+
+            for (int i = 0; i < 20; i++)
+            {
+                Guid? sagaId = await _repository.Value.ShouldContainSaga(sagaIds[i], TestTimeout);
+                Assert.IsTrue(sagaId.HasValue);
+            }
+
+            for (int i = 0; i < 20; i++)
+            {
+                tasks.Add(InputQueueSendEndpoint.Send(new Bass { CorrelationId = sagaIds[i], Name = "John" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Baritone { CorrelationId = sagaIds[i], Name = "Mark" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Tenor { CorrelationId = sagaIds[i], Name = "Anthony" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Countertenor { CorrelationId = sagaIds[i], Name = "Tom" }));
+            }
+
+            await Task.WhenAll(tasks);
+            tasks.Clear();
+
+            foreach (var sid in sagaIds)
+            {
+                var sagaId = await _repository.Value.ShouldContainSaga(x => x.CorrelationId == sid
+                && x.CurrentState == _machine.Warmup.Name, TestTimeout);
+
+                Assert.IsTrue(sagaId.HasValue);
+            }
+        }
+
+        [Test]
+        public async Task Should_not_capture_all_events_single_saga()
+        {
+            Guid correlationId = Guid.NewGuid();
+
+            await InputQueueSendEndpoint.Send(new RehersalBegins { CorrelationId = correlationId });
+
+            Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
+
+            Assert.IsTrue(sagaId.HasValue);
+
+            await Task.WhenAll(
+                InputQueueSendEndpoint.Send(new Bass { CorrelationId = correlationId, Name = "John" }),
+                InputQueueSendEndpoint.Send(new Baritone { CorrelationId = correlationId, Name = "Mark" }),
+                InputQueueSendEndpoint.Send(new Tenor { CorrelationId = correlationId, Name = "Anthony" }),
+                InputQueueSendEndpoint.Send(new Countertenor { CorrelationId = correlationId, Name = "Tom" })
+                );
+
+            sagaId = await _repository.Value.ShouldContainSaga(x => x.CorrelationId == correlationId
+                && x.CurrentState == _machine.Warmup.Name, TestTimeout);
+
+            Assert.IsTrue(sagaId.HasValue);
+        }
+
+        protected override void ConfigureBus(IInMemoryBusFactoryConfigurator configurator)
+        {
+            base.ConfigureBus(configurator);
+
+            configurator.TransportConcurrencyLimit = 16;
+        }
+    }
+}

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
@@ -31,7 +31,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         readonly SagaDbContextFactory _sagaDbContextFactory;
         readonly Lazy<ISagaRepository<ChoirState>> _repository;
 
-        protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
             _machine = new ChoirStateMachine();
 
@@ -120,9 +120,9 @@ namespace MassTransit.AutomatonymousIntegration.Tests
             Assert.IsTrue(sagaId.HasValue);
         }
 
-        protected override void ConfigureBus(IInMemoryBusFactoryConfigurator configurator)
+        protected override void PreCreateBus(IInMemoryBusFactoryConfigurator configurator)
         {
-            base.ConfigureBus(configurator);
+            base.PreCreateBus(configurator);
 
             configurator.TransportConcurrencyLimit = 16;
         }

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
@@ -1,0 +1,160 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AutomatonymousIntegration.Tests
+{
+    using Automatonymous;
+    using EntityFrameworkIntegration;
+    using EntityFrameworkIntegration.Saga;
+    using GreenPipes;
+    using NUnit.Framework;
+    using Saga;
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Entity;
+    using System.Data.Entity.Infrastructure;
+    using System.Threading.Tasks;
+    using TestFramework;
+
+    [TestFixture]
+    public class When_using_EntityFrameworkConcurrencyOptimistic :
+        InMemoryTestFixture
+    {
+        ChoirStateMachine _machine;
+        readonly SagaDbContextFactory _sagaDbContextFactory;
+        readonly Lazy<ISagaRepository<ChoirState>> _repository;
+
+        protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _machine = new ChoirStateMachine();
+
+            configurator.UseRetry(x =>
+            {
+                x.Handle<DbUpdateConcurrencyException>();
+                x.Immediate(5);
+            });
+            configurator.StateMachineSaga(_machine, _repository.Value);
+
+            configurator.TransportConcurrencyLimit = 16;
+        }
+
+        public When_using_EntityFrameworkConcurrencyOptimistic()
+        {
+            _sagaDbContextFactory =
+                () => new SagaDbContext<ChoirState, EntityFrameworkChoirStateMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString());
+            _repository = new Lazy<ISagaRepository<ChoirState>>(() => new EntityFrameworkSagaRepository<ChoirState>(_sagaDbContextFactory, optimistic: true));
+        }
+
+        async Task<ChoirState> GetSaga(Guid id)
+        {
+            using (var dbContext = _sagaDbContextFactory())
+            {
+                return await dbContext.Set<ChoirState>().SingleOrDefaultAsync(x => x.CorrelationId == id);
+            }
+        }
+
+        [Test]
+        public async Task Should_capture_all_events_many_sagas()
+        {
+            var tasks = new List<Task>();
+
+            Guid[] sagaIds = new Guid[20];
+            for (int i = 0; i < 20; i++)
+            {
+                Guid correlationId = NewId.NextGuid();
+
+                await InputQueueSendEndpoint.Send(new RehersalBegins { CorrelationId = correlationId });
+
+                sagaIds[i] = correlationId;
+            }
+
+            for (int i = 0; i < 20; i++)
+            {
+                Guid? sagaId = await _repository.Value.ShouldContainSaga(sagaIds[i], TestTimeout);
+                Assert.IsTrue(sagaId.HasValue);
+            }
+
+            for (int i = 0; i < 20; i++)
+            {
+                tasks.Add(InputQueueSendEndpoint.Send(new Bass { CorrelationId = sagaIds[i], Name = "John" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Baritone { CorrelationId = sagaIds[i], Name = "Mark" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Tenor { CorrelationId = sagaIds[i], Name = "Anthony" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Countertenor { CorrelationId = sagaIds[i], Name = "Tom" }));
+            }
+
+            await Task.WhenAll(tasks);
+            tasks.Clear();
+
+            foreach(var sid in sagaIds)
+            {
+                var sagaId = await _repository.Value.ShouldContainSaga(x => x.CorrelationId == sid
+                && x.CurrentState == _machine.Harmony.Name, TestTimeout);
+
+                Assert.IsTrue(sagaId.HasValue);
+            }
+        }
+
+        [Test]
+        public async Task Should_capture_all_events_single_saga()
+        {
+            Guid correlationId = Guid.NewGuid();
+
+            await InputQueueSendEndpoint.Send(new RehersalBegins { CorrelationId = correlationId });
+
+            Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
+
+            Assert.IsTrue(sagaId.HasValue);
+
+            await Task.WhenAll(
+                InputQueueSendEndpoint.Send(new Bass { CorrelationId = correlationId, Name = "John" }),
+                InputQueueSendEndpoint.Send(new Baritone { CorrelationId = correlationId, Name = "Mark" }),
+                InputQueueSendEndpoint.Send(new Tenor { CorrelationId = correlationId, Name = "Anthony" }),
+                InputQueueSendEndpoint.Send(new Countertenor { CorrelationId = correlationId, Name = "Tom" })
+                );
+
+            sagaId = await _repository.Value.ShouldContainSaga(x => x.CorrelationId == correlationId
+                && x.CurrentState == _machine.Harmony.Name, TestTimeout);
+
+            Assert.IsTrue(sagaId.HasValue);
+
+            ChoirState instance = await GetSaga(correlationId);
+
+            Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
+        }
+
+        protected override void ConfigureBus(IInMemoryBusFactoryConfigurator configurator)
+        {
+            base.ConfigureBus(configurator);
+
+            configurator.TransportConcurrencyLimit = 16;
+        }
+    }
+
+
+    class EntityFrameworkChoirStateMap :
+        SagaClassMapping<ChoirState>
+    {
+        public EntityFrameworkChoirStateMap()
+        {
+            Property(x => x.RowVersion)
+                .IsRowVersion();
+
+            Property(x => x.CurrentState);
+            Property(x => x.BassName);
+            Property(x => x.BaritoneName);
+            Property(x => x.TenorName);
+            Property(x => x.CountertenorName);
+
+            Property(x => x.Harmony);
+        }
+    }
+}

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
@@ -33,7 +33,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         readonly SagaDbContextFactory _sagaDbContextFactory;
         readonly Lazy<ISagaRepository<ChoirState>> _repository;
 
-        protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
             _machine = new ChoirStateMachine();
 
@@ -131,9 +131,9 @@ namespace MassTransit.AutomatonymousIntegration.Tests
             Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
         }
 
-        protected override void ConfigureBus(IInMemoryBusFactoryConfigurator configurator)
+        protected override void PreCreateBus(IInMemoryBusFactoryConfigurator configurator)
         {
-            base.ConfigureBus(configurator);
+            base.PreCreateBus(configurator);
 
             configurator.TransportConcurrencyLimit = 16;
         }

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
@@ -31,7 +31,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         readonly SagaDbContextFactory _sagaDbContextFactory;
         readonly Lazy<ISagaRepository<ChoirState>> _repository;
 
-        protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
             _machine = new ChoirStateMachine();
 
@@ -124,9 +124,9 @@ namespace MassTransit.AutomatonymousIntegration.Tests
             Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
         }
 
-        protected override void ConfigureBus(IInMemoryBusFactoryConfigurator configurator)
+        protected override void PreCreateBus(IInMemoryBusFactoryConfigurator configurator)
         {
-            base.ConfigureBus(configurator);
+            base.PreCreateBus(configurator);
 
             configurator.TransportConcurrencyLimit = 16;
         }

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
@@ -1,0 +1,149 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AutomatonymousIntegration.Tests
+{
+    using Automatonymous;
+    using EntityFrameworkIntegration;
+    using EntityFrameworkIntegration.Saga;
+    using NUnit.Framework;
+    using Saga;
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Entity;
+    using System.Threading.Tasks;
+    using TestFramework;
+
+    [TestFixture]
+    public class When_using_EntityFrameworkConcurrencyPessimistic :
+        InMemoryTestFixture
+    {
+        ChoirStateMachine _machine;
+        readonly SagaDbContextFactory _sagaDbContextFactory;
+        readonly Lazy<ISagaRepository<ChoirState>> _repository;
+
+        protected override void ConfigureInputQueueEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _machine = new ChoirStateMachine();
+
+            configurator.StateMachineSaga(_machine, _repository.Value);
+
+            configurator.TransportConcurrencyLimit = 16;
+        }
+
+        public When_using_EntityFrameworkConcurrencyPessimistic()
+        {
+            _sagaDbContextFactory =
+                () => new SagaDbContext<ChoirState, EntityFrameworkChoirStateMapPessmistic>(SagaDbContextFactoryProvider.GetLocalDbConnectionString());
+            _repository = new Lazy<ISagaRepository<ChoirState>>(() => new EntityFrameworkSagaRepository<ChoirState>(_sagaDbContextFactory));
+        }
+
+        async Task<ChoirState> GetSaga(Guid id)
+        {
+            using (var dbContext = _sagaDbContextFactory())
+            {
+                return await dbContext.Set<ChoirState>().SingleOrDefaultAsync(x => x.CorrelationId == id);
+            }
+        }
+
+        [Test]
+        public async Task Should_capture_all_events_many_sagas()
+        {
+            var tasks = new List<Task>();
+
+            Guid[] sagaIds = new Guid[20];
+            for (int i = 0; i < 20; i++)
+            {
+                Guid correlationId = NewId.NextGuid();
+
+                await InputQueueSendEndpoint.Send(new RehersalBegins { CorrelationId = correlationId });
+
+                sagaIds[i] = correlationId;
+            }
+
+            for (int i = 0; i < 20; i++)
+            {
+                Guid? sagaId = await _repository.Value.ShouldContainSaga(sagaIds[i], TestTimeout);
+                Assert.IsTrue(sagaId.HasValue);
+            }
+
+            for (int i = 0; i < 20; i++)
+            {
+                tasks.Add(InputQueueSendEndpoint.Send(new Bass { CorrelationId = sagaIds[i], Name = "John" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Baritone { CorrelationId = sagaIds[i], Name = "Mark" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Tenor { CorrelationId = sagaIds[i], Name = "Anthony" }));
+                tasks.Add(InputQueueSendEndpoint.Send(new Countertenor { CorrelationId = sagaIds[i], Name = "Tom" }));
+            }
+
+            await Task.WhenAll(tasks);
+            tasks.Clear();
+
+            foreach (var sid in sagaIds)
+            {
+                var sagaId = await _repository.Value.ShouldContainSaga(x => x.CorrelationId == sid
+                && x.CurrentState == _machine.Harmony.Name, TestTimeout);
+
+                Assert.IsTrue(sagaId.HasValue);
+            }
+        }
+
+        [Test]
+        public async Task Should_capture_all_events_single_saga()
+        {
+            Guid correlationId = Guid.NewGuid();
+
+            await InputQueueSendEndpoint.Send(new RehersalBegins { CorrelationId = correlationId });
+
+            Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
+
+            Assert.IsTrue(sagaId.HasValue);
+
+            await Task.WhenAll(
+                InputQueueSendEndpoint.Send(new Bass { CorrelationId = correlationId, Name = "John" }),
+                InputQueueSendEndpoint.Send(new Baritone { CorrelationId = correlationId, Name = "Mark" }),
+                InputQueueSendEndpoint.Send(new Tenor { CorrelationId = correlationId, Name = "Anthony" }),
+                InputQueueSendEndpoint.Send(new Countertenor { CorrelationId = correlationId, Name = "Tom" })
+                );
+
+            sagaId = await _repository.Value.ShouldContainSaga(x => x.CorrelationId == correlationId
+                && x.CurrentState == _machine.Harmony.Name, TestTimeout);
+
+            Assert.IsTrue(sagaId.HasValue);
+
+            ChoirState instance = await GetSaga(correlationId);
+
+            Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
+        }
+
+        protected override void ConfigureBus(IInMemoryBusFactoryConfigurator configurator)
+        {
+            base.ConfigureBus(configurator);
+
+            configurator.TransportConcurrencyLimit = 16;
+        }
+    }
+
+    class EntityFrameworkChoirStateMapPessmistic :
+        SagaClassMapping<ChoirState>
+    {
+        public EntityFrameworkChoirStateMapPessmistic()
+        {
+            Property(x => x.CurrentState);
+            Property(x => x.BassName);
+            Property(x => x.BaritoneName);
+            Property(x => x.TenorName);
+            Property(x => x.CountertenorName);
+
+            Property(x => x.Harmony);
+        }
+    }
+}

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFramework_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFramework_Specs.cs
@@ -23,7 +23,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
     using NUnit.Framework;
     using Saga;
     using TestFramework;
-
+    using System.Collections.Generic;
 
     [TestFixture]
     public class When_using_EntityFramework :
@@ -93,18 +93,22 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         [Test, Explicit]
         public async Task Should_handle_the_big_load()
         {
+            var tasks = new List<Task>();
+
             Guid[] sagaIds = new Guid[200];
             for (int i = 0; i < 200; i++)
             {
                 Guid correlationId = Guid.NewGuid();
 
-                InputQueueSendEndpoint.Send(new GirlfriendYelling
+                tasks.Add(InputQueueSendEndpoint.Send(new GirlfriendYelling
                 {
                     CorrelationId = correlationId
-                });
+                }));
 
                 sagaIds[i] = correlationId;
             }
+
+            await Task.WhenAll(tasks);
 
             for (int i = 0; i < 200; i++)
             {


### PR DESCRIPTION
## Pull Req

Okay so this Pull Request allows Optimistic Concurrency with EntityFramework. You can implement it [two different ways](http://www.binaryintellect.net/articles/14e67064-634c-4206-9eca-a42d3739594a.aspx) in EF. The benefit (obviously) is no row/page locks. However you will then need to retry the saga transaction if you get the DbUpdateConcurrencyException. Since the middleware .UseRetry gives us this capability, I made some concurrency unit tests to check. I put in three.

* **UsingEntityFrameworkConcurrencyPessimistic_Specs.cs** - Uses database locks (as it does today, no changes)
* **UsingEntityFrameworkConcurrencyOptimistic_Specs.cs** - Uses EF RowVersion (Timestamp). Leverages UseRetry() for DbUpdateConcurrencyException
* **UsingEntityFrameworkConcurrencyFail_Specs.cs** - The negative test. Still sets the optimistic: true flag, but omit's the UseRetry(). This shows how important it is to use the retry middleware if you opt-in for optimistic.

When passing the constructor param optimistic: true into `EntityFrameworkSagaRepository`, it should be noted that it's very important to ensure in your SagaMap, that you have a property mapped to RowVersion with the fluent mapping:
```csharp
Property(x => x.RowVersion)
    .IsRowVersion();
```

As well as make sure to have a UseRetry middleware to retry the `DbUpdateConcurrencyException`.

If this PR is accepted, I might write a bit of documentation for the RTD page to illustrate how this feature can be used.

## Unrelated Notes

Some other things I noted when I was working with these unit tests

The change you made [here](https://github.com/MassTransit/MassTransit/commit/12eaf9aed9325c301253c3637042f372e9734a59) seems to have added the explicit `Should_handle_the_big_load()` test, but if I comment out `catch (DbUpdateException ex)` in the `class EntityFrameworkSagaRepository`, the unit test still passes. So it doesn't appear to test the original intent (https://groups.google.com/d/msg/masstransit-discuss/36GzkVl3SWQ/kBRrdcjECwAJ)

Another interesting thing to note, if I remove the two spots where you lock the data (simply by passing optimistic: true), and run that test `Should_handle_the_big_load()`, then the unit test fails with an internal `EntityException (Timeout expired.. for obtaining a connection from the connection pool...)`

I think this is because the default connection pool for LocalDb (SQL Server) is 100, and the 200 is depleting all the connections from the pool. Anyways, this seems to be unrelated to the Optimistic change I made, but thought I'd let you know about it.

Thanks