### PR TITLE
Allows usage of environment variables in MassTransit.Host app setting…

### DIFF
--- a/src/MassTransit.Host/Configuration/ConfigurationProviderBase.cs
+++ b/src/MassTransit.Host/Configuration/ConfigurationProviderBase.cs
@@ -38,7 +38,7 @@ namespace MassTransit.Host.Configuration
                 return false;
             }
 
-            value = element.Value;
+            value = Environment.ExpandEnvironmentVariables(element.Value);
             return element.ElementInformation.IsPresent;
         }
 


### PR DESCRIPTION
…s configuration

A super micro PR that adds ability to use environment variables to configure MassTransit.Host configuration settings. Any value from appSettings configuration section can now contain environment variables in form of %ENV_VAR% in any part of the value attribute. This variable will be expanded to its actual value, configured in OS.
