### PR TITLE
Receiving a callback function (optionally) from user while calling Redeliver and Defer methods is added

### DIFF
--- a/src/MassTransit.RabbitMqTransport/Contexts/DelayedExchangeMessageRedeliveryContext.cs
+++ b/src/MassTransit.RabbitMqTransport/Contexts/DelayedExchangeMessageRedeliveryContext.cs
@@ -34,10 +34,12 @@ namespace MassTransit.RabbitMqTransport.Contexts
             _scheduler = scheduler;
         }
 
-        Task MessageRedeliveryContext.ScheduleRedelivery(TimeSpan delay)
+        Task MessageRedeliveryContext.ScheduleRedelivery(TimeSpan delay, Action<ConsumeContext, SendContext> callback = null)
         {
+            Action<ConsumeContext, SendContext> combinedCallback = UpdateDeliveryContext + callback;
+
             return _scheduler.ScheduleSend(_context.ReceiveContext.InputAddress, delay, _context.Message,
-                _context.CreateCopyContextPipe(UpdateDeliveryContext));
+                _context.CreateCopyContextPipe(combinedCallback));
         }
 
         static void UpdateDeliveryContext(ConsumeContext context, SendContext sendContext)

--- a/src/MassTransit.RabbitMqTransport/DeferExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/DeferExtensions.cs
@@ -28,8 +28,9 @@ namespace MassTransit
         /// <typeparam name="T"></typeparam>
         /// <param name="context"></param>
         /// <param name="delay"></param>
+        /// <param name="callback"></param>
         /// <returns></returns>
-        public static Task Defer<T>(this ConsumeContext<T> context, TimeSpan delay)
+        public static Task Defer<T>(this ConsumeContext<T> context, TimeSpan delay, Action<ConsumeContext, SendContext> callback = null)
             where T : class
         {
             var modelContext = context.ReceiveContext.GetPayload<ModelContext>();
@@ -38,7 +39,7 @@ namespace MassTransit
 
             MessageRedeliveryContext redeliveryContext = new DelayedExchangeMessageRedeliveryContext<T>(context, scheduler);
 
-            return redeliveryContext.ScheduleRedelivery(delay);
+            return redeliveryContext.ScheduleRedelivery(delay, callback);
         }
     }
 }

--- a/src/MassTransit/MessageRedeliveryContext.cs
+++ b/src/MassTransit/MessageRedeliveryContext.cs
@@ -22,10 +22,11 @@ namespace MassTransit
     public interface MessageRedeliveryContext
     {
         /// <summary>
-        /// Schedule the message to be redelivered after the specified delay.
+        /// Schedule the message to be redelivered after the specified delay with given operation.
         /// </summary>
         /// <param name="delay">The minimum delay before the message will be redelivered to the queue</param>
+        /// <param name="callback">Operation which perform during message redeliver to queue</param>
         /// <returns></returns>
-        Task ScheduleRedelivery(TimeSpan delay);
+        Task ScheduleRedelivery(TimeSpan delay, Action<ConsumeContext, SendContext> callback = null);
     }
 }

--- a/src/MassTransit/RedeliverExtensions.cs
+++ b/src/MassTransit/RedeliverExtensions.cs
@@ -21,14 +21,15 @@ namespace MassTransit
     {
         /// <summary>
         /// Redeliver uses the message scheduler to deliver the message to the queue at a future
-        /// time. The delivery count is incremented. A message scheduler must be configured on the
-        /// bus for redelivery to be enabled.
+        /// time. The delivery count is incremented. Moreover, if you give custom callback action, it perform before sending message to queueu.
+        /// A message scheduler must be configured on the bus for redelivery to be enabled.
         /// </summary>
         /// <typeparam name="T">The message type</typeparam>
         /// <param name="context">The consume context of the message</param>
         /// <param name="delay">The delay before the message is delivered. It may take longer to receive the message if the queue is not empty.</param>
+        /// <param name="callback">Operation which is executed before the message is delivered.</param>
         /// <returns></returns>
-        public static Task Redeliver<T>(this ConsumeContext<T> context, TimeSpan delay)
+        public static Task Redeliver<T>(this ConsumeContext<T> context, TimeSpan delay, Action<ConsumeContext, SendContext> callback = null)
             where T : class
         {
             if (!context.TryGetPayload(out MessageSchedulerContext schedulerContext))
@@ -36,7 +37,7 @@ namespace MassTransit
 
             MessageRedeliveryContext redeliverContext = new ScheduleMessageRedeliveryContext<T>(context, schedulerContext);
 
-            return redeliverContext.ScheduleRedelivery(delay);
+            return redeliverContext.ScheduleRedelivery(delay, callback);
         }
     }
 }


### PR DESCRIPTION
With this PR, user can add a method to run during the execution of `Defer` and `Redeliver` operations easily. This method can access `ConsumeContext` and `SendContext` objects.

Features that are added are validated via the test cases in the `DelayRetry_Spec.cs` file.

Use Case:
User might need to implement operations such as adding a new header or updating the already existing header while re-scheduling the message. `Defer` and `Redeliver` operations provide the ability to re-schedule. However, these operations do not let the user to make changes on headers. With this PR, user gains privilege of performing operations on `SendContext` and `ConsumeContext` so that user can implement various changes on message while re-scheduling.

In my test project, there are two different `Defer` operations. One of them is called when message consume operation throws an exception. This operation writes the error count on the header and re-schedules. Second `Defer`/`Redeliver` operation is used when there are no errors but when the message is re-consumed in the future. This `Defer` operation sets the value of header 0 and re-schedules the message to be consumed on a future date.

Below screenshots provide a general look of the project if it gets an approval.

![rabbitmq-test-ss](https://user-images.githubusercontent.com/6951884/38930566-01b4f2f2-4319-11e8-995d-220c045c28a0.PNG)
![extension](https://user-images.githubusercontent.com/6951884/38937572-2ac87cb4-432c-11e8-89d9-edc45f0f6ad9.PNG)