### PR TITLE
[WIP] Port Azure ServiceBus Transport to netstandard1.6

### DIFF
--- a/src/MassTransit.AzureServiceBusTransport.Tests/MassTransit.AzureServiceBusTransport.Tests.csproj
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/MassTransit.AzureServiceBusTransport.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -22,13 +22,11 @@
   <ItemGroup>
     <PackageReference Include="Automatonymous" Version="3.5.12" />
     <PackageReference Include="GreenPipes" Version="1.0.10" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -40,6 +38,13 @@
     <ProjectReference Include="..\MassTransit.AzureServiceBusTransport\MassTransit.AzureServiceBusTransport.csproj" />
     <ProjectReference Include="..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
+    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/MassTransit.AzureServiceBusTransport/BrokeredMessageContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/BrokeredMessageContext.cs
@@ -15,8 +15,9 @@ namespace MassTransit.AzureServiceBusTransport
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     /// <summary>
     /// The context of a BrokeredMessage from AzureServiceBus - gives access to the transport

--- a/src/MassTransit.AzureServiceBusTransport/BusFactoryConfiguratorExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/BusFactoryConfiguratorExtensions.cs
@@ -15,8 +15,9 @@ namespace MassTransit
     using System;
     using AzureServiceBusTransport;
     using AzureServiceBusTransport.Configurators;
+#if !NETCORE
     using Microsoft.ServiceBus;
