### PR TITLE
Changing System.Type calls to use TypeInfo

### DIFF
--- a/src/Containers/MassTransit.Containers.Tests/AutofacStateMachineSaga_Specs.cs
+++ b/src/Containers/MassTransit.Containers.Tests/AutofacStateMachineSaga_Specs.cs
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Containers.Tests
 {
+    using System.Reflection;
     using System.Threading.Tasks;
     using Autofac;
     using NUnit.Framework;
@@ -50,7 +51,7 @@ namespace MassTransit.Containers.Tests
 
             builder.RegisterType<PublishTestStartedActivity>();
 
-            builder.RegisterStateMachineSagas(typeof(TestStateMachineSaga).Assembly);
+            builder.RegisterStateMachineSagas(typeof(TestStateMachineSaga).GetTypeInfo().Assembly);
 
             _container = builder.Build();
 

--- a/src/MassTransit.AutomatonymousIntegration/MassTransitStateMachine.cs
+++ b/src/MassTransit.AutomatonymousIntegration/MassTransitStateMachine.cs
@@ -375,26 +375,27 @@ namespace Automatonymous
 
             foreach (var propertyInfo in properties)
             {
-                if (propertyInfo.PropertyType.IsGenericType)
+                var propertyTypeInfo = propertyInfo.PropertyType.GetTypeInfo();
+                if (!propertyTypeInfo.IsGenericType)
+                    continue;
+
+                if (propertyTypeInfo.GetGenericTypeDefinition() != typeof(Event<>))
+                    continue;
+
+                var messageTypeInfo = propertyTypeInfo.GetGenericArguments().First().GetTypeInfo();
+                if (messageTypeInfo.HasInterface<CorrelatedBy<Guid>>())
                 {
-                    if (propertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Event<>))
-                    {
-                        var messageType = propertyInfo.PropertyType.GetGenericArguments().First();
-                        if (messageType.HasInterface<CorrelatedBy<Guid>>())
-                        {
-                            var declarationType = typeof(CorrelatedEventRegistration<,>).MakeGenericType(typeof(TInstance), machineType,
-                                messageType);
-                            var declaration = Activator.CreateInstance(declarationType, propertyInfo);
-                            events.Add((StateMachineRegistration)declaration);
-                        }
-                        else
-                        {
-                            var declarationType = typeof(UncorrelatedEventRegistration<,>).MakeGenericType(typeof(TInstance), machineType,
-                                messageType);
-                            var declaration = Activator.CreateInstance(declarationType, propertyInfo);
-                            events.Add((StateMachineRegistration)declaration);
-                        }
-                    }
+                    var declarationType = typeof(CorrelatedEventRegistration<,>).MakeGenericType(typeof(TInstance), machineType,
+                        messageTypeInfo.AsType());
+                    var declaration = Activator.CreateInstance(declarationType, propertyInfo);
+                    events.Add((StateMachineRegistration)declaration);
+                }
+                else
+                {
+                    var declarationType = typeof(UncorrelatedEventRegistration<,>).MakeGenericType(typeof(TInstance), machineType,
+                        messageTypeInfo.AsType());
+                    var declaration = Activator.CreateInstance(declarationType, propertyInfo);
+                    events.Add((StateMachineRegistration)declaration);
                 }
             }
 

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/ServiceBusTopicSubscriptionExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/ServiceBusTopicSubscriptionExtensions.cs
@@ -15,6 +15,7 @@ namespace MassTransit.AzureServiceBusTransport
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using Microsoft.ServiceBus.Messaging;
     using Newtonsoft.Json.Linq;
     using Settings;
@@ -28,7 +29,7 @@ namespace MassTransit.AzureServiceBusTransport
             if (!IsSubscriptionMessageType(messageType))
                 yield break;
 
-            var temporary = IsTemporaryMessageType(messageType);
+            var temporary = IsTemporaryMessageType(messageType.GetTypeInfo());
 
             var topicDescription = Defaults.CreateTopicDescription(messageNameFormatter.GetMessageName(messageType).ToString());
             topicDescription.EnableExpress = temporary;
