### PR TITLE
Enahnce .NET Core DI by extension method with scope filter.

### DIFF
--- a/src/Containers/MassTransit.Containers.Tests/Scenarios/ConsumerForScopedFilter.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Scenarios/ConsumerForScopedFilter.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Containers.Tests.Scenarios
+{
+    using System;
+    using System.Threading.Tasks;
+
+
+    public class ConsumerForScopedFilter :
+        IConsumer<SimpleMessageInterface>
+    {
+        static readonly TaskCompletionSource<ConsumerForScopedFilter> _consumerCreated = new TaskCompletionSource<ConsumerForScopedFilter>();
+
+        public ConsumerForScopedFilter(IIdentifier dependency)
+        {
+            Dependency = dependency;
+            Console.WriteLine("ConsumerForScopedFilter()");
+
+            _consumerCreated.TrySetResult(this);
+        }
+
+        public IIdentifier Dependency { get; }
+
+        public static Task<ConsumerForScopedFilter> Current => _consumerCreated.Task;
+
+        public Task Consume(ConsumeContext<SimpleMessageInterface> context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Containers/MassTransit.Containers.Tests/Scenarios/When_registering_a_consumer.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Scenarios/When_registering_a_consumer.cs
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Containers.Tests.Scenarios
 {
+    using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using Shouldly;
@@ -68,6 +69,26 @@ namespace MassTransit.Containers.Tests.Scenarios
 
             lastConsumer.Dependency.SomethingDone
                 .ShouldBe(true); //Dependency was disposed before consumer executed");
+        }
+    }
+
+    [TestFixture]
+    public abstract class When_registering_a_consumer_with_scope_filter :
+        Given_a_service_bus_instance
+    {
+        [Test]
+        public async Task Should_receive_initialized_scoped_dependency()
+        {
+            const string name = "Joe";
+
+            await InputQueueSendEndpoint.Send(new SimpleMessageClass(name));
+
+            ConsumerForScopedFilter consumer = await ConsumerForScopedFilter.Current;
+            consumer.ShouldNotBe(null);
+
+            Guid identifier = consumer.Dependency.Id;
+            identifier
+                .ShouldNotBeNull($"{nameof(identifier)} should be specified.");
         }
     }
 }

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ExtensionsDependencyInjectionExtensions.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ExtensionsDependencyInjectionExtensions.cs
@@ -15,7 +15,10 @@ namespace MassTransit
     using System;
     using System.Collections.Generic;
     using ExtensionsDependencyInjectionIntegration;
+    using GreenPipes;
+    using GreenPipes.Specifications;
     using Microsoft.Extensions.DependencyInjection;
+    using Pipeline.Filters;
 
 
     public static class ExtensionsDependencyInjectionIntegrationExtensions
@@ -35,6 +38,14 @@ namespace MassTransit
 
             foreach (var saga in sagas)
                 saga.Configure(configurator, serviceProvider);
+        }
+
+        public static void UseScope(this IPipeConfigurator<ConsumeContext> configurator, IServiceProvider serviceProvider)
+        {
+            var scopeProvider = new DependencyInjectionConsumerScopeProvider(serviceProvider);
+            var specification = new FilterPipeSpecification<ConsumeContext>(new ScopeFilter(scopeProvider));
+
+            configurator.AddPipeSpecification(specification);
         }
     }
 }


### PR DESCRIPTION
Current PR contains enhancement of .NET Core DI with extension method whitch add ScopeFilter to pipe of consuming message. This give us ability to create scope before step when message will be consumed by `IConumer<>`. Basic example of that behaviour to setup context information like token, correlationId etc. Also this give us flexibility to decouple from built it methods `GetOrAddPayload`/`TryGetPayload` and prevent duplication logic of extracting of payload instead injecting dependency directly to constructor.
