### PR TITLE
Adding Send-by-convention support for Sagas

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration/BehaviorContextExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/BehaviorContextExtensions.cs
@@ -18,7 +18,7 @@ namespace Automatonymous
     using MassTransit;
 
 
-    public static class BehaviorContextExtensions
+    public static partial class BehaviorContextExtensions
     {
         public static Task Publish<TInstance, TData, T>(this BehaviorContext<TInstance, TData> context, T message)
             where T : class

--- a/src/MassTransit.AutomatonymousIntegration/BehaviorContextExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/BehaviorContextExtensions.cs
@@ -147,8 +147,7 @@ namespace Automatonymous
 
         static ConsumeContext GetConsumeContext<TInstance>(BehaviorContext<TInstance> context)
         {
-            ConsumeContext consumeContext;
-            if (context.TryGetPayload(out consumeContext))
+            if (context.TryGetPayload(out ConsumeContext consumeContext))
                 return consumeContext;
 
             throw new ArgumentException("The ConsumeContext was not present", nameof(context));

--- a/src/MassTransit.AutomatonymousIntegration/BehaviorContextSendExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/BehaviorContextSendExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Automatonymous
+{
+    using System;
+    using System.Threading.Tasks;
+    using GreenPipes;
+    using MassTransit;
+
+
+    public static partial class BehaviorContextExtensions
+    {
+        public static Task Send<TInstance, TData, T>(this BehaviorContext<TInstance, TData> context, T message)
+            where T : class =>
+            GetConsumeContext(context).Send(message);
+
+        public static Task Send<TInstance, TData, T>(this BehaviorContext<TInstance, TData> context, T message, IPipe<SendContext<T>> sendPipe)
+            where T : class =>
+            GetConsumeContext(context).Send(message, sendPipe);
+
+        public static Task Send<TInstance, TData, T>(this BehaviorContext<TInstance, TData> context, T message, IPipe<SendContext> sendPipe)
+            where T : class =>
+            GetConsumeContext(context).Send(message, sendPipe);
+
+        public static Task Send<TInstance, TData>(this BehaviorContext<TInstance, TData> context, object message) => 
+            GetConsumeContext(context).Send(message);
+
+        public static Task Send<TInstance, TData>(this BehaviorContext<TInstance, TData> context, object message, Type messageType) => 
+            GetConsumeContext(context).Send(message, messageType);
+
+        public static Task Send<TInstance, TData>(this BehaviorContext<TInstance, TData> context, object message, IPipe<SendContext> sendPipe) => 
+            GetConsumeContext(context).Send(message, sendPipe);
+
+        public static Task Send<TInstance, TData>(this BehaviorContext<TInstance, TData> context, object message, Type messageType,
+            IPipe<SendContext> sendPipe) =>
+            GetConsumeContext(context).Send(message, messageType, sendPipe);
+
+        public static Task Send<TInstance, TData, T>(this BehaviorContext<TInstance, TData> context, object values)
+            where T : class =>
+            GetConsumeContext(context).Send<T>(values);
+
+        public static Task Send<TInstance, TData, T>(this BehaviorContext<TInstance, TData> context, object values, IPipe<SendContext<T>> sendPipe)
+            where T : class =>
+            GetConsumeContext(context).Publish(values, sendPipe);
+
+        public static Task Send<TInstance, TData, T>(this BehaviorContext<TInstance, TData> context, object values, IPipe<SendContext> sendPipe)
+            where T : class =>
+            GetConsumeContext(context).Send<T>(values, sendPipe);
+    }
+}


### PR DESCRIPTION
Sagas have no extensions to do `Send` without getting the endpoint although we have send-by-convention feature. This PR fixes it.