### PR TITLE
Support for Marten 2

### DIFF
--- a/src/Persistence/MassTransit.MartenIntegration/MartenSagaRepository.cs
+++ b/src/Persistence/MassTransit.MartenIntegration/MartenSagaRepository.cs
@@ -92,7 +92,7 @@
             {
                 try
                 {
-                    IList<TSaga> instances = await session.Query<TSaga>()
+                    var instances = await session.Query<TSaga>()
                         .Where(context.Query.FilterExpression)
                         .ToListAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
Since Marten 2 returns `IReadOnlyList` and not `IList`, `IList` has been changed to just `var` so it will work in Marten 1 and 2.
