### PR TITLE
Fix when on RabbitMQ transport headers missing (Issue #884)

### DIFF
--- a/src/MassTransit.RabbitMqTransport/Transport/RabbitMqSendTransport.cs
+++ b/src/MassTransit.RabbitMqTransport/Transport/RabbitMqSendTransport.cs
@@ -66,6 +66,8 @@ namespace MassTransit.RabbitMqTransport.Transport
                     {
                         await pipe.Send(context).ConfigureAwait(false);
 
+                        var body = context.Body;
+
                         PublishContext publishContext;
                         if (context.TryGetPayload(out publishContext))
                             context.Mandatory = context.Mandatory || publishContext.Mandatory;
@@ -103,7 +105,7 @@ namespace MassTransit.RabbitMqTransport.Transport
                         await _observers.PreSend(context).ConfigureAwait(false);
 
                         await modelContext.BasicPublishAsync(context.Exchange, context.RoutingKey, context.Mandatory,
-                            context.BasicProperties, context.Body, context.AwaitAck).ConfigureAwait(false);
+                            context.BasicProperties, body, context.AwaitAck).ConfigureAwait(false);
 
                         context.LogSent();
 


### PR DESCRIPTION
Fix for issue #884 

When using RabbitMQ the custom serializer ran only when requesting the context.Body, so the custom transport headers were not populated in time. The Azure service bus implementation worked because the body stream was requested before populating the header collection. 