### PR TITLE
Add ClusterMembers Settings to MassTransit.Host

### DIFF
--- a/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
+++ b/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Assumptions\RoutingAssumptions.cs" />
     <Compile Include="Assumptions\TransactionAssumptions.cs" />
     <Compile Include="Bytes_Specs.cs" />
+    <Compile Include="RabbitMqHostBusFactory_Specs.cs" />
     <Compile Include="ConcurrencyFilter_Specs.cs" />
     <Compile Include="Configure_Specs.cs" />
     <Compile Include="ConsumerBind_Specs.cs" />

--- a/src/MassTransit.RabbitMqTransport.Tests/RabbitMqHostBusFactory_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/RabbitMqHostBusFactory_Specs.cs
@@ -1,0 +1,116 @@
+﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.RabbitMqTransport.Tests
+{
+    using NUnit.Framework;
+    using MassTransit.Hosting;
+    using System;
+    using Hosting;
+
+    [TestFixture]
+    public class WithSettings
+    {
+        RabbitMqHostBusFactory _factory;
+        TestRabbitMqSettings _settings;
+
+        [SetUp]
+        public void Init()
+        {
+            _settings = new TestRabbitMqSettings
+            {
+                Host = "localhost"
+            };
+        }
+
+        [Test]
+        public void Should_work_with_a_single_cluster_member()
+        {
+            _settings.ClusterMembers = "cluster1";
+
+            _factory = new RabbitMqHostBusFactory(new TestSettingsProvider(_settings));
+
+            var bus = _factory.CreateBus(new TestBusServiceConfiguartor(), "UnitTest");
+
+            Assert.IsNotNull(bus);
+        }
+
+        [Test]
+        public void Should_work_with_multiple_cluster_members()
+        {
+            _settings.ClusterMembers = "cluster1,cluster2,cluster3";
+
+            _factory = new RabbitMqHostBusFactory(new TestSettingsProvider(_settings));
+
+            var bus = _factory.CreateBus(new TestBusServiceConfiguartor(), "UnitTest");
+
+            Assert.IsNotNull(bus);
+        }
+
+        [Test]
+        public void Should_work_with_null()
+        {
+            _factory = new RabbitMqHostBusFactory(new TestSettingsProvider(_settings));
+
+            var bus = _factory.CreateBus(new TestBusServiceConfiguartor(), "UnitTest");
+
+            Assert.IsNotNull(bus);
+        }
+    }
+
+    class TestSettingsProvider : ISettingsProvider
+    {
+        private RabbitMqSettings _settings;
+
+        public TestSettingsProvider(RabbitMqSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public bool TryGetSettings<T>(out T settings) where T : ISettings
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetSettings<T>(string prefix, out T settings) where T : ISettings
+        {
+            settings = (T)_settings;
+
+            return true;
+        }
+    }
+
+    class TestRabbitMqSettings : RabbitMqSettings
+    {
+        public string ClusterMembers { get; set; }
+
+        public ushort? Heartbeat { get; set; }
+
+        public string Host { get; set; }
+
+        public string Password { get; set; }
+
+        public int? Port { get; set; }
+
+        public string Username { get; set; }
+
+        public string VirtualHost { get; set; }
+    }
+
+    class TestBusServiceConfiguartor : IBusServiceConfigurator
+    {
+        public void Configure(IServiceConfigurator configurator)
+        {
+            // YAY!
+        }
+    }
+}

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqHostBusFactory.cs
@@ -36,7 +36,8 @@ namespace MassTransit.RabbitMqTransport.Hosting
                 VirtualHost = string.IsNullOrWhiteSpace(settings.VirtualHost) ? "/" : settings.VirtualHost.Trim('/'),
                 Username = settings.Username ?? "guest",
                 Password = settings.Password ?? "guest",
-                Heartbeat = settings.Heartbeat ?? 0
+                Heartbeat = settings.Heartbeat ?? 0,
+                ClusterMembers = settings.ClusterMembers?.Split(',')
             };
         }
 

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqSettings.cs
@@ -48,5 +48,10 @@ namespace MassTransit.RabbitMqTransport.Hosting
         /// The virtual host for the connection
         /// </summary>
         string VirtualHost { get; }
+
+        /// <summary>
+        /// Csv string for all Clustered Members
+        /// </summary>
+        string ClusterMembers { get; }
     }
 }


### PR DESCRIPTION
PR for #751 

Since there can be one or more clustered members, I decided to use csv string which is Split() into an array for `string[] ClusterMembers`. Hope that's okay.