### PR TITLE
migrate masstransit.tests and rabbitmq.tests to .net core

### DIFF
--- a/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
+++ b/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
@@ -1,20 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.XML" />
     <ProjectReference Include="..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />

--- a/src/MassTransit.Tests/CachingTests/TestException.cs
+++ b/src/MassTransit.Tests/CachingTests/TestException.cs
@@ -17,10 +17,12 @@
         {
         }
 
+#if !NETCORE
         protected TestException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
+#endif
 
         public TestException(string message, Exception innerException)
             : base(message, innerException)

--- a/src/MassTransit.Tests/Configuration/SendSpecification_Specs.cs
+++ b/src/MassTransit.Tests/Configuration/SendSpecification_Specs.cs
@@ -15,6 +15,7 @@ namespace MassTransit.Tests.Configuration
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using System.Threading.Tasks;
     using GreenPipes;
     using GreenPipes.Filters;
@@ -205,7 +206,7 @@ namespace MassTransit.Tests.Configuration
                 yield return baseInterface;
             }
 
-            var baseType = typeof(TMessage).BaseType;
+            var baseType = typeof(TMessage).GetTypeInfo().BaseType;
             while (baseType != null && TypeMetadataCache.IsValidMessageType(baseType))
             {
                 yield return baseType;
@@ -215,7 +216,7 @@ namespace MassTransit.Tests.Configuration
                     yield return baseInterface;
                 }
 
-                baseType = baseType.BaseType;
+                baseType = baseType.GetTypeInfo().BaseType;
             }
         }
 
@@ -226,9 +227,9 @@ namespace MassTransit.Tests.Configuration
                 .Where(TypeMetadataCache.IsValidMessageType)
                 .ToArray();
 
-            if (baseType.BaseType != null && baseType.BaseType != typeof(object))
+            if (baseType.GetTypeInfo().BaseType != null && baseType.GetTypeInfo().BaseType != typeof(object))
                 baseInterfaces = baseInterfaces
-                    .Except(baseType.BaseType.GetInterfaces())
+                    .Except(baseType.GetTypeInfo().BaseType.GetInterfaces())
                     .Except(baseInterfaces.SelectMany(x => x.GetInterfaces()))
                     .ToArray();
 

--- a/src/MassTransit.Tests/ContextSetup.cs
+++ b/src/MassTransit.Tests/ContextSetup.cs
@@ -27,12 +27,16 @@ namespace MassTransit.Tests
         [OneTimeSetUp]
         public void Before_any()
         {
-            string path = AppDomain.CurrentDomain.BaseDirectory;
-
+#if NETCORE
+            string path = AppContext.BaseDirectory;
             string file = Path.Combine(path, "masstransit.tests.log4net.xml");
-
+            var logRepository = LogManager.GetRepository(System.Reflection.Assembly.GetEntryAssembly());
+            XmlConfigurator.Configure(logRepository, new FileInfo(file));
+#else
+            string path = AppDomain.CurrentDomain.BaseDirectory;
+            string file = Path.Combine(path, "masstransit.tests.log4net.xml");
             XmlConfigurator.Configure(new FileInfo(file));
-
+#endif
             Trace.WriteLine("Loading Log4net: " + file);
 
             Logger.UseLogger(new Log4NetLogger());

--- a/src/MassTransit.Tests/Courier/EncryptedArgument_Specs.cs
+++ b/src/MassTransit.Tests/Courier/EncryptedArgument_Specs.cs
@@ -28,7 +28,7 @@ namespace MassTransit.Tests.Courier
             [Test]
             public void Should_fail_if_not_supported()
             {
-                using (var provider = new AesCryptoServiceProvider())
+                using (var provider = Aes.Create())
                 {
                     provider.GenerateKey();
                     provider.GenerateIV();

--- a/src/MassTransit.Tests/HostInfo_Specs.cs
+++ b/src/MassTransit.Tests/HostInfo_Specs.cs
@@ -50,6 +50,8 @@ namespace MassTransit.Tests
         }
     }
 
+#if !NETCORE
+
     [TestFixture]
     public class Host_info_should_be_included_on_binary_serialization :
         InMemoryTestFixture
@@ -87,4 +89,6 @@ namespace MassTransit.Tests
             Assert.AreEqual(HostMetadataCache.Host.ProcessId, context.Host.ProcessId);
         }
     }
