### PR TITLE
Removed all references of RabbitMQ from ActiveMQ transport

### DIFF
--- a/src/MassTransit.ActiveMqTransport/ActiveMqBusFactory.cs
+++ b/src/MassTransit.ActiveMqTransport/ActiveMqBusFactory.cs
@@ -26,7 +26,7 @@ namespace MassTransit.ActiveMqTransport
         public static IMessageTopologyConfigurator MessageTopology => Cached.MessageTopologyValue.Value;
 
         /// <summary>
-        /// Configure and create a bus for RabbitMQ
+        /// Configure and create a bus for ActiveMQ
         /// </summary>
         /// <param name="configure">The configuration callback to configure the bus</param>
         /// <returns></returns>

--- a/src/MassTransit.ActiveMqTransport/ActiveMqHostSettings.cs
+++ b/src/MassTransit.ActiveMqTransport/ActiveMqHostSettings.cs
@@ -17,17 +17,17 @@ namespace MassTransit.ActiveMqTransport
 
 
     /// <summary>
-    /// Settings to configure a RabbitMQ host explicitly without requiring the fluent interface
+    /// Settings to configure a ActiveMQ host explicitly without requiring the fluent interface
     /// </summary>
     public interface ActiveMqHostSettings
     {
         /// <summary>
-        ///     The RabbitMQ host to connect to (should be a valid hostname)
+        ///     The ActiveMQ host to connect to (should be a valid hostname)
         /// </summary>
         string Host { get; }
 
         /// <summary>
-        ///     The RabbitMQ port to connect
+        ///     The ActiveMQ port to connect
         /// </summary>
         int Port { get; }
 

--- a/src/MassTransit.ActiveMqTransport/Configuration/ActiveMqHostConfigurationExtensions.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/ActiveMqHostConfigurationExtensions.cs
@@ -19,7 +19,7 @@ namespace MassTransit.ActiveMqTransport
     public static class ActiveMqHostConfigurationExtensions
     {
         /// <summary>
-        ///     Configure a RabbitMQ host using the configuration API
+        ///     Configure a ActiveMQ host using the configuration API
         /// </summary>
         /// <param name="configurator"></param>
         /// <param name="hostAddress">The URI host address of the RabbitMQ host (rabbitmq://host:port/vhost)</param>
@@ -37,7 +37,7 @@ namespace MassTransit.ActiveMqTransport
         }
 
         /// <summary>
-        /// Configure a RabbitMQ host with a host name and virtual host
+        /// Configure a ActiveMQ host with a host name and virtual host
         /// </summary>
         /// <param name="configurator"></param>
         /// <param name="hostName">The host name of the broker</param>
@@ -48,7 +48,7 @@ namespace MassTransit.ActiveMqTransport
         }
 
         /// <summary>
-        /// Configure a RabbitMQ host with a host name and virtual host
+        /// Configure a ActiveMQ host with a host name and virtual host
         /// </summary>
         /// <param name="configurator"></param>
         /// <param name="hostName">The host name of the broker</param>

