### PR TITLE
Pass version arguments to dotnet restore in fake

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -53,7 +53,8 @@ Target "Clean" (fun _ ->
 )
 
 Target "RestorePackages" (fun _ -> 
-  DotNetCli.Restore (fun p -> { p with Project = "./src/" } )
+  DotNetCli.Restore (fun p -> { p with Project = "./src/"
+                                       AdditionalArgs = versionArgs })
 )
 
 Target "Build" (fun _ ->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,9 +4,6 @@
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
   <Title>MassTransit</Title>
-    <Version>4.0.0.0</Version>
-    <FileVersion>4.0.0.0</FileVersion>
-    <InformationalVersion>4.0.0.0 (develop/52a30ae5)</InformationalVersion>
     <Product>MassTransit</Product>
     <Description>MassTransit is a message-based distributed application framework for .NET http://masstransit-project.com</Description>
     <PackageProjectUrl>https://github.com/MassTransit/MassTransit</PackageProjectUrl>


### PR DESCRIPTION
Pass version arguments to dotnet restore in fake, so that internal NuGet package references are correct