### PR TITLE
Add ability to configure bus endpoint queue name for MassTransit.Host…

### DIFF
--- a/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ActiveMqBusFactoryConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ActiveMqBusFactoryConfigurator.cs
@@ -139,5 +139,7 @@ namespace MassTransit.ActiveMqTransport.Configurators
 
             AddReceiveEndpointSpecification(specification);
         }
+
+        public void OverrideDefaultBusEndpointQueueName(string value) => throw new NotSupportedException("Overriding default bus queue name is not supported for ActiveMq transport.");
     }
 }

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusServiceConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusServiceConfigurator.cs
@@ -159,5 +159,7 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
         {
             _configurator.SagaMessageConfigured(configurator);
         }
+
+        public void OverrideDefaultBusEndpointQueueName(string value) => _configurator.OverrideDefaultBusEndpointQueueName(value);
     }
 }

--- a/src/MassTransit.HttpTransport/Configuration/Specifications/HttpBusFactoryConfigurator.cs
+++ b/src/MassTransit.HttpTransport/Configuration/Specifications/HttpBusFactoryConfigurator.cs
@@ -104,5 +104,7 @@ namespace MassTransit.HttpTransport.Specifications
 
             ConfigureReceiveEndpoint(configuration, configure);
         }
+
+        public void OverrideDefaultBusEndpointQueueName(string value) => throw new NotSupportedException("Overriding default bus queue name is not supported for Http transport.");
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqBusFactoryConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqBusFactoryConfigurator.cs
@@ -161,8 +161,10 @@ namespace MassTransit.RabbitMqTransport.Configurators
 
         public void OverrideDefaultBusEndpointQueueName(string value)
         {
-            _settings.ExchangeName = value;
-            _settings.QueueName = value;
+            string queueName = _busEndpointConfiguration.Topology.Consume.CreateTemporaryQueueNameUsingFormat(value);
+
+            _settings.ExchangeName = queueName;
+            _settings.QueueName = queueName;
         }
 
         public void ReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint)

--- a/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqBusFactoryConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqBusFactoryConfigurator.cs
@@ -51,13 +51,6 @@ namespace MassTransit.RabbitMqTransport
         void AddReceiveEndpointSpecification(IReceiveEndpointSpecification<IBusBuilder> specification);
 
         /// <summary>
-        /// In most cases, this is not needed and should not be used. However, if for any reason the default bus
-        /// endpoint queue name needs to be changed, this will do it. Do NOT set it to the same name as a receive
-        /// endpoint or you will screw things up.
-        /// </summary>
-        void OverrideDefaultBusEndpointQueueName(string value);
-
-        /// <summary>
         /// Configure a Host that can be connected. If only one host is specified, it is used as the default
         /// host for receive endpoints.
         /// </summary>

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqServiceConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqServiceConfigurator.cs
@@ -162,5 +162,7 @@ namespace MassTransit.RabbitMqTransport.Hosting
         {
             _configurator.SagaMessageConfigured(configurator);
         }
+
+        public void OverrideDefaultBusEndpointQueueName(string value) => _configurator.OverrideDefaultBusEndpointQueueName(value);
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Topology/IRabbitMqConsumeTopology.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/IRabbitMqConsumeTopology.cs
@@ -31,5 +31,7 @@ namespace MassTransit.RabbitMqTransport.Topology
         void Apply(IReceiveEndpointBrokerTopologyBuilder builder);
 
         string CreateTemporaryQueueName(string prefix);
+
+        string CreateTemporaryQueueNameUsingFormat(string format);
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Topology/Topologies/RabbitMqConsumeTopology.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/Topologies/RabbitMqConsumeTopology.cs
@@ -86,6 +86,35 @@ namespace MassTransit.RabbitMqTransport.Topology.Topologies
             _specifications.Add(specification);
         }
 
+        public string CreateTemporaryQueueNameUsingFormat(string format)
+        {
+            string GetSafe(string value)
+            {
+                var sb = new StringBuilder();
+
+                foreach (var c in value)
+                    if (char.IsLetterOrDigit(c))
+                        sb.Append(c);
+                    else if (c == '.' || c == '_' || c == '-' || c == ':')
+                        sb.Append(c);
+
+                return sb.ToString();
+            }
+
+            var host = HostMetadataCache.Host;
+
+            string queueName = format
+                .Replace("{MachineName}", GetSafe(host.MachineName))
+                .Replace("{ProcessName}", GetSafe(host.ProcessName))
+                .Replace("{ProcessId}", host.ProcessId.ToString())
+                .Replace("{OperatingSystemVersion}", GetSafe(host.OperatingSystemVersion))
+                .Replace("{AssemblyVersion}", GetSafe(host.AssemblyVersion))
+                .Replace("{FrameworkVersion}", GetSafe(host.FrameworkVersion))
+                .Replace("{Guid}", NewId.Next().ToString(_formatter));
+
+            return queueName;
+        }
+
         public string CreateTemporaryQueueName(string prefix)
         {
             var sb = new StringBuilder(prefix);

--- a/src/MassTransit/Configuration/IBusFactoryConfigurator.cs
+++ b/src/MassTransit/Configuration/IBusFactoryConfigurator.cs
@@ -84,5 +84,12 @@ namespace MassTransit
         /// <param name="queueName">The queue name for the receiving endpoint</param>
         /// <param name="configureEndpoint">The configuration callback</param>
         void ReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint);
+
+        /// <summary>
+        /// In most cases, this is not needed and should not be used. However, if for any reason the default bus
+        /// endpoint queue name needs to be changed, this will do it. Do NOT set it to the same name as a receive
+        /// endpoint or you will screw things up.
+        /// </summary>
+        void OverrideDefaultBusEndpointQueueName(string value);
     }
 }

--- a/src/MassTransit/Transports/InMemory/Configuration/Configurators/InMemoryBusFactoryConfigurator.cs
+++ b/src/MassTransit/Transports/InMemory/Configuration/Configurators/InMemoryBusFactoryConfigurator.cs
@@ -95,5 +95,7 @@ namespace MassTransit.Transports.InMemory.Configurators
         }
 
         public IInMemoryHost Host => _inMemoryHost;
+
+        public void OverrideDefaultBusEndpointQueueName(string value) => throw new NotSupportedException("Overriding default bus queue name is not supported for InMemory transport.");
     }
 }

--- a/src/RapidTransit/RapidTransit.Sample/FastFoodService.cs
+++ b/src/RapidTransit/RapidTransit.Sample/FastFoodService.cs
@@ -22,6 +22,8 @@ namespace RapidTransit.Sample
     {
         public void Configure(IServiceConfigurator configurator)
         {
+            configurator.OverrideDefaultBusEndpointQueueName("bus-{MachineName}-{Guid}");
+
             configurator.UseRetry(x => x.Interval(5, TimeSpan.FromMilliseconds(100)));
         }
     }


### PR DESCRIPTION
… based projects

Verified manually by starting RapidTransit.Sample project and observing that the bus queue has expected name.

All transport that do not support bus queue name overriding are throwing NotSupportedException. Additionally added ability to use some formatting based on current Host to set queue name. RapidTransit sample demonstrates how to use format to mimic current behavior of creating bus queue name.

PS if you think that the PR is OK i will add some docs.