### PR TITLE
#1048 Exception type added to the message headers

### DIFF
--- a/src/MassTransit/MessageHeaders.cs
+++ b/src/MassTransit/MessageHeaders.cs
@@ -20,6 +20,11 @@ namespace MassTransit
         public const string Reason = "MT-Reason";
 
         /// <summary>
+        /// The type of exception from a Fault
+        /// </summary>
+        public const string FaultExceptionType = "MT-Fault-ExceptionType";
+
+        /// <summary>
         /// The exception message from a Fault
         /// </summary>
         public const string FaultMessage = "MT-Fault-Message";

--- a/src/MassTransit/Pipeline/Filters/MoveExceptionToTransportFilter.cs
+++ b/src/MassTransit/Pipeline/Filters/MoveExceptionToTransportFilter.cs
@@ -16,6 +16,7 @@ namespace MassTransit.Pipeline.Filters
     using System.Threading.Tasks;
     using Events;
     using GreenPipes;
+    using GreenPipes.Internals.Extensions;
     using Transports;
     using Util;
 
@@ -52,6 +53,7 @@ namespace MassTransit.Pipeline.Filters
             {
                 sendContext.Headers.Set(MessageHeaders.Reason, "fault");
 
+                sendContext.Headers.Set(MessageHeaders.FaultExceptionType, TypeCache.GetShortName(exception.GetType()));
                 sendContext.Headers.Set(MessageHeaders.FaultMessage, exceptionMessage);
                 sendContext.Headers.Set(MessageHeaders.FaultTimestamp, context.ExceptionTimestamp.ToString("O"));
                 sendContext.Headers.Set(MessageHeaders.FaultStackTrace, ExceptionUtil.GetStackTrace(exception));


### PR DESCRIPTION
The type of thrown exception flows to the consumers in message header **MT-Fault-ExceptionType**. It is simple addition, not verified anyhow.
