### PR TITLE
add .net core test profiles to more projects according to issue #909

### DIFF
--- a/src/Containers/MassTransit.Containers.Tests/AutofacRegistrationExtension_Specs.cs
+++ b/src/Containers/MassTransit.Containers.Tests/AutofacRegistrationExtension_Specs.cs
@@ -19,7 +19,6 @@ namespace MassTransit.Containers.Tests
     using Saga;
     using Scenarios;
 
-
     [TestFixture]
     public class AutofacContainer_RegistrationExtension
     {
@@ -28,7 +27,7 @@ namespace MassTransit.Containers.Tests
         {
             var builder = new ContainerBuilder();
 
-            builder.RegisterConsumers(Assembly.GetExecutingAssembly());
+            builder.RegisterConsumers(typeof(AutofacContainer_RegistrationExtension).GetTypeInfo().Assembly);
 
             var container = builder.Build();
 
@@ -40,7 +39,7 @@ namespace MassTransit.Containers.Tests
         {
             var builder = new ContainerBuilder();
 
-            builder.RegisterConsumers(Assembly.GetExecutingAssembly());
+            builder.RegisterConsumers(typeof(AutofacContainer_RegistrationExtension).GetTypeInfo().Assembly);
             builder.RegisterType<InMemorySagaRepository<SimpleSaga>>()
                 .As<ISagaRepository<SimpleSaga>>()
                 .SingleInstance();

--- a/src/Containers/MassTransit.Containers.Tests/MassTransit.Containers.Tests.csproj
+++ b/src/Containers/MassTransit.Containers.Tests/MassTransit.Containers.Tests.csproj
@@ -1,25 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <NoWarn>1587,1591,1998,3008,3001</NoWarn>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+    <PackageTargetFallback Condition="'$(TargetFramework)'=='netcoreapp1.1.1'">
+      $(PackageTargetFallback);portable-net45+win8+wp8+wpa81
+    </PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.0" />
@@ -28,13 +13,13 @@
     <PackageReference Include="Castle.Windsor" Version="4.0.0" />
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="CommonServiceLocator" Version="1.3" />
+    <PackageReference Include="microsoft.net.test.sdk" Version="15.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.0.1" />
     <PackageReference Include="StructureMap" Version="4.5.1" />
     <PackageReference Include="Unity" Version="4.0.1" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Ninject" Version="3.2.2" />
-    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.2.0.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="SimpleInjector" Version="4.0.8" />
@@ -45,14 +30,29 @@
     <ProjectReference Include="..\MassTransit.AutofacIntegration\MassTransit.AutofacIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.Automatonymous.AutofacIntegration\MassTransit.Automatonymous.AutofacIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.Automatonymous.StructureMapIntegration\MassTransit.Automatonymous.StructureMapIntegration.csproj" />
-    <ProjectReference Include="..\MassTransit.NinjectIntegration\MassTransit.NinjectIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.SimpleInjectorIntegration\MassTransit.SimpleInjectorIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.StructureMapIntegration\MassTransit.StructureMapIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.UnityIntegration\MassTransit.UnityIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.WindsorIntegration\MassTransit.WindsorIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.ExtensionsDependencyInjectionIntegration\MassTransit.ExtensionsDependencyInjectionIntegration.csproj" />
   </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Ninject" Version="3.2.2" />
+    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.2.0.0" />
+    <ProjectReference Include="..\MassTransit.NinjectIntegration\MassTransit.NinjectIntegration.csproj" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1.1' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1.1'">
+    <Compile Remove="Ninject_Specs.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Containers/MassTransit.Containers.Tests/Unity_Specs.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Unity_Specs.cs
@@ -17,7 +17,6 @@ namespace MassTransit.Containers.Tests
     using Saga;
     using Scenarios;
 
-
     public class Unity_Consumer :
         When_registering_a_consumer
     {

--- a/src/Containers/MassTransit.WindsorIntegration/MassTransit.WindsorIntegration.csproj
+++ b/src/Containers/MassTransit.WindsorIntegration/MassTransit.WindsorIntegration.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
     <DebugType>portable</DebugType>
@@ -18,10 +19,6 @@
     <PackageReference Include="Castle.Windsor" Version="4.0.0" />
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MassTransit.Reactive.Tests/MassTransit.Reactive.Tests.csproj
+++ b/src/MassTransit.Reactive.Tests/MassTransit.Reactive.Tests.csproj
@@ -1,37 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>1587,1591,1998,3008,3001</NoWarn>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-    <Reference Include="System.Xml.Linq" />
     <ProjectReference Include="..\MassTransit.Reactive\MassTransit.Reactive.csproj" />
     <ProjectReference Include="..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/MassTransit.DocumentDbIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/MassTransit.DocumentDbIntegration.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditContextFactory.cs
@@ -15,7 +15,9 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
                 UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString(),
                     m =>
                         {
-                            m.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name);
+                            var executingAssembly = typeof(ContextFactory).GetTypeInfo().Assembly;
+
+                            m.MigrationsAssembly(executingAssembly.GetName().Name);
                             m.MigrationsHistoryTable("__AuditEFMigrationHistoryAudit");
                         });
 

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditStore_Specs.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/AuditStore_Specs.cs
@@ -65,7 +65,9 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
                 UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString(),
                 m =>
                     {
-                        m.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name);
+                        var executingAssembly = typeof(ContextFactory).GetTypeInfo().Assembly;
+
+                        m.MigrationsAssembly(executingAssembly.GetName().Name);
                         m.MigrationsHistoryTable("__AuditEFMigrationHistoryAudit");
                     });
 

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextFactory.cs
@@ -12,8 +12,14 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
         public SagaDbContext<SimpleSaga, SimpleSagaMap> Create(DbContextFactoryOptions options)
         {
             var dbContextOptionsBuilder = new DbContextOptionsBuilder<SagaDbContext<SimpleSaga, SimpleSagaMap>>();
+
             dbContextOptionsBuilder.UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString(),
-                m => m.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name));
+                m =>
+                    {
+                        var executingAssembly = typeof(ContextFactory).GetTypeInfo().Assembly;
+
+                        m.MigrationsAssembly(executingAssembly.GetName().Name);
+                    });
 
             return new SagaDbContext<SimpleSaga, SimpleSagaMap>(dbContextOptionsBuilder.Options);
         }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
