### PR TITLE
add ef core support for saga persistence

### DIFF
--- a/!i
+++ b/!i
@@ -1,0 +1,497 @@
+[33mcommit 239516a572a854f72c202b8f7997efdbd6cb854e[m
+Author: clintcparker <clintcparker@gmail.com>
+Date:   Tue Jun 27 13:44:10 2017 -0700
+
+    Fixed various typos in docs
+
+[33mcommit aeffe4bf20f8e7db937925a704cc2abe3976d018[m
+Author: Aarron Szalacinski <aarron.szalacinski@callminer.com>
+Date:   Wed Jun 28 14:48:53 2017 -0400
+
+    Fixes dotnet core dependency injection implementation; cleans up implementation API to minimize code needed to wire up a Consumer service; it should be noted that the Saga functionality needs to be revisited as I have never worked with that part of the API.
+
+[33mcommit 511d1ef97a0c31067caba1872a817224a1e4ce28[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Tue Jun 20 09:10:58 2017 -0700
+
+    Fixed missing update
+
+[33mcommit 6493cd0c840ccff85b0b72cac48765bdc6e4984f[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Tue Jun 20 08:21:42 2017 -0700
+
+    Version updates, changed packageId for dependency injection
+
+[33mcommit 9e00cba9a80644c71ec766926dc9d120f3085960[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Thu Jun 15 23:12:13 2017 -0500
+
+    Added saga support to MassTransit.ExtensionsDependencyInjectionIntegration
+
+[33mcommit 96f68cb315503bf9d7a8aac64a25ed137cf55a22[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Thu Jun 15 22:05:17 2017 -0500
+
+    Adding initial support for Microsoft.Extensions.DependencyInjection.  Consumer tests pass, now to add saga support.
+
+[33mcommit 9cedbcb030eb1756f4bc69d3d0124ab910742e06[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Thu Jun 15 08:59:30 2017 -0500
+
+    Moving existing code over.
+
+[33mcommit 0941c7cbdda9842915311c43e4bb20390b614cf7[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Sun Jun 18 08:06:27 2017 -0700
+
+    More updates for package consistency
+
+[33mcommit f086122b0f385479c16b2ba07d2463e4eb97a10a[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Sun Jun 18 07:19:52 2017 -0700
+
+    Changed my stuff to work and build clean
+
+[33mcommit acd319b65cad16c28ef42169f46fbec6ca7df822[m
+Author: jacob povar <jacob.povar@gmail.com>
+Date:   Thu Jun 15 06:34:31 2017 +0300
+
+    add .net standard support to reactive and testframework
+
+[33mcommit 114d4b9ea2065634f86f309d6917d632e734b4c0[m
+Author: jacob povar <jacob.povar@gmail.com>
+Date:   Wed Jun 14 17:25:59 2017 +0300
+
+    add .net standard support to simple injection support lib
+
+[33mcommit 5beaf551f8c8ca58cdb8fdbaf0aadbf99f673105[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Thu Jun 15 20:46:05 2017 +1000
+
+    netstandard1.6 for MongoDb integration
+
+[33mcommit ae12238bc6daf4360ceeefdd3f2c6d1661736ce4[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Thu Jun 15 21:00:31 2017 +1000
+
+    Add netstandard1.6 tfm to DocumentDb integration
+
+[33mcommit c5b716f68e0fdb008fde99742ddf219af7288557[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Thu Jun 15 21:16:48 2017 -0500
+
+    Added netstandard target for `MassTransit.Automatonymous.StructureMapIntegration`
+
+[33mcommit 31826c3ed0013f43396ba2287b47d7d57bca8b48[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Thu Jun 15 20:54:56 2017 -0500
+
+    Adding netstandard target to UnityIntegration
+
+[33mcommit 41172bc1cad746ab5f1fc3e6b35088a59db25e21[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Thu Jun 15 09:15:19 2017 -0500
+
+    Adding netstandard target for StructureMapIntegration
+
+[33mcommit 5be996ccf41c95153ab90b1fffeb33cdf6d11279[m
+Author: Nikolay Balakin <n@balakin.me>
+Date:   Fri Jun 16 17:43:30 2017 +0300
+
+    Fix concurrency issue in case of simultaneous saga update and delete operations
+
+[33mcommit 9feb4a1b4134a5e1d4a3f3d4f27c42de6fa497e6[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Tue Jun 13 22:47:56 2017 -0500
+
+    Adding logging integration for Microsoft.Extensions.Logging
+
+[33mcommit 47571ea427c90155f416342954207c5304c74e6a[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Tue Jun 13 20:56:20 2017 -0500
+
+    Added netstandard1.6 target to SerilogIntegration.
+
+[33mcommit 912051ee72067acacc1afc67f4d8ad8a8ef88f37[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Thu Jun 15 08:56:48 2017 +1000
+
+    Add netstandard1.6 support to MassTransit.AutomatonymousIntegration
+
+[33mcommit b7769a5d69e3aea9ca5fe7ffde0eb054f7a0339a[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Thu Jun 15 08:29:04 2017 +1000
+
+    Add netstandard1.6 support and upgrade to Autofac 4.6.0
+
+[33mcommit aef8b765aa1baeca0e8852fefc25e49782fd43bc[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Tue Jun 13 17:05:33 2017 -0500
+
+     Fixed Xml serialization issues.
+
+[33mcommit 544b5bb8d2581d11635db818d053d7046ff28e92[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Tue Jun 13 08:31:23 2017 -0500
+
+    Ported Log4Net logger to netstandard1.6
+
+[33mcommit 774e79b28f059217d4d1a5764c9775db4faf6de7[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Tue Jun 13 08:30:45 2017 -0500
+
+    Ported RabbitMqTransport to netstandard1.6
+
+[33mcommit bf22cc2e9e77f31382f59f2057c995fa9e8b307e[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Mon Jun 12 16:37:54 2017 -0500
+
+    MassTransit project now building for net452 and netstandard1.6
+
+[33mcommit 4f4b40d8c5576c9bc8c1ee17edc8083e82bc172f[m
+Author: Jarrod Alexander <jarrod.alexander@gmail.com>
+Date:   Fri Jun 9 16:39:27 2017 -0500
+
+    First wave of netcore port changes.
+
+[33mcommit 0086b67dc0133e21065351a45c5070e93bd37c89[m
+Author: maldworth <m@maldworth.com>
+Date:   Mon Jun 12 18:18:37 2017 -0400
+
+    Updated for .net Standard changes
+
+[33mcommit e199574847cd23f556e9482cff8dc9f2aee0dfe7[m
+Author: maldworth <m@maldworth.com>
+Date:   Sat Jun 3 08:03:42 2017 -0400
+
+    Some tweaks because the appveyor emulator behaves differently
+
+[33mcommit efe5b45b5bad2db31471e7fe7d5bffc941f7a036[m
+Author: maldworth <m@maldworth.com>
+Date:   Sat Jun 3 07:34:47 2017 -0400
+
+    Adding DocumentDb Yaml stuff
+
+[33mcommit 465446daeeda09f9cd914240e255a22e80dfc185[m
+Author: maldworth <m@maldworth.com>
+Date:   Sat Jun 3 06:59:54 2017 -0400
+
+    Using DocumentDb Emulator
+
+[33mcommit 9d3cef8dd1142a73bb4ff6abfa663098aa3f3229[m
+Author: maldworth <m@maldworth.com>
+Date:   Thu May 11 22:14:05 2017 -0400
+
+    Add DocumentDb Saga Persistence
+
+[33mcommit d02d1c7251fdf33591e203f89a799c6fbd88b756[m
+Author: John Strömblom <john.stromblom@outlook.com>
+Date:   Tue Jun 13 20:14:46 2017 +0200
+
+    Removed signing on MongoDbIntegration. Added bindingRedirect.
+
+[33mcommit 7ad70c65c61dfc5f0ddfb882dcbd22834f8d339c[m
+Author: John Strömblom <johstr@jetshop.se>
+Date:   Tue Jun 13 16:59:06 2017 +0200
+
+    Updated appveyor.yml to reflect new build paths for tests.
+
+[33mcommit 35d04560760f83fc2a70fa30e54d3bf6292673a5[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Sat Jun 10 14:28:01 2017 +0200
+
+    Changing System.Type calls to use TypeInfo
+
+[33mcommit 9f38ab333432bb083a683cacb7be85c0e1fd3edc[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Wed Jun 7 06:39:54 2017 -0700
+
+    Fixes #892 copyright/notice files
+
+[33mcommit a02e1681090245730f37f651da503d99eee033c1[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Sun Jun 4 13:26:11 2017 -0700
+
+    I think most packages are right now, and strong named where appropriate.
+
+[33mcommit a53d94ba87306da98bdf12871cee1d2d7f390dda[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Sun Jun 4 06:54:46 2017 -0700
+
+    Removed unused/incomplete projects
+
+[33mcommit 5d7d3f16030cc433e5107510169a52c1e084a673[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Fri Jun 2 16:21:41 2017 -0700
+
+    Continued to standardize the build for 2017
+
+[33mcommit 69af7a3c084a033812aeb53619ab3ddb2c89e697[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Fri Jun 2 13:45:55 2017 -0700
+
+    Continued tweaks to build
+
+[33mcommit 46227bd400249cbc2a70285141612279eb955680[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Fri Jun 2 13:19:41 2017 -0700
+
+    Reviewing all changes, updating packages, working through csproj files to standardize
+
+[33mcommit 8fa0868b7b42b34fd81ee2b9c38f9d93b961125f[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Mon May 1 16:55:07 2017 +1000
+
+    Fix build.fsx
+
+[33mcommit 37ce64b1a2d2fe42732252639dda03b0b38d3627[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Mon May 1 16:50:06 2017 +1000
+
+    Update PostgesSQL to 9.6
+
+[33mcommit 2eb894880a622745b3ddec5760db38482a8a4165[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Mon May 1 16:48:39 2017 +1000
+
+    Undo TreatWarningsAsErrors
+
+[33mcommit ce58aa1d572e06856cacec6d8ba41c0e7345d45a[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Mon May 1 16:42:37 2017 +1000
+
+    Remove extra AssemblyInfo files
+
+[33mcommit 46beb71571f98c9063d33c4f8cc4f00de019a158[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Mon May 1 16:30:31 2017 +1000
+
+    Move SolutionVersion.cs to Directory.Build.props for new build system
+
+[33mcommit cc85ddf3de8b5ab9825f58ce1e3a11140722c983[m
+Author: Andrew McClenaghan <andrew.mcclenaghan@gmail.com>
+Date:   Mon May 1 11:39:08 2017 +1000
+
+    Initial conversion to VS2017 csproj
+
+[33mcommit db0f880f34045f779712f34f63ab9855003e8764[m
+Author: Teun Duynstee <github@duynstee.com>
+Date:   Mon May 29 14:02:53 2017 +0200
+
+    Update additions-to-transport.md
+    
+    typo
+
+[33mcommit bfff6478f7cd4cf2f1465dd15a51e6f049fedd80[m
+Author: Richárd Nyüsti <richard.nyusti@outlook.com>
+Date:   Wed May 24 18:55:26 2017 +0200
+
+    Fixed issue on RabbitMQ transport when using custom serializer and custom transport headers got missing.
+
+[33mcommit 227a7ecc3aa2b985bd309b8b11ee152783ee8c5a[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Sun May 21 23:12:04 2017 +0200
+
+    Removed some autogenerated entries
+
+[33mcommit bdb595d53fbf228ae913b99c891e2cc79cfafe76[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Sun May 21 23:09:53 2017 +0200
+
+    Fixing the EF section in saga persistence
+
+[33mcommit d22bdb0952b94605f77034b9939b4547923daa74[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Thu May 18 06:43:48 2017 -0700
+
+    Changed name in unity
+
+[33mcommit 6578d00f6c26f123e949a07a049c387467346cfe[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Mon May 8 21:39:54 2017 +0200
+
+    Implementing the IRequestClient interface properly
+
+[33mcommit 34d96efb09a737eb16b40f934bbae6b3073a672b[m
+Author: Ushenko Dmitry <dushenko@mindscan.ru>
+Date:   Tue May 2 10:57:08 2017 +0300
+
+    Docs on ignoring events in saga
+
+[33mcommit 85f75dada217b0682193acdafaf7775b9665e591[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Thu May 4 20:57:37 2017 +0200
+
+    Testing start, Autofac saga fix and Redelivery
+
+[33mcommit 66f192766c529319b69999296c7dfde6e663209f[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Thu May 4 20:31:43 2017 +0200
+
+    Base structure for testing docs
+
+[33mcommit 2c4affe9317cfdbc416c9163878ed4f279dfa582[m
+Author: Octavio Fernandes <octavio.fernandes@mediamonks.com>
+Date:   Fri Apr 28 10:47:06 2017 +0200
+
+    Add back faultmessage on the log message (#871)
+
+[33mcommit d03fe966337ba4a51f097d97b23f0f3e5348286a[m
+Author: Octavio Fernandes <octavio.fernandes@mediamonks.com>
+Date:   Wed Apr 26 11:03:35 2017 +0200
+
+    Change ReceivedEndpointLoggingExtensions to log passing the exception along instead of formating inside text string (#871)
+
+[33mcommit 975cf8cbb7ef3c8ef7b7182718c5ea1b851b35b5[m
+Author: Alen Siljak <MisterY@users.noreply.github.com>
+Date:   Thu Apr 20 11:37:20 2017 +0200
+
+    minor syntax update / spelling correction
+
+[33mcommit 488217a5acc0be5b5536cba1a0bef535611e4f2c[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Wed Apr 19 19:32:03 2017 +0200
+
+    Resolves #865
+
+[33mcommit dde50256918f5bb6b61f0912c617f33f1dc05171[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Wed Apr 19 19:10:42 2017 +0200
+
+    Added some more details about request/response
+
+[33mcommit 365b40687ff1c154a8146762f5c9747bb2816367[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Sun Apr 16 10:33:51 2017 -0700
+
+    Updated csproj, added extension methods for configuration
+
+[33mcommit e754f4df202d9dbc32b8e9c53ae69c4a12f49dae[m
+Author: akayyali <amin.kayyali@hotmail.com>
+Date:   Thu Apr 13 15:28:20 2017 +0300
+
+    Registered ConsumeContext instance within the UnityConsumerFactory<TConsumer>
+    
+    Create UnityExecuteActivityFactory.cs
+    
+    Create UnityCompensateActivityFactory.cs
+
+[33mcommit ac96ad7ef476b3e91531b7caa0e062b9ef2b311e[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Sun Apr 16 10:25:42 2017 -0700
+
+    Changed consumer and saga message configuration to allow middleware prior to the consumer factory/saga repository
+
+[33mcommit 695966c72e55193552aef09549c5f7a9436ab165[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Thu Apr 6 12:47:03 2017 -0700
+
+    Dependency updation
+
+[33mcommit cdf3f318aeb854abd27b9211ff8421076a0b59df[m
+Author: jacob povar <jacob.povar@gmail.com>
+Date:   Sun Apr 2 23:32:36 2017 +0300
+
+    update simpleinjector package to 4.0
+
+[33mcommit d9deca8136a4b81e78b9a02817df98acbe12cae5[m
+Author: Alexey Zimarev <alzi@abax.no>
+Date:   Thu Apr 6 12:34:54 2017 +0200
+
+    Added a note about opening issues for questions
+
+[33mcommit f39ce1a739d6533a686188655ebd03b98aaf05f6[m
+Author: Alexey Zimarev <alzi@abax.no>
+Date:   Thu Apr 6 12:24:11 2017 +0200
+
+    Resolves #838
+
+[33mcommit 27a290447066663f8db434154573a7cad06bdc51[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Wed Mar 29 12:37:03 2017 -0700
+
+    Added initial topology page to documentation, trying images
+
+[33mcommit 6e75e281b43fc2b00b279f42fd048be343db85f9[m
+Author: Bradley Dylan Orr <orrtechnologies@gmail.com>
+Date:   Fri Mar 24 14:26:22 2017 -0500
+
+    Update README.md
+
+[33mcommit 246ec997d3bedda02d75adf3aedf324e1aad3e29[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Tue Mar 28 12:10:43 2017 -0700
+
+    Changed OperationTimeout to 60 seconds, since it's the overall maximum for anything
+
+[33mcommit 571fd98dc9deb3bb20945a77f00094f3975317ec[m
+Author: Shea Strickland <shea@strickland.com.au>
+Date:   Sat Mar 25 14:55:36 2017 +1000
+
+    Added ability to Remove a ConsumerConvention
+
+[33mcommit 9f31b66e5d2c3150ce5fcf306fa19f29a087170b[m
+Author: Alexey Zimarev <alexey@Alexeys-Mac-Pro-2.local>
+Date:   Sat Mar 25 19:59:58 2017 +0100
+
+    Final bit
+
+[33mcommit 22e67fdc00d0a104a59e23393c9becc8725b8842[m
+Author: Alexey Zimarev <alexey@Alexeys-Mac-Pro-2.local>
+Date:   Sat Mar 25 19:58:28 2017 +0100
+
+    Docs redirect for samples
+
+[33mcommit 8fe327ac683169a7ffa9bad9d2a1dc2878da5dea[m
+Author: Alexey Zimarev <alexey@Alexeys-Mac-Pro-2.local>
+Date:   Sat Mar 25 19:55:57 2017 +0100
+
+    Docs redirect scheduling
+
+[33mcommit 3e14a574e06ece8728f409037d4bb6085ff7f0e3[m
+Author: Alexey Zimarev <alexey@Alexeys-Mac-Pro-2.local>
+Date:   Sat Mar 25 19:53:45 2017 +0100
+
+    Docs redirect for middleware section
+
+[33mcommit eb2c2ced7db4d6473796575992021a776995c02b[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Thu Mar 23 19:45:52 2017 +0100
+
+    Courier docs redirects
+
+[33mcommit 51e339f3f56d8deff45f925d4d07293869af1b42[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Thu Mar 23 19:43:22 2017 +0100
+
+    Advanced section docs redirects
+
+[33mcommit c78b182f869aeba61841b196fef9a12130b8b3e6[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Thu Mar 23 19:40:27 2017 +0100
+
+    Sagas docs redirects
+
+[33mcommit e8a015c5479e907a1f79471c54e176ef47325cbd[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Thu Mar 23 19:35:18 2017 +0100
+
+    Redirects for usage docs
+
+[33mcommit 6d5327cb203355ebbf4625cce8cdedd5f8e874a3[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Thu Mar 23 08:24:36 2017 -0700
+
+    BSON is now a separate assembly with JSON.NET, wonderful.
+
+[33mcommit e9234c32f436bb9547ef9b2c0dd2d01a187900d8[m
+Author: Chris Patterson <chris@phatboyg.com>
+Date:   Wed Mar 22 11:09:47 2017 -0700
+
+    Updated package for Redis on ServiceStack
+
+[33mcommit 1b92293c12e27c7fba194d4b2bcb6842d766152e[m
+Author: Alexey Zimarev <alex@zimarev.com>
+Date:   Tue Mar 21 21:06:27 2017 +0100
+
+    Redirects for old docs

--- a/src/MassTransit.sln
+++ b/src/MassTransit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.13
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Persistence", "Persistence", "{56F516D7-BC3C-49E1-A639-83C5F14953F8}"
 EndProject
@@ -111,13 +111,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.MartenIntegrati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.MartenIntegration.Tests", "Persistence\MassTransit.MartenIntegration.Tests\MassTransit.MartenIntegration.Tests.csproj", "{92BE64BB-FF25-4CC8-B64F-3BF02F18F089}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.DocumentDbIntegration", "Persistence\MassTransit.DocumentDbIntegration\MassTransit.DocumentDbIntegration.csproj", "{7CADB8D7-9B91-4CF3-BE46-E3682CEDEB27}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.DocumentDbIntegration", "Persistence\MassTransit.DocumentDbIntegration\MassTransit.DocumentDbIntegration.csproj", "{7CADB8D7-9B91-4CF3-BE46-E3682CEDEB27}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.DocumentDbIntegration.Tests", "Persistence\MassTransit.DocumentDbIntegration.Tests\MassTransit.DocumentDbIntegration.Tests.csproj", "{54363F5F-A51A-489B-8BE7-71C10104A0A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.DocumentDbIntegration.Tests", "Persistence\MassTransit.DocumentDbIntegration.Tests\MassTransit.DocumentDbIntegration.Tests.csproj", "{54363F5F-A51A-489B-8BE7-71C10104A0A5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.ExtensionsLoggingIntegration", "Loggers\MassTransit.ExtensionsLoggingIntegration\MassTransit.ExtensionsLoggingIntegration.csproj", "{BE55A559-03CC-4C96-BEDD-F832B07F8D1C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.ExtensionsDependencyInjectionIntegration", "Containers\MassTransit.ExtensionsDependencyInjectionIntegration\MassTransit.ExtensionsDependencyInjectionIntegration.csproj", "{B1C50EC4-8E99-4D1B-A79D-A15FCAAC47D9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.EntityFrameworkCoreIntegration", "Persistence\MassTransit.EntityFrameworkCoreIntegration\MassTransit.EntityFrameworkCoreIntegration.csproj", "{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.EntityFrameworkCoreIntegration.Tests", "Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests\MassTransit.EntityFrameworkCoreIntegration.Tests.csproj", "{5991CFE3-F59B-4563-982B-371E1B03EC53}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -582,6 +586,30 @@ Global
 		{B1C50EC4-8E99-4D1B-A79D-A15FCAAC47D9}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
 		{B1C50EC4-8E99-4D1B-A79D-A15FCAAC47D9}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
 		{B1C50EC4-8E99-4D1B-A79D-A15FCAAC47D9}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.Release|x86.Build.0 = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Debug|x86.Build.0 = Debug|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Release|x86.ActiveCfg = Release|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.Release|x86.Build.0 = Release|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.ReleaseUnsigned|Any CPU.ActiveCfg = Debug|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
+		{5991CFE3-F59B-4563-982B-371E1B03EC53}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -626,6 +654,8 @@ Global
 		{54363F5F-A51A-489B-8BE7-71C10104A0A5} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
 		{BE55A559-03CC-4C96-BEDD-F832B07F8D1C} = {6A938565-BEE9-434C-9A1A-CD2905907554}
 		{B1C50EC4-8E99-4D1B-A79D-A15FCAAC47D9} = {6C61507E-FF16-45C8-8FE4-350069D9B4C1}
+		{D2F68284-BBF9-45EF-BC4B-BAD4169100AA} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
+		{5991CFE3-F59B-4563-982B-371E1B03EC53} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditContextFactory.cs
@@ -1,0 +1,25 @@
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using System.Reflection;
+
+    using MassTransit.EntityFrameworkCoreIntegration.Audit;
+
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+
+    public class AuditContextFactory : IDbContextFactory<AuditDbContext>
+    {
+        public AuditDbContext Create(DbContextFactoryOptions options)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<AuditDbContext>().
+                UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString(),
+                    m =>
+                        {
+                            m.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name);
+                            m.MigrationsHistoryTable("__AuditEFMigrationHistoryAudit");
+                        });
+
+            return new AuditDbContext(optionsBuilder.Options, "EfCoreAudit");
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditStore_Specs.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditStore_Specs.cs
@@ -1,0 +1,129 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+
+    using GreenPipes.Util;
+
+    using MassTransit.EntityFrameworkCoreIntegration.Audit;
+    using MassTransit.Testing;
+
+    using Microsoft.EntityFrameworkCore;
+
+    using NUnit.Framework;
+
+    using Shouldly;
+
+
+    [TestFixture]
+    public class Saving_audit_records_to_the_audit_store
+    {
+        [Test]
+        public async Task Should_have_consume_audit_records()
+        {
+            var consumed = this._harness.Consumed;
+            await Task.Delay(500);
+            (await this.GetAuditRecords("Consume")).ShouldBe(consumed.Count());
+        }
+
+        [Test]
+        public async Task Should_have_send_audit_record()
+        {
+            var sent = this._harness.Sent;
+            await Task.Delay(500);
+            (await this.GetAuditRecords("Send")).ShouldBe(sent.Count());
+        }
+
+        [SetUp]
+        public async Task CleanAudit()
+        {
+        }
+
+        InMemoryTestHarness _harness;
+        ConsumerTestHarness<TestConsumer> _consumer;
+        EntityFrameworkAuditStore _store;
+
+        [OneTimeSetUp]
+        public async Task Send_message_to_test_consumer()
+        {
+            // add migrations by calling
+            // dotnet ef migrations add --context auditdbcontext --output-dir Migrations\\Audit audit_init
+            DbContextOptionsBuilder<AuditDbContext> optionsBuilder = new DbContextOptionsBuilder<AuditDbContext>().
+                UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString(),
+                m =>
+                    {
+                        m.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name);
+                        m.MigrationsHistoryTable("__AuditEFMigrationHistoryAudit");
+                    });
+
+            this._store = new EntityFrameworkAuditStore(optionsBuilder.Options, "EfCoreAudit");
+            using (var dbContext = this._store.AuditContext)
+            {
+                await dbContext.Database.MigrateAsync();
+                await dbContext.Database.ExecuteSqlCommandAsync("TRUNCATE TABLE EfCoreAudit");
+            }
+
+            this._harness = new InMemoryTestHarness();
+            this._harness.OnConnectObservers += bus =>
+            {
+                bus.ConnectSendAuditObservers(this._store);
+                bus.ConnectConsumeAuditObserver(this._store);
+            };
+            this._consumer = this._harness.Consumer<TestConsumer>();
+
+            await this._harness.Start();
+
+            await this._harness.InputQueueSendEndpoint.Send(new A());
+        }
+
+        [OneTimeTearDown]
+        public async Task Teardown()
+        {
+            await this._harness.Stop();
+        }
+
+        async Task<int> GetAuditRecords(string contextType)
+        {
+            using (var dbContext = this._store.AuditContext)
+                return await dbContext.Set<AuditRecord>()
+                    .Where(x => x.ContextType == contextType)
+                    .CountAsync();
+        }
+
+
+        class TestConsumer : IConsumer<A>,
+            IConsumer<B>
+        {
+            public async Task Consume(ConsumeContext<A> context) =>
+                await context.RespondAsync(new B());
+
+            public Task Consume(ConsumeContext<B> context)
+            {
+                return TaskUtil.Completed;
+            }
+        }
+
+
+        class A
+        {
+        }
+
+
+        class B
+        {
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextFactory.cs
@@ -1,0 +1,21 @@
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using System.Reflection;
+
+    using MassTransit.Tests.Saga;
+
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+
+    public class ContextFactory : IDbContextFactory<SagaDbContext<SimpleSaga, SimpleSagaMap>>
+    {
+        public SagaDbContext<SimpleSaga, SimpleSagaMap> Create(DbContextFactoryOptions options)
+        {
+            var dbContextOptionsBuilder = new DbContextOptionsBuilder<SagaDbContext<SimpleSaga, SimpleSagaMap>>();
+            dbContextOptionsBuilder.UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString(),
+                m => m.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name));
+
+            return new SagaDbContext<SimpleSaga, SimpleSagaMap>(dbContextOptionsBuilder.Options);
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextSetup.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextSetup.cs
@@ -1,0 +1,17 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using MassTransit.Log4NetIntegration.Logging;
+
+    using NUnit.Framework;
+
+
+    [SetUpFixture]
+    public class ContextSetup
+    {
+        [OneTimeSetUp]
+        public void Before_any()
+        {
+            Log4NetLogger.Use("test.log4net.xml");
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/DbQuery.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/DbQuery.cs
@@ -1,0 +1,41 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using System.Data.SqlClient;
+
+
+    public class DbQuery
+    {
+        readonly string _connectionString;
+
+        public DbQuery(string connectionString)
+        {
+            this._connectionString = connectionString;
+        }
+
+        public object ExecuteScalar(string sql)
+        {
+            using (var conn = new SqlConnection(this._connectionString))
+            {
+                conn.Open();
+
+                using (var cmd = new SqlCommand(sql, conn))
+                {
+                    return cmd.ExecuteScalar();
+                }
+            }
+        }
+
+        public int ExecuteCommand(string sql)
+        {
+            using (var conn = new SqlConnection(this._connectionString))
+            {
+                conn.Open();
+
+                using (var cmd = new SqlCommand(sql, conn))
+                {
+                    return cmd.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/LocalDbConnectionStringProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/LocalDbConnectionStringProvider.cs
@@ -1,0 +1,63 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using System;
+    using System.Data.SqlClient;
+
+
+    public static class LocalDbConnectionStringProvider
+    {
+        /// <summary>
+        /// This is a list of the connection strings that we will attempt to find what LocalDb versions
+        /// are on the local pc which we can run the unit tests against
+        /// </summary>
+        private static readonly string[] _possibleLocalDbConnectionStrings = new[]
+        {
+            @"Data Source=(LocalDb)\MSSQLLocalDB;Integrated Security=True;Initial Catalog=MassTransitUnitTests_v12_2015;",  // the localdb installed with VS 2015
+            @"Data Source=(LocalDb)\ProjectsV12;Integrated Security=True;Initial Catalog=MassTransitUnitTests_v12;",        // the localdb with VS 2013
+            @"Data Source=(LocalDb)\v11.0;Integrated Security=True;Initial Catalog=MassTransitUnitTests_v11;"               // the older version of localdb
+        };
+
+        private static object _lockConnectionString = new object();
+        private static string _connectionString;
+
+        /// <summary>
+        /// Loops through the array of potential localdb connection strings to find one that we can use for the unit tests
+        /// </summary>
+        public static string GetLocalDbConnectionString()
+        {
+            if (!string.IsNullOrWhiteSpace(_connectionString))
+                return _connectionString;
+
+            lock (_lockConnectionString)
+            {
+                if (!string.IsNullOrWhiteSpace(_connectionString))
+                    return _connectionString;
+
+                // Lets find a localdb that we can use for our unit test
+                foreach (var connectionString in _possibleLocalDbConnectionStrings)
+                {
+                    try
+                    {
+                        using (var connection = new SqlConnection(connectionString))
+                        {
+                            // It worked, we can save this as our connection string
+                            _connectionString = connectionString;
+                            break;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Swallow
+                    }
+                }
+
+                // If we looped through all possible localdb connection strings and didn't find one, we fail.
+                if (string.IsNullOrWhiteSpace(_connectionString))
+                    throw new InvalidOperationException(
+                        "Couldn't connect to any of the LocalDB Databases. You might have a version installed that is not in the list. Please check the list and modify as necessary");
+            }
+
+            return _connectionString;
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.EntityFrameworkIntegration.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="GreenPipes" Version="1.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="Shouldly" Version="2.8.3" />
+    <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
+    <ProjectReference Include="..\..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
+    <ProjectReference Include="..\..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
+    <ProjectReference Include="..\..\MassTransit.Tests\MassTransit.Tests.csproj" />
+    <ProjectReference Include="..\MassTransit.EntityFrameworkCoreIntegration\MassTransit.EntityFrameworkCoreIntegration.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Migrations\" />
+  </ItemGroup>
+</Project>

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/20170710150441_Init.Designer.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/20170710150441_Init.Designer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using MassTransit.Tests.Saga;
+
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests.Migrations
+{
+    [DbContext(typeof(SagaDbContext<SimpleSaga, SimpleSagaMap>))]
+    [Migration("20170710150441_Init")]
+    partial class Init
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("MassTransit.Tests.Saga.SimpleSaga", b =>
+                {
+                    b.Property<Guid>("CorrelationId");
+
+                    b.Property<bool>("Completed");
+
+                    b.Property<bool>("Initiated");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(40);
+
+                    b.Property<bool>("Observed");
+
+                    b.HasKey("CorrelationId");
+
+                    b.ToTable("EfCoreSimpleSagas");
+                });
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/20170710150441_Init.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/20170710150441_Init.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests.Migrations
+{
+    public partial class Init : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EfCoreSimpleSagas",
+                columns: table => new
+                {
+                    CorrelationId = table.Column<Guid>(nullable: false),
+                    Completed = table.Column<bool>(nullable: false),
+                    Initiated = table.Column<bool>(nullable: false),
+                    Name = table.Column<string>(maxLength: 40, nullable: true),
+                    Observed = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EfCoreSimpleSagas", x => x.CorrelationId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EfCoreSimpleSagas");
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/Audit/20170710143716_audit_init.Designer.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/Audit/20170710143716_audit_init.Designer.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MassTransit.EntityFrameworkCoreIntegration.Audit;
+
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests.Migrations.Audit
+{
+    [DbContext(typeof(AuditDbContext))]
+    [Migration("20170710143716_audit_init")]
+    partial class audit_init
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("MassTransit.EntityFrameworkCoreIntegration.Audit.AuditRecord", b =>
+                {
+                    b.Property<int>("AuditRecordId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ContextType");
+
+                    b.Property<Guid?>("ConversationId");
+
+                    b.Property<Guid?>("CorrelationId");
+
+                    b.Property<string>("DestinationAddress");
+
+                    b.Property<string>("FaultAddress");
+
+                    b.Property<Guid?>("InitiatorId");
+
+                    b.Property<Guid?>("MessageId");
+
+                    b.Property<string>("MessageType");
+
+                    b.Property<Guid?>("RequestId");
+
+                    b.Property<string>("ResponseAddress");
+
+                    b.Property<string>("SourceAddress");
+
+                    b.Property<string>("_custom")
+                        .HasColumnName("Custom");
+
+                    b.Property<string>("_headers")
+                        .HasColumnName("Headers");
+
+                    b.Property<string>("_message")
+                        .HasColumnName("Message");
+
+                    b.HasKey("AuditRecordId");
+
+                    b.ToTable("EfCoreAudit");
+                });
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/Audit/20170710143716_audit_init.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/Audit/20170710143716_audit_init.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests.Migrations.Audit
+{
+    public partial class audit_init : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EfCoreAudit",
+                columns: table => new
+                {
+                    AuditRecordId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    ContextType = table.Column<string>(nullable: true),
+                    ConversationId = table.Column<Guid>(nullable: true),
+                    CorrelationId = table.Column<Guid>(nullable: true),
+                    DestinationAddress = table.Column<string>(nullable: true),
+                    FaultAddress = table.Column<string>(nullable: true),
+                    InitiatorId = table.Column<Guid>(nullable: true),
+                    MessageId = table.Column<Guid>(nullable: true),
+                    MessageType = table.Column<string>(nullable: true),
+                    RequestId = table.Column<Guid>(nullable: true),
+                    ResponseAddress = table.Column<string>(nullable: true),
+                    SourceAddress = table.Column<string>(nullable: true),
+                    Custom = table.Column<string>(nullable: true),
+                    Headers = table.Column<string>(nullable: true),
+                    Message = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EfCoreAudit", x => x.AuditRecordId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EfCoreAudit");
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/Audit/AuditDbContextModelSnapshot.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/Audit/AuditDbContextModelSnapshot.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MassTransit.EntityFrameworkCoreIntegration.Audit;
+
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests.Migrations.Audit
+{
+    [DbContext(typeof(AuditDbContext))]
+    partial class AuditDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("MassTransit.EntityFrameworkCoreIntegration.Audit.AuditRecord", b =>
+                {
+                    b.Property<int>("AuditRecordId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ContextType");
+
+                    b.Property<Guid?>("ConversationId");
+
+                    b.Property<Guid?>("CorrelationId");
+
+                    b.Property<string>("DestinationAddress");
+
+                    b.Property<string>("FaultAddress");
+
+                    b.Property<Guid?>("InitiatorId");
+
+                    b.Property<Guid?>("MessageId");
+
+                    b.Property<string>("MessageType");
+
+                    b.Property<Guid?>("RequestId");
+
+                    b.Property<string>("ResponseAddress");
+
+                    b.Property<string>("SourceAddress");
+
+                    b.Property<string>("_custom")
+                        .HasColumnName("Custom");
+
+                    b.Property<string>("_headers")
+                        .HasColumnName("Headers");
+
+                    b.Property<string>("_message")
+                        .HasColumnName("Message");
+
+                    b.HasKey("AuditRecordId");
+
+                    b.ToTable("EfCoreAudit");
+                });
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/SagaDbContextModelSnapshot.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/Migrations/SagaDbContextModelSnapshot.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MassTransit.EntityFrameworkCoreIntegration;
+
+using MassTransit.Tests.Saga;
+
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests.Migrations
+{
+    [DbContext(typeof(SagaDbContext<SimpleSaga, SimpleSagaMap>))]
+    partial class SagaDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("MassTransit.Tests.Saga.SimpleSaga", b =>
+                {
+                    b.Property<Guid>("CorrelationId");
+
+                    b.Property<bool>("Completed");
+
+                    b.Property<bool>("Initiated");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(40);
+
+                    b.Property<bool>("Observed");
+
+                    b.HasKey("CorrelationId");
+
+                    b.ToTable("EfCoreSimpleSagas");
+                });
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SagaLocator_Specs.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SagaLocator_Specs.cs
@@ -1,0 +1,83 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using MassTransit.EntityFrameworkCoreIntegration.Saga;
+    using MassTransit.Saga;
+    using MassTransit.TestFramework;
+    using MassTransit.Tests.Saga;
+    using MassTransit.Tests.Saga.Messages;
+
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+
+    using NUnit.Framework;
+
+    using Shouldly;
+
+
+    [TestFixture, Category("Integration")]
+    public class Locating_an_existing_ef_saga :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task A_correlated_message_should_find_the_correct_saga()
+        {
+            Guid sagaId = NewId.NextGuid();
+            var message = new InitiateSimpleSaga(sagaId);
+
+            await this.InputQueueSendEndpoint.Send(message);
+
+            Guid? foundId = await this._sagaRepository.Value.ShouldContainSaga(message.CorrelationId, this.TestTimeout);
+
+            foundId.HasValue.ShouldBe(true);
+
+            var nextMessage = new CompleteSimpleSaga { CorrelationId = sagaId };
+
+            await this.InputQueueSendEndpoint.Send(nextMessage);
+
+            foundId = await this._sagaRepository.Value.ShouldContainSaga(x => x.CorrelationId == sagaId && x.Completed, this.TestTimeout);
+
+            foundId.HasValue.ShouldBe(true);
+        }
+
+        [Test]
+        public async Task An_initiating_message_should_start_the_saga()
+        {
+            Guid sagaId = NewId.NextGuid();
+            var message = new InitiateSimpleSaga(sagaId);
+
+            await this.InputQueueSendEndpoint.Send(message);
+
+            Guid? foundId = await this._sagaRepository.Value.ShouldContainSaga(message.CorrelationId, this.TestTimeout);
+
+            foundId.HasValue.ShouldBe(true);
+        }
+
+        readonly SagaDbContextFactory _sagaDbContextFactory;
+
+        readonly Lazy<ISagaRepository<SimpleSaga>> _sagaRepository;
+
+        public Locating_an_existing_ef_saga()
+        {
+            // add new migration by calling 
+            // dotnet ef migrations add --context "SagaDbContext``2" Init  -v
+            var contextFactory = new ContextFactory();
+
+            using (var context = contextFactory.Create(new DbContextFactoryOptions()))
+            {
+                context.Database.Migrate();
+            }
+
+            this._sagaDbContextFactory = () => contextFactory.Create(new DbContextFactoryOptions());
+            this._sagaRepository = new Lazy<ISagaRepository<SimpleSaga>>(() => 
+                new EntityFrameworkSagaRepository<SimpleSaga>(this._sagaDbContextFactory));
+        }
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            configurator.Saga(this._sagaRepository.Value);
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SimpleSagaMap.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SimpleSagaMap.cs
@@ -1,0 +1,20 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using MassTransit.Tests.Saga;
+
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+    public class SimpleSagaMap : IEntityTypeConfiguration<SimpleSaga>
+    {
+        public void Configure(EntityTypeBuilder<SimpleSaga> entityTypeBuilder)
+        {
+            entityTypeBuilder.Property(x => x.Name)
+                .HasMaxLength(40);
+            entityTypeBuilder.Property(x => x.Initiated);
+            entityTypeBuilder.Property(x => x.Observed);
+            entityTypeBuilder.Property(x => x.Completed);
+            entityTypeBuilder.ToTable("EfCoreSimpleSagas");
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/test.log4net.xml
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/test.log4net.xml
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net" />
+  </configSections>
+  <log4net>
+    <root>
+      <level value="ALL" />
+      <appender-ref ref="LogFileAppender" />
+      <appender-ref ref="console" />
+    </root>
+
+    <logger name="MassTransit">
+      <level value="DEBUG" />
+    </logger>
+
+    <logger name="MassTransit.Messages" additivity="false">
+      <level value="DEBUG" />
+      <appender-ref ref="MessageLogAppender" />
+    </logger>
+
+    <appender name="console" type="log4net.Appender.ConsoleAppender, log4net">
+      <layout type="log4net.Layout.PatternLayout,log4net">
+        <param name="ConversionPattern" value="%d [%t] %-5p %c - %m%n" />
+      </layout>
+    </appender>
+    <appender name="LogFileAppender"
+          type="log4net.Appender.RollingFileAppender" >
+      <param name="File"
+           value="C:\LogFiles\MassTransit.ServiceBus.Tests.log" />
+      <param name="AppendToFile"
+           value="true" />
+      <rollingStyle value="Size" />
+      <maxSizeRollBackups value="4" />
+      <maximumFileSize value="10MB" />
+      <staticLogFileName value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+        <param name="ConversionPattern"
+             value="%-5p %d{yyyy-MM-dd hh:mm:ss} - %m%n" />
+      </layout>
+    </appender>
+    <appender name="MessageLogAppender"
+          type="log4net.Appender.RollingFileAppender" >
+      <param name="File"
+           value="C:\LogFiles\MassTransit.ServiceBus.Tests.Messages.log" />
+      <param name="AppendToFile"
+           value="true" />
+      <rollingStyle value="Size" />
+      <maxSizeRollBackups value="4" />
+      <maximumFileSize value="10MB" />
+      <staticLogFileName value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+        <param name="ConversionPattern"
+             value="%-5p %d{yyyy-MM-dd hh:mm:ss} - %m%n" />
+      </layout>
+    </appender>
+  </log4net>
+</configuration>

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/AuditDbContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/AuditDbContext.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Audit
+{
+    using Microsoft.EntityFrameworkCore;
+
+    public class AuditDbContext : DbContext
+    {
+        readonly string _auditTableName;
+
+        protected AuditDbContext(string auditTableName)
+        {
+            this._auditTableName = auditTableName;
+        }
+
+        public AuditDbContext(DbContextOptions options, string auditTableName)
+            : base(options)
+        {
+            this._auditTableName = auditTableName;
+        }
+
+        public DbSet<AuditRecord> AuditRecords { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ConfigureAuditMapping(this._auditTableName);
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/AuditMapping.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/AuditMapping.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Audit
+{
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+
+    public static class AuditMappingExtensions
+    {
+        public static void ConfigureAuditMapping(this ModelBuilder modelBuilder, string tableName)
+        {
+            EntityTypeBuilder<AuditRecord> typeBuilder = modelBuilder.Entity<AuditRecord>();
+            typeBuilder.ToTable(tableName);
+
+            typeBuilder.HasKey(x => x.AuditRecordId);
+                typeBuilder.Property(x => x.AuditRecordId)
+                .ValueGeneratedOnAdd();
+
+            typeBuilder.Property(x => x.ContextType);
+            typeBuilder.Property(x => x.MessageId);
+            typeBuilder.Property(x => x.InitiatorId);
+            typeBuilder.Property(x => x.ConversationId);
+            typeBuilder.Property(x => x.CorrelationId);
+            typeBuilder.Property(x => x.RequestId);
+            typeBuilder.Property(x => x.SourceAddress);
+            typeBuilder.Property(x => x.DestinationAddress);
+            typeBuilder.Property(x => x.ResponseAddress);
+            typeBuilder.Property(x => x.FaultAddress);
+            typeBuilder.Property(x => x.MessageType);
+            typeBuilder.Property(x => x._headers).HasColumnName("Headers");
+            typeBuilder.Property(x => x._custom).HasColumnName("Custom");
+            typeBuilder.Property(x => x._message).HasColumnName("Message");
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/AuditRecord.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/AuditRecord.cs
@@ -1,0 +1,94 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Audit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations.Schema;
+
+    using MassTransit.Audit;
+
+    using Newtonsoft.Json;
+
+
+    public class AuditRecord
+    {
+        public int AuditRecordId { get; set; }
+        public Guid? MessageId { get; set; }
+        public Guid? ConversationId { get; set; }
+        public Guid? CorrelationId { get; set; }
+        public Guid? InitiatorId { get; set; }
+        public Guid? RequestId { get; set; }
+        public string SourceAddress { get; set; }
+        public string DestinationAddress { get; set; }
+        public string ResponseAddress { get; set; }
+        public string FaultAddress { get; set; }
+        public string ContextType { get; set; }
+        public string MessageType { get; set; }
+
+        internal string _custom { get; set; }
+
+        [NotMapped]
+        public Dictionary<string, string> Custom
+        {
+            get => string.IsNullOrEmpty(this._custom)
+                       ? new Dictionary<string, string>()
+                       : JsonConvert.DeserializeObject<Dictionary<string, string>>(this._custom);
+            set => this._custom = JsonConvert.SerializeObject(value);
+        }
+
+        internal string _headers { get; set; }
+
+        [NotMapped]
+        public Dictionary<string, string> Headers
+        {
+            get => string.IsNullOrEmpty(this._headers)
+                       ? new Dictionary<string, string>()
+                       : JsonConvert.DeserializeObject<Dictionary<string, string>>(this._headers);
+            set => this._headers = JsonConvert.SerializeObject(value);
+        }
+
+        internal string _message { get; set; }
+
+        [NotMapped]
+        public object Message
+        {
+            get => string.IsNullOrEmpty(this._message)
+                       ? null
+                       : JsonConvert.DeserializeObject(this._message);
+            set => this._message = JsonConvert.SerializeObject(value);
+        }
+
+        internal static AuditRecord Create<T>(T message, string messageType, MessageAuditMetadata metadata)
+            where T : class
+        {
+            return new AuditRecord
+            {
+                ContextType = metadata.ContextType,
+                MessageId = metadata.MessageId,
+                ConversationId = metadata.ConversationId,
+                CorrelationId = metadata.CorrelationId,
+                InitiatorId = metadata.InitiatorId,
+                RequestId = metadata.RequestId,
+                SourceAddress = metadata.SourceAddress,
+                DestinationAddress = metadata.DestinationAddress,
+                ResponseAddress = metadata.ResponseAddress,
+                FaultAddress = metadata.FaultAddress,
+                Headers = metadata.Headers,
+                Custom = metadata.Custom,
+                Message = message,
+                MessageType = messageType
+            };
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/EntityFrameworkAuditStore.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Audit/EntityFrameworkAuditStore.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Audit
+{
+    using System.Threading.Tasks;
+
+    using MassTransit.Audit;
+    using MassTransit.Util;
+
+    using Microsoft.EntityFrameworkCore;
+
+    public class EntityFrameworkAuditStore : IMessageAuditStore
+    {
+        readonly DbContextOptions _contextOptions;
+
+        readonly string _auditTableName;
+
+        public EntityFrameworkAuditStore(DbContextOptions contextOptions, string auditTableName)
+        {
+            this._contextOptions = contextOptions;
+            this._auditTableName = auditTableName;
+        }
+
+        public DbContext AuditContext =>
+            new AuditDbContext(this._contextOptions, this._auditTableName);
+
+        async Task IMessageAuditStore.StoreMessage<T>(T message, MessageAuditMetadata metadata)
+        {
+            using (var dbContext = this.AuditContext)
+            {
+                var auditRecord = AuditRecord.Create(message, TypeMetadataCache<T>.ShortName, metadata);
+
+                dbContext.Set<AuditRecord>().Add(auditRecord);
+
+                await dbContext.SaveChangesAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/DbContextExtensions.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/DbContextExtensions.cs
@@ -1,0 +1,47 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration
+{
+    using System;
+    using System.Collections.Concurrent;
+
+    using Microsoft.EntityFrameworkCore;
+
+
+    public static class DbContextExtensions
+    {
+        private static readonly ConcurrentDictionary<Type, string> TableNames = new ConcurrentDictionary<Type, string>();
+
+        public static string GetTableName<T>(this DbContext context) where T : class
+        {
+            return GetTableName(context, typeof(T));
+        }
+
+        public static string GetTableName(this DbContext context, Type t)
+        {
+            string result;
+
+            if (!TableNames.TryGetValue(t, out result))
+            {
+                var sql = context.Model.FindEntityType(t).SqlServer();
+                var sqlSchema = sql.Schema;
+                if (string.IsNullOrEmpty(sqlSchema))
+                {
+                    sqlSchema = "dbo";
+                }
+
+                result = $"[{sqlSchema}].[{sql.TableName}]";
+
+                if(!string.IsNullOrWhiteSpace(result))
+                {
+                    TableNames.TryAdd(t, result);
+                }
+                else
+                {
+                    throw new MassTransitException("Couldn't determine table and schema name (using model metadata).");
+                }
+            }
+
+            return result;
+
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/IEntityTypeConfiguration.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/IEntityTypeConfiguration.cs
@@ -1,0 +1,10 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration
+{
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+    // todo: should become obsolete once ef core 2.0 is released
+    public interface IEntityTypeConfiguration<T> where T : class
+    {
+        void Configure(EntityTypeBuilder<T> entityTypeBuilder);
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.EntityFrameworkIntegration.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="GreenPipes" Version="1.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Saga/EntityFrameworkSagaConsumeContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Saga/EntityFrameworkSagaConsumeContext.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Saga
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using MassTransit.Context;
+    using MassTransit.Logging;
+    using MassTransit.Saga;
+    using MassTransit.Util;
+
+    using Microsoft.EntityFrameworkCore;
+
+
+    public class EntityFrameworkSagaConsumeContext<TSaga, TMessage> :
+        ConsumeContextProxyScope<TMessage>,
+        SagaConsumeContext<TSaga, TMessage>
+        where TMessage : class
+        where TSaga : class, ISaga
+    {
+        static readonly ILog _log = Logger.Get<EntityFrameworkSagaRepository<TSaga>>();
+        readonly DbContext _dbContext;
+        readonly bool _existing;
+
+        public EntityFrameworkSagaConsumeContext(DbContext dbContext, ConsumeContext<TMessage> context, TSaga instance, bool existing = true)
+            : base(context)
+        {
+            this.Saga = instance;
+            this._dbContext = dbContext;
+            this._existing = existing;
+        }
+
+        Guid? MessageContext.CorrelationId => this.Saga.CorrelationId;
+
+        SagaConsumeContext<TSaga, T> SagaConsumeContext<TSaga>.PopContext<T>()
+        {
+            var context = this as SagaConsumeContext<TSaga, T>;
+            if (context == null)
+                throw new ContextException($"The ConsumeContext<{TypeMetadataCache<TMessage>.ShortName}> could not be cast to {TypeMetadataCache<T>.ShortName}");
+
+            return context;
+        }
+
+        public async Task SetCompleted()
+        {
+            this.IsCompleted = true;
+            if (this._existing)
+            {
+                this._dbContext.Set<TSaga>().Remove(this.Saga);
+
+                if (_log.IsDebugEnabled)
+                {
+                    _log.DebugFormat("SAGA:{0}:{1} Removed {2}", TypeMetadataCache<TSaga>.ShortName, TypeMetadataCache<TMessage>.ShortName,
+                        this.Saga.CorrelationId);
+                }
+
+                await this._dbContext.SaveChangesAsync(this.CancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public bool IsCompleted { get; private set; }
+        public TSaga Saga { get; }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Saga/EntityFrameworkSagaRepository.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Saga/EntityFrameworkSagaRepository.cs
@@ -1,0 +1,423 @@
+﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Saga
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using GreenPipes;
+
+    using MassTransit.Logging;
+    using MassTransit.Saga;
+    using MassTransit.Util;
+
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+    public class EntityFrameworkSagaRepository<TSaga> :
+        ISagaRepository<TSaga>,
+        IQuerySagaRepository<TSaga>
+        where TSaga : class, ISaga
+    {
+        static readonly ILog _log = Logger.Get<EntityFrameworkSagaRepository<TSaga>>();
+        readonly IsolationLevel _isolationLevel;
+        readonly SagaDbContextFactory _sagaDbContextFactory;
+        readonly bool _optimistic;
+
+        public EntityFrameworkSagaRepository(SagaDbContextFactory sagaDbContextFactory, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, bool optimistic = false)
+        {
+            this._sagaDbContextFactory = sagaDbContextFactory;
+            this._isolationLevel = isolationLevel;
+            this._optimistic = optimistic;
+        }
+
+        async Task<IEnumerable<Guid>> IQuerySagaRepository<TSaga>.Find(ISagaQuery<TSaga> query)
+        {
+            using (var dbContext = this._sagaDbContextFactory())
+            {
+                return await dbContext.Set<TSaga>()
+                    .Where(query.FilterExpression)
+                    .Select(x => x.CorrelationId)
+                    .ToListAsync().ConfigureAwait(false);
+            }
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("sagaRepository");
+            using (var dbContext = this._sagaDbContextFactory())
+            {
+                scope.Set(new
+                {
+                    Persistence = "entityFramework",
+                    Entities = dbContext.Model.GetEntityTypes().Select(type => type.Name)
+                    //Entities = workspace.GetItems<EntityType>(DataSpace.SSpace).Select(x => x.Name)
+                });
+            }
+        }
+
+        async Task ISagaRepository<TSaga>.Send<T>(ConsumeContext<T> context, ISagaPolicy<TSaga, T> policy,
+            IPipe<SagaConsumeContext<TSaga, T>> next)
+        {
+            if (!context.CorrelationId.HasValue)
+                throw new SagaException("The CorrelationId was not specified", typeof(TSaga), typeof(T));
+
+            var sagaId = context.CorrelationId.Value;
+
+            using (var dbContext = this._sagaDbContextFactory())
+            using (var transaction = dbContext.Database.BeginTransaction(this._isolationLevel))
+            {
+                if (!this._optimistic)
+                {
+                    try
+                    {
+                        // Hack for locking row for the duration of the transaction.
+                        var tableName = dbContext.GetTableName<TSaga>();
+                        await dbContext.Database.ExecuteSqlCommandAsync(
+                            $"select 1 from {tableName} WITH (UPDLOCK, ROWLOCK) WHERE CorrelationId = @p0", CancellationToken.None, sagaId)
+                            .ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        // todo: schema is empty??
+                        Console.WriteLine(e);
+                        throw;
+                    }
+                }
+
+                var inserted = false;
+
+                TSaga instance;
+                if (policy.PreInsertInstance(context, out instance))
+                {
+                    inserted = await PreInsertSagaInstance<T>(dbContext, instance, context.CancellationToken).ConfigureAwait(false);
+                }
+
+                try
+                {
+                    if (instance == null)
+                        instance = dbContext.Set<TSaga>().SingleOrDefault(x => x.CorrelationId == sagaId);
+                    if (instance == null)
+                    {
+                        var missingSagaPipe = new MissingPipe<T>(dbContext, next);
+
+                        await policy.Missing(context, missingSagaPipe).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        if (_log.IsDebugEnabled)
+                        {
+                            _log.DebugFormat("SAGA:{0}:{1} Used {2}", TypeMetadataCache<TSaga>.ShortName, instance.CorrelationId,
+                                TypeMetadataCache<T>.ShortName);
+                        }
+
+                        var sagaConsumeContext = new EntityFrameworkSagaConsumeContext<TSaga, T>(dbContext, context, instance);
+
+                        await policy.Existing(sagaConsumeContext, next).ConfigureAwait(false);
+                    }
+
+                    await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+                    transaction.Commit();
+                }
+                catch (DbUpdateConcurrencyException ex)
+                {
+                    try
+                    {
+                        transaction.Rollback();
+                    }
+                    catch (Exception innerException)
+                    {
+                        if (_log.IsWarnEnabled)
+                            _log.Warn("The transaction rollback failed", innerException);
+                    }
+
+                    throw;
+                }
+                catch (DbUpdateException ex)
+                {
+                    if (IsDeadlockException(ex))
+                    {
+                        // deadlock, no need to rollback
+                    }
+                    else
+                    {
+                        if (_log.IsErrorEnabled)
+                            _log.Error($"SAGA:{TypeMetadataCache<TSaga>.ShortName} Exception {TypeMetadataCache<T>.ShortName}", ex);
+
+                        try
+                        {
+                            transaction.Rollback();
+                        }
+                        catch (Exception innerException)
+                        {
+                            if (_log.IsWarnEnabled)
+                                _log.Warn("The transaction rollback failed", innerException);
+                        }
+                    }
+
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    if (_log.IsErrorEnabled)
+                        _log.Error($"SAGA:{TypeMetadataCache<TSaga>.ShortName} Exception {TypeMetadataCache<T>.ShortName}", ex);
+
+                    try
+                    {
+                        transaction.Rollback();
+                    }
+                    catch (Exception innerException)
+                    {
+                        if (_log.IsWarnEnabled)
+                            _log.Warn("The transaction rollback failed", innerException);
+                    }
+                    throw;
+                }
+            }
+        }
+
+        public async Task SendQuery<T>(SagaQueryConsumeContext<TSaga, T> context, ISagaPolicy<TSaga, T> policy,
+            IPipe<SagaConsumeContext<TSaga, T>> next) where T : class
+        {
+            using (var dbContext = this._sagaDbContextFactory())
+            {
+                // We just get the correlation ids related to our Filter.
+                // We do this outside of the transaction to make sure we don't create a range lock.
+                List<Guid> correlationIds = await dbContext.Set<TSaga>().Where(context.Query.FilterExpression)
+                    .Select(x => x.CorrelationId)
+                    .ToListAsync()
+                    .ConfigureAwait(false);
+
+                using (var transaction = dbContext.Database.BeginTransaction(this._isolationLevel))
+                {
+                    try
+                    {
+                        var missingCorrelationIds = new List<Guid>();
+                        if (correlationIds.Any())
+                        {
+                            var tableName = dbContext.GetTableName<TSaga>();
+                            foreach (var correlationId in correlationIds)
+                            {
+                                if (!this._optimistic)
+                                {
+                                    // Hack for locking row for the duration of the transaction. 
+                                    // We only lock one at a time, since we don't want an accidental range lock.
+                                    await
+                                        dbContext.Database.ExecuteSqlCommandAsync(
+                                            $"select 2 from {tableName} WITH (UPDLOCK, ROWLOCK) WHERE CorrelationId = @p0",
+                                            CancellationToken.None,
+                                            correlationId).ConfigureAwait(false);
+                                }
+
+                                var instance = dbContext.Set<TSaga>().SingleOrDefault(x => x.CorrelationId == correlationId);
+
+                                if (instance != null)
+                                {
+                                    await this.SendToInstance(context, dbContext, policy, instance, next).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    missingCorrelationIds.Add(correlationId);
+                                }
+                            }
+                        }
+
+                        // If no sagas are found or all are missing
+                        if (correlationIds.Count == missingCorrelationIds.Count)
+                        {
+                            var missingSagaPipe = new MissingPipe<T>(dbContext, next);
+
+                            await policy.Missing(context, missingSagaPipe).ConfigureAwait(false);
+                        }
+
+                        await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+                        transaction.Commit();
+                    }
+                    catch (DbUpdateConcurrencyException ex)
+                    {
+                        try
+                        {
+                            transaction.Rollback();
+                        }
+                        catch (Exception innerException)
+                        {
+                            if (_log.IsWarnEnabled)
+                                _log.Warn("The transaction rollback failed", innerException);
+                        }
+
+                        throw;
+                    }
+                    catch (DbUpdateException ex)
+                    {
+                        if (IsDeadlockException(ex))
+                        {
+                            // deadlock, no need to rollback
+                        }
+                        else
+                        {
+                            try
+                            {
+                                transaction.Rollback();
+                            }
+                            catch (Exception innerException)
+                            {
+                                if (_log.IsWarnEnabled)
+                                    _log.Warn("The transaction rollback failed", innerException);
+                            }
+                        }
+
+                        throw;
+                    }
+                    catch (SagaException sex)
+                    {
+                        if (_log.IsErrorEnabled)
+                            _log.Error($"SAGA:{TypeMetadataCache<TSaga>.ShortName} Exception {TypeMetadataCache<T>.ShortName}", sex);
+
+                        try
+                        {
+                            transaction.Rollback();
+                        }
+                        catch (Exception innerException)
+                        {
+                            if (_log.IsWarnEnabled)
+                                _log.Warn("The transaction rollback failed", innerException);
+                        }
+
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        try
+                        {
+                            transaction.Rollback();
+                        }
+                        catch (Exception innerException)
+                        {
+                            if (_log.IsWarnEnabled)
+                                _log.Warn("The transaction rollback failed", innerException);
+                        }
+
+                        if (_log.IsErrorEnabled)
+                            _log.Error($"SAGA:{TypeMetadataCache<TSaga>.ShortName} Exception {TypeMetadataCache<T>.ShortName}", ex);
+
+                        throw new SagaException(ex.Message, typeof(TSaga), typeof(T), Guid.Empty, ex);
+                    }
+                }
+            }
+        }
+
+        static bool IsDeadlockException(Exception exception)
+        {
+            var baseException = exception.GetBaseException() as SqlException;
+
+            return baseException != null && baseException.Number == 1205;
+        }
+
+        static async Task<bool> PreInsertSagaInstance<T>(DbContext dbContext, TSaga instance, CancellationToken cancellationToken)
+        {
+            try
+            {
+                dbContext.Set<TSaga>().Add(instance);
+                await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                _log.DebugFormat("SAGA:{0}:{1} Insert {2}", TypeMetadataCache<TSaga>.ShortName, instance.CorrelationId,
+                    TypeMetadataCache<T>.ShortName);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (_log.IsDebugEnabled)
+                {
+                    _log.DebugFormat("SAGA:{0}:{1} Dupe {2} - {3}", TypeMetadataCache<TSaga>.ShortName, instance.CorrelationId,
+                        TypeMetadataCache<T>.ShortName, ex.Message);
+                }
+            }
+
+            return false;
+        }
+
+        async Task SendToInstance<T>(SagaQueryConsumeContext<TSaga, T> context, DbContext dbContext, ISagaPolicy<TSaga, T> policy, TSaga instance,
+            IPipe<SagaConsumeContext<TSaga, T>> next)
+            where T : class
+        {
+            try
+            {
+                if (_log.IsDebugEnabled)
+                    _log.DebugFormat("SAGA:{0}:{1} Used {2}", TypeMetadataCache<TSaga>.ShortName, instance.CorrelationId, TypeMetadataCache<T>.ShortName);
+
+                var sagaConsumeContext = new EntityFrameworkSagaConsumeContext<TSaga, T>(dbContext, context, instance);
+
+                await policy.Existing(sagaConsumeContext, next).ConfigureAwait(false);
+            }
+            catch (SagaException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new SagaException(ex.Message, typeof(TSaga), typeof(T), instance.CorrelationId, ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Once the message pipe has processed the saga instance, add it to the saga repository
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        class MissingPipe<TMessage> :
+            IPipe<SagaConsumeContext<TSaga, TMessage>>
+            where TMessage : class
+        {
+            readonly DbContext _dbContext;
+            readonly IPipe<SagaConsumeContext<TSaga, TMessage>> _next;
+
+            public MissingPipe(DbContext dbContext, IPipe<SagaConsumeContext<TSaga, TMessage>> next)
+            {
+                this._dbContext = dbContext;
+                this._next = next;
+            }
+
+            void IProbeSite.Probe(ProbeContext context)
+            {
+                this._next.Probe(context);
+            }
+
+            public async Task Send(SagaConsumeContext<TSaga, TMessage> context)
+            {
+                if (_log.IsDebugEnabled)
+                {
+                    _log.DebugFormat("SAGA:{0}:{1} Added {2}", TypeMetadataCache<TSaga>.ShortName,
+                        context.Saga.CorrelationId,
+                        TypeMetadataCache<TMessage>.ShortName);
+                }
+
+                var proxy = new EntityFrameworkSagaConsumeContext<TSaga, TMessage>(this._dbContext, context, context.Saga, false);
+
+                await this._next.Send(proxy).ConfigureAwait(false);
+
+                if (!proxy.IsCompleted)
+                    this._dbContext.Set<TSaga>().Add(context.Saga);
+
+                await this._dbContext.SaveChangesAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaClassMapping.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaClassMapping.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration
+{
+    using GreenPipes.Internals.Extensions;
+    using GreenPipes.Internals.Reflection;
+
+    using MassTransit.Saga;
+
+    using Microsoft.EntityFrameworkCore;
+
+    public static class SagaClassMapping
+    {
+        public static void ConfigureDefaultSagaMap<T>(this ModelBuilder modelBuilder)
+            where T : class, ISaga
+        {
+            ReadWriteProperty<T> property;
+            if (!TypeCache<T>.ReadWritePropertyCache.TryGetProperty("CorrelationId", out property))
+                throw new ConfigurationException("The CorrelationId property must be read/write for use with Entity Framework. Add a setter to the property.");
+
+            modelBuilder.Entity<T>().HasKey(t => t.CorrelationId);
+
+            modelBuilder.Entity<T>().Property(t => t.CorrelationId)
+                .ValueGeneratedNever();
+        } 
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaDbContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaDbContext.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration
+{
+    using System;
+
+    using MassTransit.Saga;
+
+    using Microsoft.EntityFrameworkCore;
+
+    public class SagaDbContext<TSaga, TEntityConfiguration>:
+        DbContext
+        where TSaga : class, ISaga
+        where TEntityConfiguration : IEntityTypeConfiguration<TSaga>, new()
+    {
+        public SagaDbContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ConfigureDefaultSagaMap<TSaga>();
+
+            var configuration = Activator.CreateInstance<TEntityConfiguration>();
+            configuration.Configure(modelBuilder.Entity<TSaga>());
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaDbContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaDbContextFactory.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration
+{
+
+    using Microsoft.EntityFrameworkCore;
+
+    /// <summary>
+    /// Factory method for creating new database context connections.
+    /// </summary>
+    public delegate DbContext SagaDbContextFactory();
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/Audit/AuditRecord.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/Audit/AuditRecord.cs
@@ -18,7 +18,6 @@ namespace MassTransit.EntityFrameworkIntegration.Audit
     using MassTransit.Audit;
     using Newtonsoft.Json;
 
-
     public class AuditRecord
     {
         public int AuditRecordId { get; set; }
@@ -39,13 +38,10 @@ namespace MassTransit.EntityFrameworkIntegration.Audit
         [NotMapped]
         public Dictionary<string, string> Custom
         {
-            get
-            {
-                return string.IsNullOrEmpty(_custom)
-                    ? new Dictionary<string, string>()
-                    : JsonConvert.DeserializeObject<Dictionary<string, string>>(_custom);
-            }
-            set { _custom = JsonConvert.SerializeObject(value); }
+            get => string.IsNullOrEmpty(_custom)
+                       ? new Dictionary<string, string>()
+                       : JsonConvert.DeserializeObject<Dictionary<string, string>>(_custom);
+            set => _custom = JsonConvert.SerializeObject(value);
         }
 
         internal string _headers { get; set; }
@@ -53,13 +49,10 @@ namespace MassTransit.EntityFrameworkIntegration.Audit
         [NotMapped]
         public Dictionary<string, string> Headers
         {
-            get
-            {
-                return string.IsNullOrEmpty(_headers)
-                    ? new Dictionary<string, string>()
-                    : JsonConvert.DeserializeObject<Dictionary<string, string>>(_headers);
-            }
-            set { _headers = JsonConvert.SerializeObject(value); }
+            get => string.IsNullOrEmpty(_headers)
+                       ? new Dictionary<string, string>()
+                       : JsonConvert.DeserializeObject<Dictionary<string, string>>(_headers);
+            set => _headers = JsonConvert.SerializeObject(value);
         }
 
         internal string _message { get; set; }
@@ -67,13 +60,10 @@ namespace MassTransit.EntityFrameworkIntegration.Audit
         [NotMapped]
         public object Message
         {
-            get
-            {
-                return string.IsNullOrEmpty(_message)
-                    ? null
-                    : JsonConvert.DeserializeObject(_message);
-            }
-            set { _message = JsonConvert.SerializeObject(value); }
+            get => string.IsNullOrEmpty(_message)
+                       ? null
+                       : JsonConvert.DeserializeObject(_message);
+            set => _message = JsonConvert.SerializeObject(value);
         }
 
         internal static AuditRecord Create<T>(T message, string messageType, MessageAuditMetadata metadata)

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/EntityFrameworkSagaConsumeContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/EntityFrameworkSagaConsumeContext.cs
@@ -20,7 +20,6 @@ namespace MassTransit.EntityFrameworkIntegration.Saga
     using MassTransit.Saga;
     using Util;
 
-
     public class EntityFrameworkSagaConsumeContext<TSaga, TMessage> :
         ConsumeContextProxyScope<TMessage>,
         SagaConsumeContext<TSaga, TMessage>


### PR DESCRIPTION
This pr adds support for entity framework core persistence with .net standard 1.6 support as discussed in #909 . 

The logic is almost exact copy of classic ef 6 persistence package. 
Therefore, there is some code that depends on sql server support, like deadlock detection in sagaRepository:
```
static bool IsDeadlockException(Exception exception)
        {
            var baseException = exception.GetBaseException() as SqlException;

            return baseException != null && baseException.Number == 1205;
        }
``` 

Also, ef core does not support automatic migrations. You can either 
- call `database.EnsureCreated()` which creates database with desired configuration and is mostly suitable only for development/testing; 
- call `database.Migrate()` which requires creating manual migrations via command line. In the test project there are manually created migrations. 

Tests use the same local database as tests for ef6, but different schema to avoid collisions when doing migrations. 