### PR TITLE
.net standard support to SimpleInjector, Reactive, TestFramework

### DIFF
--- a/src/Containers/MassTransit.SimpleInjectorIntegration/MassTransit.SimpleInjectorIntegration.csproj
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/MassTransit.SimpleInjectorIntegration.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
     <DebugType>portable</DebugType>
@@ -14,8 +15,6 @@
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="SimpleInjector" Version="4.0.7" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
 	<ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MassTransit.Reactive/MassTransit.Reactive.csproj
+++ b/src/MassTransit.Reactive/MassTransit.Reactive.csproj
@@ -1,42 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>1587,1591,1998,3008,3001</NoWarn>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\Release\MassTransit.Reactive.XML</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
-	<AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-	<ProjectReference Include="..\MassTransit\MassTransit.csproj" />
+	  <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MassTransit.TestFramework/IntentionalTestException.cs
+++ b/src/MassTransit.TestFramework/IntentionalTestException.cs
@@ -38,9 +38,12 @@ namespace MassTransit.TestFramework
         {
         }
 
+
+#if !NETCORE
         protected IntentionalTestException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
+++ b/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
@@ -1,61 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>1587,1591,1998,3008,3001</NoWarn>
-    <DocumentationFile>
-    </DocumentationFile>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\MassTransit.TestFramework.XML</DocumentationFile>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>1587,1591,1998,3008,3001</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworks>netstandard1.6;net452</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.xml</DocumentationFile>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="NUnit" Version="3.6.1" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-	<ProjectReference Include="..\MassTransit\MassTransit.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
+	  <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MassTransit.TestFramework/SerializerCache.cs
+++ b/src/MassTransit.TestFramework/SerializerCache.cs
@@ -14,6 +14,7 @@ namespace MassTransit.TestFramework
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
     using System.Threading;
     using GreenPipes.Internals.Extensions;
     using GreenPipes.Internals.Reflection;
@@ -78,7 +79,7 @@ namespace MassTransit.TestFramework
 
             public override bool CanConvert(Type objectType)
             {
-                return objectType.IsInterface;
+                return objectType.GetTypeInfo().IsInterface;
             }
         }
     }

--- a/src/MassTransit.TestFramework/TestConsumeContext.cs
+++ b/src/MassTransit.TestFramework/TestConsumeContext.cs
@@ -16,6 +16,7 @@ namespace MassTransit.TestFramework
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using Context;
@@ -186,7 +187,7 @@ namespace MassTransit.TestFramework
 
         public bool HasMessageType(Type messageType)
         {
-            return messageType.IsAssignableFrom(typeof(TMessage));
+            return messageType.GetTypeInfo().IsAssignableFrom(typeof(TMessage));
         }
 
         public bool TryGetMessage<T>(out ConsumeContext<T> consumeContext)

--- a/src/MassTransit.TestFramework/TestSymmetricKeyProvider.cs
+++ b/src/MassTransit.TestFramework/TestSymmetricKeyProvider.cs
@@ -35,15 +35,13 @@ namespace MassTransit.TestFramework
                 byte[] key;
                 byte[] iv;
 
-                using (var provider = new AesCryptoServiceProvider())
+                using (var aes = Aes.Create())
                 {
-                    provider.GenerateIV();
-                    provider.GenerateKey();
+                    aes.GenerateKey();
+                    aes.GenerateIV();
 
-                    key = provider.Key;
-                    iv = provider.IV;
-
-                    provider.Clear();
+                    key = aes.Key;
+                    iv = aes.IV;
                 }
 
                 _keys.Add(id, new TestSymmetricKey(key, iv));


### PR DESCRIPTION
These changes add support for .net standard 1.6 to following projects, as discussed in #909 

- MassTransit.SimpleInjectorIntegration
- MassTransit.Reactive
- MassTransit.TestFramework

Test project for reactive MassTransit.Reactive.Tests can also be easily ported, but that requires 
[referencing NUnit3TestAdapter version 3.8](http://www.alteridem.net/2017/05/04/test-net-core-nunit-vs2017/), which is still in alpha state. 
