### PR TITLE
Fixing SQLite tests for NHibernate

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ test:
   - src/MassTransit.AutomatonymousIntegration.Tests/bin/Release/net461/MassTransit.AutomatonymousIntegration.Tests.dll
   - src/Persistence/MassTransit.MongoDbIntegration.Tests/bin/Release/net452/MassTransit.MongoDbIntegration.Tests.dll
   - src/Persistence/MassTransit.MartenIntegration.Tests/bin/Release/net452/MassTransit.MartenIntegration.Tests.dll
-  - src/Persistence/MassTransit.NHibernateIntegration.Tests/bin/Release/net461/MassTransit.MartenIntegration.Tests.dll
+  - src/Persistence/MassTransit.NHibernateIntegration.Tests/bin/Release/net461/MassTransit.NHibernateIntegration.Tests.dll
   - src/Persistence/MassTransit.DocumentDbIntegration.Tests/bin/Release/MassTransit.DocumentDbIntegration.Tests.dll
   - src/MassTransit.HttpTransport.Tests/bin/Release/net452/MassTransit.HttpTransport.Tests.dll
   categories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,9 +47,10 @@ test:
   assemblies:
   - src/MassTransit.Tests/bin/Release/net452/MassTransit.Tests.dll
   - src/Containers/MassTransit.Containers.Tests/bin/Release/net452/MassTransit.Containers.Tests.dll
-  - src/MassTransit.AutomatonymousIntegration.Tests/bin/Release/net452/MassTransit.AutomatonymousIntegration.Tests.dll
+  - src/MassTransit.AutomatonymousIntegration.Tests/bin/Release/net461/MassTransit.AutomatonymousIntegration.Tests.dll
   - src/Persistence/MassTransit.MongoDbIntegration.Tests/bin/Release/net452/MassTransit.MongoDbIntegration.Tests.dll
   - src/Persistence/MassTransit.MartenIntegration.Tests/bin/Release/net452/MassTransit.MartenIntegration.Tests.dll
+  - src/Persistence/MassTransit.NHibernateIntegration.Tests/bin/Release/net461/MassTransit.MartenIntegration.Tests.dll
   - src/Persistence/MassTransit.DocumentDbIntegration.Tests/bin/Release/MassTransit.DocumentDbIntegration.Tests.dll
   - src/MassTransit.HttpTransport.Tests/bin/Release/net452/MassTransit.HttpTransport.Tests.dll
   categories:

--- a/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/MassTransit.AutomatonymousIntegration.Tests.csproj
@@ -21,8 +21,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108"/>
     <ProjectReference Include="..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.AutomatonymousIntegration\MassTransit.AutomatonymousIntegration.csproj" />
     <ProjectReference Include="..\MassTransit.QuartzIntegration\MassTransit.QuartzIntegration.csproj" />

--- a/src/MassTransit.AutomatonymousIntegration.Tests/SqlLiteSessionFactoryProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/SqlLiteSessionFactoryProvider.cs
@@ -15,7 +15,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
     using System;
     using System.Data;
     using System.Data.Common;
-    using Microsoft.Data.Sqlite;
+    using System.Data.SQLite;
     using NHibernate;
     using NHibernate.Cache;
     using NHibernate.Cfg;
@@ -34,7 +34,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         const string InMemoryConnectionString = "Data Source=:memory:;Version=3;New=True;Pooling=True;Max Pool Size=1;";
         bool _disposed;
         ISessionFactory _innerSessionFactory;
-        SqliteConnection _openConnection;
+        SQLiteConnection _openConnection;
         SingleConnectionSessionFactory _sessionFactory;
 
         public SQLiteSessionFactoryProvider(string connectionString, params Type[] mappedTypes)
@@ -85,7 +85,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         public override ISessionFactory GetSessionFactory()
         {
             string connectionString = Configuration.Properties[NHibernate.Cfg.Environment.ConnectionString];
-            _openConnection = new SqliteConnection(connectionString);
+            _openConnection = new SQLiteConnection(connectionString);
             _openConnection.Open();
 
             BuildSchema(Configuration, _openConnection);

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -29,6 +28,12 @@
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
     <Reference Include="System.Xml" Condition="'$(TargetFramework)' == 'net461'" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.108"/>
+  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+        <PackageReference Include="System.Data.SQLite" Version="1.0.108"/>
+    </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/NHibernateSessionFactoryProvider.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/NHibernateSessionFactoryProvider.cs
@@ -109,8 +109,7 @@ namespace MassTransit.NHibernateIntegration.Tests
 
             configuration.DataBaseIntegration(c =>
             {
-                if (_databaseIntegration != null)
-                    _databaseIntegration(c);
+                _databaseIntegration?.Invoke(c);
 
                 c.KeywordsAutoImport = Hbm2DDLKeyWords.AutoQuote;
                 c.SchemaAction = SchemaAutoAction.Update;

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/SagaLocator_Specs.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/SagaLocator_Specs.cs
@@ -80,10 +80,8 @@ namespace MassTransit.NHibernateIntegration.Tests
         [OneTimeTearDown]
         public void Teardown()
         {
-            if (_sessionFactory != null)
-                _sessionFactory.Dispose();
-            if (_provider != null)
-                _provider.Dispose();
+            _sessionFactory?.Dispose();
+            _provider?.Dispose();
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
@@ -15,7 +15,7 @@ namespace MassTransit.NHibernateIntegration.Tests
     using System;
     using System.Data;
     using System.Data.Common;
-    using Microsoft.Data.Sqlite;
+    using System.Data.SQLite;
     using NHibernate;
     using NHibernate.Cache;
     using NHibernate.Cfg;
@@ -34,7 +34,7 @@ namespace MassTransit.NHibernateIntegration.Tests
         const string InMemoryConnectionString = "Data Source=:memory:;Version=3;New=True;Pooling=True;Max Pool Size=1;";
         bool _disposed;
         ISessionFactory _innerSessionFactory;
-        SqliteConnection _openConnection;
+        SQLiteConnection _openConnection;
         SingleConnectionSessionFactory _sessionFactory;
 
         public SQLiteSessionFactoryProvider(string connectionString, params Type[] mappedTypes)
@@ -86,7 +86,7 @@ namespace MassTransit.NHibernateIntegration.Tests
         public override ISessionFactory GetSessionFactory()
         {
             string connectionString = Configuration.Properties[NHibernate.Cfg.Environment.ConnectionString];
-            _openConnection = new SqliteConnection(connectionString);
+            _openConnection = new SQLiteConnection(connectionString);
             _openConnection.Open();
 
             BuildSchema(Configuration, _openConnection);


### PR DESCRIPTION
Fixing SQLite tests for NHibernate
Adding NHibernate integration tests to the build

Tests that involve the RequestClient fail but this does not seem to be related to the persistence.
`Should_publish_the_event_of_the_missing_instance` fails because the `status.Status` is `Cancelled`.
