### PR TITLE
NInject and Unity .net standard support

### DIFF
--- a/src/Containers/MassTransit.Containers.Tests/MassTransit.Containers.Tests.csproj
+++ b/src/Containers/MassTransit.Containers.Tests/MassTransit.Containers.Tests.csproj
@@ -9,9 +9,7 @@
     <PackageReference Include="Castle.Core" Version="4.2.0" />
     <PackageReference Include="Castle.Windsor" Version="4.1.0" />
     <PackageReference Include="GreenPipes" Version="1.2.0" />
-    <PackageReference Include="CommonServiceLocator" Version="1.3" />
     <PackageReference Include="microsoft.net.test.sdk" Version="15.0.0" />
-    <PackageReference Include="Ninject" Version="3.2.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.0" />
@@ -32,9 +30,6 @@
     <ProjectReference Include="..\MassTransit.UnityIntegration\MassTransit.UnityIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.WindsorIntegration\MassTransit.WindsorIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.ExtensionsDependencyInjectionIntegration\MassTransit.ExtensionsDependencyInjectionIntegration.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.2.0.0" />
     <ProjectReference Include="..\MassTransit.NinjectIntegration\MassTransit.NinjectIntegration.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -43,7 +38,4 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <Compile Remove="Ninject_Specs.cs" />
-  </ItemGroup>
 </Project>

--- a/src/Containers/MassTransit.Containers.Tests/Unity_Specs.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Unity_Specs.cs
@@ -12,10 +12,12 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Containers.Tests
 {
-    using Microsoft.Practices.Unity;
     using NUnit.Framework;
     using Saga;
     using Scenarios;
+    using Unity;
+    using Unity.Lifetime;
+
 
     public class Unity_Consumer :
         When_registering_a_consumer

--- a/src/Containers/MassTransit.NinjectIntegration/MassTransit.NinjectIntegration.csproj
+++ b/src/Containers/MassTransit.NinjectIntegration/MassTransit.NinjectIntegration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
     <DebugType>portable</DebugType>
@@ -14,10 +14,8 @@
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Ninject" Version="3.2.0" />
-    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.2.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <PackageReference Include="Ninject" Version="3.3.3" />
+    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.3.0" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Containers/MassTransit.UnityIntegration/MassTransit.UnityIntegration.csproj
+++ b/src/Containers/MassTransit.UnityIntegration/MassTransit.UnityIntegration.csproj
@@ -14,8 +14,7 @@
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="CommonServiceLocator" Version="1.3" />
-    <PackageReference Include="Unity" Version="4.0.1" />
+    <PackageReference Include="Unity" Version="5.2.0" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Containers/MassTransit.UnityIntegration/UnityCompensateActivityScopeProvider.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnityCompensateActivityScopeProvider.cs
@@ -15,9 +15,11 @@ namespace MassTransit.UnityIntegration
     using Courier;
     using Courier.Hosts;
     using GreenPipes;
-    using Microsoft.Practices.Unity;
     using Scoping;
     using Scoping.CourierContexts;
+    using Unity;
+    using Unity.Injection;
+    using Unity.Resolution;
 
 
     public class UnityCompensateActivityScopeProvider<TActivity, TLog> :

--- a/src/Containers/MassTransit.UnityIntegration/UnityConsumerFactory.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnityConsumerFactory.cs
@@ -14,8 +14,8 @@ namespace MassTransit.UnityIntegration
 {
     using System.Threading.Tasks;
     using GreenPipes;
-    using Microsoft.Practices.Unity;
     using Scoping;
+    using Unity;
 
 
     public class UnityConsumerFactory<TConsumer> :

--- a/src/Containers/MassTransit.UnityIntegration/UnityConsumerScopeProvider.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnityConsumerScopeProvider.cs
@@ -14,9 +14,9 @@ namespace MassTransit.UnityIntegration
 {
     using Context;
     using GreenPipes;
-    using Microsoft.Practices.Unity;
     using Scoping;
     using Scoping.ConsumerContexts;
+    using Unity;
     using Util;
 
 

--- a/src/Containers/MassTransit.UnityIntegration/UnityExecuteActivityScopeProvider.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnityExecuteActivityScopeProvider.cs
@@ -15,9 +15,11 @@ namespace MassTransit.UnityIntegration
     using Courier;
     using Courier.Hosts;
     using GreenPipes;
-    using Microsoft.Practices.Unity;
     using Scoping;
     using Scoping.CourierContexts;
+    using Unity;
+    using Unity.Injection;
+    using Unity.Resolution;
 
 
     public class UnityExecuteActivityScopeProvider<TActivity, TArguments> :

--- a/src/Containers/MassTransit.UnityIntegration/UnityExtensions.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnityExtensions.cs
@@ -18,11 +18,11 @@ namespace MassTransit
     using ConsumeConfigurators;
     using Courier;
     using Internals.Extensions;
-    using Microsoft.Practices.Unity;
     using PipeConfigurators;
     using Saga;
     using Saga.SubscriptionConfigurators;
     using Scoping;
+    using Unity;
     using UnityIntegration;
 
 

--- a/src/Containers/MassTransit.UnityIntegration/UnitySagaRepository.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnitySagaRepository.cs
@@ -14,9 +14,9 @@ namespace MassTransit.UnityIntegration
 {
     using System.Threading.Tasks;
     using GreenPipes;
-    using Microsoft.Practices.Unity;
     using Saga;
     using Scoping;
+    using Unity;
 
 
     public class UnitySagaRepository<TSaga> :

--- a/src/Containers/MassTransit.UnityIntegration/UnitySagaRepositoryFactory.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnitySagaRepositoryFactory.cs
@@ -12,9 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.UnityIntegration
 {
-    using Microsoft.Practices.Unity;
     using Saga;
     using Scoping;
+    using Unity;
 
 
     public class UnitySagaRepositoryFactory :

--- a/src/Containers/MassTransit.UnityIntegration/UnitySagaScopeProvider.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnitySagaScopeProvider.cs
@@ -15,10 +15,10 @@ namespace MassTransit.UnityIntegration
     using Context;
     using GreenPipes;
     using GreenPipes.Payloads;
-    using Microsoft.Practices.Unity;
     using Saga;
     using Scoping;
     using Scoping.SagaContexts;
+    using Unity;
 
 
     public class UnitySagaScopeProvider<TSaga> :


### PR DESCRIPTION
This pr updates Ninject and Unity libraries to versions that support .Net Standard. 