--- a/src/MassTransit.ActiveMqTransport/Configuration/BusFactoryConfiguratorExtensions.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/BusFactoryConfiguratorExtensions.cs
@@ -18,7 +18,7 @@ namespace MassTransit.ActiveMqTransport
     public static class BusFactoryConfiguratorExtensions
     {
         /// <summary>
-        /// Select RabbitMQ as the transport for the service bus
+        /// Select ActiveMQ as the transport for the service bus
         /// </summary>
         public static IBusControl CreateUsingActiveMq(this IBusFactorySelector selector, Action<IActiveMqBusFactoryConfigurator> configure)
         {

--- a/src/MassTransit.ActiveMqTransport/Configuration/IActiveMqHostConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/IActiveMqHostConfigurator.cs
@@ -15,13 +15,13 @@ namespace MassTransit.ActiveMqTransport
     public interface IActiveMqHostConfigurator
     {
         /// <summary>
-        /// Sets the username for the connection to RabbitMQ
+        /// Sets the username for the connection to ActiveMQ
         /// </summary>
         /// <param name="username"></param>
         void Username(string username);
 
         /// <summary>
-        /// Sets the password for the connection to RabbitMQ
+        /// Sets the password for the connection to ActiveMQ
         /// </summary>
         /// <param name="password"></param>
         void Password(string password);

--- a/src/MassTransit.ActiveMqTransport/Configuration/IActiveMqReceiveEndpointConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/IActiveMqReceiveEndpointConfigurator.cs
@@ -17,7 +17,7 @@ namespace MassTransit.ActiveMqTransport
 
 
     /// <summary>
-    /// Configure a receiving RabbitMQ endpoint
+    /// Configure a receiving ActiveMQ endpoint
     /// </summary>
     public interface IActiveMqReceiveEndpointConfigurator :
         IReceiveEndpointConfigurator,

--- a/src/MassTransit.ActiveMqTransport/Configuration/IQueueConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/IQueueConfigurator.cs
@@ -13,7 +13,7 @@
 namespace MassTransit.ActiveMqTransport
 {
     /// <summary>
-    /// Configures a queue/exchange pair in RabbitMQ
+    /// Configures a queue/exchange pair in ActiveMQ
     /// </summary>
     public interface IQueueConfigurator
     {

--- a/src/MassTransit.ActiveMqTransport/Configuration/ITopicConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/ITopicConfigurator.cs
@@ -13,7 +13,7 @@
 namespace MassTransit.ActiveMqTransport
 {
     /// <summary>
-    /// Configures an exchange for RabbitMQ
+    /// Configures an exchange for ActiveMQ
     /// </summary>
     public interface ITopicConfigurator
     {

--- a/src/MassTransit.ActiveMqTransport/ConnectionContext.cs
+++ b/src/MassTransit.ActiveMqTransport/ConnectionContext.cs
@@ -23,7 +23,7 @@ namespace MassTransit.ActiveMqTransport
         PipeContext
     {
         /// <summary>
-        /// The RabbitMQ Connection
+        /// The ActiveMQ Connection
         /// </summary>
         IConnection Connection { get; }
 

--- a/src/MassTransit.ActiveMqTransport/Pipeline/ActiveMqBasicConsumer.cs
+++ b/src/MassTransit.ActiveMqTransport/Pipeline/ActiveMqBasicConsumer.cs
@@ -28,7 +28,7 @@ namespace MassTransit.ActiveMqTransport.Pipeline
 
 
     /// <summary>
-    /// Receives messages from RabbitMQ, pushing them to the InboundPipe of the service endpoint.
+    /// Receives messages from ActiveMQ, pushing them to the InboundPipe of the service endpoint.
     /// </summary>
     public sealed class ActiveMqBasicConsumer :
         Supervisor,

--- a/src/MassTransit.ActiveMqTransport/Topology/Entities/Consumer.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/Entities/Consumer.cs
@@ -13,7 +13,7 @@
 namespace MassTransit.ActiveMqTransport.Topology.Entities
 {
     /// <summary>
-    /// The exchange to queue binding details to declare the binding to RabbitMQ
+    /// The exchange to queue binding details to declare the binding to ActiveMQ
     /// </summary>
     public interface Consumer
     {

--- a/src/MassTransit.ActiveMqTransport/Topology/Entities/Queue.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/Entities/Queue.cs
@@ -13,7 +13,7 @@
 namespace MassTransit.ActiveMqTransport.Topology.Entities
 {
     /// <summary>
-    /// The queue details used to declare the queue to RabbitMQ
+    /// The queue details used to declare the queue to ActiveMQ
     /// </summary>
     public interface Queue
     {

--- a/src/MassTransit.ActiveMqTransport/Topology/Entities/Topic.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/Entities/Topic.cs
@@ -13,7 +13,7 @@
 namespace MassTransit.ActiveMqTransport.Topology.Entities
 {
     /// <summary>
-    /// The exchange details used to declare the exchange to RabbitMQ
+    /// The exchange details used to declare the exchange to ActiveMQ
     /// </summary>
     public interface Topic
     {

--- a/src/MassTransit.ActiveMqTransport/Topology/IActiveMqHostTopology.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/IActiveMqHostTopology.cs
@@ -44,7 +44,7 @@ namespace MassTransit.ActiveMqTransport.Topology
         /// off the query string to properly configure the settings, including exchange and queue
         /// durability, etc.
         /// </summary>
-        /// <param name="address">The RabbitMQ endpoint address</param>
+        /// <param name="address">The ActiveMQ endpoint address</param>
         /// <returns>The send settings for the address</returns>
         SendSettings GetSendSettings(Uri address);
 

--- a/src/MassTransit.ActiveMqTransport/Transport/ActiveMqHost.cs
+++ b/src/MassTransit.ActiveMqTransport/Transport/ActiveMqHost.cs
@@ -70,7 +70,7 @@ namespace MassTransit.ActiveMqTransport.Transport
             var scope = context.CreateScope("host");
             scope.Set(new
             {
-                Type = "RabbitMQ",
+                Type = "ActiveMQ",
                 _settings.Host,
                 _settings.Port,
                 _settings.Username,

--- a/src/MassTransit.ActiveMqTransport/Transport/ActiveMqReceiveTransport.cs
+++ b/src/MassTransit.ActiveMqTransport/Transport/ActiveMqReceiveTransport.cs
@@ -57,7 +57,7 @@ namespace MassTransit.ActiveMqTransport.Transport
         void IProbeSite.Probe(ProbeContext context)
         {
             var scope = context.CreateScope("transport");
-            scope.Add("type", "RabbitMQ");
+            scope.Add("type", "ActiveMQ");
             scope.Set(_settings);
             var topologyScope = scope.CreateScope("topology");
             _context.BrokerTopology.Probe(topologyScope);


### PR DESCRIPTION
Was reviewing ActiveMQ transport and saw a few references of RabbitMQ replaced them with ActiveMQ.