### PR TITLE
Add support for .net standard 2.0 for core lib

### DIFF
--- a/src/MassTransit.RabbitMqTransport/Exceptions/MessageNotConfirmedException.cs
+++ b/src/MassTransit.RabbitMqTransport/Exceptions/MessageNotConfirmedException.cs
@@ -36,11 +36,9 @@ namespace MassTransit.RabbitMqTransport
         {
         }
 
-#if !NETCORE
         protected MessageNotConfirmedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Exceptions/PublishNackException.cs
+++ b/src/MassTransit.RabbitMqTransport/Exceptions/PublishNackException.cs
@@ -31,11 +31,9 @@ namespace MassTransit.RabbitMqTransport
         {
         }
 
-#if !NETCORE
         protected PublishNackException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Exceptions/PublishReturnedException.cs
+++ b/src/MassTransit.RabbitMqTransport/Exceptions/PublishReturnedException.cs
@@ -37,11 +37,9 @@ namespace MassTransit.RabbitMqTransport
         {
         }
 
-#if !NETCORE
         protected PublishReturnedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Exceptions/RabbitMqConnectionException.cs
+++ b/src/MassTransit.RabbitMqTransport/Exceptions/RabbitMqConnectionException.cs
@@ -34,11 +34,9 @@ namespace MassTransit.RabbitMqTransport
         {
         }
 
-#if !NETCORE
         protected RabbitMqConnectionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/MassTransit.Tests/ContextSetup.cs
+++ b/src/MassTransit.Tests/ContextSetup.cs
@@ -27,14 +27,13 @@ namespace MassTransit.Tests
         [OneTimeSetUp]
         public void Before_any()
         {
-#if NETCORE
-            string path = AppContext.BaseDirectory;
+            string path = AppDomain.CurrentDomain.BaseDirectory;
             string file = Path.Combine(path, "masstransit.tests.log4net.xml");
+
+#if NETCORE
             var logRepository = LogManager.GetRepository(System.Reflection.Assembly.GetEntryAssembly());
             XmlConfigurator.Configure(logRepository, new FileInfo(file));
 #else
-            string path = AppDomain.CurrentDomain.BaseDirectory;
-            string file = Path.Combine(path, "masstransit.tests.log4net.xml");
             XmlConfigurator.Configure(new FileInfo(file));
 #endif
             Trace.WriteLine("Loading Log4net: " + file);

--- a/src/MassTransit.Tests/MassTransit.Tests.csproj
+++ b/src/MassTransit.Tests/MassTransit.Tests.csproj
@@ -23,11 +23,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
     <Compile Remove="Diagnostics/**" />
-    <Compile Remove="Pipeline/Transaction_Specs.cs" />
     <Compile Remove="BinarySerializer_Specs.cs" />
-    <Compile Remove="SimpleConfiguration_Specs.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/src/MassTransit.Tests/MessageData/DataBus_Specs.cs
+++ b/src/MassTransit.Tests/MessageData/DataBus_Specs.cs
@@ -72,11 +72,8 @@ namespace MassTransit.Tests.MessageData
 
             protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
             {
-#if NETCORE
-                string baseDirectory = AppContext.BaseDirectory;
-#else
                 string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-#endif
+                
                 string messageDataPath = Path.Combine(baseDirectory, "MessageData");
 
                 var dataDirectory = new DirectoryInfo(messageDataPath);

--- a/src/MassTransit/Exceptions/CommandException.cs
+++ b/src/MassTransit/Exceptions/CommandException.cs
@@ -34,11 +34,9 @@ namespace MassTransit
         {
         }
 
-#if !NETCORE
         protected CommandException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -14,16 +14,8 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <Compile Remove="TransactionContext.cs" />
-    <Compile Remove="TransactionContextExtensions.cs" />
-    <Compile Remove="Transports/HttpEndpoint.cs" />
     <Compile Remove="Util/NHProfIntegration.cs" />
-    <Compile Remove="Pipeline/Filters/TransactionFilter.cs" />
-    <Compile Remove="Context/SystemTransactionContext.cs" />
-    <Compile Remove="Configuration/ITransactionConfigurator.cs" />
-    <Compile Remove="Configuration/TransactionConfiguratorExtensions.cs" />
     <Compile Remove="Configuration/BusConfigurators/PerformanceCounterBusFactorySpecification.cs" />
-    <Compile Remove="Configuration/PipeConfigurators/TransactionPipeSpecification.cs" />
     <Compile Remove="Serialization/StaticHeaders.cs" />
     <Compile Remove="Serialization/StaticConsumeContext.cs" />
     <Compile Remove="Serialization/ExtensionsForBinaryMessageSerializer.cs" />
@@ -32,16 +24,13 @@
     <Compile Remove="Monitoring/Performance/**" />
     <Compile Remove="Configuration/PerformanceCounterExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    <Compile Remove="NetCore.cs" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.0.10" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />

--- a/src/MassTransit/Util/BusHostInfo.cs
+++ b/src/MassTransit/Util/BusHostInfo.cs
@@ -27,15 +27,9 @@ namespace MassTransit.Util
 
         public BusHostInfo(bool initialize)
         {
-#if NETCORE
-            FrameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-            OperatingSystemVersion = System.Runtime.InteropServices.RuntimeInformation.OSDescription;            
-            var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
-#else
             FrameworkVersion = Environment.Version.ToString();
             OperatingSystemVersion = Environment.OSVersion.ToString();
             var entryAssembly = System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetCallingAssembly();
-#endif
             var currentProcess = Process.GetCurrentProcess();
             MachineName = Environment.MachineName;
             MassTransitVersion = FileVersionInfo.GetVersionInfo(typeof(IBus).GetTypeInfo().Assembly.Location).FileVersion;

--- a/src/MassTransit/Util/LimitedConcurrencyLevelTaskScheduler.cs
+++ b/src/MassTransit/Util/LimitedConcurrencyLevelTaskScheduler.cs
@@ -75,11 +75,7 @@ namespace MassTransit.Util
         /// </summary> 
         private void NotifyThreadPoolOfPendingWork()
         {
-#if NETCORE
-            ThreadPool.QueueUserWorkItem(_ =>
-#else
             ThreadPool.UnsafeQueueUserWorkItem(_ =>
-#endif
             {
                 // Note that the current thread is now processing work items. 
                 // This is necessary to enable inlining of tasks into this thread. 

--- a/src/MassTransit/Util/Scanning/AssemblyScanner.cs
+++ b/src/MassTransit/Util/Scanning/AssemblyScanner.cs
@@ -193,13 +193,6 @@ namespace MassTransit.Util.Scanning
             return _assemblies.Any();
         }
 
-#if NETCORE
-        public void TheCallingAssembly()
-        {
-            throw new ConfigurationException("Could not determine the calling assembly, you may need to explicitly call IAssemblyScanner.Assembly()");
-        }
-
-#else
         public void TheCallingAssembly()
         {
             var callingAssembly = FindTheCallingAssembly();
@@ -237,6 +230,5 @@ namespace MassTransit.Util.Scanning
             }
             return callingAssembly;
         }
-#endif
     }
 }


### PR DESCRIPTION
This adds .net standard 2.0 build target to core masstransit lib and .net core 2.0 profile for tests for tests. 
It doesn't remove .net standard 1.6, since other projects depend on it. 