### PR TITLE
Added ability to Remove a ConsumerConvention

### DIFF
--- a/src/MassTransit.Tests/Conventional/ConventionConsumer_Specs.cs
+++ b/src/MassTransit.Tests/Conventional/ConventionConsumer_Specs.cs
@@ -12,17 +12,30 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests.Conventional
 {
+    using System;
     using System.Threading.Tasks;
+    using ConsumeConnectors;
+    using Internals.Extensions;
     using NUnit.Framework;
     using TestFramework;
+    using Util;
 
 
     [TestFixture]
-    public class Configuring_a_consumer_by_convention :
+    public class Configuring_a_consumer_by_custom_convention :
         InMemoryTestFixture
     {
         TaskCompletionSource<MessageA> _receivedA;
         TaskCompletionSource<MessageB> _receivedB;
+
+
+        [TearDown]
+        public Task TearDown()
+        {
+            ConsumerConvention.Remove<CustomConsumerConvention>();
+            return TaskUtil.Completed;
+        }
+
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
@@ -83,6 +96,156 @@ namespace MassTransit.Tests.Conventional
 
             await _receivedA.Task;
             await _receivedB.Task;
+        }
+    }
+
+    [TestFixture]
+    public class Configuring_a_consumer_by_default_conventions :
+    InMemoryTestFixture
+    {
+        TaskCompletionSource<MessageA> _receivedA;
+        TaskCompletionSource<MessageB> _receivedB;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            base.ConfigureInMemoryReceiveEndpoint(configurator);
+
+            _receivedA = GetTask<MessageA>();
+            _receivedB = GetTask<MessageB>();
+
+            configurator.Consumer(typeof(DefaultConventionHandlers), type => new DefaultConventionHandlers(_receivedA, _receivedB));
+        }
+
+
+        class DefaultConventionHandlers :
+            IConsumer<MessageA>,
+            IMessageConsumer<MessageB>
+        {
+            readonly TaskCompletionSource<MessageA> _receivedA;
+            readonly TaskCompletionSource<MessageB> _receivedB;
+
+            public DefaultConventionHandlers(TaskCompletionSource<MessageA> receivedA, TaskCompletionSource<MessageB> receivedB)
+            {
+                _receivedA = receivedA;
+                _receivedB = receivedB;
+            }
+
+            public Task Consume(ConsumeContext<MessageA> context)
+            {
+                _receivedA.TrySetResult(context.Message);
+                return Task.FromResult(0);
+
+            }
+
+            public void Consume(MessageB message)
+            {
+                _receivedB.TrySetResult(message);
+            }
+        }
+
+
+        public interface MessageA
+        {
+            string Value { get; }
+        }
+
+
+        public interface MessageB
+        {
+            string Name { get; }
+        }
+
+
+        [Test]
+        public async Task Should_find_the_message_handlers()
+        {
+
+            await Bus.Publish<MessageA>(new { Value = "Hello" });
+            await Bus.Publish<MessageB>(new { Name = "World" });
+
+            await _receivedA.Task;
+            await _receivedB.Task;
+        }
+    }
+
+    [TestFixture]
+    public class Configuring_a_consumer_without_a_matching_convention :
+    InMemoryTestFixture
+    {
+        TaskCompletionSource<MessageA> _receivedA;
+        TaskCompletionSource<MessageB> _receivedB;
+
+
+        [TearDown]
+        public Task TearDown()
+        {
+            ConsumerConvention.Register<AsyncConsumerConvention>();
+            ConsumerConvention.Register<LegacyConsumerConvention>();
+            return TaskUtil.Completed;
+        }
+
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            base.ConfigureInMemoryReceiveEndpoint(configurator);
+
+            _receivedA = GetTask<MessageA>();
+            _receivedB = GetTask<MessageB>();
+
+            ConsumerConvention.Remove<AsyncConsumerConvention>();
+            ConsumerConvention.Remove<LegacyConsumerConvention>();
+
+            configurator.Consumer(typeof(DefaultHandlers), type => new DefaultHandlers(_receivedA, _receivedB));
+        }
+
+
+        class DefaultHandlers :
+            IConsumer<MessageA>,
+            IMessageConsumer<MessageB>
+        {
+            readonly TaskCompletionSource<MessageA> _receivedA;
+            readonly TaskCompletionSource<MessageB> _receivedB;
+
+            public DefaultHandlers(TaskCompletionSource<MessageA> receivedA, TaskCompletionSource<MessageB> receivedB)
+            {
+                _receivedA = receivedA;
+                _receivedB = receivedB;
+            }
+
+            public Task Consume(ConsumeContext<MessageA> context)
+            {
+                _receivedA.TrySetResult(context.Message);
+                return Task.FromResult(0);
+
+            }
+
+            public void Consume(MessageB message)
+            {
+                _receivedB.TrySetResult(message);
+            }
+        }
+
+
+        public interface MessageA
+        {
+            string Value { get; }
+        }
+
+
+        public interface MessageB
+        {
+            string Name { get; }
+        }
+
+
+        [Test]
+        public async Task Should_not_find_the_message_handlers()
+        {
+            await Bus.Publish<MessageA>(new { Value = "Hello" });
+            await Bus.Publish<MessageB>(new { Name = "World" });
+
+            Assert.That(async () => await _receivedA.Task.WithTimeout(TimeSpan.FromSeconds(3)), Throws.TypeOf<TaskCanceledException>());
+            Assert.That(async () => await _receivedB.Task.WithTimeout(TimeSpan.FromSeconds(3)), Throws.TypeOf<TaskCanceledException>());
         }
     }
 }

