### PR TITLE
#1071

### DIFF
--- a/src/MassTransit/Util/BusHostInfo.cs
+++ b/src/MassTransit/Util/BusHostInfo.cs
@@ -32,13 +32,13 @@ namespace MassTransit.Util
             var entryAssembly = System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetCallingAssembly();
             var currentProcess = Process.GetCurrentProcess();
             MachineName = Environment.MachineName;
-            MassTransitVersion = FileVersionInfo.GetVersionInfo(typeof(IBus).GetTypeInfo().Assembly.Location).FileVersion;
+            MassTransitVersion = typeof(IBus).GetTypeInfo().Assembly.GetName().Version.ToString();
             ProcessId = currentProcess.Id;
             ProcessName = currentProcess.ProcessName;
             
             var assemblyName = entryAssembly.GetName();
             Assembly = assemblyName.Name;
-            AssemblyVersion = FileVersionInfo.GetVersionInfo(entryAssembly.Location).FileVersion;
+            AssemblyVersion = assemblyName.Version.ToString();
         }
 
         public string MachineName { get; private set; }


### PR DESCRIPTION
System.TypeInitializationException thrown using Assembly.Load(File.ReadAllBytes(path)); fixed.

Instructions on how I verified my changes work:
 1. Take Zip-File "MassTransitIssue.zip" from https://github.com/MassTransit/MassTransit/issues/1071
 2. Compile changed MassTransit.dll
 3. Replace the MassTransit.dll in MassTransitIssue-Project
 4. Test if everything works
 5. Replace the MassTransit.dll in my Application
 6. Test if everything works

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
