### PR TITLE
Docs publish from master only. Ignore docs for main build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
 skip_tags: true
 skip_commits:
   files:
-    - docs/*
+    - docs/**/*
     - '**/*.html'
 image: Visual Studio 2015
 configuration: Release

--- a/docs.yml
+++ b/docs.yml
@@ -1,10 +1,9 @@
 branches:
   only:
-    - develop
     - master
 only_commits:
   files:
-    - docs/*
+    - docs/**/*
     - '**/*.md'
     - '**/*.html'
     - docs.yml


### PR DESCRIPTION
`docs.yml` has been already changed in `develop` but PR built takes it from `master` so docs are still being published on PR builds. This should fix it.

Exclude commits filter was not full and changes in subfolders of `docs` were still triggering the main build. This should prevent main build from being triggered by any change in docs.