@@ -14,9 +14,11 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
     <ProjectReference Include="..\..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />

--- a/src/Persistence/MassTransit.MartenIntegration.Tests/MassTransit.MartenIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.MartenIntegration.Tests/MassTransit.MartenIntegration.Tests.csproj
@@ -1,64 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Baseline" Version="1.3.0" />
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="Marten" Version="1.5.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Npgsql" Version="3.2.2" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="Remotion.Linq" Version="2.1.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
-    <Reference Include="System" />
-    <PackageReference Include="System.AppContext" Version="4.3.0" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <PackageReference Include="System.Console" Version="4.3.0" />
-    <Reference Include="System.Core" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.3.1" />
-    <PackageReference Include="System.Globalization.Calendars" Version="4.3.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <Reference Include="System.IO.Compression.FileSystem" />
-    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
-    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <Reference Include="System.Numerics" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
     <ProjectReference Include="..\..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
     <ProjectReference Include="..\MassTransit.MartenIntegration\MassTransit.MartenIntegration.csproj" />

--- a/src/Persistence/MassTransit.MongoDbIntegration.Tests/MassTransit.MongoDbIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.MongoDbIntegration.Tests/MassTransit.MongoDbIntegration.Tests.csproj
@@ -1,22 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="MongoMessageDataRepositoryTestsForGettingMessageData.cs" />
@@ -33,10 +18,8 @@
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="Autofixture" Version="3.50.2" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <ProjectReference Include="..\..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
     <ProjectReference Include="..\..\MassTransit.AutomatonymousIntegration\MassTransit.AutomatonymousIntegration.csproj" />
     <ProjectReference Include="..\..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />


### PR DESCRIPTION
This pr continues .net core/.net standard migration as discussed in #909 
- it adds .net standard support to castle windsor integration
- .net core tests suppport to containers tests (except for unsupported containers), ef core, marten, mongo db, rx. All tests pass. 