### PR TITLE
Add SagaClassMapping.ConfigureDefaultSagaMaps

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaClassMapping.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SagaClassMapping.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.EntityFrameworkCoreIntegration
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
     using GreenPipes.Internals.Extensions;
     using GreenPipes.Internals.Reflection;
 
@@ -33,5 +36,20 @@ namespace MassTransit.EntityFrameworkCoreIntegration
             modelBuilder.Entity<T>().Property(t => t.CorrelationId)
                 .ValueGeneratedNever();
         } 
+
+        public static void ConfigureDefaultSagaMaps(this ModelBuilder modelBuilder, IEnumerable<Type> sagas)
+        {
+            MethodInfo method = typeof(SagaClassMapping).GetMethod("ConfigureDefaultSagaMap");
+            var isagaType = typeof(ISaga);
+
+            foreach (var saga in sagas)
+            {
+                if (!isagaType.IsAssignableFrom(saga))
+                    throw new ArgumentOutOfRangeException(nameof(sagas), $"Type \'{saga}\' does not implement {isagaType}\'");
+
+                MethodInfo genericMethod = method.MakeGenericMethod(saga);
+                genericMethod.Invoke(null, new object[] { modelBuilder });
+            }
+        }
     }
 }


### PR DESCRIPTION
Enable calling ConfigureDefaultSagaMap by means of a list of types. This makes it easy to register a bunch of sagas for the same DBContext. 

Currently I'm developing around 20 sagas using the same DBContext, Thus I want to add a new saga to  my implementation with changing as few places as possible.

Solution is  provided only for EFCore since I do not know if you accept the idea in the first place - also I do not use the other ORMS :)

