### PR TITLE
Fixing saga multiple requests timeout

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration.Tests/Request_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/Request_Specs.cs
@@ -178,6 +178,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         class TestState :
             SagaStateMachineInstance
         {
+            Guid? _doSomethingRequestId;
             public State CurrentState { get; set; }
 
             public string MemberNumber { get; set; }
@@ -187,6 +188,8 @@ namespace MassTransit.AutomatonymousIntegration.Tests
             public Guid? ValidateAddressRequestId { get; set; }
 
             public Guid CorrelationId { get; set; }
+
+            public Guid? DoSomethingRequestId { get; set; }
         }
 
 
@@ -265,6 +268,11 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         }
 
 
+        interface DoSomething { }
+
+        interface DoSomethingResponse { }
+
+
         class TestStateMachine :
             MassTransitStateMachine<TestState>
         {
@@ -275,6 +283,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
                     .SelectId(context => NewId.NextGuid()));
 
                 Request(() => ValidateAddress, x => x.ValidateAddressRequestId, settings);
+                Request(() => DoSomething, x => x.DoSomethingRequestId, settings);
 
                 Initially(
                     When(Register)
@@ -310,6 +319,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
             }
 
             public Request<TestState, ValidateAddress, AddressValidated> ValidateAddress { get; private set; }
+            public Request<TestState, DoSomething, DoSomethingResponse> DoSomething { get; private set; }
 
             public Event<RegisterMember> Register { get; private set; }
 

--- a/src/MassTransit.AutomatonymousIntegration/Activities/RequestActivityImpl.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Activities/RequestActivityImpl.cs
@@ -47,7 +47,7 @@ namespace Automatonymous.Activities
                 var now = DateTime.UtcNow;
                 var expirationTime = now + _request.Settings.Timeout;
 
-                RequestTimeoutExpired message = new TimeoutExpired(now, expirationTime, context.Instance.CorrelationId, pipe.RequestId);
+                RequestTimeoutExpired<TRequest> message = new TimeoutExpired<TRequest>(now, expirationTime, context.Instance.CorrelationId, pipe.RequestId);
 
                 MessageSchedulerContext schedulerContext;
                 if (_request.Settings.SchedulingServiceAddress != null)
@@ -103,8 +103,8 @@ namespace Automatonymous.Activities
         }
 
 
-        class TimeoutExpired :
-            RequestTimeoutExpired
+        class TimeoutExpired<T> :
+            RequestTimeoutExpired<T> where T : class
         {
             public TimeoutExpired(DateTime timestamp, DateTime expirationTime, Guid correlationId, Guid requestId)
             {

--- a/src/MassTransit.AutomatonymousIntegration/Events/RequestTimeoutExpired.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Events/RequestTimeoutExpired.cs
@@ -15,7 +15,7 @@ namespace Automatonymous.Events
     using System;
 
 
-    public interface RequestTimeoutExpired
+    public interface RequestTimeoutExpired<TRequest> where TRequest : class
     {
         /// <summary>
         /// The correlationId of the state machine

--- a/src/MassTransit.AutomatonymousIntegration/Request.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Request.cs
@@ -52,7 +52,7 @@ namespace Automatonymous
         /// <summary>
         /// The event raised when the request times out with no response received
         /// </summary>
-        Event<RequestTimeoutExpired> TimeoutExpired { get; set; }
+        Event<RequestTimeoutExpired<TRequest>> TimeoutExpired { get; set; }
 
         /// <summary>
         /// The state that is transitioned to once the request is pending

--- a/src/MassTransit.AutomatonymousIntegration/RequestExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/RequestExtensions.cs
@@ -21,11 +21,6 @@ namespace Automatonymous
 
     public static class RequestExtensions
     {
-        static RequestExtensions()
-        {
-            ScheduleTokenId.UseTokenId<RequestTimeoutExpired>(x => x.RequestId);
-        }
-
         /// <summary>
         /// Send a request to the configured service endpoint, and setup the state machine to accept the response.
         /// </summary>
@@ -45,6 +40,7 @@ namespace Automatonymous
             where TRequest : class
             where TResponse : class
         {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
             var activity = new RequestActivity<TInstance, TData, TRequest, TResponse>(request, messageFactory);
 
             return binder.Add(activity);
@@ -70,6 +66,7 @@ namespace Automatonymous
             where TRequest : class
             where TResponse : class
         {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
             var activity = new RequestActivity<TInstance, TData, TRequest, TResponse>(request, serviceAddressProvider, messageFactory);
 
             return binder.Add(activity);
@@ -96,6 +93,7 @@ namespace Automatonymous
             where TResponse : class
             where TException : Exception
         {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
             var activity = new FaultedRequestActivity<TInstance, TData, TException, TRequest, TResponse>(request, messageFactory);
 
             return binder.Add(activity);
@@ -124,6 +122,7 @@ namespace Automatonymous
             where TResponse : class
             where TException : Exception
         {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
             var activity = new FaultedRequestActivity<TInstance, TData, TException, TRequest, TResponse>(request, serviceAddressProvider, messageFactory);
 
             return binder.Add(activity);
@@ -146,6 +145,7 @@ namespace Automatonymous
             where TRequest : class
             where TResponse : class
         {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
             var activity = new RequestActivity<TInstance, TRequest, TResponse>(request, messageFactory);
 
             return binder.Add(activity);
@@ -169,6 +169,7 @@ namespace Automatonymous
             where TRequest : class
             where TResponse : class
         {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
             var activity = new RequestActivity<TInstance, TRequest, TResponse>(request, serviceAddressProvider, messageFactory);
 
             return binder.Add(activity);

--- a/src/MassTransit.AutomatonymousIntegration/Requests/StateMachineRequest.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Requests/StateMachineRequest.cs
@@ -42,7 +42,7 @@ namespace Automatonymous.Requests
         RequestSettings Request<TInstance, TRequest, TResponse>.Settings => _settings;
         public Event<TResponse> Completed { get; set; }
         public Event<Fault<TRequest>> Faulted { get; set; }
-        public Event<RequestTimeoutExpired> TimeoutExpired { get; set; }
+        public Event<RequestTimeoutExpired<TRequest>> TimeoutExpired { get; set; }
         public State Pending { get; set; }
 
         public void SetRequestId(TInstance instance, Guid? requestId)

--- a/src/MassTransit/Context/ScheduleTokenIdCache.cs
+++ b/src/MassTransit/Context/ScheduleTokenIdCache.cs
@@ -64,7 +64,7 @@ namespace MassTransit.Context
         internal static void UseTokenId(TokenIdSelector tokenIdSelector)
         {
             if (Cached.Metadata.IsValueCreated)
-                throw new InvalidOperationException("The correlationId pipe has already been created");
+                return;
 
             Cached.Metadata = new Lazy<IScheduleTokenIdCache<T>>(() => new ScheduleTokenIdCache<T>(tokenIdSelector));
         }


### PR DESCRIPTION
Resolves #793 but I am not sure why it was the intention to throw on duplicate correlation id pipeline for scheduled messages, I changed it to ignore but may be this conflicts with the intention.