+
+#endif
 }

--- a/src/MassTransit.Tests/MassTransit.Tests.csproj
+++ b/src/MassTransit.Tests/MassTransit.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -10,24 +10,31 @@
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
     <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Management" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
     <ProjectReference Include="..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1.1'">
+    <Compile Remove="Diagnostics/**" />
+    <Compile Remove="Pipeline/Transaction_Specs.cs" />
+    <Compile Remove="BinarySerializer_Specs.cs" />
+    <Compile Remove="SimpleConfiguration_Specs.cs" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Transactions" Condition="'$(TargetFramework)' == 'net452'" />
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1.1' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/MassTransit.Tests/MessageData/DataBus_Specs.cs
+++ b/src/MassTransit.Tests/MessageData/DataBus_Specs.cs
@@ -72,8 +72,11 @@ namespace MassTransit.Tests.MessageData
 
             protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
             {
+#if NETCORE
+                string baseDirectory = AppContext.BaseDirectory;
+#else
                 string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-
+#endif
                 string messageDataPath = Path.Combine(baseDirectory, "MessageData");
 
                 var dataDirectory = new DirectoryInfo(messageDataPath);
@@ -136,7 +139,11 @@ namespace MassTransit.Tests.MessageData
 
             protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
             {
+#if NETCORE
+                string baseDirectory = AppContext.BaseDirectory;
+#else
                 string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+#endif
 
                 string messageDataPath = Path.Combine(baseDirectory, "MessageData");
 

--- a/src/MassTransit.Tests/MessageData/FileSystem_Specs.cs
+++ b/src/MassTransit.Tests/MessageData/FileSystem_Specs.cs
@@ -37,8 +37,12 @@
         [OneTimeSetUp]
         public void Setup()
         {
-            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-
+#if NETCORE
+            string baseDirectory = AppContext.BaseDirectory;
+#else
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+#endif
+            
             var messageDataPath = Path.Combine(baseDirectory, "MessageData");
 
             var dataDirectory = new DirectoryInfo(messageDataPath);

--- a/src/MassTransit.Tests/Retry_Specs.cs
+++ b/src/MassTransit.Tests/Retry_Specs.cs
@@ -412,7 +412,7 @@ namespace MassTransit.Tests
 
                 _lastAttempt = context.GetRetryAttempt();
 
-                throw new ApplicationException("Yonder", new IntentionalTestException());
+                throw new Exception("Yonder", new IntentionalTestException());
             });
         }
     }

--- a/src/MassTransit.Tests/Saga/RegisterUserController.cs
+++ b/src/MassTransit.Tests/Saga/RegisterUserController.cs
@@ -66,14 +66,14 @@ namespace MassTransit.Tests.Saga
 
         bool WaitOn(WaitHandle handle, TimeSpan timeout, string message)
         {
-            int result = WaitHandle.WaitAny(new[] { handle }, timeout, true);
+            int result = WaitHandle.WaitAny(new[] { handle }, timeout);
             if (result == 0)
                 return true;
 
             if (result == 1)
                 return false;
 
-            throw new ApplicationException(message);
+            throw new Exception(message);
         }
 	}
 }

--- a/src/MassTransit.Tests/Serialization/Interface_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/Interface_Specs.cs
@@ -14,6 +14,7 @@ namespace MassTransit.Tests.Serialization
 {
     using System;
     using System.Linq;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Builders;
     using MassTransit.Serialization;
@@ -193,7 +194,7 @@ namespace MassTransit.Tests.Serialization
                 return false;
             if (ReferenceEquals(this, obj))
                 return true;
-            if (!typeof(ComplaintAdded).IsAssignableFrom(obj.GetType()))
+            if (!typeof(ComplaintAdded).GetTypeInfo().IsAssignableFrom(obj.GetType()))
                 return false;
             return Equals((ComplaintAdded)obj);
         }

--- a/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
@@ -17,6 +17,7 @@ namespace MassTransit.Tests.Serialization
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
     using System.Xml.Linq;
     using GreenPipes.Internals.Extensions;
@@ -464,7 +465,7 @@ namespace MassTransit.Tests.Serialization
 
             public override bool CanConvert(Type objectType)
             {
-                return typeof(string).IsAssignableFrom(objectType);
+                return typeof(string).GetTypeInfo().IsAssignableFrom(objectType);
             }
         }
 

