### PR TITLE
Change ReceivedEndpointLoggingExtensions to log passing the exception along

### DIFF
--- a/src/MassTransit/Transports/ReceiveEndpointLoggingExtensions.cs
+++ b/src/MassTransit/Transports/ReceiveEndpointLoggingExtensions.cs
@@ -61,10 +61,9 @@ namespace MassTransit.Transports
         {
             if (_messages.IsErrorEnabled)
             {
-                var faultMessage = GetFaultMessage(exception);
-
                 _messages.Error(
-                    $"R-FAULT {context.ReceiveContext.InputAddress} {GetMessageId(context.ReceiveContext)} {TypeMetadataCache<T>.ShortName} {consumerType}({duration}) {faultMessage}");
+                    $"R-FAULT {context.ReceiveContext.InputAddress} {GetMessageId(context.ReceiveContext)} {TypeMetadataCache<T>.ShortName} {consumerType}({duration})",
+                    exception);
             }
         }
 
@@ -72,9 +71,7 @@ namespace MassTransit.Transports
         {
             if (_messages.IsWarnEnabled)
             {
-                var faultMessage = GetFaultMessage(exception);
-
-                _messages.Warn($"R-RETRY {context.ReceiveContext.InputAddress} {GetMessageId(context.ReceiveContext)} {faultMessage}");
+                _messages.Warn($"R-RETRY {context.ReceiveContext.InputAddress} {GetMessageId(context.ReceiveContext)}", exception);
             }
         }
 
@@ -83,9 +80,7 @@ namespace MassTransit.Transports
         {
             if (_messages.IsWarnEnabled)
             {
-                var faultMessage = GetFaultMessage(exception);
-
-                _messages.Warn($"S-FAULT {context.DestinationAddress} {context.MessageId} {TypeMetadataCache<T>.ShortName} {faultMessage}");
+                _messages.Warn($"S-FAULT {context.DestinationAddress} {context.MessageId} {TypeMetadataCache<T>.ShortName}", exception);
             }
         }
 
@@ -102,13 +97,6 @@ namespace MassTransit.Transports
             if (_messages.IsDebugEnabled)
                 _messages.Debug(
                     $"SCHED {context.DestinationAddress} {context.MessageId} {TypeMetadataCache<T>.ShortName} {deliveryTime:G} {context.ScheduledMessageId?.ToString("N") ?? ""}");
-        }
-
-        static string GetFaultMessage(Exception exception)
-        {
-            var baseException = exception.GetBaseException() ?? exception;
-
-            return ExceptionUtil.GetMessage(baseException);
         }
     }
 }


### PR DESCRIPTION
Change ReceivedEndpointLoggingExtensions to log passing the exception along instead of formating inside text string. This is related to issue #871 