### PR TITLE
Redis integration with Saga pessimistic lock

### DIFF
--- a/src/Persistence/MassTransit.RedisIntegration/RedisSagaRepository.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/RedisSagaRepository.cs
@@ -45,7 +45,7 @@ namespace MassTransit.RedisIntegration
             TSaga instance;
             ITypedDatabase<TSaga> sagas = db.As<TSaga>();
 
-            using (var pesimisticLock = db.AcquireLockAsync(sagaId))
+            using (var pesimisticLock = await db.AcquireLockAsync(sagaId))
             {
                 if (policy.PreInsertInstance(context, out instance))
                     await PreInsertSagaInstance<T>(sagas, instance).ConfigureAwait(false);

--- a/src/Persistence/MassTransit.RedisIntegration/TypedDatabase.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/TypedDatabase.cs
@@ -25,14 +25,14 @@ namespace MassTransit.RedisIntegration
 
         public async Task<T> Get(Guid key)
         {
-            var value = await _db.StringGetAsync(key.ToString()).ConfigureAwait(false);
+            var value = await _db.StringGetAsync(DatabaseExtensions.SagaPrefix + key.ToString()).ConfigureAwait(false);
             return value.IsNullOrEmpty ? null : SagaSerializer.Deserialize<T>(value);
         }
 
         public async Task Put(Guid key, T value) =>
-            await _db.StringSetAsync(key.ToString(), SagaSerializer.Serialize(value)).ConfigureAwait(false);
+            await _db.StringSetAsync(DatabaseExtensions.SagaPrefix + key.ToString(), SagaSerializer.Serialize(value)).ConfigureAwait(false);
         
-        public async Task Delete(Guid key) => await _db.KeyDeleteAsync(key.ToString()).ConfigureAwait(false);
+        public async Task Delete(Guid key) => await _db.KeyDeleteAsync(DatabaseExtensions.SagaPrefix + key.ToString()).ConfigureAwait(false);
     }
 
     public interface ITypedDatabase<T> where T: class
@@ -44,6 +44,9 @@ namespace MassTransit.RedisIntegration
 
     public static class DatabaseExtensions
     {
+        public const string SagaPrefix = "saga:";
+        public const string SagaLockSuffix = "_lock";
+
         public static ITypedDatabase<T> As<T>(this IDatabase db) where T: class =>
             new TypedDatabase<T>(db);
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Optimistic locking is a good solution but pessimistic lock is way better. If Saga machine is hosted on multiple instances than only one solution is to use storage with a pessimistic locking mechanism. Since now Redis integration brings this feature to Saga.

Prefixes of keys improve readability and organization in Redis storage. 
Screenshot example:
![image](https://user-images.githubusercontent.com/38204363/39045957-b8ddcffe-4494-11e8-8ff3-b330347103c2.png)