@@ -58,10 +59,10 @@ namespace MassTransit.AzureServiceBusTransport
             return builder.Uri;
         }
 
-        static bool IsTemporaryMessageType(this Type messageType)
+        static bool IsTemporaryMessageType(this TypeInfo messageTypeInfo)
         {
-            return (!messageType.IsVisible && messageType.IsClass)
-                || (messageType.IsGenericType && messageType.GetGenericArguments().Any(IsTemporaryMessageType));
+            return (!messageTypeInfo.IsVisible && messageTypeInfo.IsClass)
+                || (messageTypeInfo.IsGenericType && messageTypeInfo.GetGenericArguments().Any(x => IsTemporaryMessageType(x.GetTypeInfo())));
         }
 
 

--- a/src/MassTransit.HttpTransport/Clients/HttpSendTransport.cs
+++ b/src/MassTransit.HttpTransport/Clients/HttpSendTransport.cs
@@ -35,7 +35,7 @@ namespace MassTransit.HttpTransport.Clients
     {
         static readonly ILog _log = Logger.Get<HttpSendTransport>();
 
-        static readonly string Version = GetAssemblyFileVersion(typeof(IBusControl).Assembly);
+        static readonly string Version = GetAssemblyFileVersion(typeof(IBusControl).GetTypeInfo().Assembly);
         readonly ClientCache _clientCache;
         readonly SendObservable _observers;
         readonly IReceiveObserver _receiveObserver;

--- a/src/MassTransit.RabbitMqTransport/Topology/RabbitMqExchangeBindingExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/RabbitMqExchangeBindingExtensions.cs
@@ -15,6 +15,7 @@ namespace MassTransit.RabbitMqTransport.Topology
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
 
 
     public static class RabbitMqExchangeBindingExtensions
@@ -28,10 +29,10 @@ namespace MassTransit.RabbitMqTransport.Topology
             return binding;
         }
 
-        public static bool IsTemporaryMessageType(this Type messageType)
+        public static bool IsTemporaryMessageType(this TypeInfo messageTypeInfo)
         {
-            return (!messageType.IsVisible && messageType.IsClass)
-                || (messageType.IsGenericType && messageType.GetGenericArguments().Any(IsTemporaryMessageType));
+            return (!messageTypeInfo.IsVisible && messageTypeInfo.IsClass)
+                || (messageTypeInfo.IsGenericType && messageTypeInfo.GetGenericArguments().Any(x => IsTemporaryMessageType(x.GetTypeInfo())));
         }
 
 

