### PR TITLE
Quartz Host was missing container registrations

### DIFF
--- a/src/MassTransit.Host.Quartz/QuartzModule.cs
+++ b/src/MassTransit.Host.Quartz/QuartzModule.cs
@@ -17,6 +17,7 @@ using StdSchedulerFactory = Quartz.Impl.StdSchedulerFactory;
 namespace MassTransit.Host.Quartz
 {
     using Autofac;
+    using QuartzIntegration;
     using QuartzIntegration.Configuration;
 
 
@@ -37,6 +38,12 @@ namespace MassTransit.Host.Quartz
             builder.Register(CreateScheduler)
                 .As<IScheduler>()
                 .SingleInstance();
+
+            builder.RegisterType<ScheduleMessageConsumer>()
+                .AsSelf();
+
+            builder.RegisterType<CancelScheduledMessageConsumer>()
+                .AsSelf();
         }
 
         static IScheduler CreateScheduler(IComponentContext context)


### PR DESCRIPTION
Minor sample fix.

The project for Quartz Host was missing the container registration. The host would start up fine, the error was only when I would schedule a message.

```
2017-01-12 07:47:50.232 -05:00 [ERROR][MassTransit.Messages] R-FAULT rabbitmq://localhost/dev/masstransit_quartz_scheduler N/A MassTransit.Scheduling.ScheduleMessage MassTransit.QuartzIntegration.ScheduleMessageConsumer(00:00:00.0012379) The requested service 'MassTransit.QuartzIntegration.ScheduleMessageConsumer' has not been registered. To avoid this exception, either register a component to provide the service, check for service registration using IsRegistered(), or use the ResolveOptional() method to resolve an optional dependency.
```