--- a/src/MassTransit/Configuration/ConsumeConnectors/ConsumerConventionCache.cs
+++ b/src/MassTransit/Configuration/ConsumeConnectors/ConsumerConventionCache.cs
@@ -15,12 +15,23 @@ namespace MassTransit.ConsumeConnectors
     using System.Collections.Concurrent;
     using System.Collections.Generic;
 
-
     public static class ConsumerConventionCache
     {
+        static ConsumerConventionCache()
+        {
+            ConsumerConvention.Register<AsyncConsumerConvention>();
+            ConsumerConvention.Register<LegacyConsumerConvention>();
+        }
+
         public static void Add(string conventionName, IConsumerConvention convention)
         {
             Cached.Instance.AddOrUpdate(conventionName, add => convention, (_, update) => convention);
+        }
+
+        public static void Remove(string conventionName)
+        {
+            IConsumerConvention _;
+            Cached.Instance.TryRemove(conventionName, out _);
         }
 
         /// <summary>
@@ -31,9 +42,6 @@ namespace MassTransit.ConsumeConnectors
         public static IEnumerable<IConsumerMessageConvention> GetConventions<T>()
             where T : class
         {
-            yield return new AsyncConsumerMessageConvention<T>();
-            yield return new LegacyConsumerMessageConvention<T>();
-
             foreach (var convention in Cached.Instance.Values)
             {
                 yield return convention.GetConsumerMessageConvention<T>();

--- a/src/MassTransit/Configuration/ConsumerConvention.cs
+++ b/src/MassTransit/Configuration/ConsumerConvention.cs
@@ -46,5 +46,15 @@ namespace MassTransit
 
             ConsumerConventionCache.Add(TypeMetadataCache<T>.ShortName, convention);
         }
+
+        /// <summary>
+        /// Remove a consumer convention used for finding message types
+        /// </summary>
+        /// <typeparam name="T">The convention type to remove</typeparam>
+        public static void Remove<T>()
+            where T : IConsumerConvention
+        {
+            ConsumerConventionCache.Remove(TypeMetadataCache<T>.ShortName);
+        }
     }
 }


### PR DESCRIPTION
Adding a custom consumer convention, we'd like to be able to remove the default consumer conventions. In order to remove the ability to accidentally implement the default interfaces.