### PR TITLE
Created github issue and pull request template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -104,5 +104,5 @@
   We still appreciate the report though, as eventually somebody else might
   create a reproducible example for it.
 
-  Thanks for helping us help you!
+  Thanks for helping us help you! 
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,108 @@
+<!--
+  PLEASE READ THE FIRST SECTION :-)
+-->
+
+### Is this a bug report?
+
+(write your answer here)
+
+<!--
+  If you answered "Yes":
+  
+    Please note that your issue will be fixed much faster if you spend about
+    half an hour preparing it, including the exact reproduction steps and a demo.
+    
+    If you're in a hurry or don't feel confident, it's fine to report bugs with
+    less details, but this makes it less likely they'll get fixed soon.
+
+    In either case, please fill as many fields below as you can.
+
+  If you answered "No":
+
+    If this is a question or a discussion, please use [StackOverflow](https://stackoverflow.com/questions/tagged/masstransit) or [MT mailing list for questions](https://groups.google.com/forum/#!forum/masstransit-discuss)
+-->
+
+
+### Can you also reproduce the problem with the lastest version?
+
+(Write your answer here.)
+
+
+### Environment
+
+<!--
+  Please fill in all the relevant fields.
+-->
+
+1. Operating system:
+2. Visual Studio version:
+3. Dotnet version:
+
+### Steps to Reproduce
+
+<!--
+  How would you describe your issue to someone who doesn’t know you or your project?
+  Try to write a sequence of steps that anybody can repeat to see the issue.
+-->
+
+(Write your steps here:)
+
+1. 
+2. 
+3. 
+
+
+### Expected Behavior
+
+<!--
+  How did you expect the tool to behave?
+  It’s fine if you’re not sure your understanding is correct.
+  Just write down what you thought would happen.
+-->
+
+(Write what you thought would happen.)
+
+
+### Actual Behavior
+
+<!--
+  Did something go wrong?
+  Is something broken, or not behaving as you expected?
+  Please attach screenshots if possible! They are extremely helpful for diagnosing issues.
+-->
+
+(Write what happened. Please add screenshots!)
+
+
+### Reproducible Demo
+
+<!--
+  If you can, please share a project that reproduces the issue.
+  This is the single most effective way to get an issue fixed soon.
+
+  There are two ways to do it:
+
+    * Create a new app and try to reproduce the issue in it.
+      This is useful if you roughly know where the problem is, or can’t share the real code.
+
+    * Or, copy your app and remove things until you’re left with the minimal reproducible demo.
+      This is useful for finding the root cause. You may then optionally create a new project.
+
+  This is a good guide to creating bug demos: https://stackoverflow.com/help/mcve
+  Once you’re done, push the project to GitHub and paste the link to it below:
+-->
+
+(Paste the link to an example project and exact instructions to reproduce the issue.)
+
+<!--
+  What happens if you skip this step?
+  
+  We will try to help you, but in many cases it is impossible because crucial
+  information is missing. In that case we'll tag an issue as having a low priority,
+  and eventually close it if there is no clear direction.
+  
+  We still appreciate the report though, as eventually somebody else might
+  create a reproducible example for it.
+
+  Thanks for helping us help you!
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!--
+Thank you for sending the PR!
+
+If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!
+
+Happy contributing!
+-->


### PR DESCRIPTION
I modified the create-react-app ones to suite our needs, would be good to have a new these template to aid how people file issues. 

Would reduce ~aggressive~ comments like these. https://github.com/MassTransit/MassTransit/issues/957#issuecomment-320874708

Having an issue templated makes it clear what we expect to see in an issue, and how we priorities these issue, and where to post questions.