--- a/src/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
@@ -16,7 +16,9 @@ namespace MassTransit.Tests.Serialization {
     [TestFixture(typeof(JsonMessageSerializer))]
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+#if !NETCORE
     [TestFixture(typeof(BinaryMessageSerializer))]
+#endif
     public class ReceiveFault_Serialization_Specs :
         SerializationTest {
         public ReceiveFault_Serialization_Specs(Type serializerType)

--- a/src/MassTransit.Tests/Serialization/SeparateSerializer_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/SeparateSerializer_Specs.cs
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests.Serialization
 {
+    using System;
     using System.Threading.Tasks;
     using MassTransit.Serialization;
     using NUnit.Framework;
@@ -32,11 +33,13 @@ namespace MassTransit.Tests.Serialization
 
             ConsumeContext<PingMessage> pingContext = await _handled;
 
-            Assert.That(pingContext.ReceiveContext.ContentType, Is.EqualTo(JsonMessageSerializer.JsonContentType));
+            Assert.That(pingContext.ReceiveContext.ContentType, Is.EqualTo(JsonMessageSerializer.JsonContentType),
+                $"actual ping type is {pingContext.ReceiveContext.ContentType}");
 
             ConsumeContext<PongMessage> pongContext = await ponged;
 
-            Assert.That(pongContext.ReceiveContext.ContentType, Is.EqualTo(BsonMessageSerializer.BsonContentType));
+            Assert.That(pongContext.ReceiveContext.ContentType, Is.EqualTo(BsonMessageSerializer.BsonContentType),
+                $"actual type is {pongContext.ReceiveContext.ContentType}");
         }
 
         Task<ConsumeContext<PingMessage>> _handled;

--- a/src/MassTransit.Tests/Serialization/SerializationTest.cs
+++ b/src/MassTransit.Tests/Serialization/SerializationTest.cs
@@ -70,10 +70,12 @@ namespace MassTransit.Tests.Serialization
                 Serializer = new EncryptedMessageSerializer(streamProvider);
                 Deserializer = new EncryptedMessageDeserializer(BsonMessageSerializer.Deserializer, streamProvider);
             }
+#if !NETCORE
             else if (_serializerType == typeof(BinaryMessageSerializer)) {
                 Serializer = new BinaryMessageSerializer();
                 Deserializer = new BinaryMessageDeserializer();
             }
+#endif
             else
                 throw new ArgumentException("The serializer type is unknown");
         }

--- a/src/MassTransit.Tests/SerializationFault_Specs.cs
+++ b/src/MassTransit.Tests/SerializationFault_Specs.cs
@@ -56,6 +56,8 @@ namespace MassTransit.Tests
         }
     }
 
+#if !NETCORE
+
     [TestFixture]
     public class When_a_message_response_fails_to_serialize_properly_and_is_using_the_binary_serializer :
         InMemoryTestFixture
@@ -104,8 +106,9 @@ namespace MassTransit.Tests
 
             _faulted = Handled<ReceiveFault>(configurator);
         }
-
     }
+
+    #endif
 
     /// <summary>
     /// this requires debugger tricks to make it work

--- a/src/MassTransit/NetCore.cs
+++ b/src/MassTransit/NetCore.cs
@@ -1,6 +1,6 @@
 namespace System.Net.Mime
 {
-    public class ContentType
+    public class ContentType : IEquatable<ContentType>
     {
         public ContentType(string mediaType)
         {
@@ -8,15 +8,40 @@ namespace System.Net.Mime
         }
 
         public string MediaType { get; private set; }
+
+        public bool Equals(ContentType other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return string.Equals(this.MediaType, other.MediaType);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((ContentType)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (this.MediaType != null ? this.MediaType.GetHashCode() : 0);
+        }
+
+        public static bool operator ==(ContentType left, ContentType right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(ContentType left, ContentType right)
+        {
+            return !Equals(left, right);
+        }
     }
 }
-
-// namespace System
-// {
-//     internal class SerializableAttribute : Attribute { }
-// }
-
-// namespace System.Runtime.Serialization
-// {
-//     public interface ISerializable { }
-// }


### PR DESCRIPTION
In order to test libraries built for .net standard, new tests profiles were added targeting .net core.

I had to explicitly target .net core version 1.1.1, otherwise build log was full of system.runtime version mismatch warning. 