-
+#endif
 
     public static class BusFactoryConfiguratorExtensions
     {

--- a/src/MassTransit.AzureServiceBusTransport/BusFactoryConfiguratorExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/BusFactoryConfiguratorExtensions.cs
@@ -17,6 +17,8 @@ namespace MassTransit
     using AzureServiceBusTransport.Configurators;
 #if !NETCORE
     using Microsoft.ServiceBus;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public static class BusFactoryConfiguratorExtensions

--- a/src/MassTransit.AzureServiceBusTransport/ClientContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ClientContext.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport
     using System.Threading.Tasks;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     /// <summary>

--- a/src/MassTransit.AzureServiceBusTransport/ClientContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ClientContext.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport
 {
     using System;
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     /// <summary>
     /// The client context is used to access the queue/subscription/topic client.

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusHostConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusHostConfigurator.cs
@@ -13,10 +13,13 @@
 namespace MassTransit.AzureServiceBusTransport.Configurators
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Microsoft.ServiceBus.Messaging.Amqp;
-
+#else
+    using Microsoft.Azure.ServiceBus;
+#endif
 
     public class ServiceBusHostConfigurator :
         IServiceBusHostConfigurator

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusReceiveEndpointSpecification.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusReceiveEndpointSpecification.cs
@@ -17,7 +17,9 @@ namespace MassTransit.AzureServiceBusTransport.Configurators
     using Builders;
     using GreenPipes;
     using MassTransit.Builders;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Pipeline;
     using Settings;
     using Specifications;

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusReceiveEndpointSpecification.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusReceiveEndpointSpecification.cs
@@ -19,6 +19,8 @@ namespace MassTransit.AzureServiceBusTransport.Configurators
     using MassTransit.Builders;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Pipeline;
     using Settings;

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusSubscriptionEndpointSpecification.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusSubscriptionEndpointSpecification.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport.Configurators
     using MassTransit.Builders;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Pipeline;
     using Settings;

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusSubscriptionEndpointSpecification.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/Configurators/ServiceBusSubscriptionEndpointSpecification.cs
@@ -16,7 +16,9 @@ namespace MassTransit.AzureServiceBusTransport.Configurators
     using Builders;
     using GreenPipes;
     using MassTransit.Builders;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Pipeline;
     using Settings;
     using Specifications;

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/Defaults.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/Defaults.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport
 {
     using System;
     using System.ComponentModel;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     static class Defaults

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/Defaults.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/Defaults.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport
     using System.ComponentModel;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/IServiceBusHostConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/IServiceBusHostConfigurator.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport
 #if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface IServiceBusHostConfigurator

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/IServiceBusHostConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/IServiceBusHostConfigurator.cs
@@ -13,9 +13,10 @@
 namespace MassTransit.AzureServiceBusTransport
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public interface IServiceBusHostConfigurator
     {

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/ISharedAccessSignatureTokenProviderConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/ISharedAccessSignatureTokenProviderConfigurator.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport
     using System;
 #if !NETCORE
     using Microsoft.ServiceBus;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface ISharedAccessSignatureTokenProviderConfigurator :

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/ISharedAccessSignatureTokenProviderConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/ISharedAccessSignatureTokenProviderConfigurator.cs
@@ -13,8 +13,9 @@
 namespace MassTransit.AzureServiceBusTransport
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus;
-
+#endif
 
     public interface ISharedAccessSignatureTokenProviderConfigurator :
         ITokenProviderConfigurator

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/ServiceBusTopicSubscriptionExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/ServiceBusTopicSubscriptionExtensions.cs
@@ -16,7 +16,9 @@ namespace MassTransit.AzureServiceBusTransport
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Newtonsoft.Json.Linq;
     using Settings;
     using Transports;

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/ServiceBusTopicSubscriptionExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/ServiceBusTopicSubscriptionExtensions.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport
     using System.Reflection;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Newtonsoft.Json.Linq;
     using Settings;

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/SharedAccessSignatureTokenProviderConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/SharedAccessSignatureTokenProviderConfigurator.cs
@@ -13,8 +13,9 @@
 namespace MassTransit.AzureServiceBusTransport
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus;
-
+#endif
 
     public class SharedAccessSignatureTokenProviderConfigurator :
         ISharedAccessSignatureTokenProviderConfigurator

--- a/src/MassTransit.AzureServiceBusTransport/Configuration/SharedAccessSignatureTokenProviderConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Configuration/SharedAccessSignatureTokenProviderConfigurator.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport
     using System;
 #if !NETCORE
     using Microsoft.ServiceBus;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class SharedAccessSignatureTokenProviderConfigurator :

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/BrokeredMessageSessionContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/BrokeredMessageSessionContext.cs
@@ -15,8 +15,9 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
     using System;
     using System.IO;
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class BrokeredMessageSessionContext :
         MessageSessionContext

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/BrokeredMessageSessionContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/BrokeredMessageSessionContext.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
     using System.Threading.Tasks;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class BrokeredMessageSessionContext :

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/QueueClientContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/QueueClientContext.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
 {
     using System;
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class QueueClientContext :
         ClientContext

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/QueueClientContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/QueueClientContext.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
     using System.Threading.Tasks;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class QueueClientContext :

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusNamespaceContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusNamespaceContext.cs
@@ -19,6 +19,8 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
 #if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusNamespaceContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusNamespaceContext.cs
@@ -16,8 +16,10 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
     using System.Threading.Tasks;
     using GreenPipes;
     using GreenPipes.Payloads;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Util;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusReceiveContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusReceiveContext.cs
@@ -21,6 +21,8 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
     using MassTransit.Topology;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transports;
 

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusReceiveContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusReceiveContext.cs
@@ -19,7 +19,9 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
     using System.Threading.Tasks;
     using Context;
     using MassTransit.Topology;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transports;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/SubscriptionClientContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/SubscriptionClientContext.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
     using System.Threading.Tasks;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class SubscriptionClientContext :

--- a/src/MassTransit.AzureServiceBusTransport/Contexts/SubscriptionClientContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/SubscriptionClientContext.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
 {
     using System;
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class SubscriptionClientContext :
         ClientContext

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusHostBusFactory.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusHostBusFactory.cs
@@ -19,6 +19,8 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Microsoft.ServiceBus.Messaging.Amqp;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class ServiceBusHostBusFactory :

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusHostBusFactory.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusHostBusFactory.cs
@@ -15,10 +15,11 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
     using System;
     using Logging;
     using MassTransit.Hosting;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Microsoft.ServiceBus.Messaging.Amqp;
-
+#endif
 
     public class ServiceBusHostBusFactory :
         IHostBusFactory

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusSettings.cs
@@ -14,9 +14,10 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
 {
     using System;
     using MassTransit.Hosting;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public interface ServiceBusSettings :
         ISettings

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusSettings.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
 #if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface ServiceBusSettings :

--- a/src/MassTransit.AzureServiceBusTransport/IServiceBusHost.cs
+++ b/src/MassTransit.AzureServiceBusTransport/IServiceBusHost.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport
 #if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transports;
     using Util;

--- a/src/MassTransit.AzureServiceBusTransport/IServiceBusHost.cs
+++ b/src/MassTransit.AzureServiceBusTransport/IServiceBusHost.cs
@@ -15,8 +15,10 @@ namespace MassTransit.AzureServiceBusTransport
     using System;
     using System.Threading.Tasks;
     using GreenPipes;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transports;
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/MassTransit.AzureServiceBusTransport.csproj
+++ b/src/MassTransit.AzureServiceBusTransport/MassTransit.AzureServiceBusTransport.csproj
@@ -1,10 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.AzureServiceBus</PackageId><Title>MassTransit.AzureServiceBus</Title>
@@ -14,15 +18,24 @@
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageReference Include="NewId" Version="3.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MassTransit.AzureServiceBusTransport/NamespaceContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/NamespaceContext.cs
@@ -15,8 +15,10 @@ namespace MassTransit.AzureServiceBusTransport
     using System;
     using System.Threading.Tasks;
     using GreenPipes;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Util;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/NamespaceContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/NamespaceContext.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport
 #if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/NamespaceManagerExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/NamespaceManagerExtensions.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport
 #if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public static class NamespaceManagerExtensions

--- a/src/MassTransit.AzureServiceBusTransport/NamespaceManagerExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/NamespaceManagerExtensions.cs
@@ -15,9 +15,10 @@ namespace MassTransit.AzureServiceBusTransport
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public static class NamespaceManagerExtensions
     {

--- a/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareQueueClientFilter.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareQueueClientFilter.cs
@@ -16,7 +16,9 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
     using Contexts;
     using GreenPipes;
     using Logging;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transport;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareQueueClientFilter.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareQueueClientFilter.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
     using Logging;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transport;
 

--- a/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareSubscriptionClientFilter.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareSubscriptionClientFilter.cs
@@ -16,7 +16,9 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
     using Contexts;
     using GreenPipes;
     using Logging;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transport;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareSubscriptionClientFilter.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Pipeline/PrepareSubscriptionClientFilter.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
     using Logging;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transport;
 

--- a/src/MassTransit.AzureServiceBusTransport/Pipeline/RenewLockFilter.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Pipeline/RenewLockFilter.cs
@@ -17,8 +17,9 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
     using System.Threading.Tasks;
     using GreenPipes;
     using Logging;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class RenewLockFilter :
         IFilter<ConsumeContext>

--- a/src/MassTransit.AzureServiceBusTransport/Pipeline/RenewLockFilter.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Pipeline/RenewLockFilter.cs
@@ -19,6 +19,8 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
     using Logging;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class RenewLockFilter :

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusAddressExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusAddressExtensions.cs
@@ -16,7 +16,9 @@ namespace MassTransit.AzureServiceBusTransport
     using System.Text;
     using Configurators;
     using Internals.Extensions;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using NewIdFormatters;
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusAddressExtensions.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusAddressExtensions.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport
     using Internals.Extensions;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using NewIdFormatters;
     using Util;

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusHost.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusHost.cs
@@ -23,6 +23,8 @@ namespace MassTransit.AzureServiceBusTransport
 #if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Settings;
     using Transport;

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusHost.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusHost.cs
@@ -20,8 +20,10 @@ namespace MassTransit.AzureServiceBusTransport
     using GreenPipes;
     using Logging;
     using MassTransit.Pipeline;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Settings;
     using Transport;
     using Transports;

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusHostSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusHostSettings.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Microsoft.ServiceBus.Messaging.Amqp;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     /// <summary>

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusHostSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusHostSettings.cs
@@ -13,10 +13,11 @@
 namespace MassTransit.AzureServiceBusTransport
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus;
     using Microsoft.ServiceBus.Messaging;
     using Microsoft.ServiceBus.Messaging.Amqp;
-
+#endif
 
     /// <summary>
     /// The host settings used to configure the service bus connection

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusTokenProviderSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusTokenProviderSettings.cs
@@ -13,8 +13,9 @@
 namespace MassTransit.AzureServiceBusTransport
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus;
-
+#endif
 
     public interface ServiceBusTokenProviderSettings
     {

--- a/src/MassTransit.AzureServiceBusTransport/ServiceBusTokenProviderSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/ServiceBusTokenProviderSettings.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport
     using System;
 #if !NETCORE
     using Microsoft.ServiceBus;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface ServiceBusTokenProviderSettings

--- a/src/MassTransit.AzureServiceBusTransport/Settings/ReceiveEndpointSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Settings/ReceiveEndpointSettings.cs
@@ -16,7 +16,9 @@ namespace MassTransit.AzureServiceBusTransport.Settings
     using System.Collections.Generic;
     using System.Reflection;
     using GreenPipes.Internals.Reflection;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transport;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Settings/ReceiveEndpointSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Settings/ReceiveEndpointSettings.cs
@@ -18,6 +18,8 @@ namespace MassTransit.AzureServiceBusTransport.Settings
     using GreenPipes.Internals.Reflection;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transport;
 

--- a/src/MassTransit.AzureServiceBusTransport/Settings/SubscriptionEndpointSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Settings/SubscriptionEndpointSettings.cs
@@ -14,7 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Settings
 {
     using System;
     using System.Collections.Generic;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transport;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Settings/SubscriptionEndpointSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Settings/SubscriptionEndpointSettings.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Settings
     using System.Collections.Generic;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transport;
 

--- a/src/MassTransit.AzureServiceBusTransport/Settings/TopicSubscriptionSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Settings/TopicSubscriptionSettings.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AzureServiceBusTransport.Settings
 {
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     /// <summary>

--- a/src/MassTransit.AzureServiceBusTransport/Settings/TopicSubscriptionSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Settings/TopicSubscriptionSettings.cs
@@ -12,8 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Settings
 {
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     /// <summary>
     /// Settings for a subscription to be bound into the RabbitMQ exchanges

--- a/src/MassTransit.AzureServiceBusTransport/Testing/AzureServiceBusTestHarness.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Testing/AzureServiceBusTestHarness.cs
@@ -15,8 +15,9 @@ namespace MassTransit.AzureServiceBusTransport.Testing
     using System;
     using Logging;
     using MassTransit.Testing;
+#if !NETCORE
     using Microsoft.ServiceBus;
-
+#endif
 
     public class AzureServiceBusTestHarness :
         BusTestHarness

--- a/src/MassTransit.AzureServiceBusTransport/Testing/AzureServiceBusTestHarness.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Testing/AzureServiceBusTestHarness.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport.Testing
     using MassTransit.Testing;
 #if !NETCORE
     using Microsoft.ServiceBus;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class AzureServiceBusTestHarness :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Builders/IServiceBusTopologyBuilder.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Builders/IServiceBusTopologyBuilder.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Builders
     using Entities;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface IServiceBusTopologyBuilder

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Builders/IServiceBusTopologyBuilder.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Builders/IServiceBusTopologyBuilder.cs
@@ -13,8 +13,9 @@
 namespace MassTransit.AzureServiceBusTransport.Topology.Builders
 {
     using Entities;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public interface IServiceBusTopologyBuilder
     {

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Builders/PublishEndpointTopologyBuilder.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Builders/PublishEndpointTopologyBuilder.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Builders
 {
     using System;
     using Entities;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class PublishEndpointTopologyBuilder :
         ServiceBusTopologyBuilder,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Builders/PublishEndpointTopologyBuilder.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Builders/PublishEndpointTopologyBuilder.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Builders
     using Entities;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class PublishEndpointTopologyBuilder :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Builders/ServiceBusTopologyBuilder.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Builders/ServiceBusTopologyBuilder.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Builders
     using MassTransit.Topology.Entities;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public abstract class ServiceBusTopologyBuilder :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Builders/ServiceBusTopologyBuilder.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Builders/ServiceBusTopologyBuilder.cs
@@ -15,8 +15,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Builders
     using System.Threading;
     using Entities;
     using MassTransit.Topology.Entities;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public abstract class ServiceBusTopologyBuilder :
         IServiceBusTopologyBuilder

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
@@ -13,8 +13,9 @@
 namespace MassTransit.AzureServiceBusTransport.Topology.Configurators
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class QueueConfigurator :
         MessageEntityConfigurator,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Configurators
     using System;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class QueueConfigurator :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/SubscriptionConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/SubscriptionConfigurator.cs
@@ -13,8 +13,9 @@
 namespace MassTransit.AzureServiceBusTransport.Topology.Configurators
 {
     using System;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class SubscriptionConfigurator :
         EntityConfigurator,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/SubscriptionConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/SubscriptionConfigurator.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Configurators
     using System;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class SubscriptionConfigurator :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Configurators
 {
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class TopicConfigurator :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
@@ -12,8 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Topology.Configurators
 {
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class TopicConfigurator :
         MessageEntityConfigurator,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Queue.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Queue.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     /// <summary>

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Queue.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Queue.cs
@@ -12,8 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     /// <summary>
     /// The queue details used to declare the queue to RabbitMQ

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueEntity.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
     using System.Collections.Generic;
     using System.Linq;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class QueueEntity :
         Queue,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueEntity.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
     using System.Linq;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class QueueEntity :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueSubscriptionEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueSubscriptionEntity.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
     using System.Linq;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class QueueSubscriptionEntity :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueSubscriptionEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/QueueSubscriptionEntity.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
     using System.Collections.Generic;
     using System.Linq;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class QueueSubscriptionEntity :
         QueueSubscription,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Subscription.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Subscription.cs
@@ -12,8 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     /// <summary>
     /// A subscription, as defined

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Subscription.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Subscription.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     /// <summary>

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/SubscriptionEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/SubscriptionEntity.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
     using System.Collections.Generic;
     using System.Linq;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class SubscriptionEntity :
         Subscription,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/SubscriptionEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/SubscriptionEntity.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
     using System.Linq;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class SubscriptionEntity :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Topic.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Topic.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     /// <summary>

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Topic.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/Topic.cs
@@ -12,8 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     /// <summary>
     /// The exchange details used to declare the exchange to RabbitMQ

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicEntity.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
     using System.Collections.Generic;
     using System.Linq;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class TopicEntity :
         Topic,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicEntity.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
     using System.Linq;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class TopicEntity :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicSubscriptionEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicSubscriptionEntity.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
 {
     using System.Collections.Generic;
     using System.Linq;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public class TopicSubscriptionEntity :
         TopicSubscription,

--- a/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicSubscriptionEntity.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/Entities/TopicSubscriptionEntity.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology.Entities
     using System.Linq;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public class TopicSubscriptionEntity :

--- a/src/MassTransit.AzureServiceBusTransport/Topology/QueueSubscriptionConsumeTopologySpecification.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/QueueSubscriptionConsumeTopologySpecification.cs
@@ -17,7 +17,9 @@ namespace MassTransit.AzureServiceBusTransport.Topology
     using System.Text;
     using Builders;
     using GreenPipes;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using NewIdFormatters;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Topology/QueueSubscriptionConsumeTopologySpecification.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Topology/QueueSubscriptionConsumeTopologySpecification.cs
@@ -19,6 +19,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology
     using GreenPipes;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using NewIdFormatters;
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/IReceiveClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/IReceiveClient.cs
@@ -13,8 +13,9 @@
 namespace MassTransit.AzureServiceBusTransport.Transport
 {
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public interface IReceiveClient
     {

--- a/src/MassTransit.AzureServiceBusTransport/Transport/IReceiveClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/IReceiveClient.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using System.Threading.Tasks;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface IReceiveClient

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ISendClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ISendClient.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using System.Threading.Tasks;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface ISendClient

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ISendClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ISendClient.cs
@@ -14,8 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
 {
     using System;
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public interface ISendClient
     {

--- a/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandler.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandler.cs
@@ -19,6 +19,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using MassTransit.Topology;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transports.Metrics;
     using Util;

--- a/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandler.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandler.cs
@@ -17,7 +17,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using Contexts;
     using Logging;
     using MassTransit.Topology;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transports.Metrics;
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandlerFactory.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandlerFactory.cs
@@ -16,6 +16,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using MassTransit.Topology;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transports.Metrics;
     using Util;

--- a/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandlerFactory.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/MessageSessionAsyncHandlerFactory.cs
@@ -14,7 +14,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
 {
     using System;
     using MassTransit.Topology;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transports.Metrics;
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/QueueSendClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/QueueSendClient.cs
@@ -15,7 +15,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using System;
     using System.Threading.Tasks;
     using GreenPipes;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Policies;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/QueueSendClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/QueueSendClient.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using GreenPipes;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Policies;
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ReceiveSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ReceiveSettings.cs
@@ -12,8 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Transport
 {
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public interface ReceiveSettings :
         ClientSettings

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ReceiveSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ReceiveSettings.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
 {
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface ReceiveSettings :

--- a/src/MassTransit.AzureServiceBusTransport/Transport/Receiver.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/Receiver.cs
@@ -20,7 +20,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using Internals.Extensions;
     using Logging;
     using MassTransit.Topology;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transports.Metrics;
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/Receiver.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/Receiver.cs
@@ -22,6 +22,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using MassTransit.Topology;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transports.Metrics;
     using Util;

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransport.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransport.cs
@@ -25,7 +25,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using Logging;
     using MassTransit.Pipeline.Observables;
     using MassTransit.Scheduling;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Serialization;
     using Transports;
     using Util;

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransport.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransport.cs
@@ -27,6 +27,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using MassTransit.Scheduling;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Serialization;
     using Transports;

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransportProvider.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransportProvider.cs
@@ -15,7 +15,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using System;
     using System.Linq;
     using System.Threading.Tasks;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Policies;
     using Transports;
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransportProvider.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransportProvider.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using System.Threading.Tasks;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Policies;
     using Transports;

--- a/src/MassTransit.AzureServiceBusTransport/Transport/SessionReceiver.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/SessionReceiver.cs
@@ -21,6 +21,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using MassTransit.Topology;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Transports.Metrics;
     using Util;

--- a/src/MassTransit.AzureServiceBusTransport/Transport/SessionReceiver.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/SessionReceiver.cs
@@ -19,7 +19,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using Internals.Extensions;
     using Logging;
     using MassTransit.Topology;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Transports.Metrics;
     using Util;
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/SubscriptionSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/SubscriptionSettings.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
 {
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
 
     public interface SubscriptionSettings :

--- a/src/MassTransit.AzureServiceBusTransport/Transport/SubscriptionSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/SubscriptionSettings.cs
@@ -12,8 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Transport
 {
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
-
+#endif
 
     public interface SubscriptionSettings :
         ClientSettings

--- a/src/MassTransit.AzureServiceBusTransport/Transport/TopicSendClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/TopicSendClient.cs
@@ -15,7 +15,9 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using System;
     using System.Threading.Tasks;
     using GreenPipes;
+#if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#endif
     using Policies;
 
 

--- a/src/MassTransit.AzureServiceBusTransport/Transport/TopicSendClient.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/TopicSendClient.cs
@@ -17,6 +17,8 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using GreenPipes;
 #if !NETCORE
     using Microsoft.ServiceBus.Messaging;
+#else
+    using Microsoft.Azure.ServiceBus;
 #endif
     using Policies;
 


### PR DESCRIPTION
- [ ] Fix compile error for `TransportType`
- [ ] Fix compile error for `TokenProvider`
- [ ] Fix compile error for `AmqpTransportSettings`
- [ ] Fix compile error for `MessageState`
- [ ] Fix compile error for `BrokeredMessage`
- [ ] Fix compile error for `NetMessagingTransportSettings`