--- a/src/MassTransit.RabbitMqTransport/Topology/RabbitMqTopology.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/RabbitMqTopology.cs
@@ -14,6 +14,7 @@ namespace MassTransit.RabbitMqTransport.Topology
 {
     using System;
     using System.Net;
+    using System.Reflection;
     using System.Text;
     using System.Text.RegularExpressions;
     using NewIdFormatters;
@@ -108,7 +109,7 @@ namespace MassTransit.RabbitMqTransport.Topology
 
         public Uri GetDestinationAddress(Type messageType, Action<IExchangeConfigurator> configure = null)
         {
-            var isTemporary = messageType.IsTemporaryMessageType();
+            var isTemporary = messageType.GetTypeInfo().IsTemporaryMessageType();
 
             var durable = !isTemporary;
             var autoDelete = isTemporary;

--- a/src/MassTransit.Tests/Conventional/CustomConsumerMessageConvention.cs
+++ b/src/MassTransit.Tests/Conventional/CustomConsumerMessageConvention.cs
@@ -14,6 +14,7 @@ namespace MassTransit.Tests.Conventional
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
 
 
     class CustomConsumerMessageConvention<T> :
@@ -22,18 +23,19 @@ namespace MassTransit.Tests.Conventional
     {
         public IEnumerable<IMessageInterfaceType> GetMessageTypes()
         {
-            if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(IHandler<>))
+            var typeInfo = typeof(T).GetTypeInfo();
+            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(IHandler<>))
             {
-                var interfaceType = new CustomConsumerInterfaceType(typeof(T).GetGenericArguments()[0], typeof(T));
-                if (interfaceType.MessageType.IsValueType == false && interfaceType.MessageType != typeof(string))
+                var interfaceType = new CustomConsumerInterfaceType(typeInfo.GetGenericArguments()[0], typeof(T));
+                if (interfaceType.MessageType.GetTypeInfo().IsValueType == false && interfaceType.MessageType != typeof(string))
                     yield return interfaceType;
             }
 
             IEnumerable<CustomConsumerInterfaceType> types = typeof(T).GetInterfaces()
-                .Where(x => x.IsGenericType)
-                .Where(x => x.GetGenericTypeDefinition() == typeof(IHandler<>))
-                .Select(x => new CustomConsumerInterfaceType(x.GetGenericArguments()[0], typeof(T)))
-                .Where(x => x.MessageType.IsValueType == false && x.MessageType != typeof(string));
+                .Where(x => x.GetTypeInfo().IsGenericType)
+                .Where(x => x.GetTypeInfo().GetGenericTypeDefinition() == typeof(IHandler<>))
+                .Select(x => new CustomConsumerInterfaceType(x.GetTypeInfo().GetGenericArguments()[0], typeof(T)))
+                .Where(x => x.MessageType.GetTypeInfo().IsValueType == false && x.MessageType != typeof(string));
 
             foreach (CustomConsumerInterfaceType type in types)
                 yield return type;

--- a/src/MassTransit/Configuration/ConsumeConnectors/AsyncConsumerMessageConvention.cs
+++ b/src/MassTransit/Configuration/ConsumeConnectors/AsyncConsumerMessageConvention.cs
@@ -14,6 +14,8 @@ namespace MassTransit.ConsumeConnectors
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
+
 
     /// <summary>
     /// A default convention that looks for IConsumerOfT message types
@@ -25,18 +27,19 @@ namespace MassTransit.ConsumeConnectors
     {
         public IEnumerable<IMessageInterfaceType> GetMessageTypes()
         {
-            if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(IConsumer<>))
+            var typeInfo = typeof(T).GetTypeInfo();
+            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(IConsumer<>))
             {
                 var interfaceType = new ConsumerInterfaceType(typeof(T).GetGenericArguments()[0], typeof(T));
-                if (interfaceType.MessageType.IsValueType == false && interfaceType.MessageType != typeof(string))
+                if (interfaceType.MessageType.GetTypeInfo().IsValueType == false && interfaceType.MessageType != typeof(string))
                     yield return interfaceType;
             }
 
             IEnumerable<IMessageInterfaceType> types = typeof(T).GetInterfaces()
-                .Where(x => x.IsGenericType)
+                .Where(x => x.GetTypeInfo().IsGenericType)
                 .Where(x => x.GetGenericTypeDefinition() == typeof(IConsumer<>))
                 .Select(x => new ConsumerInterfaceType(x.GetGenericArguments()[0], typeof(T)))
-                .Where(x => x.MessageType.IsValueType == false && x.MessageType != typeof(string));
+                .Where(x => x.MessageType.GetTypeInfo().IsValueType == false && x.MessageType != typeof(string));
 
             foreach (IMessageInterfaceType type in types)
                 yield return type;

--- a/src/MassTransit/Configuration/ConsumeConnectors/LegacyConsumerMessageConvention.cs
+++ b/src/MassTransit/Configuration/ConsumeConnectors/LegacyConsumerMessageConvention.cs
@@ -14,6 +14,7 @@ namespace MassTransit.ConsumeConnectors
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
 
 
     /// <summary>
@@ -26,18 +27,18 @@ namespace MassTransit.ConsumeConnectors
     {
         public IEnumerable<IMessageInterfaceType> GetMessageTypes()
         {
-            if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(IMessageConsumer<>))
+            if (typeof(T).GetTypeInfo().IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(IMessageConsumer<>))
             {
                 var interfaceType = new LegacyConsumerInterfaceType(typeof(T).GetGenericArguments()[0], typeof(T));
-                if (interfaceType.MessageType.IsValueType == false && interfaceType.MessageType != typeof(string))
+                if (interfaceType.MessageType.GetTypeInfo().IsValueType == false && interfaceType.MessageType != typeof(string))
                     yield return interfaceType;
             }
 
             IEnumerable<LegacyConsumerInterfaceType> types = typeof(T).GetInterfaces()
-                .Where(x => x.IsGenericType)
+                .Where(x => x.GetTypeInfo().IsGenericType)
                 .Where(x => x.GetGenericTypeDefinition() == typeof(IMessageConsumer<>))
                 .Select(x => new LegacyConsumerInterfaceType(x.GetGenericArguments()[0], typeof(T)))
-                .Where(x => x.MessageType.IsValueType == false && x.MessageType != typeof(string));
+                .Where(x => x.MessageType.GetTypeInfo().IsValueType == false && x.MessageType != typeof(string));
 
             foreach (LegacyConsumerInterfaceType type in types)
                 yield return type;

--- a/src/MassTransit/MessageUrn.cs
+++ b/src/MassTransit/MessageUrn.cs
@@ -15,6 +15,7 @@ namespace MassTransit
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Runtime.Serialization;
     using System.Text;
 
@@ -94,26 +95,27 @@ namespace MassTransit
 
 		static string GetMessageName(StringBuilder sb, Type type, bool includeScope)
 		{
-            if (type.IsGenericParameter)
+		    var typeInfo = type.GetTypeInfo();
+            if (typeInfo.IsGenericParameter)
                 return "";
 
-			if (includeScope && type.Namespace != null)
+			if (includeScope && typeInfo.Namespace != null)
 			{
-				string ns = type.Namespace;
+				string ns = typeInfo.Namespace;
 				sb.Append(ns);
 
 				sb.Append(':');
 			}
 
-			if (type.IsNested)
+			if (typeInfo.IsNested)
 			{
-				GetMessageName(sb, type.DeclaringType, false);
+				GetMessageName(sb, typeInfo.DeclaringType, false);
 				sb.Append('+');
 			}
 
-			if (type.IsGenericType)
+			if (typeInfo.IsGenericType)
 			{
-			    var name = type.GetGenericTypeDefinition().Name;
+			    var name = typeInfo.GetGenericTypeDefinition().Name;
 
                 //remove `1
 			    int index = name.IndexOf('`');
@@ -124,7 +126,7 @@ namespace MassTransit
 			    sb.Append(name);
 				sb.Append('[');
 
-				Type[] arguments = type.GetGenericArguments();
+				Type[] arguments = typeInfo.GetGenericArguments();
 				for (int i = 0; i < arguments.Length; i++)
 				{
 					if (i > 0)
@@ -138,7 +140,7 @@ namespace MassTransit
 				sb.Append(']');
 			}
 			else
-				sb.Append(type.Name);
+				sb.Append(typeInfo.Name);
 
 			return sb.ToString();
 		}

--- a/src/MassTransit/Saga/SagaMetadataCache.cs
+++ b/src/MassTransit/Saga/SagaMetadataCache.cs
@@ -15,6 +15,7 @@ namespace MassTransit.Saga
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
@@ -134,7 +135,7 @@ namespace MassTransit.Saga
         static IEnumerable<SagaInterfaceType> GetInitiatingTypes()
         {
             return typeof(TSaga).GetInterfaces()
-                .Where(x => x.IsGenericType)
+                .Where(x => x.GetTypeInfo().IsGenericType)
                 .Where(x => x.GetGenericTypeDefinition() == typeof(InitiatedBy<>))
                 .Select(x => new SagaInterfaceType(x, x.GetGenericArguments()[0], typeof(TSaga)))
                 .Where(x => x.MessageType.IsValueType == false && x.MessageType != typeof(string));
@@ -143,7 +144,7 @@ namespace MassTransit.Saga
         static IEnumerable<SagaInterfaceType> GetOrchestratingTypes()
         {
             return typeof(TSaga).GetInterfaces()
-                .Where(x => x.IsGenericType)
+                .Where(x => x.GetTypeInfo().IsGenericType)
                 .Where(x => x.GetGenericTypeDefinition() == typeof(Orchestrates<>))
                 .Select(x => new SagaInterfaceType(x, x.GetGenericArguments()[0], typeof(TSaga)))
                 .Where(x => x.MessageType.IsValueType == false && x.MessageType != typeof(string));
@@ -152,7 +153,7 @@ namespace MassTransit.Saga
         static IEnumerable<SagaInterfaceType> GetObservingTypes()
         {
             return typeof(TSaga).GetInterfaces()
-                .Where(x => x.IsGenericType)
+                .Where(x => x.GetTypeInfo().IsGenericType)
                 .Where(x => x.GetGenericTypeDefinition() == typeof(Observes<,>))
                 .Select(x => new SagaInterfaceType(x, x.GetGenericArguments()[0], typeof(TSaga)))
                 .Where(x => x.MessageType.IsValueType == false && x.MessageType != typeof(string));

--- a/src/MassTransit/Scheduling/DefaultRecurringSchedule.cs
+++ b/src/MassTransit/Scheduling/DefaultRecurringSchedule.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.Scheduling
 {
     using System;
+    using System.Reflection;
     using Util;
 
 
@@ -21,7 +22,7 @@ namespace MassTransit.Scheduling
         protected DefaultRecurringSchedule()
         {
             ScheduleId = TypeMetadataCache.GetShortName(GetType());
-            ScheduleGroup = GetType().Assembly.FullName.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)[0];
+            ScheduleGroup = GetType().GetTypeInfo().Assembly.FullName.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)[0];
 
             TimeZoneId = TimeZoneInfo.Local.Id;
             StartTime = DateTime.Now;

--- a/src/MassTransit/Serialization/BinaryMessageSerializer.cs
+++ b/src/MassTransit/Serialization/BinaryMessageSerializer.cs
@@ -16,6 +16,7 @@ namespace MassTransit.Serialization
     using System.Collections.Generic;
     using System.IO;
     using System.Net.Mime;
+    using System.Reflection;
     using System.Runtime.Remoting.Messaging;
     using System.Runtime.Serialization.Formatters.Binary;
     using Util;
@@ -52,7 +53,7 @@ namespace MassTransit.Serialization
             if (message == null)
                 throw new ArgumentNullException(nameof(context), "The message must not be null");
 
-            Type t = message.GetType();
+            Type t = message.GetType().GetTypeInfo();
             if (!t.IsSerializable)
             {
                 throw new ConventionException(

--- a/src/MassTransit/Serialization/JsonConverters/ListJsonConverter.cs
+++ b/src/MassTransit/Serialization/JsonConverters/ListJsonConverter.cs
@@ -15,6 +15,7 @@ namespace MassTransit.Serialization.JsonConverters
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Reflection;
     using Internals.Extensions;
     using Newtonsoft.Json;
 
@@ -45,18 +46,19 @@ namespace MassTransit.Serialization.JsonConverters
 
         public override bool CanConvert(Type objectType)
         {
-            if (objectType.IsArray)
+            var typeInfo = objectType.GetTypeInfo();
+            if (typeInfo.IsArray)
             {
-                if (objectType.HasElementType && objectType.GetElementType() == typeof(byte))
+                if (typeInfo.HasElementType && typeInfo.GetElementType() == typeof(byte))
                     return false;
 
-                return objectType.HasInterface<IEnumerable>();
+                return typeInfo.HasInterface<IEnumerable>();
             }
 
-            if (objectType.IsGenericType)
+            if (typeInfo.IsGenericType)
             {
-                Type definition = objectType.GetGenericTypeDefinition();
-                if ((definition == typeof(IList<>) || definition == typeof(List<>) || definition == typeof(IEnumerable<>)))
+                Type definition = typeInfo.GetGenericTypeDefinition();
+                if (definition == typeof(IList<>) || definition == typeof(List<>) || definition == typeof(IEnumerable<>))
                     return true;
             }
 

--- a/src/MassTransit/Util/BusHostInfo.cs
+++ b/src/MassTransit/Util/BusHostInfo.cs
@@ -29,7 +29,7 @@ namespace MassTransit.Util
         {
             MachineName = Environment.MachineName;
 
-            MassTransitVersion = GetAssemblyInformationalVersion(typeof(IBus).Assembly);
+            MassTransitVersion = GetAssemblyInformationalVersion(typeof(IBus).GetTypeInfo().Assembly);
             FrameworkVersion = Environment.Version.ToString();
             OperatingSystemVersion = Environment.OSVersion.ToString();
             var currentProcess = Process.GetCurrentProcess();

--- a/src/MassTransit/Util/Scanning/AssemblyScanner.cs
+++ b/src/MassTransit/Util/Scanning/AssemblyScanner.cs
@@ -20,6 +20,7 @@ namespace MassTransit.Util.Scanning
     using System.Threading.Tasks;
     using Internals.Extensions;
 
+
     public class AssemblyScanner :
         IAssemblyScanner
     {
@@ -39,7 +40,7 @@ namespace MassTransit.Util.Scanning
 
         public void Assembly(string assemblyName)
         {
-            Assembly(System.Reflection.Assembly.Load(assemblyName));
+            Assembly(System.Reflection.Assembly.Load(new AssemblyName(assemblyName)));
         }
 
         public void AssemblyContainingType<T>()
@@ -209,22 +210,19 @@ namespace MassTransit.Util.Scanning
         {
             var trace = new StackTrace(false);
 
-            var thisAssembly = System.Reflection.Assembly.GetExecutingAssembly();
-            var mtAssembly = typeof(IBus).Assembly;
+            var thisAssembly = typeof(AssemblyScanner).GetTypeInfo().Assembly;
+            var mtAssembly = typeof(IBus).GetTypeInfo().Assembly;
 
             Assembly callingAssembly = null;
             for (var i = 0; i < trace.FrameCount; i++)
             {
                 var frame = trace.GetFrame(i);
-                var declaringType = frame.GetMethod().DeclaringType;
-                if (declaringType != null)
+                var assembly = frame.GetMethod().DeclaringType?.GetTypeInfo()?.Assembly;
+
+                if (assembly != null && assembly != thisAssembly && assembly != mtAssembly)
                 {
-                    var assembly = declaringType.Assembly;
-                    if (assembly != thisAssembly && assembly != mtAssembly)
-                    {
-                        callingAssembly = assembly;
-                        break;
-                    }
+                    callingAssembly = assembly;
+                    break;
                 }
             }
             return callingAssembly;

--- a/src/Persistence/MassTransit.MongoDbIntegration/MassTransitMongoDbConventions.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MassTransitMongoDbConventions.cs
@@ -14,6 +14,7 @@ namespace MassTransit.MongoDbIntegration
 {
     using System;
     using System.Linq.Expressions;
+    using System.Reflection;
     using Courier;
     using Courier.Documents;
     using Courier.Events;
@@ -61,7 +62,7 @@ namespace MassTransit.MongoDbIntegration
 
         static bool IsSagaClass(Type type)
         {
-            return type.IsClass && typeof(IVersionedSaga).IsAssignableFrom(type);
+            return type.GetTypeInfo().IsClass && typeof(IVersionedSaga).IsAssignableFrom(type);
         }
 
         public void RegisterClass<T>(Expression<Func<T, Guid>> id)


### PR DESCRIPTION
New code in MT repo uses the `TypeInfo` to get type information. Microsoft API compatibility checker advises to use that type as well. So I changed all suggested calls to use `TypeInfo` instead of `Type`.