### PR TITLE
Adding TurnoutEndpoint to IServiceConfigurator

### DIFF
--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusServiceConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusServiceConfigurator.cs
@@ -20,6 +20,7 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
     using MassTransit.Hosting;
     using MassTransit.Saga;
     using MassTransit.Saga.SubscriptionConfigurators;
+    using Turnout.Configuration;
 
 
     /// <summary>
@@ -47,6 +48,12 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
 
                 configureEndpoint(x);
             });
+        }
+
+        public void TurnoutEndpoint<T>(string queueName, Action<ITurnoutServiceConfigurator<T>> configureTurnout)
+            where T : class
+        {
+            _configurator.TurnoutEndpoint(_host, queueName, configureTurnout);
         }
 
         public void AddPipeSpecification(IPipeSpecification<ConsumeContext> specification)

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqServiceConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqServiceConfigurator.cs
@@ -20,6 +20,7 @@ namespace MassTransit.RabbitMqTransport.Hosting
     using MassTransit.Hosting;
     using Saga;
     using Saga.SubscriptionConfigurators;
+    using Turnout.Configuration;
 
 
     /// <summary>
@@ -47,6 +48,12 @@ namespace MassTransit.RabbitMqTransport.Hosting
 
                 configureEndpoint(x);
             });
+        }
+
+        public void TurnoutEndpoint<T>(string queueName, Action<ITurnoutServiceConfigurator<T>> configureTurnout)
+            where T : class
+        {
+            _configurator.TurnoutEndpoint(_host, queueName, configureTurnout);
         }
 
         public void AddPipeSpecification(IPipeSpecification<ConsumeContext> specification)

--- a/src/MassTransit/Hosting/IServiceConfigurator.cs
+++ b/src/MassTransit/Hosting/IServiceConfigurator.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.Hosting
 {
     using System;
+    using Turnout.Configuration;
 
 
     /// <summary>
@@ -22,5 +23,9 @@ namespace MassTransit.Hosting
         IBusFactoryConfigurator
     {
         void ReceiveEndpoint(string queueName, int consumerLimit, Action<IReceiveEndpointConfigurator> configureEndpoint);
+
+        void TurnoutEndpoint<T>(string queueName, Action<ITurnoutServiceConfigurator<T>> configureTurnout)
+            where T : class;
+
     }
 }


### PR DESCRIPTION
This is my very first contribution and Pull Request to the Open Source Community, so I apologize ahead of time if I make a mistake or don't follow the correct procedures.

To maintain consistency with the existing `IServiceConfigurator` abstraction layer, I would like to propose to add the `TurnoutEndpoint` method to this interface. This would allow developers to configure their usual endpoints with the added ability to also configure turnouts for long running tasks.

Both the Azure and RabbitMq transports support this method so the code changes are minimal.

I assumed that `IServiceConfigurator` was the correct place to add this function. Let me know what you think?

Thank you,
Marcin