### PR TITLE
V2 EncryptedMessage Serializer/Deserializer

### DIFF
--- a/src/MassTransit.RabbitMqTransport.Tests/Encrypted_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/Encrypted_Specs.cs
@@ -20,6 +20,42 @@ namespace MassTransit.RabbitMqTransport.Tests
 
 
     [TestFixture]
+    public class Publishing_an_encrypted_message_to_an_endpoint_with_a_symmetric_key :
+        RabbitMqTestFixture
+    {
+        Task<ConsumeContext<PingMessage>> _handler;
+
+        protected override void ConfigureRabbitMqReceiveEndpoint(IRabbitMqReceiveEndpointConfigurator configurator)
+        {
+            _handler = Handled<PingMessage>(configurator);
+        }
+
+        protected override void ConfigureRabbitMqBus(IRabbitMqBusFactoryConfigurator configurator)
+        {
+            var key = new byte[]
+            {
+                31, 182, 254, 29, 98, 114, 85, 168, 176, 48, 113,
+                206, 198, 176, 181, 125, 106, 134, 98, 217, 113,
+                158, 88, 75, 118, 223, 117, 160, 224, 1, 47, 162
+            };
+
+            configurator.UseEncryption(key);
+
+            base.ConfigureRabbitMqBus(configurator);
+        }
+
+        [Test]
+        public async Task Should_succeed()
+        {
+            await Bus.Publish(new PingMessage());
+
+            ConsumeContext<PingMessage> received = await _handler;
+
+            Assert.AreEqual(EncryptedMessageSerializerV2.EncryptedContentType, received.ReceiveContext.ContentType);
+        }
+    }
+
+    [TestFixture]
     public class Publishing_an_encrypted_message_to_an_endpoint_with_a_specific_key :
         RabbitMqTestFixture
     {

--- a/src/MassTransit.Tests/Serialization/GivenAComplexMessage.cs
+++ b/src/MassTransit.Tests/Serialization/GivenAComplexMessage.cs
@@ -24,6 +24,7 @@ namespace MassTransit.Tests.Serialization
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(XmlMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     public class Given_a_variety_of_challenging_messages :
         SerializationTest
     {

--- a/src/MassTransit.Tests/Serialization/IEnumerable_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/IEnumerable_Specs.cs
@@ -20,8 +20,11 @@ namespace MassTransit.Tests.Serialization
     using Shouldly;
 
 
-    [TestFixture(typeof(JsonMessageSerializer)), TestFixture(typeof(BsonMessageSerializer)), TestFixture(typeof(XmlMessageSerializer)),
-     TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(JsonMessageSerializer))]
+    [TestFixture(typeof(BsonMessageSerializer))]
+    [TestFixture(typeof(XmlMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     public class Deserializing_an_enumerable_property :
         SerializationTest
     {

--- a/src/MassTransit.Tests/Serialization/Interface_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/Interface_Specs.cs
@@ -28,6 +28,7 @@ namespace MassTransit.Tests.Serialization
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(XmlMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     public class Deserializing_an_interface :
         SerializationTest
     {

--- a/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
@@ -327,7 +327,9 @@ namespace MassTransit.Tests.Serialization
     }
 
 
-    [TestFixture(typeof(JsonMessageSerializer)), TestFixture(typeof(BsonMessageSerializer)), TestFixture(typeof(XmlMessageSerializer))]
+    [TestFixture(typeof(JsonMessageSerializer))]
+    [TestFixture(typeof(BsonMessageSerializer))]
+    [TestFixture(typeof(XmlMessageSerializer))]
     public class Using_JsonConverterAttribute_on_a_class :
         SerializationTest
     {
@@ -426,7 +428,9 @@ namespace MassTransit.Tests.Serialization
     }
 
 
-    [TestFixture(typeof(JsonMessageSerializer)), TestFixture(typeof(BsonMessageSerializer)), TestFixture(typeof(XmlMessageSerializer))]
+    [TestFixture(typeof(JsonMessageSerializer))]
+    [TestFixture(typeof(BsonMessageSerializer))]
+    [TestFixture(typeof(XmlMessageSerializer))]
     public class Using_JsonConverterAttribute_on_a_property :
         SerializationTest
     {

--- a/src/MassTransit.Tests/Serialization/MessageDataSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/MessageDataSerialization_Specs.cs
@@ -12,6 +12,7 @@
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(XmlMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     public class Serialization_a_message_data_property :
         SerializationTest
     {

--- a/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
@@ -23,6 +23,7 @@ namespace MassTransit.Tests.Serialization
     [TestFixture(typeof(JsonMessageSerializer))]
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     public class MoreSerialization_Specs :
         SerializationTest
     {

--- a/src/MassTransit.Tests/Serialization/Performance_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/Performance_Specs.cs
@@ -31,6 +31,7 @@ namespace MassTransit.Tests.Serialization
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(XmlMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     [Explicit]
     public class Serializer_performance :
         SerializationTest

--- a/src/MassTransit.Tests/Serialization/PropertyType_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/PropertyType_Specs.cs
@@ -22,6 +22,7 @@ namespace MassTransit.Tests.Serialization
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(XmlMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     public class Serializing_a_property_of_type_char :
         SerializationTest
     {
@@ -88,6 +89,7 @@ namespace MassTransit.Tests.Serialization
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(XmlMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
     public class Serializing_a_string_with_an_escaped_character :
         SerializationTest
     {

--- a/src/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
@@ -16,6 +16,7 @@ namespace MassTransit.Tests.Serialization {
     [TestFixture(typeof(JsonMessageSerializer))]
     [TestFixture(typeof(BsonMessageSerializer))]
     [TestFixture(typeof(EncryptedMessageSerializer))]
+    [TestFixture(typeof(EncryptedMessageSerializerV2))]
 #if !NETCORE
     [TestFixture(typeof(BinaryMessageSerializer))]
 #endif

--- a/src/MassTransit.Tests/Serialization/SerializationTest.cs
+++ b/src/MassTransit.Tests/Serialization/SerializationTest.cs
@@ -72,6 +72,20 @@ namespace MassTransit.Tests.Serialization
                 Serializer = new EncryptedMessageSerializer(streamProvider);
                 Deserializer = new EncryptedMessageDeserializer(BsonMessageSerializer.Deserializer, streamProvider);
             }
+            else if (_serializerType == typeof(EncryptedMessageSerializerV2))
+            {
+                var key = new byte[]
+                {
+                    31, 182, 254, 29, 98, 114, 85, 168, 176, 48, 113,
+                    206, 198, 176, 181, 125, 106, 134, 98, 217, 113,
+                    158, 88, 75, 118, 223, 117, 160, 224, 1, 47, 162
+                };
+                var keyProvider = new ConstantSecureKeyProvider(key);
+                var streamProvider = new AesCryptoStreamProviderV2(keyProvider);
+
+                Serializer = new EncryptedMessageSerializerV2(streamProvider);
+                Deserializer = new EncryptedMessageDeserializerV2(BsonMessageSerializer.Deserializer, streamProvider);
+            }
 #if !NETCORE
             else if (_serializerType == typeof(BinaryMessageSerializer)) {
                 Serializer = new BinaryMessageSerializer();

--- a/src/MassTransit/Configuration/SerializerConfigurationExtensions.cs
+++ b/src/MassTransit/Configuration/SerializerConfigurationExtensions.cs
@@ -94,6 +94,80 @@ namespace MassTransit
         }
 
         /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="symmetricKey">Cryptographic key for both encryption of plaintext message and decryption of ciphertext message</param>
+        public static void UseEncryption(this IBusFactoryConfigurator configurator, byte[] symmetricKey)
+        {
+            var keyProvider = new ConstantSecureKeyProvider(symmetricKey);
+            var streamProvider = new AesCryptoStreamProviderV2(keyProvider);
+
+            configurator.UseEncryptedSerializerV2(streamProvider);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="symmetricKey">Cryptographic key for both encryption of plaintext message and decryption of ciphertext message</param>
+        public static void UseEncryption(this IReceiveEndpointConfigurator configurator, byte[] symmetricKey)
+        {
+            var keyProvider = new ConstantSecureKeyProvider(symmetricKey);
+            var streamProvider = new AesCryptoStreamProviderV2(keyProvider);
+
+            configurator.UseEncryptedSerializerV2(streamProvider);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="keyProvider">The custom key provider to provide the symmetric key for encryption of plaintext message and decryption of ciphertext message</param>
+        public static void UseEncryption(this IBusFactoryConfigurator configurator, ISecureKeyProvider keyProvider)
+        {
+            var streamProvider = new AesCryptoStreamProviderV2(keyProvider);
+
+            configurator.UseEncryptedSerializerV2(streamProvider);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="keyProvider">The custom key provider to provide the symmetric key for encryption of plaintext message and decryption of ciphertext message</param>
+        public static void UseEncryption(this IReceiveEndpointConfigurator configurator, ISecureKeyProvider keyProvider)
+        {
+            var streamProvider = new AesCryptoStreamProviderV2(keyProvider);
+
+            configurator.UseEncryptedSerializerV2(streamProvider);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        public static void UseEncryptedSerializerV2(this IBusFactoryConfigurator configurator, ICryptoStreamProviderV2 streamProvider)
+        {
+            configurator.SetMessageSerializer(() => new EncryptedMessageSerializerV2(streamProvider));
+
+            configurator.AddMessageDeserializer(EncryptedMessageSerializerV2.EncryptedContentType,
+                () => new EncryptedMessageDeserializerV2(BsonMessageSerializer.Deserializer, streamProvider));
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        public static void UseEncryptedSerializerV2(this IReceiveEndpointConfigurator configurator, ICryptoStreamProviderV2 streamProvider)
+        {
+            configurator.SetMessageSerializer(() => new EncryptedMessageSerializerV2(streamProvider));
+
+            configurator.AddMessageDeserializer(EncryptedMessageSerializerV2.EncryptedContentType,
+                () => new EncryptedMessageDeserializerV2(BsonMessageSerializer.Deserializer, streamProvider));
+        }
+
+        /// <summary>
         /// Serialize messages using the XML message serializer
         /// </summary>
         /// <param name="configurator"></param>
@@ -110,6 +184,7 @@ namespace MassTransit
         {
             configurator.SetMessageSerializer(() => new XmlMessageSerializer());
         }
+        
 
     #if !NETCORE
         /// <summary>

--- a/src/MassTransit/Serialization/AesCryptoStreamProvider.cs
+++ b/src/MassTransit/Serialization/AesCryptoStreamProvider.cs
@@ -89,39 +89,5 @@ namespace MassTransit.Serialization
 
         Aes CreateAes()
             => new AesCryptoServiceProvider {Padding = _paddingMode};
-
-        class DisposingCryptoStream :
-            CryptoStream
-        {
-            Stream _stream;
-            ICryptoTransform _transform;
-
-            public DisposingCryptoStream(Stream stream, ICryptoTransform transform, CryptoStreamMode mode)
-                : base(stream, transform, mode)
-            {
-                _stream = stream;
-                _transform = transform;
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                if (!disposing)
-                    return;
-
-                base.Dispose(true);
-
-                if (_stream != null)
-                {
-                    _stream.Dispose();
-                    _stream = null;
-                }
-
-                if (_transform != null)
-                {
-                    _transform.Dispose();
-                    _transform = null;
-                }
-            }
-        }
     }
 }

--- a/src/MassTransit/Serialization/AesCryptoStreamProviderV2.cs
+++ b/src/MassTransit/Serialization/AesCryptoStreamProviderV2.cs
@@ -72,10 +72,12 @@ namespace MassTransit.Serialization
 
         byte[] GenerateIv()
         {
-            var aes = CreateAes();
-            aes.GenerateIV();
+            using (var aes = CreateAes())
+            {
+                aes.GenerateIV();
 
-            return aes.IV;
+                return aes.IV;
+            }
         }
 
         ICryptoTransform CreateEncryptor(byte[] key, byte[] iv)

--- a/src/MassTransit/Serialization/AesCryptoStreamProviderV2.cs
+++ b/src/MassTransit/Serialization/AesCryptoStreamProviderV2.cs
@@ -1,0 +1,94 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Serialization
+{
+    using System.IO;
+    using System.Security.Cryptography;
+    using GreenPipes;
+
+
+    public class AesCryptoStreamProviderV2 : ICryptoStreamProviderV2
+    {
+        readonly PaddingMode _paddingMode;
+        readonly ISecureKeyProvider _secureKeyProvider;
+
+        public AesCryptoStreamProviderV2(ISecureKeyProvider secureKeyProvider,
+            PaddingMode paddingMode = PaddingMode.PKCS7)
+        {
+            _secureKeyProvider = secureKeyProvider;
+            _paddingMode = paddingMode;
+        }
+
+        public Stream GetDecryptStream(Stream stream, ReceiveContext context)
+        {
+            var key = _secureKeyProvider.GetKey(context);
+
+            var iv = new byte[16];
+            stream.Read(iv, 0, iv.Length);
+
+            var encryptor = CreateDecryptor(key, iv);
+
+            return new DisposingCryptoStream(stream, encryptor, CryptoStreamMode.Read);
+        }
+
+        public Stream GetEncryptStream(Stream stream, SendContext context)
+        {
+            var key = _secureKeyProvider.GetKey(context);
+
+            var iv = GenerateIv();
+
+            stream.Write(iv, 0, iv.Length);
+            var encryptor = CreateEncryptor(key, iv);
+
+            return new DisposingCryptoStream(stream, encryptor, CryptoStreamMode.Write);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("aes");
+
+            scope.Add("paddingMode", _paddingMode.ToString());
+
+            _secureKeyProvider.Probe(scope);
+        }
+
+        ICryptoTransform CreateDecryptor(byte[] key, byte[] iv)
+        {
+            using (var provider = CreateAes())
+            {
+                return provider.CreateDecryptor(key, iv);
+            }
+        }
+
+        byte[] GenerateIv()
+        {
+            var aes = CreateAes();
+            aes.GenerateIV();
+
+            return aes.IV;
+        }
+
+        ICryptoTransform CreateEncryptor(byte[] key, byte[] iv)
+        {
+            using (var provider = CreateAes())
+            {
+                return provider.CreateEncryptor(key, iv);
+            }
+        }
+
+        Aes CreateAes()
+        {
+            return new AesCryptoServiceProvider { Padding = _paddingMode };
+        }
+    }
+}

--- a/src/MassTransit/Serialization/ConstantSecureKeyProvider.cs
+++ b/src/MassTransit/Serialization/ConstantSecureKeyProvider.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Serialization
+{
+    using GreenPipes;
+
+
+    public class ConstantSecureKeyProvider : ISecureKeyProvider
+    {
+        readonly byte[] _key;
+
+        public ConstantSecureKeyProvider(byte[] key)
+        {
+            _key = key;
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            context.Add("key", "constant");
+        }
+
+        public byte[] GetKey(ReceiveContext receiveContext)
+        {
+            return GetKey();
+        }
+
+        public byte[] GetKey(SendContext sendContext)
+        {
+            return GetKey();
+        }
+
+        byte[] GetKey()
+        {
+            return _key;
+        }
+    }
+}

--- a/src/MassTransit/Serialization/DisposingCryptoStream.cs
+++ b/src/MassTransit/Serialization/DisposingCryptoStream.cs
@@ -1,0 +1,51 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Serialization
+{
+    using System.IO;
+    using System.Security.Cryptography;
+
+    class DisposingCryptoStream :
+        CryptoStream
+    {
+        Stream _stream;
+        ICryptoTransform _transform;
+
+        internal DisposingCryptoStream(Stream stream, ICryptoTransform transform, CryptoStreamMode mode)
+            : base(stream, transform, mode)
+        {
+            _stream = stream;
+            _transform = transform;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!disposing)
+                return;
+
+            base.Dispose(true);
+
+            if (_stream != null)
+            {
+                _stream.Dispose();
+                _stream = null;
+            }
+
+            if (_transform != null)
+            {
+                _transform.Dispose();
+                _transform = null;
+            }
+        }
+    }
+}

--- a/src/MassTransit/Serialization/EncryptedMessageDeserializerV2.cs
+++ b/src/MassTransit/Serialization/EncryptedMessageDeserializerV2.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Serialization
+{
+    using System;
+    using System.Net.Mime;
+    using System.Runtime.Serialization;
+    using GreenPipes;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Bson;
+    using Util;
+
+
+    public class EncryptedMessageDeserializerV2 :
+        IMessageDeserializer
+    {
+        readonly ICryptoStreamProviderV2 _cryptoStreamProvider;
+        readonly JsonSerializer _deserializer;
+        readonly IObjectTypeDeserializer _objectTypeDeserializer;
+
+        public EncryptedMessageDeserializerV2(JsonSerializer deserializer, ICryptoStreamProviderV2 cryptoStreamProvider)
+        {
+            _deserializer = deserializer;
+            _cryptoStreamProvider = cryptoStreamProvider;
+            _objectTypeDeserializer = new ObjectTypeDeserializer(_deserializer);
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("encrypted");
+            scope.Add("contentType", ContentType.MediaType);
+            _cryptoStreamProvider.Probe(scope);
+        }
+
+        public ContentType ContentType => EncryptedMessageSerializerV2.EncryptedContentType;
+
+        public ConsumeContext Deserialize(ReceiveContext receiveContext)
+        {
+            try
+            {
+                using (var body = receiveContext.GetBodyStream())
+                {
+                    using (var disposingCryptoStream = _cryptoStreamProvider.GetDecryptStream(body, receiveContext))
+                    {
+                        using (var jsonReader = new BsonDataReader(disposingCryptoStream))
+                        {
+                            var messageEnvelope = _deserializer.Deserialize<MessageEnvelope>(jsonReader);
+
+                            return new JsonConsumeContext(_deserializer, _objectTypeDeserializer, receiveContext,
+                                messageEnvelope);
+                        }
+                    }
+                }
+            }
+            catch (JsonSerializationException ex)
+            {
+                throw new SerializationException(
+                    "A JSON serialization exception occurred while deserializing the message envelope", ex);
+            }
+            catch (SerializationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new SerializationException("An exception occurred while deserializing the message envelope", ex);
+            }
+        }
+    }
+}

--- a/src/MassTransit/Serialization/EncryptedMessageSerializerV2.cs
+++ b/src/MassTransit/Serialization/EncryptedMessageSerializerV2.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Serialization
+{
+    using System.IO;
+    using System.Net.Mime;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Bson;
+    using Util;
+
+
+    public class EncryptedMessageSerializerV2 :
+        IMessageSerializer
+    {
+        public const string ContentTypeHeaderValue = "application/vnd.masstransit.v2+aes";
+        public static readonly ContentType EncryptedContentType = new ContentType(ContentTypeHeaderValue);
+        readonly JsonSerializer _serializer;
+        readonly ICryptoStreamProviderV2 _streamProvider;
+
+        public EncryptedMessageSerializerV2(ICryptoStreamProviderV2 streamProvider)
+        {
+            _streamProvider = streamProvider;
+            _serializer = BsonMessageSerializer.Serializer;
+        }
+
+        ContentType IMessageSerializer.ContentType => EncryptedContentType;
+
+        void IMessageSerializer.Serialize<T>(Stream stream, SendContext<T> context)
+        {
+            context.ContentType = EncryptedContentType;
+
+            var envelope = new JsonMessageEnvelope(context, context.Message, TypeMetadataCache<T>.MessageTypeNames);
+
+            using (var cryptoStream = _streamProvider.GetEncryptStream(stream, context))
+            {
+                using (var jsonWriter = new BsonDataWriter(cryptoStream))
+                {
+                    _serializer.Serialize(jsonWriter, envelope, typeof(MessageEnvelope));
+
+                    jsonWriter.Flush();
+                }
+            }
+        }
+    }
+}

--- a/src/MassTransit/Serialization/ICryptoStreamProviderV2.cs
+++ b/src/MassTransit/Serialization/ICryptoStreamProviderV2.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Serialization
+{
+    using System.IO;
+    using GreenPipes;
+
+    public interface ICryptoStreamProviderV2 : IProbeSite
+    {
+        Stream GetDecryptStream(Stream stream, ReceiveContext context);
+
+        Stream GetEncryptStream(Stream stream, SendContext context);
+    }
+}

--- a/src/MassTransit/Serialization/ISecureKeyProvider.cs
+++ b/src/MassTransit/Serialization/ISecureKeyProvider.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Serialization
+{
+    using GreenPipes;
+
+
+    public interface ISecureKeyProvider : IProbeSite
+    {
+        byte[] GetKey(ReceiveContext receiveContext);
+
+        byte[] GetKey(SendContext sendContext);
+    }
+}


### PR DESCRIPTION
PR includes a new encrypted message serializer and deserializer that supports reading and writing the IV to the start of the stream. The IV is also rotated on each message so that even if we have the same message content the cyphertext will differ each time.

I've also ended the basic `ISecureKeyProvider` so this takes in `ReceiveContext` and `SendContext` to allow other implementation such as AWS KMS (See [KmsSecureKeyProvider](https://github.com/BigChangeApps/BigChange.MassTransit.AWSKeyManagementService/blob/master/src/BigChange.MassTransit.AwsKeyManagementService/KmsSecureKeyProvider.cs)).

This change is forward compatible due to the content type being changed to include a version (`application/vnd.masstransit.v2+aes`) so both the old and new can be run side by side until people have fully upgraded.

You might want to review the namings of the extensions I've added on top of `IBusFactoryConfigurator` and `IReceiveEndpointConfigurator` to make sure these align with other extensions methods.

Do you want me to mark the old classes/methods for the old serializer and deserializer as deprecated?
