### PR TITLE
Make it possible to specify scheduling queue name

### DIFF
--- a/src/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
+++ b/src/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
@@ -23,7 +23,7 @@ namespace MassTransit
 
     public static class QuartzIntegrationExtensions
     {
-        public static void UseInMemoryScheduler(this IBusFactoryConfigurator configurator)
+        public static void UseInMemoryScheduler(this IBusFactoryConfigurator configurator, string queueName = "quartz")
         {
             if (configurator == null)
                 throw new ArgumentNullException(nameof(configurator));
@@ -31,7 +31,7 @@ namespace MassTransit
             ISchedulerFactory schedulerFactory = new StdSchedulerFactory();
             var scheduler = schedulerFactory.GetScheduler();
 
-            configurator.ReceiveEndpoint("quartz", e =>
+            configurator.ReceiveEndpoint(queueName, e =>
             {
                 var partitioner = configurator.CreatePartitioner(16);
 


### PR DESCRIPTION
Now when using in-memory scheduler, which runs on a real transport, the queue name is defaulted to `quartz`, which makes this feature unusable when multiple services run on the same RMQ. It would be great to allow specifying the queue name. The default will be the same.
