### PR TITLE
Fix an issue where Saga instance wasn't being saved properly

### DIFF
--- a/src/Persistence/MassTransit.MartenIntegration.Tests/Messages.cs
+++ b/src/Persistence/MassTransit.MartenIntegration.Tests/Messages.cs
@@ -33,6 +33,17 @@
         public string Name { get; set; }
     }
 
+    [Serializable]
+    public class ObservableSagaMessage
+    {
+        public ObservableSagaMessage()
+        {
+
+        }
+
+        public string Name { get; set; }
+    }
+
 
     [Serializable]
     public class CompleteSimpleSaga : SimpleSagaMessageBase

--- a/src/Persistence/MassTransit.MartenIntegration.Tests/SimpleSaga.cs
+++ b/src/Persistence/MassTransit.MartenIntegration.Tests/SimpleSaga.cs
@@ -2,11 +2,13 @@
 using System.Threading.Tasks;
 using Marten.Schema;
 using MassTransit.Saga;
+using System.Linq.Expressions;
 
 namespace MassTransit.MartenIntegration.Tests
 {
     public class SimpleSaga :
         InitiatedBy<InitiateSimpleSaga>,
+        Observes<ObservableSagaMessage, SimpleSaga>,
         Orchestrates<CompleteSimpleSaga>,
         ISaga
     {
@@ -24,15 +26,15 @@ namespace MassTransit.MartenIntegration.Tests
         [Identity]
         public Guid CorrelationId { get; set; }
 
-        //public async Task Consume(ConsumeContext<ObservableSagaMessage> message)
-        //{
-        //    Observed = true;
-        //}
+        public async Task Consume(ConsumeContext<ObservableSagaMessage> message)
+        {
+            Observed = true;
+        }
 
-        //public Expression<Func<SimpleSaga, ObservableSagaMessage, bool>> CorrelationExpression
-        //{
-        //    get { return (saga, message) => saga.Name == message.Name; }
-        //}
+        Expression<Func<SimpleSaga, ObservableSagaMessage, bool>> Observes<ObservableSagaMessage, SimpleSaga>.CorrelationExpression
+        {
+            get { return (saga, message) => saga.Name == message.Name; }
+        }
 
         public async Task Consume(ConsumeContext<CompleteSimpleSaga> message)
         {

--- a/src/Persistence/MassTransit.MartenIntegration/MartenSagaRepository.cs
+++ b/src/Persistence/MassTransit.MartenIntegration/MartenSagaRepository.cs
@@ -88,7 +88,7 @@
         public async Task SendQuery<T>(SagaQueryConsumeContext<TSaga, T> context, ISagaPolicy<TSaga, T> policy,
             IPipe<SagaConsumeContext<TSaga, T>> next) where T : class
         {
-            using (var session = _store.LightweightSession())
+            using (var session = _store.DirtyTrackedSession())
             {
                 try
                 {


### PR DESCRIPTION
Fixes #1016 

I verified the fix by first adding a new test that uses observed messages, rather than orchestrated messages. That test failed, as expected since it can't find the saga instance with the Observed property to true since the state isn't being changed in the database. I then changed the MartenSagaRepository to use a dirty tracked session for the SendQuery path as well, which made the test turn green. Existing tests were unmodified and are still green.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
