### PR TITLE
Updating to NHibernate 5.1

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -8,13 +8,13 @@
     <PackageReference Include="Automatonymous.NHibernate" Version="4.0.1" />
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="GreenPipes" Version="2.0.0" />
-    <PackageReference Include="Iesi.Collections" Version="4.0.1.4000" />
+    <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.19.1" />
     <PackageReference Include="microsoft.net.test.sdk" Version="15.6.1" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NHibernate" Version="4.1.1.4000" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Quartz" Version="3.0.4" />

--- a/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -22,8 +22,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.104.0" />
-    <Reference Include="System.XML" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
     <ProjectReference Include="..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.AutomatonymousIntegration\MassTransit.AutomatonymousIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.QuartzIntegration\MassTransit.QuartzIntegration.csproj" />
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\Persistence\MassTransit.DocumentDbIntegration\MassTransit.DocumentDbIntegration.csproj" />
     <ProjectReference Include="..\Persistence\MassTransit.EntityFrameworkIntegration\MassTransit.EntityFrameworkIntegration.csproj" />
     <ProjectReference Include="..\Persistence\MassTransit.NHibernateIntegration\MassTransit.NHibernateIntegration.csproj" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/MassTransit.AutomatonymousIntegration.Tests/SingleConnectionSessionFactory.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/SingleConnectionSessionFactory.cs
@@ -1,154 +1,133 @@
-﻿namespace MassTransit.AutomatonymousIntegration.Tests
+// Copyright 2007-2012 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AutomatonymousIntegration.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.Data;
+    using System.Data.Common;
+    using System.Threading;
+    using System.Threading.Tasks;
     using NHibernate;
     using NHibernate.Engine;
     using NHibernate.Metadata;
     using NHibernate.Stat;
 
 
-    class SingleConnectionSessionFactory :
+    class SingleConnectionSessionFactory : 
         ISessionFactory
     {
         readonly ISessionFactory _inner;
-        readonly IDbConnection _liveConnection;
+        readonly DbConnection _liveConnection;
 
-        public SingleConnectionSessionFactory(ISessionFactory inner, IDbConnection liveConnection)
+        public SingleConnectionSessionFactory(ISessionFactory inner, DbConnection liveConnection)
         {
             _inner = inner;
             _liveConnection = liveConnection;
         }
 
-        public void Dispose()
+        public void Dispose() => _inner.Dispose();
+
+        public ISession OpenSession(DbConnection conn) => _inner.OpenSession(_liveConnection);
+
+        public Task CloseAsync(CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.CloseAsync(cancellationToken);
+
+        public Task EvictAsync(Type persistentClass, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictAsync(persistentClass, cancellationToken);
+
+        public Task EvictAsync(Type persistentClass, object id, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictAsync(persistentClass, id, cancellationToken);
+
+        public Task EvictEntityAsync(string entityName, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictEntityAsync(entityName, cancellationToken);
+
+        public Task EvictEntityAsync(string entityName, object id, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictEntityAsync(entityName, id, cancellationToken);
+
+        public Task EvictCollectionAsync(string roleName, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictCollectionAsync(roleName, cancellationToken);
+
+        public Task EvictCollectionAsync(string roleName, object id, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictCollectionAsync(roleName, id, cancellationToken);
+
+        public Task EvictQueriesAsync(CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictQueriesAsync(cancellationToken);
+
+        public Task EvictQueriesAsync(string cacheRegion, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictQueriesAsync(cacheRegion, cancellationToken);
+
+        public ISessionBuilder WithOptions() => _inner.WithOptions();
+
+        public ISession OpenSession(IInterceptor sessionLocalInterceptor) => 
+            _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
+
+        public ISession OpenSession(DbConnection conn, IInterceptor sessionLocalInterceptor) => 
+            _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
+
+        public ISession OpenSession() => _inner.OpenSession(_liveConnection);
+
+        public IStatelessSessionBuilder WithStatelessOptions()
         {
-            _inner.Dispose();
+            throw new NotImplementedException();
         }
 
-        public ISession OpenSession(IDbConnection conn)
-        {
-            return _inner.OpenSession(_liveConnection);
-        }
+        public IClassMetadata GetClassMetadata(Type persistentClass) => 
+            _inner.GetClassMetadata(persistentClass);
 
-        public ISession OpenSession(IInterceptor sessionLocalInterceptor)
-        {
-            return _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
-        }
+        public IClassMetadata GetClassMetadata(string entityName) => 
+            _inner.GetClassMetadata(entityName);
 
-        public ISession OpenSession(IDbConnection conn, IInterceptor sessionLocalInterceptor)
-        {
-            return _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
-        }
+        public ICollectionMetadata GetCollectionMetadata(string roleName) => 
+            _inner.GetCollectionMetadata(roleName);
 
-        public ISession OpenSession()
-        {
-            return _inner.OpenSession(_liveConnection);
-        }
+        public IDictionary<string, IClassMetadata> GetAllClassMetadata() => 
+            _inner.GetAllClassMetadata();
 
-        public IClassMetadata GetClassMetadata(Type persistentClass)
-        {
-            return _inner.GetClassMetadata(persistentClass);
-        }
+        public IDictionary<string, ICollectionMetadata> GetAllCollectionMetadata() => 
+            _inner.GetAllCollectionMetadata();
 
-        public IClassMetadata GetClassMetadata(string entityName)
-        {
-            return _inner.GetClassMetadata(entityName);
-        }
+        public void Close() => _inner.Close();
 
-        public ICollectionMetadata GetCollectionMetadata(string roleName)
-        {
-            return _inner.GetCollectionMetadata(roleName);
-        }
+        public void Evict(Type persistentClass) => _inner.Evict(persistentClass);
 
-        public IDictionary<string, IClassMetadata> GetAllClassMetadata()
-        {
-            return _inner.GetAllClassMetadata();
-        }
+        public void Evict(Type persistentClass, object id) => _inner.Evict(persistentClass, id);
 
-        public IDictionary<string, ICollectionMetadata> GetAllCollectionMetadata()
-        {
-            return _inner.GetAllCollectionMetadata();
-        }
+        public void EvictEntity(string entityName) => _inner.EvictEntity(entityName);
 
-        public void Close()
-        {
-            _inner.Close();
-        }
+        public void EvictEntity(string entityName, object id) => _inner.EvictEntity(entityName, id);
 
-        public void Evict(Type persistentClass)
-        {
-            _inner.Evict(persistentClass);
-        }
+        public void EvictCollection(string roleName) => _inner.EvictCollection(roleName);
 
-        public void Evict(Type persistentClass, object id)
-        {
-            _inner.Evict(persistentClass, id);
-        }
+        public void EvictCollection(string roleName, object id) => _inner.EvictCollection(roleName, id);
 
-        public void EvictEntity(string entityName)
-        {
-            _inner.EvictEntity(entityName);
-        }
+        public void EvictQueries() => _inner.EvictQueries();
 
-        public void EvictEntity(string entityName, object id)
-        {
-            _inner.EvictEntity(entityName, id);
-        }
+        public void EvictQueries(string cacheRegion) => _inner.EvictQueries(cacheRegion);
 
-        public void EvictCollection(string roleName)
-        {
-            _inner.EvictCollection(roleName);
-        }
+        public IStatelessSession OpenStatelessSession() => _inner.OpenStatelessSession();
 
-        public void EvictCollection(string roleName, object id)
-        {
-            _inner.EvictCollection(roleName, id);
-        }
+        public IStatelessSession OpenStatelessSession(DbConnection connection) => 
+            _inner.OpenStatelessSession(connection);
 
-        public void EvictQueries()
-        {
-            _inner.EvictQueries();
-        }
+        public FilterDefinition GetFilterDefinition(string filterName) => 
+            _inner.GetFilterDefinition(filterName);
 
-        public void EvictQueries(string cacheRegion)
-        {
-            _inner.EvictQueries(cacheRegion);
-        }
+        public ISession GetCurrentSession() => _inner.GetCurrentSession();
 
-        public IStatelessSession OpenStatelessSession()
-        {
-            return _inner.OpenStatelessSession();
-        }
+        public IStatistics Statistics => _inner.Statistics;
 
-        public IStatelessSession OpenStatelessSession(IDbConnection connection)
-        {
-            return _inner.OpenStatelessSession(connection);
-        }
+        public bool IsClosed => _inner.IsClosed;
 
-        public FilterDefinition GetFilterDefinition(string filterName)
-        {
-            return _inner.GetFilterDefinition(filterName);
-        }
-
-        public ISession GetCurrentSession()
-        {
-            return _inner.GetCurrentSession();
-        }
-
-        public IStatistics Statistics
-        {
-            get { return _inner.Statistics; }
-        }
-
-        public bool IsClosed
-        {
-            get { return _inner.IsClosed; }
-        }
-
-        public ICollection<string> DefinedFilterNames
-        {
-            get { return _inner.DefinedFilterNames; }
-        }
+        public ICollection<string> DefinedFilterNames => _inner.DefinedFilterNames;
     }
 }

--- a/src/MassTransit.AutomatonymousIntegration.Tests/SqlLiteSessionFactoryProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/SqlLiteSessionFactoryProvider.cs
@@ -15,8 +15,8 @@ namespace MassTransit.AutomatonymousIntegration.Tests
     using System;
     using System.Data;
     using System.Data.Common;
-    using System.Data.SQLite;
     using Automatonymous;
+    using Microsoft.Data.Sqlite;
     using NHibernate;
     using NHibernate.Cache;
     using NHibernate.Cfg;
@@ -35,7 +35,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         const string InMemoryConnectionString = "Data Source=:memory:;Version=3;New=True;Pooling=True;Max Pool Size=1;";
         bool _disposed;
         ISessionFactory _innerSessionFactory;
-        SQLiteConnection _openConnection;
+        SqliteConnection _openConnection;
         SingleConnectionSessionFactory _sessionFactory;
 
         public SQLiteSessionFactoryProvider(string connectionString, params Type[] mappedTypes)
@@ -87,7 +87,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         public override ISessionFactory GetSessionFactory()
         {
             string connectionString = Configuration.Properties[NHibernate.Cfg.Environment.ConnectionString];
-            _openConnection = new SQLiteConnection(connectionString);
+            _openConnection = new SqliteConnection(connectionString);
             _openConnection.Open();
 
             BuildSchema(Configuration, _openConnection);

--- a/src/MassTransit.AutomatonymousIntegration.Tests/SqlLiteSessionFactoryProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/SqlLiteSessionFactoryProvider.cs
@@ -14,6 +14,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
 {
     using System;
     using System.Data;
+    using System.Data.Common;
     using System.Data.SQLite;
     using Automatonymous;
     using NHibernate;
@@ -99,7 +100,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
             return _sessionFactory;
         }
 
-        static void BuildSchema(Configuration config, IDbConnection connection)
+        static void BuildSchema(Configuration config, DbConnection connection)
         {
             new SchemaExport(config).Execute(true, true, false, connection, null);
         }

--- a/src/MassTransit.Futures.Tests/MassTransit.Futures.Tests.csproj
+++ b/src/MassTransit.Futures.Tests/MassTransit.Futures.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\MassTransit.Futures\MassTransit.Futures.csproj" />
     <ProjectReference Include="..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/DbQuery.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/DbQuery.cs
@@ -14,6 +14,7 @@ namespace MassTransit.NHibernateIntegration.Tests
 {
 	using System.Data.SqlClient;
 
+
 	public class DbQuery
 	{
 		readonly string _connectionString;

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
@@ -8,26 +8,26 @@
     <PackageReference Include="GreenPipes" Version="2.0.0" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="microsoft.net.test.sdk" Version="15.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.104.0" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.XML" />
     <ProjectReference Include="..\..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
     <ProjectReference Include="..\..\MassTransit.AutomatonymousIntegration\MassTransit.AutomatonymousIntegration.csproj" />
     <ProjectReference Include="..\..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
     <ProjectReference Include="..\MassTransit.NHibernateIntegration\MassTransit.NHibernateIntegration.csproj" />
     <ProjectReference Include="..\..\MassTransit.Tests\MassTransit.Tests.csproj" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
+    <Reference Include="System.Xml" Condition="'$(TargetFramework)' == 'net461'" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Automatonymous" Version="4.0.1" />
     <PackageReference Include="GreenPipes" Version="2.0.0" />
-    <PackageReference Include="Iesi.Collections" Version="4.0.1.4000" />
+    <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="microsoft.net.test.sdk" Version="15.6.1" />
     <PackageReference Include="NewId" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NHibernate" Version="4.1.1.4000" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/SingleConnectionSessionFactory.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/SingleConnectionSessionFactory.cs
@@ -15,6 +15,9 @@ namespace MassTransit.NHibernateIntegration.Tests
     using System;
     using System.Collections.Generic;
     using System.Data;
+    using System.Data.Common;
+    using System.Threading;
+    using System.Threading.Tasks;
     using NHibernate;
     using NHibernate.Engine;
     using NHibernate.Metadata;
@@ -24,142 +27,107 @@ namespace MassTransit.NHibernateIntegration.Tests
         ISessionFactory
     {
         readonly ISessionFactory _inner;
-        readonly IDbConnection _liveConnection;
+        readonly DbConnection _liveConnection;
 
-        public SingleConnectionSessionFactory(ISessionFactory inner, IDbConnection liveConnection)
+        public SingleConnectionSessionFactory(ISessionFactory inner, DbConnection liveConnection)
         {
             _inner = inner;
             _liveConnection = liveConnection;
         }
 
-        public void Dispose()
+        public void Dispose() => _inner.Dispose();
+
+        public ISession OpenSession(DbConnection conn) => _inner.OpenSession(_liveConnection);
+
+        public Task CloseAsync(CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.CloseAsync(cancellationToken);
+
+        public Task EvictAsync(Type persistentClass, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictAsync(persistentClass, cancellationToken);
+
+        public Task EvictAsync(Type persistentClass, object id, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictAsync(persistentClass, id, cancellationToken);
+
+        public Task EvictEntityAsync(string entityName, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictEntityAsync(entityName, cancellationToken);
+
+        public Task EvictEntityAsync(string entityName, object id, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictEntityAsync(entityName, id, cancellationToken);
+
+        public Task EvictCollectionAsync(string roleName, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictCollectionAsync(roleName, cancellationToken);
+
+        public Task EvictCollectionAsync(string roleName, object id, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictCollectionAsync(roleName, id, cancellationToken);
+
+        public Task EvictQueriesAsync(CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictQueriesAsync(cancellationToken);
+
+        public Task EvictQueriesAsync(string cacheRegion, CancellationToken cancellationToken = new CancellationToken()) => 
+            _inner.EvictQueriesAsync(cacheRegion, cancellationToken);
+
+        public ISessionBuilder WithOptions() => _inner.WithOptions();
+
+        public ISession OpenSession(IInterceptor sessionLocalInterceptor) => 
+            _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
+
+        public ISession OpenSession(DbConnection conn, IInterceptor sessionLocalInterceptor) => 
+            _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
+
+        public ISession OpenSession() => _inner.OpenSession(_liveConnection);
+
+        public IStatelessSessionBuilder WithStatelessOptions()
         {
-            _inner.Dispose();
+            throw new NotImplementedException();
         }
 
-        public ISession OpenSession(IDbConnection conn)
-        {
-            return _inner.OpenSession(_liveConnection);
-        }
+        public IClassMetadata GetClassMetadata(Type persistentClass) => 
+            _inner.GetClassMetadata(persistentClass);
 
-        public ISession OpenSession(IInterceptor sessionLocalInterceptor)
-        {
-            return _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
-        }
+        public IClassMetadata GetClassMetadata(string entityName) => 
+            _inner.GetClassMetadata(entityName);
 
-        public ISession OpenSession(IDbConnection conn, IInterceptor sessionLocalInterceptor)
-        {
-            return _inner.OpenSession(_liveConnection, sessionLocalInterceptor);
-        }
+        public ICollectionMetadata GetCollectionMetadata(string roleName) => 
+            _inner.GetCollectionMetadata(roleName);
 
-        public ISession OpenSession()
-        {
-            return _inner.OpenSession(_liveConnection);
-        }
+        public IDictionary<string, IClassMetadata> GetAllClassMetadata() => 
+            _inner.GetAllClassMetadata();
 
-        public IClassMetadata GetClassMetadata(Type persistentClass)
-        {
-            return _inner.GetClassMetadata(persistentClass);
-        }
+        public IDictionary<string, ICollectionMetadata> GetAllCollectionMetadata() => 
+            _inner.GetAllCollectionMetadata();
 
-        public IClassMetadata GetClassMetadata(string entityName)
-        {
-            return _inner.GetClassMetadata(entityName);
-        }
+        public void Close() => _inner.Close();
 
-        public ICollectionMetadata GetCollectionMetadata(string roleName)
-        {
-            return _inner.GetCollectionMetadata(roleName);
-        }
+        public void Evict(Type persistentClass) => _inner.Evict(persistentClass);
 
-        public IDictionary<string, IClassMetadata> GetAllClassMetadata()
-        {
-            return _inner.GetAllClassMetadata();
-        }
+        public void Evict(Type persistentClass, object id) => _inner.Evict(persistentClass, id);
 
-        public IDictionary<string, ICollectionMetadata> GetAllCollectionMetadata()
-        {
-            return _inner.GetAllCollectionMetadata();
-        }
+        public void EvictEntity(string entityName) => _inner.EvictEntity(entityName);
 
-        public void Close()
-        {
-            _inner.Close();
-        }
+        public void EvictEntity(string entityName, object id) => _inner.EvictEntity(entityName, id);
 
-        public void Evict(Type persistentClass)
-        {
-            _inner.Evict(persistentClass);
-        }
+        public void EvictCollection(string roleName) => _inner.EvictCollection(roleName);
 
-        public void Evict(Type persistentClass, object id)
-        {
-            _inner.Evict(persistentClass, id);
-        }
+        public void EvictCollection(string roleName, object id) => _inner.EvictCollection(roleName, id);
 
-        public void EvictEntity(string entityName)
-        {
-            _inner.EvictEntity(entityName);
-        }
+        public void EvictQueries() => _inner.EvictQueries();
 
-        public void EvictEntity(string entityName, object id)
-        {
-            _inner.EvictEntity(entityName, id);
-        }
+        public void EvictQueries(string cacheRegion) => _inner.EvictQueries(cacheRegion);
 
-        public void EvictCollection(string roleName)
-        {
-            _inner.EvictCollection(roleName);
-        }
+        public IStatelessSession OpenStatelessSession() => _inner.OpenStatelessSession();
 
-        public void EvictCollection(string roleName, object id)
-        {
-            _inner.EvictCollection(roleName, id);
-        }
+        public IStatelessSession OpenStatelessSession(DbConnection connection) => 
+            _inner.OpenStatelessSession(connection);
 
-        public void EvictQueries()
-        {
-            _inner.EvictQueries();
-        }
+        public FilterDefinition GetFilterDefinition(string filterName) => 
+            _inner.GetFilterDefinition(filterName);
 
-        public void EvictQueries(string cacheRegion)
-        {
-            _inner.EvictQueries(cacheRegion);
-        }
+        public ISession GetCurrentSession() => _inner.GetCurrentSession();
 
-        public IStatelessSession OpenStatelessSession()
-        {
-            return _inner.OpenStatelessSession();
-        }
+        public IStatistics Statistics => _inner.Statistics;
 
-        public IStatelessSession OpenStatelessSession(IDbConnection connection)
-        {
-            return _inner.OpenStatelessSession(connection);
-        }
+        public bool IsClosed => _inner.IsClosed;
 
-        public FilterDefinition GetFilterDefinition(string filterName)
-        {
-            return _inner.GetFilterDefinition(filterName);
-        }
-
-        public ISession GetCurrentSession()
-        {
-            return _inner.GetCurrentSession();
-        }
-
-        public IStatistics Statistics
-        {
-            get { return _inner.Statistics; }
-        }
-
-        public bool IsClosed
-        {
-            get { return _inner.IsClosed; }
-        }
-
-        public ICollection<string> DefinedFilterNames
-        {
-            get { return _inner.DefinedFilterNames; }
-        }
+        public ICollection<string> DefinedFilterNames => _inner.DefinedFilterNames;
     }
 }

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
@@ -15,7 +15,7 @@ namespace MassTransit.NHibernateIntegration.Tests
     using System;
     using System.Data;
     using System.Data.Common;
-    using System.Data.SQLite;
+    using Microsoft.Data.Sqlite;
     using NHibernate;
     using NHibernate.Cache;
     using NHibernate.Cfg;
@@ -34,7 +34,7 @@ namespace MassTransit.NHibernateIntegration.Tests
         const string InMemoryConnectionString = "Data Source=:memory:;Version=3;New=True;Pooling=True;Max Pool Size=1;";
         bool _disposed;
         ISessionFactory _innerSessionFactory;
-        SQLiteConnection _openConnection;
+        SqliteConnection _openConnection;
         SingleConnectionSessionFactory _sessionFactory;
 
         public SQLiteSessionFactoryProvider(string connectionString, params Type[] mappedTypes)
@@ -86,7 +86,7 @@ namespace MassTransit.NHibernateIntegration.Tests
         public override ISessionFactory GetSessionFactory()
         {
             string connectionString = Configuration.Properties[NHibernate.Cfg.Environment.ConnectionString];
-            _openConnection = new SQLiteConnection(connectionString);
+            _openConnection = new SqliteConnection(connectionString);
             _openConnection.Open();
 
             BuildSchema(Configuration, _openConnection);

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
@@ -14,6 +14,7 @@ namespace MassTransit.NHibernateIntegration.Tests
 {
     using System;
     using System.Data;
+    using System.Data.Common;
     using System.Data.SQLite;
     using NHibernate;
     using NHibernate.Cache;
@@ -98,7 +99,7 @@ namespace MassTransit.NHibernateIntegration.Tests
             return _sessionFactory;
         }
 
-        static void BuildSchema(Configuration config, IDbConnection connection)
+        static void BuildSchema(Configuration config, DbConnection connection)
         {
             new SchemaExport(config).Execute(true, true, false, connection, null);
         }

--- a/src/Persistence/MassTransit.NHibernateIntegration/BinaryGuidType.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration/BinaryGuidType.cs
@@ -14,7 +14,9 @@ namespace MassTransit.NHibernateIntegration
 {
     using System;
     using System.Data;
+    using System.Data.Common;
     using NHibernate;
+    using NHibernate.Engine;
     using NHibernate.SqlTypes;
     using NHibernate.UserTypes;
 
@@ -22,32 +24,20 @@ namespace MassTransit.NHibernateIntegration
     public class BinaryGuidType :
         IUserType
     {
-        static readonly int[] _byteOrder = new[] {10, 11, 12, 13, 14, 15, 8, 9, 6, 7, 4, 5, 0, 1, 2, 3};
-        static readonly SqlType[] _types = new[] {new SqlType(DbType.Binary)};
+        static readonly int[] _byteOrder = {10, 11, 12, 13, 14, 15, 8, 9, 6, 7, 4, 5, 0, 1, 2, 3};
+        static readonly SqlType[] _types = {new SqlType(DbType.Binary)};
 
-        public SqlType[] SqlTypes
-        {
-            get { return _types; }
-        }
+        public SqlType[] SqlTypes => _types;
 
-        public Type ReturnedType
-        {
-            get { return typeof(Guid); }
-        }
+        public Type ReturnedType => typeof(Guid);
 
-        public new bool Equals(object x, object y)
-        {
-            return (x != null && x.Equals(y));
-        }
+        public new bool Equals(object x, object y) => x != null && x.Equals(y);
 
-        public int GetHashCode(object x)
+        public int GetHashCode(object x) => x.GetHashCode();
+        
+        public object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner)
         {
-            return x.GetHashCode();
-        }
-
-        public object NullSafeGet(IDataReader rs, string[] names, object owner)
-        {
-            var bytes = (byte[])NHibernateUtil.Binary.NullSafeGet(rs, names[0]);
+            var bytes = (byte[])NHibernateUtil.Binary.NullSafeGet(rs, names[0], session);
             if (bytes == null || bytes.Length == 0)
                 return null;
 
@@ -59,7 +49,7 @@ namespace MassTransit.NHibernateIntegration
             return new Guid(reorderedBytes);
         }
 
-        public void NullSafeSet(IDbCommand cmd, object value, int index)
+        public void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
         {
             if (null != value)
             {
@@ -69,35 +59,20 @@ namespace MassTransit.NHibernateIntegration
                 for (int i = 0; i < 16; i++)
                     reorderedBytes[i] = bytes[_byteOrder[i]];
 
-                NHibernateUtil.Binary.NullSafeSet(cmd, reorderedBytes, index);
+                NHibernateUtil.Binary.NullSafeSet(cmd, reorderedBytes, index, session);
             }
             else
-                NHibernateUtil.Binary.NullSafeSet(cmd, null, index);
+                NHibernateUtil.Binary.NullSafeSet(cmd, null, index, session);
         }
 
-        public object DeepCopy(object value)
-        {
-            return value;
-        }
+        public object DeepCopy(object value) => value;
 
-        public bool IsMutable
-        {
-            get { return false; }
-        }
+        public bool IsMutable => false;
 
-        public object Replace(object original, object target, object owner)
-        {
-            return original;
-        }
+        public object Replace(object original, object target, object owner) => original;
 
-        public object Assemble(object cached, object owner)
-        {
-            return cached;
-        }
+        public object Assemble(object cached, object owner) => cached;
 
-        public object Disassemble(object value)
-        {
-            return value;
-        }
+        public object Disassemble(object value) => value;
     }
 }

--- a/src/Persistence/MassTransit.NHibernateIntegration/MassTransit.NHibernateIntegration.csproj
+++ b/src/Persistence/MassTransit.NHibernateIntegration/MassTransit.NHibernateIntegration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -14,9 +14,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="2.0.0" />
-    <PackageReference Include="Iesi.Collections" Version="4.0.1.4000" />
+    <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NHibernate" Version="4.1.1.4000" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/Persistence/MassTransit.NHibernateIntegration/Saga/NHibernateSagaConsumeContext.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration/Saga/NHibernateSagaConsumeContext.cs
@@ -41,24 +41,21 @@ namespace MassTransit.NHibernateIntegration.Saga
 
         SagaConsumeContext<TSaga, T> SagaConsumeContext<TSaga>.PopContext<T>()
         {
-            var context = this as SagaConsumeContext<TSaga, T>;
-            if (context == null)
+            if (!(this is SagaConsumeContext<TSaga, T> context))
                 throw new ContextException($"The ConsumeContext<{TypeMetadataCache<TMessage>.ShortName}> could not be cast to {TypeMetadataCache<T>.ShortName}");
 
             return context;
         }
 
-        Task SagaConsumeContext<TSaga>.SetCompleted()
+        async Task SagaConsumeContext<TSaga>.SetCompleted()
         {
-            _session.Delete(Saga);
+            await _session.DeleteAsync(Saga).ConfigureAwait(false);
             IsCompleted = true;
             if (_log.IsDebugEnabled)
             {
                 _log.DebugFormat("SAGA:{0}:{1} Removed {2}", TypeMetadataCache<TSaga>.ShortName, TypeMetadataCache<TMessage>.ShortName,
                     Saga.CorrelationId);
             }
-
-            return TaskUtil.Completed;
         }
 
         public bool IsCompleted { get; private set; }

--- a/src/Persistence/MassTransit.NHibernateIntegration/UriUserType.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration/UriUserType.cs
@@ -14,7 +14,9 @@ namespace MassTransit.NHibernateIntegration
 {
 	using System;
 	using System.Data;
+	using System.Data.Common;
 	using NHibernate;
+	using NHibernate.Engine;
 	using NHibernate.SqlTypes;
 	using NHibernate.UserTypes;
 
@@ -41,47 +43,33 @@ namespace MassTransit.NHibernateIntegration
 			return x.GetHashCode();
 		}
 
-		public object NullSafeGet(IDataReader rs, string[] names, object owner)
+		public object NullSafeGet(DbDataReader rs, string[] names, ISessionImplementor session, object owner)
 		{
-			string value = (string) NHibernateUtil.String.NullSafeGet(rs, names);
+			string value = (string) NHibernateUtil.String.NullSafeGet(rs, names, session);
 
-			Uri uri = new Uri(value);
-
-			return uri;
+			return new Uri(value);
 		}
 
-		public void NullSafeSet(IDbCommand cmd, object value, int index)
+		public void NullSafeSet(DbCommand cmd, object value, int index, ISessionImplementor session)
 		{
 			if (value == null)
 			{
-				NHibernateUtil.String.NullSafeSet(cmd, null, index);
+				NHibernateUtil.String.NullSafeSet(cmd, null, index, session);
 				return;
 			}
 
 			value = value.ToString();
 
-			NHibernateUtil.String.NullSafeSet(cmd, value, index);
+			NHibernateUtil.String.NullSafeSet(cmd, value, index, session);
 		}
 
-		public object DeepCopy(object value)
-		{
-			return value ?? null;
-		}
+		public object DeepCopy(object value) => value ?? null;
 
-		public object Replace(object original, object target, object owner)
-		{
-			return original;
-		}
+		public object Replace(object original, object target, object owner) => original;
 
-		public object Assemble(object cached, object owner)
-		{
-			return cached;
-		}
+		public object Assemble(object cached, object owner) => cached;
 
-		public object Disassemble(object value)
-		{
-			return value;
-		}
+		public object Disassemble(object value) => value;
 
 		public SqlType[] SqlTypes => new[] {NHibernateUtil.String.SqlType};
 


### PR DESCRIPTION
Due to NH version limitations, 4.5.2 is not supported. 4.6.1 and .NET Standard 2.0 are there.
All sync db calls are replaced to async.