### PR TITLE
Additional transport using Amazon SNS and SQS

### DIFF
--- a/src/MassTransit.AmazonSqsTransport.Tests/AmazonSqsTestFixture.cs
+++ b/src/MassTransit.AmazonSqsTransport.Tests/AmazonSqsTestFixture.cs
@@ -1,0 +1,93 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Configuration;
+    using MassTransit.Testing;
+    using NUnit.Framework;
+    using TestFramework;
+    using Testing;
+
+
+    public class AmazonSqsTestFixture :
+        BusTestFixture
+    {
+        public AmazonSqsTestFixture(string inputQueueName = null)
+            : this(new AmazonSqsTestHarness(inputQueueName))
+        {
+        }
+
+        public AmazonSqsTestFixture(AmazonSqsTestHarness harness)
+            : base(harness)
+        {
+            AmazonSqsTestHarness = harness;
+
+            AmazonSqsTestHarness.OnConfigureAmazonSqsHost += ConfigureAmazonSqsHost;
+            AmazonSqsTestHarness.OnConfigureAmazonSqsBus += ConfigureAmazonSqsBus;
+            AmazonSqsTestHarness.OnConfigureAmazonSqsBusHost += ConfigureAmazonSqsBusHost;
+            AmazonSqsTestHarness.OnConfigureAmazonSqsReceiveEndoint += ConfigureAmazonSqsReceiveEndpoint;
+        }
+
+        protected AmazonSqsTestHarness AmazonSqsTestHarness { get; }
+
+        /// <summary>
+        /// The sending endpoint for the InputQueue
+        /// </summary>
+        protected ISendEndpoint InputQueueSendEndpoint => AmazonSqsTestHarness.InputQueueSendEndpoint;
+
+        protected Uri InputQueueAddress => AmazonSqsTestHarness.InputQueueAddress;
+
+        protected Uri HostAddress => AmazonSqsTestHarness.HostAddress;
+
+        /// <summary>
+        /// The sending endpoint for the Bus
+        /// </summary>
+        protected ISendEndpoint BusSendEndpoint => AmazonSqsTestHarness.BusSendEndpoint;
+
+        protected ISentMessageList Sent => AmazonSqsTestHarness.Sent;
+
+        protected Uri BusAddress => AmazonSqsTestHarness.BusAddress;
+
+        protected IAmazonSqsHost Host => AmazonSqsTestHarness.Host;
+
+        [OneTimeSetUp]
+        public Task SetupInMemoryTestFixture()
+        {
+            return AmazonSqsTestHarness.Start();
+        }
+
+        [OneTimeTearDown]
+        public Task TearDownInMemoryTestFixture()
+        {
+            return AmazonSqsTestHarness.Stop();
+        }
+
+        protected virtual void ConfigureAmazonSqsHost(IAmazonSqsHostConfigurator configurator)
+        {
+        }
+
+        protected virtual void ConfigureAmazonSqsBus(IAmazonSqsBusFactoryConfigurator configurator)
+        {
+        }
+
+        protected virtual void ConfigureAmazonSqsBusHost(IAmazonSqsBusFactoryConfigurator configurator, IAmazonSqsHost host)
+        {
+        }
+
+        protected virtual void ConfigureAmazonSqsReceiveEndpoint(IAmazonSqsReceiveEndpointConfigurator configurator)
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport.Tests/Configure_Specs.cs
+++ b/src/MassTransit.AmazonSqsTransport.Tests/Configure_Specs.cs
@@ -1,0 +1,289 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Configuration;
+    using GreenPipes.Internals.Extensions;
+    using MassTransit.Testing;
+    using NUnit.Framework;
+    using TestFramework.Messages;
+    using Testing;
+
+
+    [TestFixture]
+    public class Using_the_handler_test_factory
+    {
+        AmazonSqsTestHarness _harness;
+        HandlerTestHarness<A> _handler;
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            _harness = new AmazonSqsTestHarness();
+            _handler = _harness.Handler<A>(async context =>
+            {
+                var endpoint = await context.GetSendEndpoint(context.SourceAddress);
+
+                await endpoint.Send(new C());
+
+                await context.Publish(new D());
+            });
+
+            await _harness.Start();
+
+            await _harness.InputQueueSendEndpoint.Send(new A());
+            await _harness.Bus.Publish(new B());
+        }
+
+        [OneTimeTearDown]
+        public async Task Teardown()
+        {
+            await _harness.Stop();
+        }
+
+        [Test]
+        public void Should_have_received_a_message_of_type_a()
+        {
+            Assert.That(_harness.Consumed.Select<A>().Any(), Is.True);
+        }
+
+        [Test]
+        public void Should_have_sent_a_message_of_type_a()
+        {
+            Assert.That(_harness.Sent.Select<A>().Any(), Is.True);
+        }
+
+        [Test]
+        public void Should_have_published_a_message_of_type_b()
+        {
+            Assert.That(_harness.Published.Select<B>().Any(), Is.True);
+        }
+
+        [Test]
+        public void Should_have_sent_a_message_of_type_c()
+        {
+            Assert.That(_harness.Sent.Select<C>().Any(), Is.True);
+        }
+
+        [Test]
+        public void Should_have_published_a_message_of_type_d()
+        {
+            Assert.That(_harness.Published.Select<D>().Any(), Is.True);
+        }
+
+        [Test]
+        public void Should_support_a_simple_handler()
+        {
+            Assert.That(_handler.Consumed.Select().Any(), Is.True);
+        }
+
+
+        class A
+        {
+        }
+
+
+        class B
+        {
+        }
+
+
+        class C
+        {
+        }
+
+
+        class D
+        {
+        }
+    }
+
+
+    [TestFixture]
+    public class Configuring_AmazonSQS
+    {
+        [Test]
+        public async Task Should_succeed_and_connect_when_properly_configured()
+        {
+            TaskCompletionSource<bool> received = new TaskCompletionSource<bool>();
+
+            IAmazonSqsHost _host = null;
+
+            var busControl = Bus.Factory.CreateUsingAmazonSqs(cfg =>
+            {
+                _host = cfg.Host("ap-southeast-2", h =>
+                {
+                    h.AccessKey("{AWS-ACCESS-KEY}");
+                    h.SecretKey("{AWS-SECRET-ACCESS-KEY}");
+                });
+
+                cfg.ReceiveEndpoint(_host, "input-queue", x =>
+                {
+                    x.Handler<PingMessage>(async context =>
+                    {
+                        await context.Publish(new PongMessage(context.Message.CorrelationId));
+                    });
+                });
+
+                cfg.ReceiveEndpoint(_host, "input-queue-too", x =>
+                {
+                    x.Handler<PongMessage>(async context =>
+                    {
+                        received.TrySetResult(true);
+                    });
+                });
+            });
+
+            await busControl.StartAsync();
+
+            var sendAddress = _host.Topology.GetDestinationAddress(typeof(PingMessage));
+
+            var sendEndpoint = await busControl.GetSendEndpoint(sendAddress);
+
+            await sendEndpoint.Send(new PingMessage());
+
+            await received.Task.UntilCompletedOrTimeout(TimeSpan.FromSeconds(30));
+
+            await busControl.StopAsync();
+        }
+
+        [Test]
+        public async Task Should_do_a_bunch_of_requests_and_responses()
+        {
+            var bus = Bus.Factory.CreateUsingAmazonSqs(sbc =>
+            {
+                var host = sbc.Host("ap-southeast-2", h =>
+                {
+                    h.AccessKey("{AWS-ACCESS-KEY}");
+                    h.SecretKey("{AWS-SECRET-ACCESS-KEY}");
+                });
+
+                sbc.ReceiveEndpoint(host, "test", e =>
+                {
+                    e.Handler<PingMessage>(async context =>
+                    {
+                        await context.RespondAsync(new PongMessage(context.Message.CorrelationId));
+                    });
+                });
+            });
+
+            await bus.StartAsync();
+            try
+            {
+                for (var i = 0; i < 100; i = i + 1)
+                {
+                    var result = await bus.Request<PingMessage, PongMessage>(new PingMessage(), timeout: TimeSpan.FromSeconds(60));
+                }
+            }
+            finally
+            {
+                await bus.StopAsync();
+            }
+        }
+
+        [Test]
+        public async Task Should_connect_locally()
+        {
+            var busControl = Bus.Factory.CreateUsingAmazonSqs(cfg =>
+            {
+                cfg.Host("localhost", h =>
+                {
+                    h.AccessKey("admin");
+                    h.SecretKey("admin");
+                });
+            });
+
+            await busControl.StartAsync(new CancellationTokenSource(10000).Token);
+
+            await busControl.StopAsync(new CancellationTokenSource(10000).Token);
+        }
+
+        [Test]
+        public async Task Should_connect_locally_with_test_harness()
+        {
+            var harness = new AmazonSqsTestHarness();
+
+            await harness.Start();
+
+            await harness.Stop();
+        }
+
+        [Test]
+        public async Task Should_connect_locally_with_test_harness_and_a_handler()
+        {
+            var harness = new AmazonSqsTestHarness();
+            var handler = harness.Handler<PingMessage>(async context =>
+            {
+            });
+
+            await harness.Start();
+
+            await harness.InputQueueSendEndpoint.Send(new PingMessage());
+
+            await harness.Stop();
+        }
+
+        [Test]
+        public async Task Should_connect_locally_with_test_harness_and_a_publisher()
+        {
+            var harness = new AmazonSqsTestHarness();
+            var handler = harness.Handler<PingMessage>();
+            var handler2 = harness.Handler<PongMessage>();
+
+            await harness.Start();
+
+            await harness.Bus.Publish(new PingMessage());
+
+            Assert.That(handler.Consumed.Select().Any(), Is.True);
+
+            //            await Task.Delay(20000);
+
+            await harness.Bus.Publish(new PongMessage());
+
+            Assert.That(handler2.Consumed.Select().Any(), Is.True);
+
+            await harness.Stop().UntilCompletedOrTimeout(5000);
+
+            await harness.Stop();
+        }
+
+        [Test]
+        public async Task Should_connect_locally_with_test_harness_and_publish_without_consumer()
+        {
+            var harness = new AmazonSqsTestHarness();
+
+            await harness.Start();
+
+            await harness.Bus.Publish(new PingMessage());
+
+            await harness.Stop();
+        }
+
+        [Test]
+        public void Should_succeed_when_properly_configured()
+        {
+            var busControl = Bus.Factory.CreateUsingAmazonSqs(cfg =>
+            {
+                cfg.Host("ap-southeast-2", h =>
+                {
+                    h.AccessKey("{AWS-ACCESS-KEY}");
+                    h.SecretKey("{AWS-SECRET-ACCESS-KEY}");
+                });
+            });
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport.Tests/ContextSetup.cs
+++ b/src/MassTransit.AmazonSqsTransport.Tests/ContextSetup.cs
@@ -1,0 +1,30 @@
+// Copyright 2007-2012 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Tests
+{
+    using Log4NetIntegration.Logging;
+    using NUnit.Framework;
+
+
+    [SetUpFixture]
+    public class ContextSetup
+    {
+        [OneTimeSetUp]
+        public void Before_any()
+        {
+            string file = "test.log4net.xml";
+
+            Log4NetLogger.Use(file);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport.Tests/ErrorQueue_Specs.cs
+++ b/src/MassTransit.AmazonSqsTransport.Tests/ErrorQueue_Specs.cs
@@ -1,0 +1,131 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Tests
+{
+    using System;
+    using System.Runtime.Serialization;
+    using System.Threading.Tasks;
+    using Configuration;
+    using GreenPipes;
+    using NUnit.Framework;
+    using TestFramework.Messages;
+    using Util;
+
+
+    [TestFixture]
+    public class A_serialization_exception :
+        AmazonSqsTestFixture
+    {
+        [Test]
+        public async Task Should_have_the_correlation_id()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.CorrelationId, Is.EqualTo(_correlationId));
+        }
+
+        [Test]
+        public async Task Should_have_the_exception()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.ReceiveContext.TransportHeaders.Get("MT-Fault-Message", (string)null), Is.EqualTo("This is fine, forcing death"));
+        }
+
+        [Test]
+        public async Task Should_have_the_host_machine_name()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.ReceiveContext.TransportHeaders.Get("MT-Host-MachineName", (string)null), Is.EqualTo(HostMetadataCache.Host.MachineName));
+        }
+
+        [Test]
+        public async Task Should_have_the_original_destination_address()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.DestinationAddress, Is.EqualTo(InputQueueAddress));
+        }
+
+        [Test]
+        public async Task Should_have_the_original_fault_address()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.FaultAddress, Is.EqualTo(BusAddress));
+        }
+
+        [Test]
+        public async Task Should_have_the_original_response_address()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.ResponseAddress, Is.EqualTo(BusAddress));
+        }
+
+        [Test]
+        public async Task Should_have_the_original_source_address()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.SourceAddress, Is.EqualTo(BusAddress));
+        }
+
+        [Test]
+        public async Task Should_have_the_reason()
+        {
+            ConsumeContext<PingMessage> context = await _errorHandler;
+
+            Assert.That(context.ReceiveContext.TransportHeaders.Get("MT-Reason", (string)null), Is.EqualTo("fault"));
+        }
+
+        [Test]
+        public async Task Should_move_the_message_to_the_error_queue()
+        {
+            await _errorHandler;
+        }
+
+        Task<ConsumeContext<PingMessage>> _errorHandler;
+        readonly Guid? _correlationId = NewId.NextGuid();
+
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            await InputQueueSendEndpoint.Send(new PingMessage(), Pipe.Execute<SendContext<PingMessage>>(context =>
+            {
+                context.CorrelationId = _correlationId;
+                context.ResponseAddress = Bus.Address;
+                context.FaultAddress = Bus.Address;
+            }));
+        }
+
+        protected override void ConfigureAmazonSqsBusHost(IAmazonSqsBusFactoryConfigurator configurator, IAmazonSqsHost host)
+        {
+            configurator.ReceiveEndpoint(host, "input_queue_error", x =>
+            {
+                x.BindMessageTopics = false;
+
+                _errorHandler = Handled<PingMessage>(x);
+            });
+        }
+
+        protected override void ConfigureAmazonSqsReceiveEndpoint(IAmazonSqsReceiveEndpointConfigurator configurator)
+        {
+            Handler<PingMessage>(configurator, context =>
+            {
+                throw new SerializationException("This is fine, forcing death");
+            });
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
+++ b/src/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="GreenPipes" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="NewId" Version="3.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <ProjectReference Include="..\Loggers\MassTransit.Log4NetIntegration\MassTransit.Log4NetIntegration.csproj" />
+    <ProjectReference Include="..\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />
+    <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
+    <ProjectReference Include="..\MassTransit.AmazonSqsTransport\MassTransit.AmazonSqsTransport.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="test.log4net.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/src/MassTransit.AmazonSqsTransport.Tests/test.log4net.xml
+++ b/src/MassTransit.AmazonSqsTransport.Tests/test.log4net.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<configSections>
+		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net" />
+	</configSections>
+	<log4net>
+		<root>
+			<level value="DEBUG" />
+			<appender-ref ref="console" />
+		</root>
+
+<!--		<logger name="MassTransit">-->
+<!--			<level value="DEBUG" />-->
+<!--		</logger>-->
+<!---->
+<!--		<logger name="MassTransit.RabbitMqTransport">-->
+<!--			<level value="DEBUG" />-->
+<!--		</logger>-->
+<!---->
+
+		<appender name="console" type="log4net.Appender.ConsoleAppender, log4net">
+			<layout type="log4net.Layout.PatternLayout,log4net">
+				<param name="ConversionPattern" value="%d [%t] %-5p %c - %m%n" />
+			</layout>
+		</appender>
+	</log4net>
+</configuration>

--- a/src/MassTransit.AmazonSqsTransport/AmazonSqsBusFactory.cs
+++ b/src/MassTransit.AmazonSqsTransport/AmazonSqsBusFactory.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using System;
+    using System.Threading;
+    using Configuration;
+    using Configuration.Configuration;
+    using Configuration.Configurators;
+    using MassTransit.Topology;
+    using MassTransit.Topology.EntityNameFormatters;
+    using MassTransit.Topology.Topologies;
+
+
+    public static class AmazonSqsBusFactory
+    {
+        public static IMessageTopologyConfigurator MessageTopology => Cached.MessageTopologyValue.Value;
+
+        /// <summary>
+        /// Configure and create a bus for AmazonSQS
+        /// </summary>
+        /// <param name="configure">The configuration callback to configure the bus</param>
+        /// <returns></returns>
+        public static IBusControl Create(Action<IAmazonSqsBusFactoryConfigurator> configure)
+        {
+            var topologyConfiguration = new AmazonSqsTopologyConfiguration(MessageTopology);
+            var busConfiguration = new AmazonSqsBusConfiguration(topologyConfiguration);
+            var busEndpoingConfiguration = busConfiguration.CreateEndpointConfiguration();
+
+            var configurator = new AmazonSqsBusFactoryConfigurator(busConfiguration, busEndpoingConfiguration);
+
+            configure(configurator);
+
+            return configurator.Build();
+        }
+
+
+        static class Cached
+        {
+            internal static readonly Lazy<IMessageTopologyConfigurator> MessageTopologyValue =
+                new Lazy<IMessageTopologyConfigurator>(() => new MessageTopology(_entityNameFormatter),
+                    LazyThreadSafetyMode.PublicationOnly);
+
+            static readonly IEntityNameFormatter _entityNameFormatter;
+
+            static Cached()
+            {
+                _entityNameFormatter = new MessageNameFormatterEntityNameFormatter(new AmazonSqsMessageNameFormatter());
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/AmazonSqsHostSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/AmazonSqsHostSettings.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using System;
+    using Amazon;
+
+
+    /// <summary>
+    /// Settings to configure a AmazonSQS host explicitly without requiring the fluent interface
+    /// </summary>
+    public interface AmazonSqsHostSettings
+    {
+        /// <summary>
+        ///     The AmazonSQS region to connect
+        /// </summary>
+        RegionEndpoint Region { get; }
+
+        /// <summary>
+        ///     The AccessKey for connecting to the host
+        /// </summary>
+        string AccessKey { get; }
+
+        /// <summary>
+        ///     The password for connection to the host
+        ///     MAYBE this should be a SecureString instead of a regular string
+        /// </summary>
+        string SecretKey { get; }
+
+        Uri HostAddress { get; }
+
+        IConnection CreateConnection();
+    }
+
+
+}

--- a/src/MassTransit.AmazonSqsTransport/AmazonSqsMessageContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/AmazonSqsMessageContext.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using System.Collections.Generic;
+    using Amazon.SQS.Model;
+
+
+    public interface AmazonSqsMessageContext
+    {
+        Message TransportMessage { get; }
+
+        Dictionary<string, MessageAttributeValue> Attributes { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/AmazonSqsMessageNameFormatter.cs
+++ b/src/MassTransit.AmazonSqsTransport/AmazonSqsMessageNameFormatter.cs
@@ -1,0 +1,128 @@
+// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Reflection;
+    using System.Text;
+    using Transports;
+
+
+    public class AmazonSqsMessageNameFormatter :
+        IMessageNameFormatter
+    {
+        readonly IMessageNameFormatter _formatter;
+
+        public AmazonSqsMessageNameFormatter()
+        {
+            _formatter = new AmazonArnMessageNameFormatter(
+                genericArgumentSeparator: "__",
+                genericTypeSeparator: "--",
+                namespaceSeparator: "-",
+                nestedTypeSeparator: "_");
+        }
+
+        public MessageName GetMessageName(Type type)
+        {
+            return _formatter.GetMessageName(type);
+        }
+    }
+
+    public class AmazonArnMessageNameFormatter :
+        IMessageNameFormatter
+    {
+        readonly ConcurrentDictionary<Type, string> _cache;
+        readonly string _genericArgumentSeparator;
+        readonly string _genericTypeSeparator;
+        readonly string _namespaceSeparator;
+        readonly string _nestedTypeSeparator;
+
+        public AmazonArnMessageNameFormatter(string genericArgumentSeparator, string genericTypeSeparator,
+            string namespaceSeparator, string nestedTypeSeparator)
+        {
+            _genericArgumentSeparator = genericArgumentSeparator;
+            _genericTypeSeparator = genericTypeSeparator;
+            _namespaceSeparator = namespaceSeparator;
+            _nestedTypeSeparator = nestedTypeSeparator;
+
+            _cache = new ConcurrentDictionary<Type, string>();
+        }
+
+        public MessageName GetMessageName(Type type)
+        {
+            return new MessageName(_cache.GetOrAdd(type, CreateMessageName));
+        }
+
+        string CreateMessageName(Type type)
+        {
+            if (type.GetTypeInfo().IsGenericTypeDefinition)
+                throw new ArgumentException("An open generic type cannot be used as a message name");
+
+            var sb = new StringBuilder("");
+
+            return GetMessageName(sb, type, null);
+        }
+
+        string GetMessageName(StringBuilder sb, Type type, string scope)
+        {
+            var typeInfo = type.GetTypeInfo();
+            if (typeInfo.IsGenericParameter)
+                return "";
+
+            if (typeInfo.Namespace != null)
+            {
+                string ns = typeInfo.Namespace.Replace(".", _nestedTypeSeparator);
+                if (!ns.Equals(scope))
+                {
+                    sb.Append(ns);
+                    sb.Append(_namespaceSeparator);
+                }
+            }
+
+            if (typeInfo.IsNested)
+            {
+                GetMessageName(sb, typeInfo.DeclaringType, typeInfo.Namespace);
+                sb.Append(_nestedTypeSeparator);
+            }
+
+            if (typeInfo.IsGenericType)
+            {
+                string name = typeInfo.GetGenericTypeDefinition().Name;
+
+                //remove `1
+                int index = name.IndexOf('`');
+                if (index > 0)
+                    name = name.Remove(index);
+
+                sb.Append(name);
+                sb.Append(_genericTypeSeparator);
+
+                Type[] arguments = typeInfo.GetGenericArguments();
+                for (int i = 0; i < arguments.Length; i++)
+                {
+                    if (i > 0)
+                        sb.Append(_genericArgumentSeparator);
+
+                    GetMessageName(sb, arguments[i], typeInfo.Namespace);
+                }
+
+                sb.Append(_genericTypeSeparator);
+            }
+            else
+                sb.Append(typeInfo.Name);
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/AmazonSqsSendContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/AmazonSqsSendContext.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    public interface AmazonSqsSendContext<out T> :
+        AmazonSqsSendContext,
+        SendContext<T>
+        where T : class
+    {
+    }
+
+
+    public interface AmazonSqsSendContext :
+        SendContext
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsHostConfigurationExtensions.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsHostConfigurationExtensions.cs
@@ -1,0 +1,108 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    using System;
+    using Configurators;
+
+
+    public static class AmazonSqsHostConfigurationExtensions
+    {
+        /// <summary>
+        ///     Configure a AmazonSQS host using the configuration API
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="hostAddress">The URI host address of the RabbitMQ host (rabbitmq://host:port/vhost)</param>
+        /// <param name="configure"></param>
+        public static IAmazonSqsHost Host(this IAmazonSqsBusFactoryConfigurator configurator, Uri hostAddress, Action<IAmazonSqsHostConfigurator> configure)
+        {
+            if (hostAddress == null)
+                throw new ArgumentNullException(nameof(hostAddress));
+
+            var hostConfigurator = new AmazonSqsHostConfigurator(hostAddress);
+
+            configure(hostConfigurator);
+
+            return configurator.Host(hostConfigurator.Settings);
+        }
+
+        /// <summary>
+        /// Configure a AmazonSQS host with a host name and virtual host
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="hostName">The host name of the broker</param>
+        /// <param name="configure">The configuration callback</param>
+        public static IAmazonSqsHost Host(this IAmazonSqsBusFactoryConfigurator configurator, string hostName, Action<IAmazonSqsHostConfigurator> configure)
+        {
+            return configurator.Host(new UriBuilder("amazonsqs", hostName).Uri, configure);
+        }
+
+        /// <summary>
+        /// Declare a ReceiveEndpoint using a unique generated queue name. This queue defaults to auto-delete
+        /// and non-durable. By default all services bus instances include a default receiveEndpoint that is
+        /// of this type (created automatically upon the first receiver binding).
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="host"></param>
+        /// <param name="configure"></param>
+        public static void ReceiveEndpoint(this IAmazonSqsBusFactoryConfigurator configurator, IAmazonSqsHost host,
+            Action<IAmazonSqsReceiveEndpointConfigurator> configure)
+        {
+            var queueName = host.Topology.CreateTemporaryQueueName("receiveEndpoint-");
+
+            configurator.ReceiveEndpoint(host, queueName, x =>
+            {
+                x.AutoDelete = true;
+                x.Durable = false;
+
+                configure(x);
+            });
+        }
+
+        /// <summary>
+        /// Registers a management endpoint on the bus, which can be used to control
+        /// filters and other management control points on the bus.
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="host">The host where the endpoint is to be created</param>
+        /// <param name="configure">Configure additional values of the underlying receive endpoint</param>
+        /// <returns></returns>
+        public static IManagementEndpointConfigurator ManagementEndpoint(this IAmazonSqsBusFactoryConfigurator configurator,
+            IAmazonSqsHost host, Action<IAmazonSqsReceiveEndpointConfigurator> configure = null)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+
+            if (host == null)
+                throw new ArgumentNullException(nameof(host));
+
+            var queueName = host.Topology.CreateTemporaryQueueName("manage-");
+
+            IAmazonSqsReceiveEndpointConfigurator specification = null;
+
+            configurator.ReceiveEndpoint(host, queueName, x =>
+            {
+                x.AutoDelete = true;
+                x.Durable = false;
+
+                configure?.Invoke(x);
+
+                specification = x;
+            });
+
+            var managementEndpointConfigurator = new ManagementEndpointConfigurator(specification);
+
+            return managementEndpointConfigurator;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointBuilder.cs
@@ -18,6 +18,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Builders
     using MassTransit.Builders;
     using Topology;
     using Topology.Builders;
+    using Topology.Entities;
 
 
     public class AmazonSqsReceiveEndpointBuilder :
@@ -56,6 +57,10 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Builders
             var topologyBuilder = new ReceiveEndpointBrokerTopologyBuilder();
 
             topologyBuilder.Queue = topologyBuilder.CreateQueue(settings.EntityName, settings.Durable, settings.AutoDelete);
+
+            topologyBuilder.Topic = topologyBuilder.CreateTopic(settings.EntityName, settings.Durable, settings.AutoDelete);
+
+            topologyBuilder.CreateTopicSubscription(topologyBuilder.Topic, topologyBuilder.Queue);
 
             _configuration.Topology.Consume.Apply(topologyBuilder);
 

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointBuilder.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Builders
+{
+    using Configuration;
+    using Contexts;
+    using GreenPipes;
+    using MassTransit.Builders;
+    using Topology;
+    using Topology.Builders;
+
+
+    public class AmazonSqsReceiveEndpointBuilder :
+        ReceiveEndpointBuilder,
+        IReceiveEndpointBuilder
+    {
+        readonly IAmazonSqsReceiveEndpointConfiguration _configuration;
+
+        public AmazonSqsReceiveEndpointBuilder(IAmazonSqsReceiveEndpointConfiguration configuration)
+            : base(configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public override ConnectHandle ConnectConsumePipe<T>(IPipe<ConsumeContext<T>> pipe)
+        {
+            if (_configuration.BindMessageTopics)
+            {
+                _configuration.Topology.Consume
+                    .GetMessageTopology<T>()
+                    .Bind();
+            }
+
+            return base.ConnectConsumePipe(pipe);
+        }
+
+        public AmazonSqsReceiveEndpointContext CreateReceiveEndpointContext()
+        {
+            var brokerTopology = BuildTopology(_configuration.Settings);
+
+            return new AmazonSqsConsumerReceiveEndpointContext(_configuration, brokerTopology, ReceiveObservers, TransportObservers, EndpointObservers);
+        }
+
+        BrokerTopology BuildTopology(ReceiveSettings settings)
+        {
+            var topologyBuilder = new ReceiveEndpointBrokerTopologyBuilder();
+
+            topologyBuilder.Queue = topologyBuilder.CreateQueue(settings.EntityName, settings.Durable, settings.AutoDelete);
+
+            _configuration.Topology.Consume.Apply(topologyBuilder);
+
+            return topologyBuilder.BuildTopologyLayout();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointFactory.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointFactory.cs
@@ -1,0 +1,47 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Builders
+{
+    using System;
+    using Configuration;
+    using MassTransit.Configurators;
+    using Transport;
+
+
+    public class AmazonSqsReceiveEndpointFactory :
+        IAmazonSqsReceiveEndpointFactory
+    {
+        readonly IAmazonSqsBusConfiguration _configuration;
+        readonly AmazonSqsHost _host;
+
+        public AmazonSqsReceiveEndpointFactory(IAmazonSqsBusConfiguration configuration, AmazonSqsHost host)
+        {
+            _host = host;
+            _configuration = configuration;
+        }
+
+        public void CreateReceiveEndpoint(string queueName, Action<IAmazonSqsReceiveEndpointConfigurator> configure)
+        {
+            if (!_configuration.TryGetHost(_host, out var hostConfiguration))
+                throw new ConfigurationException("The host was not properly configured");
+
+            var configuration = hostConfiguration.CreateReceiveEndpointConfiguration(queueName);
+
+            configure?.Invoke(configuration.Configurator);
+
+            BusConfigurationResult.CompileResults(configuration.Validate());
+
+            configuration.Build();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Builders/IAmazonSqsReceiveEndpointFactory.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Builders/IAmazonSqsReceiveEndpointFactory.cs
@@ -1,0 +1,22 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Builders
+{
+    using System;
+
+
+    public interface IAmazonSqsReceiveEndpointFactory
+    {
+        void CreateReceiveEndpoint(string queueName, Action<IAmazonSqsReceiveEndpointConfigurator> configure);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/BusFactoryConfiguratorExtensions.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/BusFactoryConfiguratorExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    using System;
+
+
+    public static class BusFactoryConfiguratorExtensions
+    {
+        /// <summary>
+        /// Select AmazonSQS as the transport for the service bus
+        /// </summary>
+        public static IBusControl CreateUsingAmazonSqs(this IBusFactorySelector selector, Action<IAmazonSqsBusFactoryConfigurator> configure)
+        {
+            return AmazonSqsBusFactory.Create(configure);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsBusConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsBusConfiguration.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using System;
+    using MassTransit.Configuration;
+    using Topology;
+    using Topology.Settings;
+    using Topology.Topologies;
+
+
+    public class AmazonSqsBusConfiguration :
+        AmazonSqsEndpointConfiguration,
+        IAmazonSqsBusConfiguration
+    {
+        readonly IHostCollection<IAmazonSqsHostConfiguration> _hosts;
+
+        public AmazonSqsBusConfiguration(IAmazonSqsTopologyConfiguration topology)
+            : base(topology)
+        {
+            _hosts = new HostCollection<IAmazonSqsHostConfiguration>();
+        }
+
+        public bool DeployTopologyOnly { get; set; }
+
+        public bool TryGetHost(Uri address, out IAmazonSqsHostConfiguration hostConfiguration)
+        {
+            return _hosts.TryGetHost(address, out hostConfiguration);
+        }
+
+        public bool TryGetHost(IAmazonSqsHost host, out IAmazonSqsHostConfiguration hostConfiguration)
+        {
+            return _hosts.TryGetHost(host, out hostConfiguration);
+        }
+
+        public IAmazonSqsHostTopology CreateHostTopology(Uri hostAddress)
+        {
+            return new AmazonSqsHostTopology(new AmazonSqsMessageNameFormatter(), hostAddress, Topology);
+        }
+
+        public IAmazonSqsHostConfiguration CreateHostConfiguration(IAmazonSqsHostControl host)
+        {
+            var hostConfiguration = new AmazonSqsHostConfiguration(this, host);
+
+            _hosts.Add(hostConfiguration);
+
+            return hostConfiguration;
+        }
+
+        public IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(string queueName, IAmazonSqsEndpointConfiguration endpointConfiguration)
+        {
+            if (_hosts.Count == 0)
+                throw new ConfigurationException("At least one host must be configured");
+
+            var configuration = new AmazonSqsReceiveEndpointConfiguration(_hosts[0], queueName, endpointConfiguration);
+
+            return configuration;
+        }
+
+        public IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(AmazonSqsReceiveSettings settings, IAmazonSqsEndpointConfiguration endpointConfiguration)
+        {
+            if (_hosts.Count == 0)
+                throw new ConfigurationException("At least one host must be configured");
+
+            var configuration = new AmazonSqsReceiveEndpointConfiguration(_hosts[0], settings, endpointConfiguration);
+
+            return configuration;
+        }
+
+        public IReadOnlyHostCollection Hosts => _hosts;
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsEndpointConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsEndpointConfiguration.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using MassTransit.Configuration;
+    using MassTransit.Pipeline;
+
+
+    public class AmazonSqsEndpointConfiguration :
+        EndpointConfiguration,
+        IAmazonSqsEndpointConfiguration
+    {
+        readonly IAmazonSqsTopologyConfiguration _topologyConfiguration;
+
+        public AmazonSqsEndpointConfiguration(IAmazonSqsTopologyConfiguration topologyConfiguration, IConsumePipe consumePipe = null)
+            : base(topologyConfiguration, consumePipe)
+        {
+            _topologyConfiguration = topologyConfiguration;
+        }
+
+        AmazonSqsEndpointConfiguration(IEndpointConfiguration parentConfiguration, IAmazonSqsTopologyConfiguration topologyConfiguration,
+            IConsumePipe consumePipe = null)
+            : base(parentConfiguration, topologyConfiguration, consumePipe)
+        {
+            _topologyConfiguration = topologyConfiguration;
+        }
+
+        public new IAmazonSqsTopologyConfiguration Topology => _topologyConfiguration;
+
+        public IAmazonSqsEndpointConfiguration CreateEndpointConfiguration()
+        {
+            var topologyConfiguration = new AmazonSqsTopologyConfiguration(_topologyConfiguration);
+
+            return new AmazonSqsEndpointConfiguration(this, topologyConfiguration);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsHostConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsHostConfiguration.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using MassTransit.Configuration;
+    using Transports;
+
+
+    public class AmazonSqsHostConfiguration :
+        IAmazonSqsHostConfiguration
+    {
+        readonly IAmazonSqsBusConfiguration _busConfiguration;
+        readonly IAmazonSqsHostControl _host;
+
+        public AmazonSqsHostConfiguration(IAmazonSqsBusConfiguration busConfiguration, IAmazonSqsHostControl host)
+        {
+            _host = host;
+            _busConfiguration = busConfiguration;
+        }
+
+        IAmazonSqsBusConfiguration IAmazonSqsHostConfiguration.BusConfiguration => _busConfiguration;
+        IAmazonSqsHostControl IAmazonSqsHostConfiguration.Host => _host;
+
+        public IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(string queueName)
+        {
+            return new AmazonSqsReceiveEndpointConfiguration(this, queueName, _busConfiguration.CreateEndpointConfiguration());
+        }
+
+        IBusHostControl IHostConfiguration.Host => _host;
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
@@ -1,0 +1,226 @@
+﻿namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using System;
+    using System.Collections.Generic;
+    using Builders;
+    using Context;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using GreenPipes.Builders;
+    using GreenPipes.Configurators;
+    using MassTransit.Configuration;
+    using MassTransit.Pipeline;
+    using MassTransit.Pipeline.Filters;
+    using Pipeline;
+    using Topology;
+    using Topology.Settings;
+    using Transport;
+    using Transports;
+
+
+    public class AmazonSqsReceiveEndpointConfiguration :
+        ReceiveEndpointConfiguration,
+        IAmazonSqsReceiveEndpointConfiguration,
+        IAmazonSqsReceiveEndpointConfigurator
+    {
+        readonly IBuildPipeConfigurator<ConnectionContext> _connectionConfigurator;
+        readonly IAmazonSqsEndpointConfiguration _endpointConfiguration;
+        readonly IAmazonSqsHostConfiguration _hostConfiguration;
+        readonly Lazy<Uri> _inputAddress;
+        readonly IBuildPipeConfigurator<ModelContext> _modelConfigurator;
+        readonly AmazonSqsReceiveSettings _settings;
+
+        public AmazonSqsReceiveEndpointConfiguration(IAmazonSqsHostConfiguration hostConfiguration, string queueName,
+            IAmazonSqsEndpointConfiguration endpointConfiguration)
+            : this(hostConfiguration, endpointConfiguration)
+        {
+            BindMessageTopics = true;
+
+            _settings = new AmazonSqsReceiveSettings(queueName, true, false);
+        }
+
+        public AmazonSqsReceiveEndpointConfiguration(IAmazonSqsHostConfiguration hostConfiguration, AmazonSqsReceiveSettings settings,
+            IAmazonSqsEndpointConfiguration endpointConfiguration)
+            : this(hostConfiguration, endpointConfiguration)
+        {
+            _settings = settings;
+        }
+
+        AmazonSqsReceiveEndpointConfiguration(IAmazonSqsHostConfiguration hostConfiguration, IAmazonSqsEndpointConfiguration endpointConfiguration)
+            : base(endpointConfiguration)
+        {
+            _hostConfiguration = hostConfiguration;
+            _endpointConfiguration = endpointConfiguration;
+
+            _connectionConfigurator = new PipeConfigurator<ConnectionContext>();
+            _modelConfigurator = new PipeConfigurator<ModelContext>();
+
+            HostAddress = hostConfiguration.Host.Address;
+
+            _inputAddress = new Lazy<Uri>(FormatInputAddress);
+        }
+
+        public IAmazonSqsReceiveEndpointConfigurator Configurator => this;
+
+        public IAmazonSqsBusConfiguration BusConfiguration => _hostConfiguration.BusConfiguration;
+
+        public IAmazonSqsHostControl Host => _hostConfiguration.Host;
+
+        public bool BindMessageTopics { get; set; }
+
+        public ReceiveSettings Settings => _settings;
+
+        public override Uri HostAddress { get; }
+
+        public override Uri InputAddress => _inputAddress.Value;
+
+        public override IReceiveEndpoint CreateReceiveEndpoint(string endpointName, IReceiveTransport receiveTransport, IReceivePipe receivePipe,
+            ReceiveEndpointContext receiveEndpointContext)
+        {
+            var receiveEndpoint = new ReceiveEndpoint(receiveTransport, receivePipe, receiveEndpointContext);
+
+            _hostConfiguration.Host.AddReceiveEndpoint(endpointName, receiveEndpoint);
+
+            return receiveEndpoint;
+        }
+
+        IAmazonSqsTopologyConfiguration IAmazonSqsEndpointConfiguration.Topology => _endpointConfiguration.Topology;
+
+        public override IReceiveEndpoint Build()
+        {
+            var builder = new AmazonSqsReceiveEndpointBuilder(this);
+
+            ApplySpecifications(builder);
+
+            var receivePipe = CreateReceivePipe();
+
+            var receiveEndpointContext = builder.CreateReceiveEndpointContext();
+
+            _modelConfigurator.UseFilter(new ConfigureTopologyFilter<ReceiveSettings>(_settings, receiveEndpointContext.BrokerTopology));
+
+            IAgent consumerAgent;
+            if (_hostConfiguration.BusConfiguration.DeployTopologyOnly)
+            {
+                var transportReadyFilter = new TransportReadyFilter<ModelContext>(builder.TransportObservers, InputAddress);
+                _modelConfigurator.UseFilter(transportReadyFilter);
+
+                consumerAgent = transportReadyFilter;
+            }
+            else
+            {
+                var deadLetterTransport = CreateDeadLetterTransport();
+
+                var errorTransport = CreateErrorTransport();
+
+                var consumerFilter = new AmazonSqsConsumerFilter(receivePipe, builder.ReceiveObservers, builder.TransportObservers, receiveEndpointContext,
+                    deadLetterTransport, errorTransport);
+
+                _modelConfigurator.UseFilter(consumerFilter);
+
+                consumerAgent = consumerFilter;
+            }
+
+            IFilter<ConnectionContext> sessionFilter = new ReceiveModelFilter(_modelConfigurator.Build(), _hostConfiguration.Host);
+
+            _connectionConfigurator.UseFilter(sessionFilter);
+
+            var transport = new AmazonSqsReceiveTransport(_hostConfiguration.Host, _settings, _connectionConfigurator.Build(), receiveEndpointContext,
+                builder.ReceiveObservers, builder.TransportObservers);
+
+            transport.Add(consumerAgent);
+
+            return CreateReceiveEndpoint(_settings.EntityName ?? NewId.Next().ToString(), transport, receivePipe, receiveEndpointContext);
+        }
+
+        IAmazonSqsHost IAmazonSqsReceiveEndpointConfigurator.Host => Host;
+
+        public bool Durable
+        {
+            set
+            {
+                _settings.Durable = value;
+
+                Changed("Durable");
+            }
+        }
+
+        public bool AutoDelete
+        {
+            set
+            {
+                _settings.AutoDelete = value;
+
+                Changed("AutoDelete");
+            }
+        }
+
+        public bool Lazy
+        {
+            set => _settings.Lazy = value;
+        }
+
+        public void Bind(string topicName, Action<ITopicBindingConfigurator> configure = null)
+        {
+            if (topicName == null)
+                throw new ArgumentNullException(nameof(topicName));
+
+            _endpointConfiguration.Topology.Consume.Bind(topicName, configure);
+        }
+
+        public void Bind<T>(Action<ITopicBindingConfigurator> configure = null)
+            where T : class
+        {
+            _endpointConfiguration.Topology.Consume.GetMessageTopology<T>().Bind(configure);
+        }
+
+        public void ConfigureSession(Action<IPipeConfigurator<ModelContext>> configure)
+        {
+            configure?.Invoke(_modelConfigurator);
+        }
+
+        public void ConfigureConnection(Action<IPipeConfigurator<ConnectionContext>> configure)
+        {
+            configure?.Invoke(_connectionConfigurator);
+        }
+
+        Uri FormatInputAddress()
+        {
+            return _settings.GetInputAddress(_hostConfiguration.Host.Settings.HostAddress);
+        }
+
+        IErrorTransport CreateErrorTransport()
+        {
+            var errorSettings = _endpointConfiguration.Topology.Send.GetErrorSettings(_settings);
+            var filter = new ConfigureTopologyFilter<ErrorSettings>(errorSettings, errorSettings.GetBrokerTopology());
+
+            return new AmazonSqsErrorTransport(errorSettings.EntityName, filter);
+        }
+
+        IDeadLetterTransport CreateDeadLetterTransport()
+        {
+            var deadLetterSettings = _endpointConfiguration.Topology.Send.GetDeadLetterSettings(_settings);
+            var filter = new ConfigureTopologyFilter<DeadLetterSettings>(deadLetterSettings, deadLetterSettings.GetBrokerTopology());
+
+            return new AmazonSqsDeadLetterTransport(deadLetterSettings.EntityName, filter);
+        }
+
+        protected override bool IsAlreadyConfigured()
+        {
+            return _inputAddress.IsValueCreated || base.IsAlreadyConfigured();
+        }
+
+        public override IEnumerable<ValidationResult> Validate()
+        {
+            var queueName = $"{_settings.EntityName}";
+
+            if (!AmazonSqsEntityNameValidator.Validator.IsValidEntityName(_settings.EntityName))
+                yield return this.Failure(queueName, "must be a valid queue name");
+
+            if (_settings.PurgeOnStartup)
+                yield return this.Warning(queueName, "Existing messages in the queue will be purged on service start");
+
+            foreach (var result in base.Validate())
+                yield return result.WithParentKey(queueName);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
@@ -154,6 +154,24 @@
             }
         }
 
+        public ushort PrefetchCount
+        {
+            set
+            {
+                _settings.PrefetchCount = value;
+                Changed("PrefetchCount");
+            }
+        }
+
+        public ushort WaitTimeSeconds
+        {
+            set
+            {
+                _settings.WaitTimeSeconds = value;
+                Changed("WaitTimeSeconds");
+            }
+        }
+
         public bool Lazy
         {
             set => _settings.Lazy = value;

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsTopologyConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsTopologyConfiguration.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using GreenPipes;
+    using MassTransit.Configuration;
+    using MassTransit.Topology;
+    using MassTransit.Topology.Observers;
+    using MassTransit.Topology.Topologies;
+    using Topology;
+    using Topology.Configuration;
+    using Topology.Topologies;
+
+
+    public class AmazonSqsTopologyConfiguration :
+        IAmazonSqsTopologyConfiguration
+    {
+        readonly IAmazonSqsConsumeTopologyConfigurator _consumeTopology;
+        readonly IMessageTopologyConfigurator _messageTopology;
+        readonly IAmazonSqsPublishTopologyConfigurator _publishTopology;
+        readonly IAmazonSqsSendTopologyConfigurator _sendTopology;
+
+        public AmazonSqsTopologyConfiguration(IMessageTopologyConfigurator messageTopology)
+        {
+            _messageTopology = messageTopology;
+
+            _sendTopology = new AmazonSqsSendTopology(AmazonSqsEntityNameValidator.Validator);
+            _sendTopology.Connect(new DelegateSendTopologyConfigurationObserver(GlobalTopology.Send));
+
+            _publishTopology = new AmazonSqsPublishTopology(messageTopology);
+            _publishTopology.Connect(new DelegatePublishTopologyConfigurationObserver(GlobalTopology.Publish));
+
+            var observer = new PublishToSendTopologyConfigurationObserver(_sendTopology);
+            _publishTopology.Connect(observer);
+
+            _consumeTopology = new AmazonSqsConsumeTopology(messageTopology, _publishTopology);
+        }
+
+        public AmazonSqsTopologyConfiguration(IAmazonSqsTopologyConfiguration topologyConfiguration)
+        {
+            _messageTopology = topologyConfiguration.Message;
+            _sendTopology = topologyConfiguration.Send;
+            _publishTopology = topologyConfiguration.Publish;
+
+            _consumeTopology = new AmazonSqsConsumeTopology(topologyConfiguration.Message, topologyConfiguration.Publish);
+        }
+
+        IMessageTopologyConfigurator ITopologyConfiguration.Message => _messageTopology;
+        ISendTopologyConfigurator ITopologyConfiguration.Send => _sendTopology;
+        IPublishTopologyConfigurator ITopologyConfiguration.Publish => _publishTopology;
+        IConsumeTopologyConfigurator ITopologyConfiguration.Consume => _consumeTopology;
+
+        IAmazonSqsPublishTopologyConfigurator IAmazonSqsTopologyConfiguration.Publish => _publishTopology;
+        IAmazonSqsSendTopologyConfigurator IAmazonSqsTopologyConfiguration.Send => _sendTopology;
+        IAmazonSqsConsumeTopologyConfigurator IAmazonSqsTopologyConfiguration.Consume => _consumeTopology;
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            return _sendTopology.Validate()
+                .Concat(_publishTopology.Validate())
+                .Concat(_consumeTopology.Validate());
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsBusConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsBusConfiguration.cs
@@ -1,0 +1,79 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using System;
+    using MassTransit.Configuration;
+    using Topology;
+    using Topology.Settings;
+
+
+    public interface IAmazonSqsBusConfiguration :
+        IBusConfiguration
+    {
+        new IAmazonSqsTopologyConfiguration Topology { get; }
+
+        /// <summary>
+        /// If true, only the broker topology will be deployed
+        /// </summary>
+        bool DeployTopologyOnly { get; set; }
+
+        /// <summary>
+        /// Return the host that supports the specified address
+        /// </summary>
+        /// <param name="address">The address to match</param>
+        /// <param name="hostConfiguration">The matching host, if present</param>
+        /// <returns>True if the host was found, otherwise false</returns>
+        bool TryGetHost(Uri address, out IAmazonSqsHostConfiguration hostConfiguration);
+
+        /// <summary>
+        /// Return the host if it is part of the configuration
+        /// </summary>
+        /// <param name="host"></param>
+        /// <returns></returns>
+        /// <param name="hostConfiguration"></param>
+        bool TryGetHost(IAmazonSqsHost host, out IAmazonSqsHostConfiguration hostConfiguration);
+
+        IAmazonSqsHostTopology CreateHostTopology(Uri hostAddress);
+
+        /// <summary>
+        /// Create an endpoint configuration on the bus, which can later be turned into a receive endpoint
+        /// </summary>
+        /// <returns></returns>
+        IAmazonSqsEndpointConfiguration CreateEndpointConfiguration();
+
+        /// <summary>
+        /// Create a host configuration, by adding a host to the bus
+        /// </summary>
+        /// <param name="host"></param>
+        /// <returns></returns>
+        IAmazonSqsHostConfiguration CreateHostConfiguration(IAmazonSqsHostControl host);
+
+        /// <summary>
+        /// Create a receive endpoint configuration for the default host
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <param name="endpointConfiguration"></param>
+        /// <returns></returns>
+        IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(string queueName, IAmazonSqsEndpointConfiguration endpointConfiguration);
+
+        /// <summary>
+        /// Create a receive endpoint configuration for the default host
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="endpointConfiguration"></param>
+        /// <returns></returns>
+        IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(AmazonSqsReceiveSettings settings,
+            IAmazonSqsEndpointConfiguration endpointConfiguration);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsEndpointConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsEndpointConfiguration.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using MassTransit.Configuration;
+
+
+    public interface IAmazonSqsEndpointConfiguration :
+        IEndpointConfiguration
+    {
+        new IAmazonSqsTopologyConfiguration Topology { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsHostConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsHostConfiguration.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using MassTransit.Configuration;
+
+
+    public interface IAmazonSqsHostConfiguration :
+        IHostConfiguration
+    {
+        IAmazonSqsBusConfiguration BusConfiguration { get; }
+
+        new IAmazonSqsHostControl Host { get; }
+
+        /// <summary>
+        /// Create a receive endpoint configuration using the specified host
+        /// </summary>
+        /// <returns></returns>
+        IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(string queueName);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsReceiveEndpointConfiguration.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using MassTransit.Configuration;
+    using Topology;
+
+
+    public interface IAmazonSqsReceiveEndpointConfiguration :
+        IReceiveEndpointConfiguration,
+        IAmazonSqsEndpointConfiguration
+    {
+        IAmazonSqsReceiveEndpointConfigurator Configurator { get; }
+
+        IAmazonSqsBusConfiguration BusConfiguration { get; }
+
+        IAmazonSqsHostControl Host { get; }
+
+        bool BindMessageTopics { get; set; }
+
+        ReceiveSettings Settings { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsTopologyConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsTopologyConfiguration.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
+{
+    using MassTransit.Configuration;
+    using Topology.Configuration;
+
+
+    public interface IAmazonSqsTopologyConfiguration :
+        ITopologyConfiguration
+    {
+        new IAmazonSqsPublishTopologyConfigurator Publish { get; }
+
+        new IAmazonSqsSendTopologyConfigurator Send { get; }
+
+        new IAmazonSqsConsumeTopologyConfigurator Consume { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
@@ -1,0 +1,144 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
+{
+    using System;
+    using System.Collections.Generic;
+    using BusConfigurators;
+    using Configuration;
+    using EndpointSpecifications;
+    using GreenPipes;
+    using MassTransit.Builders;
+    using Topology.Configuration;
+    using Topology.Settings;
+    using Transport;
+
+
+    public class AmazonSqsBusFactoryConfigurator :
+        BusFactoryConfigurator,
+        IAmazonSqsBusFactoryConfigurator,
+        IBusFactory
+    {
+        readonly IAmazonSqsBusConfiguration _configuration;
+        readonly IAmazonSqsEndpointConfiguration _busEndpointConfiguration;
+        readonly AmazonSqsReceiveSettings _settings;
+
+        public AmazonSqsBusFactoryConfigurator(IAmazonSqsBusConfiguration configuration, IAmazonSqsEndpointConfiguration busEndpointConfiguration)
+            : base(configuration, busEndpointConfiguration)
+        {
+            _configuration = configuration;
+            _busEndpointConfiguration = busEndpointConfiguration;
+
+            var queueName = _configuration.Topology.Consume.CreateTemporaryQueueName("bus-");
+            _settings = new AmazonSqsReceiveSettings(queueName, false, true);
+        }
+
+        public IBusControl CreateBus()
+        {
+            var busReceiveEndpointConfiguration = _configuration.CreateReceiveEndpointConfiguration(_settings, _busEndpointConfiguration);
+
+            var builder = new ConfigurationBusBuilder(_configuration, busReceiveEndpointConfiguration, BusObservable);
+
+            ApplySpecifications(builder);
+
+            return builder.Build();
+        }
+
+        public override IEnumerable<ValidationResult> Validate()
+        {
+            foreach (var result in base.Validate())
+                yield return result;
+
+            if (string.IsNullOrWhiteSpace(_settings.EntityName))
+                yield return this.Failure("Bus", "The bus queue name must not be null or empty");
+        }
+
+        public bool Durable
+        {
+            set => _settings.Durable = value;
+        }
+
+        public bool AutoDelete
+        {
+            set => _settings.AutoDelete = value;
+        }
+
+        public bool Lazy
+        {
+            set => _settings.Lazy = value;
+        }
+
+        public IAmazonSqsHost Host(AmazonSqsHostSettings settings)
+        {
+            var hostTopology = _configuration.CreateHostTopology(settings.HostAddress);
+
+            var host = new AmazonSqsHost(_configuration, settings, hostTopology);
+
+            _configuration.CreateHostConfiguration(host);
+
+            return host;
+        }
+
+        void IAmazonSqsBusFactoryConfigurator.Send<T>(Action<IAmazonSqsMessageSendTopologyConfigurator<T>> configureTopology)
+        {
+            IAmazonSqsMessageSendTopologyConfigurator<T> configurator = _configuration.Topology.Send.GetMessageTopology<T>();
+
+            configureTopology?.Invoke(configurator);
+        }
+
+        void IAmazonSqsBusFactoryConfigurator.Publish<T>(Action<IAmazonSqsMessagePublishTopologyConfigurator<T>> configureTopology)
+        {
+            IAmazonSqsMessagePublishTopologyConfigurator<T> configurator = _configuration.Topology.Publish.GetMessageTopology<T>();
+
+            configureTopology?.Invoke(configurator);
+        }
+
+        public new IAmazonSqsSendTopologyConfigurator SendTopology => _configuration.Topology.Send;
+        public new IAmazonSqsPublishTopologyConfigurator PublishTopology => _configuration.Topology.Publish;
+
+        public bool DeployTopologyOnly
+        {
+            set => _configuration.DeployTopologyOnly = value;
+        }
+
+        public void ReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint)
+        {
+            var configuration = _configuration.CreateReceiveEndpointConfiguration(queueName, _configuration.CreateEndpointConfiguration());
+
+            ConfigureReceiveEndpoint(configuration, configureEndpoint);
+        }
+
+        public void ReceiveEndpoint(IAmazonSqsHost host, string queueName, Action<IAmazonSqsReceiveEndpointConfigurator> configure)
+        {
+            if (!_configuration.TryGetHost(host, out var hostConfiguration))
+                throw new ArgumentException("The host was not configured on this bus", nameof(host));
+
+            var configuration = hostConfiguration.CreateReceiveEndpointConfiguration(queueName);
+
+            ConfigureReceiveEndpoint(configuration, configure);
+        }
+
+        void ConfigureReceiveEndpoint(IAmazonSqsReceiveEndpointConfiguration configuration, Action<IAmazonSqsReceiveEndpointConfigurator> configure)
+        {
+            configuration.ConnectConsumerConfigurationObserver(this);
+            configuration.ConnectSagaConfigurationObserver(this);
+            configuration.ConnectHandlerConfigurationObserver(this);
+
+            configure?.Invoke(configuration.Configurator);
+
+            var specification = new ConfigurationReceiveEndpointSpecification(configuration);
+
+            AddReceiveEndpointSpecification(specification);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
@@ -63,6 +63,16 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
                 yield return this.Failure("Bus", "The bus queue name must not be null or empty");
         }
 
+        public ushort PrefetchCount
+        {
+            set => _settings.PrefetchCount = value;
+        }
+
+        public ushort WaitTimeSeconds
+        {
+            set => _settings.WaitTimeSeconds = value;
+        }
+
         public bool Durable
         {
             set => _settings.Durable = value;

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsHostConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsHostConfigurator.cs
@@ -14,6 +14,8 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
 {
     using System;
     using Amazon;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
     using Exceptions;
 
 
@@ -27,11 +29,15 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
             if (string.Compare("amazonsqs", address.Scheme, StringComparison.OrdinalIgnoreCase) != 0)
                 throw new AmazonSqsTransportConfigurationException($"The address scheme was invalid: {address.Scheme}");
 
+            var regionEndpoint = RegionEndpoint.GetBySystemName(address.Host);
+
             _settings = new ConfigurationHostSettings
             {
-                Region = RegionEndpoint.GetBySystemName(address.Host),
+                Region = regionEndpoint,
                 AccessKey = "",
                 SecretKey = "",
+                AmazonSqsConfig = new AmazonSQSConfig { RegionEndpoint = regionEndpoint },
+                AmazonSnsConfig = new AmazonSimpleNotificationServiceConfig { RegionEndpoint = regionEndpoint },
             };
 
             if (!string.IsNullOrEmpty(address.UserInfo))
@@ -54,6 +60,16 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
         public void SecretKey(string secretKey)
         {
             _settings.SecretKey = secretKey;
+        }
+
+        public void Config(AmazonSQSConfig config)
+        {
+            _settings.AmazonSqsConfig = config;
+        }
+
+        public void Config(AmazonSimpleNotificationServiceConfig config)
+        {
+            _settings.AmazonSnsConfig = config;
         }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsHostConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsHostConfigurator.cs
@@ -1,0 +1,59 @@
+// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
+{
+    using System;
+    using Amazon;
+    using Exceptions;
+
+
+    public class AmazonSqsHostConfigurator :
+        IAmazonSqsHostConfigurator
+    {
+        readonly ConfigurationHostSettings _settings;
+
+        public AmazonSqsHostConfigurator(Uri address)
+        {
+            if (string.Compare("amazonsqs", address.Scheme, StringComparison.OrdinalIgnoreCase) != 0)
+                throw new AmazonSqsTransportConfigurationException($"The address scheme was invalid: {address.Scheme}");
+
+            _settings = new ConfigurationHostSettings
+            {
+                Region = RegionEndpoint.GetBySystemName(address.Host),
+                AccessKey = "",
+                SecretKey = "",
+            };
+
+            if (!string.IsNullOrEmpty(address.UserInfo))
+            {
+                string[] parts = address.UserInfo.Split(':');
+                _settings.AccessKey = parts[0];
+
+                if (parts.Length >= 2)
+                    _settings.SecretKey = parts[1];
+            }
+        }
+
+        public AmazonSqsHostSettings Settings => _settings;
+
+        public void AccessKey(string accessKey)
+        {
+            _settings.AccessKey = accessKey;
+        }
+
+        public void SecretKey(string secretKey)
+        {
+            _settings.SecretKey = secretKey;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -1,0 +1,60 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
+{
+    using System;
+    using Amazon;
+
+    public class ConfigurationHostSettings :
+        AmazonSqsHostSettings
+    {
+        readonly Lazy<Uri> _hostAddress;
+
+        public ConfigurationHostSettings()
+        {
+            _hostAddress = new Lazy<Uri>(FormatHostAddress);
+        }
+
+        public RegionEndpoint Region { get; set; }
+        public string AccessKey { get; set; }
+        public string SecretKey { get; set; }
+
+        public Uri HostAddress => _hostAddress.Value;
+
+        public IConnection CreateConnection()
+        {
+            return new Connection(AccessKey, SecretKey, Region);
+        }
+
+        Uri FormatHostAddress()
+        {
+            var builder = new UriBuilder
+            {
+                Scheme = "amazonsqs",
+                Host = Region.SystemName,
+                Path = "/"
+            };
+
+            return builder.Uri;
+        }
+
+        public override string ToString()
+        {
+            return new UriBuilder
+            {
+                Scheme = "https",
+                Host = Region.SystemName
+            }.Uri.ToString();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -14,12 +14,15 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
 {
     using System;
     using Amazon;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
+
 
     public class ConfigurationHostSettings :
         AmazonSqsHostSettings
     {
         readonly Lazy<Uri> _hostAddress;
-
+        
         public ConfigurationHostSettings()
         {
             _hostAddress = new Lazy<Uri>(FormatHostAddress);
@@ -29,11 +32,15 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
         public string AccessKey { get; set; }
         public string SecretKey { get; set; }
 
+        public AmazonSQSConfig AmazonSqsConfig { get; set; }
+
+        public AmazonSimpleNotificationServiceConfig AmazonSnsConfig { get; set; }
+
         public Uri HostAddress => _hostAddress.Value;
 
         public IConnection CreateConnection()
         {
-            return new Connection(AccessKey, SecretKey, Region);
+            return new Connection(AccessKey, SecretKey, Region, AmazonSqsConfig, AmazonSnsConfig);
         }
 
         Uri FormatHostAddress()

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsBusFactoryConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsBusFactoryConfigurator.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    using System;
+    using System.ComponentModel;
+    using MassTransit.Builders;
+    using Topology.Configuration;
+
+
+    public interface IAmazonSqsBusFactoryConfigurator :
+        IBusFactoryConfigurator,
+        IQueueEndpointConfigurator
+    {
+        new IAmazonSqsSendTopologyConfigurator SendTopology { get; }
+
+        new IAmazonSqsPublishTopologyConfigurator PublishTopology { get; }
+
+        /// <summary>
+        /// Set to true if the topology should be deployed only
+        /// </summary>
+        bool DeployTopologyOnly { set; }
+
+        /// <summary>
+        /// Configure the send topology of the message type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="configureTopology"></param>
+        void Send<T>(Action<IAmazonSqsMessageSendTopologyConfigurator<T>> configureTopology)
+            where T : class;
+
+        /// <summary>
+        /// Configure the send topology of the message type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="configureTopology"></param>
+        void Publish<T>(Action<IAmazonSqsMessagePublishTopologyConfigurator<T>> configureTopology)
+            where T : class;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void AddReceiveEndpointSpecification(IReceiveEndpointSpecification<IBusBuilder> specification);
+
+        /// <summary>
+        /// Configure a Host that can be connected. If only one host is specified, it is used as the default
+        /// host for receive endpoints.
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        IAmazonSqsHost Host(AmazonSqsHostSettings settings);
+
+        /// <summary>
+        /// Declare a ReceiveEndpoint on the broker and configure the endpoint settings and message consumers.
+        /// </summary>
+        /// <param name="host">The host for this endpoint</param>
+        /// <param name="queueName">The input queue name</param>
+        /// <param name="configure">The configuration method</param>
+        void ReceiveEndpoint(IAmazonSqsHost host, string queueName, Action<IAmazonSqsReceiveEndpointConfigurator> configure);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsHostConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsHostConfigurator.cs
@@ -12,6 +12,10 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AmazonSqsTransport.Configuration
 {
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
+
+
     public interface IAmazonSqsHostConfigurator
     {
         /// <summary>
@@ -25,5 +29,17 @@ namespace MassTransit.AmazonSqsTransport.Configuration
         /// </summary>
         /// <param name="secretKey"></param>
         void SecretKey(string secretKey);
+
+        /// <summary>
+        /// Sets the default config for the connection to AmazonSQS
+        /// </summary>
+        /// <param name="config"></param>
+        void Config(AmazonSQSConfig config);
+
+        /// <summary>
+        /// Sets the default config for the connection to AmazonSNS
+        /// </summary>
+        /// <param name="config"></param>
+        void Config(AmazonSimpleNotificationServiceConfig config);
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsHostConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsHostConfigurator.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    public interface IAmazonSqsHostConfigurator
+    {
+        /// <summary>
+        /// Sets the accessKey for the connection to AmazonSQS
+        /// </summary>
+        /// <param name="accessKey"></param>
+        void AccessKey(string accessKey);
+
+        /// <summary>
+        /// Sets the secretKey for the connection to AmazonSQS
+        /// </summary>
+        /// <param name="secretKey"></param>
+        void SecretKey(string secretKey);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsReceiveEndpointConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsReceiveEndpointConfigurator.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    using System;
+    using GreenPipes;
+
+
+    /// <summary>
+    /// Configure a receiving AmazonSQS endpoint
+    /// </summary>
+    public interface IAmazonSqsReceiveEndpointConfigurator :
+        IReceiveEndpointConfigurator,
+        IQueueEndpointConfigurator
+    {
+        /// <summary>
+        /// The host on which the endpoint is being configured
+        /// </summary>
+        IAmazonSqsHost Host { get; }
+
+        /// <summary>
+        /// If true, creates message consumers for the message types in consumers, handlers, etc.
+        /// With AmazonSQS, these are virtual consumers tied to the virtual topics
+        /// </summary>
+        bool BindMessageTopics { set; }
+
+        /// <summary>
+        /// Bind an existing exchange for the message type to the receive endpoint by name
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        void Bind<T>(Action<ITopicBindingConfigurator> callback = null)
+            where T : class;
+
+        /// <summary>
+        /// Bind an exchange to the receive endpoint exchange
+        /// </summary>
+        /// <param name="topicName">The exchange name</param>
+        /// <param name="callback">Configure the exchange and binding</param>
+        void Bind(string topicName, Action<ITopicBindingConfigurator> callback);
+
+        void ConfigureSession(Action<IPipeConfigurator<ModelContext>> configure);
+        void ConfigureConnection(Action<IPipeConfigurator<ConnectionContext>> configure);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IQueueBindingConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IQueueBindingConfigurator.cs
@@ -15,9 +15,5 @@ namespace MassTransit.AmazonSqsTransport.Configuration
     public interface IQueueBindingConfigurator :
         IQueueConfigurator
     {
-        /// <summary>
-        /// A routing key for the exchange binding
-        /// </summary>
-        string Selector { set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IQueueBindingConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IQueueBindingConfigurator.cs
@@ -1,0 +1,23 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    public interface IQueueBindingConfigurator :
+        IQueueConfigurator
+    {
+        /// <summary>
+        /// A routing key for the exchange binding
+        /// </summary>
+        string Selector { set; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IQueueConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IQueueConfigurator.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    /// <summary>
+    /// Configures a queue/exchange pair in AmazonSQS
+    /// </summary>
+    public interface IQueueConfigurator
+    {
+        /// <summary>
+        /// Specify the queue should be durable (survives broker restart) or in-memory
+        /// </summary>
+        /// <value>True for a durable queue, False for an in-memory queue</value>
+        bool Durable { set; }
+
+        /// <summary>
+        /// Specify that the queue (and the exchange of the same name) should be created as auto-delete
+        /// </summary>
+        bool AutoDelete { set; }
+
+        /// <summary>
+        /// Sets the queue to be lazy (using less memory)
+        /// </summary>
+        bool Lazy { set; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IQueueEndpointConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IQueueEndpointConfigurator.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    public interface IQueueEndpointConfigurator :
+        IQueueConfigurator
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IQueueEndpointConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IQueueEndpointConfigurator.cs
@@ -15,5 +15,8 @@ namespace MassTransit.AmazonSqsTransport.Configuration
     public interface IQueueEndpointConfigurator :
         IQueueConfigurator
     {
+        ushort PrefetchCount { set; }
+
+        ushort WaitTimeSeconds { set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/ITopicBindingConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/ITopicBindingConfigurator.cs
@@ -18,9 +18,5 @@ namespace MassTransit.AmazonSqsTransport.Configuration
     public interface ITopicBindingConfigurator :
         ITopicConfigurator
     {
-        /// <summary>
-        /// A routing key for the exchange binding
-        /// </summary>
-        string Selector { set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/ITopicBindingConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/ITopicBindingConfigurator.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    /// <summary>
+    /// Used to configure the binding of an exchange (to either a queue or another exchange)
+    /// </summary>
+    public interface ITopicBindingConfigurator :
+        ITopicConfigurator
+    {
+        /// <summary>
+        /// A routing key for the exchange binding
+        /// </summary>
+        string Selector { set; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Configuration/ITopicConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/ITopicConfigurator.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Configuration
+{
+    /// <summary>
+    /// Configures an exchange for AmazonSQS
+    /// </summary>
+    public interface ITopicConfigurator
+    {
+        /// <summary>
+        /// Specify the queue should be durable (survives broker restart) or in-memory
+        /// </summary>
+        /// <value>True for a durable queue, False for an in-memory queue</value>
+        bool Durable { set; }
+
+        /// <summary>
+        /// Specify that the queue (and the exchange of the same name) should be created as auto-delete
+        /// </summary>
+        bool AutoDelete { set; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Connection.cs
+++ b/src/MassTransit.AmazonSqsTransport/Connection.cs
@@ -1,0 +1,74 @@
+namespace MassTransit.AmazonSqsTransport
+{
+    using System;
+    using Amazon;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
+
+    public interface IConnection :
+        IDisposable
+    {
+        string AccessKey { get; }
+
+        string SecretKey { get; }
+
+        RegionEndpoint Region { get; }
+
+        IAmazonSQS CreateAmazonSqs();
+
+        IAmazonSimpleNotificationService CreateAmazonSns();
+    }
+    public class Connection :
+        IConnection
+    {
+        public Connection(string accessKey, string secretKey, RegionEndpoint region, string serviceUrl = null)
+        {
+            AccessKey = accessKey;
+            SecretKey = secretKey;
+            Region = region;
+            ServiceUrl = serviceUrl;
+        }
+
+        public string AccessKey { get; }
+
+        public string SecretKey { get; }
+
+        public RegionEndpoint Region { get; }
+
+        public string ServiceUrl { get; }
+
+        public IAmazonSQS CreateAmazonSqs()
+        {
+            var config = new AmazonSQSConfig
+            {
+                RegionEndpoint = Region ?? RegionEndpoint.USEast1
+            };
+
+            if (ServiceUrl != null)
+            {
+                config.ServiceURL = ServiceUrl;
+            }
+
+            return new AmazonSQSClient(AccessKey, SecretKey, config);
+        }
+
+        public IAmazonSimpleNotificationService CreateAmazonSns()
+        {
+            var config = new AmazonSimpleNotificationServiceConfig
+            {
+                RegionEndpoint = Region ?? RegionEndpoint.USEast1
+            };
+
+            if (ServiceUrl != null)
+            {
+                config.ServiceURL = ServiceUrl;
+            }
+
+            return new AmazonSimpleNotificationServiceClient(AccessKey, SecretKey, config);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Connection.cs
+++ b/src/MassTransit.AmazonSqsTransport/Connection.cs
@@ -12,59 +12,41 @@ namespace MassTransit.AmazonSqsTransport
 
         string SecretKey { get; }
 
-        RegionEndpoint Region { get; }
+        AmazonSQSConfig AmazonSqsConfig { get; }
 
-        IAmazonSQS CreateAmazonSqs();
+        AmazonSimpleNotificationServiceConfig AmazonSnsConfig { get; }
 
-        IAmazonSimpleNotificationService CreateAmazonSns();
+        IAmazonSQS CreateAmazonSqsClient();
+
+        IAmazonSimpleNotificationService CreateAmazonSnsClient();
     }
     public class Connection :
         IConnection
     {
-        public Connection(string accessKey, string secretKey, RegionEndpoint region, string serviceUrl = null)
+        public Connection(string accessKey, string secretKey, RegionEndpoint regionEndpoint = null, AmazonSQSConfig amazonSqsConfig = null, AmazonSimpleNotificationServiceConfig amazonSnsConfig = null)
         {
             AccessKey = accessKey;
             SecretKey = secretKey;
-            Region = region;
-            ServiceUrl = serviceUrl;
+            AmazonSqsConfig = amazonSqsConfig ?? new AmazonSQSConfig { RegionEndpoint = regionEndpoint ?? RegionEndpoint.USEast1 };
+            AmazonSnsConfig = amazonSnsConfig ?? new AmazonSimpleNotificationServiceConfig { RegionEndpoint = regionEndpoint ?? RegionEndpoint.USEast1 };
         }
 
         public string AccessKey { get; }
 
         public string SecretKey { get; }
 
-        public RegionEndpoint Region { get; }
+        public AmazonSQSConfig AmazonSqsConfig { get; }
 
-        public string ServiceUrl { get; }
+        public AmazonSimpleNotificationServiceConfig AmazonSnsConfig { get;  }
 
-        public IAmazonSQS CreateAmazonSqs()
+        public IAmazonSQS CreateAmazonSqsClient()
         {
-            var config = new AmazonSQSConfig
-            {
-                RegionEndpoint = Region ?? RegionEndpoint.USEast1
-            };
-
-            if (ServiceUrl != null)
-            {
-                config.ServiceURL = ServiceUrl;
-            }
-
-            return new AmazonSQSClient(AccessKey, SecretKey, config);
+            return new AmazonSQSClient(AccessKey, SecretKey, AmazonSqsConfig);
         }
 
-        public IAmazonSimpleNotificationService CreateAmazonSns()
+        public IAmazonSimpleNotificationService CreateAmazonSnsClient()
         {
-            var config = new AmazonSimpleNotificationServiceConfig
-            {
-                RegionEndpoint = Region ?? RegionEndpoint.USEast1
-            };
-
-            if (ServiceUrl != null)
-            {
-                config.ServiceURL = ServiceUrl;
-            }
-
-            return new AmazonSimpleNotificationServiceClient(AccessKey, SecretKey, config);
+            return new AmazonSimpleNotificationServiceClient(AccessKey, SecretKey, AmazonSnsConfig);
         }
 
         public void Dispose()

--- a/src/MassTransit.AmazonSqsTransport/ConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/ConnectionContext.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using System;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
+    using GreenPipes;
+    using Topology;
+
+
+    public interface ConnectionContext :
+        PipeContext
+    {
+        /// <summary>
+        /// The Amazon Connection
+        /// </summary>
+        IConnection Connection { get; }
+
+        /// <summary>
+        /// The connection description, useful to debug output
+        /// </summary>
+        string Description { get; }
+
+        /// <summary>
+        /// The Host Address for this connection
+        /// </summary>
+        Uri HostAddress { get; }
+
+        IAmazonSqsHostTopology Topology { get; }
+
+        /// <summary>
+        /// The host settings for the connection
+        /// </summary>
+        AmazonSqsHostSettings HostSettings { get; }
+
+        /// <summary>
+        /// Create a model on the connection
+        /// </summary>
+        /// <returns></returns>
+        Task<IAmazonSQS> CreateAmazonSqs();
+
+        /// <summary>
+        /// Create a model on the connection
+        /// </summary>
+        /// <returns></returns>
+        Task<IAmazonSimpleNotificationService> CreateAmazonSns();
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSnsHeaderAdapter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSnsHeaderAdapter.cs
@@ -1,0 +1,80 @@
+﻿namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using System.Collections.Generic;
+    using Amazon.SimpleNotificationService.Model;
+    using Util;
+
+
+    public class AmazonSnsHeaderAdapter :
+        SendHeaders
+    {
+        readonly IDictionary<string, MessageAttributeValue> _attributes;
+
+        public AmazonSnsHeaderAdapter(IDictionary<string, MessageAttributeValue> attributes)
+        {
+            _attributes = attributes;
+        }
+
+        public void Set(string key, string value)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            if (value == null)
+                _attributes.Remove(key);
+            else
+                _attributes[key].StringValue = value;
+        }
+
+        public void Set(string key, object value)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            if (value == null)
+                _attributes.Remove(key);
+            else
+                _attributes[key].StringValue = value.ToString();
+        }
+
+        public bool TryGetHeader(string key, out object value)
+        {
+            var found = _attributes.ContainsKey(key);
+            if (found)
+            {
+                value = _attributes[key];
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public IEnumerable<KeyValuePair<string, object>> GetAll()
+        {
+            foreach (string key in _attributes.Keys)
+            {
+                var value = _attributes[key];
+
+                yield return new KeyValuePair<string, object>(key, value);
+            }
+        }
+
+        T Headers.Get<T>(string key, T defaultValue)
+        {
+            if (TryGetHeader(key, out var value))
+                return ObjectTypeDeserializer.Deserialize(value, defaultValue);
+
+            return defaultValue;
+        }
+
+        T? Headers.Get<T>(string key, T? defaultValue)
+        {
+            if (TryGetHeader(key, out var value))
+                return ObjectTypeDeserializer.Deserialize(value, defaultValue);
+
+            return defaultValue;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
@@ -54,12 +54,12 @@ namespace MassTransit.AmazonSqsTransport.Contexts
 
         public Task<IAmazonSQS> CreateAmazonSqs()
         {
-            return Task.Factory.StartNew(() => Connection.CreateAmazonSqs(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
+            return Task.Factory.StartNew(() => Connection.CreateAmazonSqsClient(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
         }
 
         public Task<IAmazonSimpleNotificationService> CreateAmazonSns()
         {
-            return Task.Factory.StartNew(() => Connection.CreateAmazonSns(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
+            return Task.Factory.StartNew(() => Connection.CreateAmazonSnsClient(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
         }
 
         Task IAsyncDisposable.DisposeAsync(CancellationToken cancellationToken)

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
@@ -1,0 +1,86 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
+    using GreenPipes;
+    using GreenPipes.Payloads;
+    using Logging;
+    using Topology;
+    using Util;
+
+
+    public class AmazonSqsConnectionContext :
+        BasePipeContext,
+        ConnectionContext,
+        IAsyncDisposable
+    {
+        static readonly ILog _log = Logger.Get<AmazonSqsConnectionContext>();
+
+        readonly LimitedConcurrencyLevelTaskScheduler _taskScheduler;
+
+        public AmazonSqsConnectionContext(IConnection connection, AmazonSqsHostSettings hostSettings, IAmazonSqsHostTopology topology, string description,
+            CancellationToken cancellationToken)
+            : base(new PayloadCache(), cancellationToken)
+        {
+            Connection = connection;
+            HostSettings = hostSettings;
+            Topology = topology;
+
+            Description = description;
+
+            _taskScheduler = new LimitedConcurrencyLevelTaskScheduler(1);
+        }
+
+        public IConnection Connection { get; }
+        public IAmazonSqsHostTopology Topology { get; }
+        public AmazonSqsHostSettings HostSettings { get; }
+        public string Description { get; }
+        public Uri HostAddress => HostSettings.HostAddress;
+
+        public Task<IAmazonSQS> CreateAmazonSqs()
+        {
+            return Task.Factory.StartNew(() => Connection.CreateAmazonSqs(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
+        }
+
+        public Task<IAmazonSimpleNotificationService> CreateAmazonSns()
+        {
+            return Task.Factory.StartNew(() => Connection.CreateAmazonSns(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
+        }
+
+        Task IAsyncDisposable.DisposeAsync(CancellationToken cancellationToken)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Disconnecting: {0}", Description);
+
+            try
+            {
+                Connection.Dispose();
+            }
+            catch (Exception exception)
+            {
+                if (_log.IsErrorEnabled)
+                    _log.Error($"Close _connection Faulted: {Description}", exception);
+            }
+
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Disconnected: {0}", Description);
+
+            return TaskUtil.Completed;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConsumerReceiveEndpointContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConsumerReceiveEndpointContext.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using Configuration.Configuration;
+    using Context;
+    using MassTransit.Pipeline.Observables;
+    using Topology;
+    using Topology.Builders;
+    using Transport;
+    using Transports;
+
+
+    public class AmazonSqsConsumerReceiveEndpointContext :
+        BaseReceiveEndpointContext,
+        AmazonSqsReceiveEndpointContext
+    {
+        readonly IAmazonSqsReceiveEndpointConfiguration _configuration;
+        readonly Lazy<ISendTransportProvider> _sendTransportProvider;
+        readonly Lazy<IPublishTransportProvider> _publishTransportProvider;
+        readonly IAmazonSqsPublishTopology _publishTopology;
+
+        public AmazonSqsConsumerReceiveEndpointContext(IAmazonSqsReceiveEndpointConfiguration configuration, BrokerTopology brokerTopology,
+            ReceiveObservable receiveObservers, ReceiveTransportObservable transportObservers, ReceiveEndpointObservable endpointObservers)
+            : base(configuration, receiveObservers, transportObservers, endpointObservers)
+        {
+            _configuration = configuration;
+            BrokerTopology = brokerTopology;
+
+            _publishTopology = configuration.Topology.Publish;
+
+            _sendTransportProvider = new Lazy<ISendTransportProvider>(CreateSendTransportProvider);
+            _publishTransportProvider = new Lazy<IPublishTransportProvider>(CreatePublishTransportProvider);
+        }
+
+        public BrokerTopology BrokerTopology { get; }
+
+        public ISendEndpointProvider CreateSendEndpointProvider(ReceiveContext receiveContext)
+        {
+            return SendEndpointProvider;
+        }
+
+        public IPublishEndpointProvider CreatePublishEndpointProvider(ReceiveContext receiveContext)
+        {
+            return PublishEndpointProvider;
+        }
+
+        ISendTransportProvider CreateSendTransportProvider()
+        {
+            return new SendTransportProvider(_configuration.BusConfiguration);
+        }
+
+        IPublishTransportProvider CreatePublishTransportProvider()
+        {
+            return new PublishTransportProvider(_configuration.Host, _publishTopology);
+        }
+
+        protected override ISendEndpointProvider CreateSendEndpointProvider()
+        {
+            return new SendEndpointProvider(_sendTransportProvider.Value, SendObservers, Serializer, InputAddress, SendPipe);
+        }
+
+        protected override IPublishEndpointProvider CreatePublishEndpointProvider()
+        {
+            return new PublishEndpointProvider(_publishTransportProvider.Value, _configuration.HostAddress, PublishObservers, SendObservers, Serializer,
+                InputAddress, PublishPipe, _publishTopology);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsHeaderAdapter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsHeaderAdapter.cs
@@ -1,0 +1,92 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using System.Collections.Generic;
+    using Amazon.SQS.Model;
+    using Util;
+
+
+    public class AmazonSqsHeaderAdapter :
+        SendHeaders
+    {
+        readonly IDictionary<string, MessageAttributeValue> _attributes;
+
+        public AmazonSqsHeaderAdapter(IDictionary<string, MessageAttributeValue> attributes)
+        {
+            _attributes = attributes;
+        }
+
+        public void Set(string key, string value)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            if (value == null)
+                _attributes.Remove(key);
+            else
+                _attributes[key].StringValue = value;
+        }
+
+        public void Set(string key, object value)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            if (value == null)
+                _attributes.Remove(key);
+            else
+                _attributes[key].StringValue = value.ToString();
+        }
+
+        public bool TryGetHeader(string key, out object value)
+        {
+            var found = _attributes.ContainsKey(key);
+            if (found)
+            {
+                value = _attributes[key];
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public IEnumerable<KeyValuePair<string, object>> GetAll()
+        {
+            foreach (string key in _attributes.Keys)
+            {
+                var value = _attributes[key];
+
+                yield return new KeyValuePair<string, object>(key, value);
+            }
+        }
+
+        T Headers.Get<T>(string key, T defaultValue)
+        {
+            if (TryGetHeader(key, out var value))
+                return ObjectTypeDeserializer.Deserialize(value, defaultValue);
+
+            return defaultValue;
+        }
+
+        T? Headers.Get<T>(string key, T? defaultValue)
+        {
+            if (TryGetHeader(key, out var value))
+                return ObjectTypeDeserializer.Deserialize(value, defaultValue);
+
+            return defaultValue;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsHeaderProvider.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsHeaderProvider.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using System.Collections.Generic;
+    using Amazon.SQS.Model;
+    using Context;
+
+
+    public class AmazonSqsHeaderProvider :
+        IHeaderProvider
+    {
+        readonly Message _message;
+        readonly AmazonSqsHeaderAdapter _adapter;
+
+        public AmazonSqsHeaderProvider(Message message)
+        {
+            _message = message;
+            _adapter = new AmazonSqsHeaderAdapter(message.MessageAttributes);
+        }
+
+        public IEnumerable<KeyValuePair<string, object>> GetAll()
+        {
+            yield return new KeyValuePair<string, object>("MessageId", _message.MessageId);
+            yield return new KeyValuePair<string, object>("CorrelationId", _message.MessageAttributes["CorrelationId"].StringValue);
+
+            foreach (var header in _adapter.GetAll())
+                yield return header;
+        }
+
+        public bool TryGetHeader(string key, out object value)
+        {
+            if ("MessageId".Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = _message.MessageId;
+                return true;
+            }
+
+            return _adapter.TryGetHeader(key, out value);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsModelContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsModelContext.cs
@@ -1,0 +1,143 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SimpleNotificationService.Model;
+    using Amazon.SQS;
+    using Amazon.SQS.Model;
+    using GreenPipes;
+    using GreenPipes.Payloads;
+    using Logging;
+    using Pipeline;
+    using Topology;
+    using Util;
+
+
+    public class AmazonSqsModelContext :
+        BasePipeContext,
+        ModelContext,
+        IAsyncDisposable
+    {
+        static readonly ILog _log = Logger.Get<AmazonSqsModelContext>();
+
+        readonly ConnectionContext _connectionContext;
+        readonly IAmazonSqsHost _host;
+        readonly IAmazonSQS _amazonSqs;
+        readonly IAmazonSimpleNotificationService _amazonSns;
+        readonly LimitedConcurrencyLevelTaskScheduler _taskScheduler;
+
+        public AmazonSqsModelContext(ConnectionContext connectionContext, IAmazonSQS amazonSqs, IAmazonSimpleNotificationService amazonSns, IAmazonSqsHost host, CancellationToken cancellationToken)
+            : base(new PayloadCacheScope(connectionContext), cancellationToken)
+        {
+            _connectionContext = connectionContext;
+            _amazonSqs = amazonSqs;
+            _amazonSns = amazonSns;
+            _host = host;
+
+            _taskScheduler = new LimitedConcurrencyLevelTaskScheduler(1);
+        }
+
+        public Task DisposeAsync(CancellationToken cancellationToken)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Closing model: {0}", _connectionContext.Description);
+
+            _amazonSqs?.Dispose();
+            _amazonSns?.Dispose();
+
+            return GreenPipes.Util.TaskUtil.Completed;
+        }
+
+        IAmazonSqsPublishTopology ModelContext.PublishTopology => _host.Topology.PublishTopology;
+
+        ConnectionContext ModelContext.ConnectionContext => _connectionContext;
+
+        public async Task<string> GetTopic(string topicName)
+        {
+            return (await _amazonSns.CreateTopicAsync(topicName, CancellationToken).ConfigureAwait(false)).TopicArn;
+        }
+
+        public async Task<string> GetQueue(string queueName)
+        {
+            return (await _amazonSqs.CreateQueueAsync(queueName, CancellationToken).ConfigureAwait(false)).QueueUrl;
+        }
+
+        public async Task GetTopicSubscription(string topicName, string queueName)
+        {
+            var topicArn = await GetTopic(topicName).ConfigureAwait(false);
+            var queueUrl = await GetQueue(queueName).ConfigureAwait(false);
+
+            await _amazonSns.SubscribeQueueAsync(topicArn, _amazonSqs, queueUrl).ConfigureAwait(false);
+        }
+
+        public async Task DeleteTopic(string topicName)
+        {
+            var topicArn = await GetTopic(topicName).ConfigureAwait(false);
+
+            await _amazonSns.DeleteTopicAsync(topicArn, CancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task DeleteQueue(string queueName)
+        {
+            var queueUrl = await GetQueue(queueName).ConfigureAwait(false);
+
+            await _amazonSqs.DeleteQueueAsync(queueUrl, CancellationToken).ConfigureAwait(false);
+        }
+
+        public Task BasicConsume(string queueUrl, int prefetchCount, AmazonSqsBasicConsumer consumer)
+        {
+            return Task.Factory.StartNew(async () =>
+            {
+                while (!CancellationToken.IsCancellationRequested)
+                {
+                    var request = new ReceiveMessageRequest(queueUrl)
+                    {
+                        MaxNumberOfMessages = prefetchCount,
+                        //WaitTimeSeconds = 1,
+                        AttributeNames = new List<string> {"All"},
+                        MessageAttributeNames = new List<string> {"All"}
+                    };
+
+                    var response = await _amazonSqs.ReceiveMessageAsync(request, CancellationToken).ConfigureAwait(false);
+
+                    foreach (var message in response.Messages)
+                    {
+                        await consumer.HandleMessage(message).ConfigureAwait(false);
+                    }
+                }
+            }, CancellationToken, TaskCreationOptions.None, _taskScheduler);
+        }
+
+        public PublishRequest CreateTransportMessage(string topicArn, byte[] body)
+        {
+            var message = Encoding.UTF8.GetString(body);
+
+            return new PublishRequest(topicArn, message);
+        }
+
+        public Task Publish(PublishRequest publishRequest, CancellationToken cancellationToken)
+        {
+            return _amazonSns.PublishAsync(publishRequest, cancellationToken);
+        }
+
+        public Task DeleteMessage(string queueUrl, string receiptHandle, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _amazonSqs.DeleteMessageAsync(queueUrl, receiptHandle, cancellationToken);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsModelContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsModelContext.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.AmazonSqsTransport.Contexts
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -123,10 +124,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
 
                     var response = await _amazonSqs.ReceiveMessageAsync(request, CancellationToken).ConfigureAwait(false);
 
-                    foreach (var message in response.Messages)
-                    {
-                        await consumer.HandleMessage(message).ConfigureAwait(false);
-                    }
+                    await Task.WhenAll(response.Messages.Select(consumer.HandleMessage)).ConfigureAwait(false);
                 }
             }, CancellationToken, TaskCreationOptions.None, _taskScheduler);
         }

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsReceiveContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsReceiveContext.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using Amazon.SQS.Model;
+    using Context;
+    using Exceptions;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Util;
+
+
+    public sealed class AmazonSqsReceiveContext :
+        BaseReceiveContext,
+        AmazonSqsMessageContext
+    {
+        readonly AmazonSqsReceiveEndpointContext _context;
+        readonly Message _transportMessage;
+        byte[] _body;
+
+        public AmazonSqsReceiveContext(Uri inputAddress, Message transportMessage, bool redelivered, IReceiveObserver observer, AmazonSqsReceiveEndpointContext context)
+            : base(inputAddress, redelivered, observer, context)
+        {
+            _transportMessage = transportMessage;
+            _context = context;
+        }
+
+        protected override IHeaderProvider HeaderProvider => new AmazonSqsHeaderProvider(_transportMessage);
+
+        public Message TransportMessage => _transportMessage;
+
+        public Dictionary<string, MessageAttributeValue> Attributes => _transportMessage.MessageAttributes;
+
+        protected override ISendEndpointProvider GetSendEndpointProvider()
+        {
+            return _context.CreateSendEndpointProvider(this);
+        }
+
+        protected override IPublishEndpointProvider GetPublishEndpointProvider()
+        {
+            return _context.CreatePublishEndpointProvider(this);
+        }
+
+        public override byte[] GetBody()
+        {
+            if (_body != null)
+                return _body;
+
+            if (_transportMessage != null)
+            {
+                var envelope = JsonConvert.DeserializeObject<JToken>(TransportMessage.Body);
+
+                var envelopeType = envelope["Type"].ToString();
+                if (envelopeType == "Notification")
+                    return _body = Encoding.UTF8.GetBytes(envelope["Message"].ToString());
+
+                return Encoding.UTF8.GetBytes(TransportMessage.Body);
+            }
+
+            throw new AmazonSqsTransportException($"The message type is not supported: {TypeMetadataCache.GetShortName(_transportMessage.GetType())}");
+        }
+
+        public override Stream GetBodyStream()
+        {
+            return new MemoryStream(GetBody());
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsReceiveEndpointContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsReceiveEndpointContext.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using Context;
+    using Topology.Builders;
+
+
+    public interface AmazonSqsReceiveEndpointContext :
+        ReceiveEndpointContext
+    {
+        BrokerTopology BrokerTopology { get; }
+
+        ISendEndpointProvider CreateSendEndpointProvider(ReceiveContext receiveContext);
+
+        IPublishEndpointProvider CreatePublishEndpointProvider(ReceiveContext receiveContext);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/SharedConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/SharedConnectionContext.cs
@@ -1,0 +1,74 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
+    using GreenPipes;
+    using Topology;
+
+
+    public class SharedConnectionContext :
+        ConnectionContext
+    {
+        readonly CancellationToken _cancellationToken;
+        readonly ConnectionContext _context;
+
+        public SharedConnectionContext(ConnectionContext context, CancellationToken cancellationToken)
+        {
+            _context = context;
+            _cancellationToken = cancellationToken;
+        }
+
+        CancellationToken PipeContext.CancellationToken => _cancellationToken;
+
+        bool PipeContext.HasPayloadType(Type contextType)
+        {
+            return _context.HasPayloadType(contextType);
+        }
+
+        bool PipeContext.TryGetPayload<TPayload>(out TPayload payload)
+        {
+            return _context.TryGetPayload(out payload);
+        }
+
+        TPayload PipeContext.GetOrAddPayload<TPayload>(PayloadFactory<TPayload> payloadFactory)
+        {
+            return _context.GetOrAddPayload(payloadFactory);
+        }
+
+        T PipeContext.AddOrUpdatePayload<T>(PayloadFactory<T> addFactory, UpdatePayloadFactory<T> updateFactory)
+        {
+            return _context.AddOrUpdatePayload(addFactory, updateFactory);
+        }
+
+        IConnection ConnectionContext.Connection => _context.Connection;
+        public string Description => _context.Description;
+        public Uri HostAddress => _context.HostAddress;
+        public IAmazonSqsHostTopology Topology => _context.Topology;
+        AmazonSqsHostSettings ConnectionContext.HostSettings => _context.HostSettings;
+
+        Task<IAmazonSQS> ConnectionContext.CreateAmazonSqs()
+        {
+            return _context.CreateAmazonSqs();
+        }
+
+        Task<IAmazonSimpleNotificationService> ConnectionContext.CreateAmazonSns()
+        {
+            return _context.CreateAmazonSns();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/SharedModelContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/SharedModelContext.cs
@@ -100,9 +100,9 @@ namespace MassTransit.AmazonSqsTransport.Contexts
             return _context.DeleteQueue(queueName);
         }
 
-        Task ModelContext.BasicConsume(string queueUrl, int prefetchCount, AmazonSqsBasicConsumer consumer)
+        Task ModelContext.BasicConsume(string queueUrl, ReceiveSettings receiveSettings, IBasicConsumer consumer)
         {
-            return _context.BasicConsume(queueUrl, prefetchCount, consumer);
+            return _context.BasicConsume(queueUrl, receiveSettings, consumer);
         }
 
         PublishRequest ModelContext.CreateTransportMessage(string topicArn, byte[] body)
@@ -110,9 +110,9 @@ namespace MassTransit.AmazonSqsTransport.Contexts
             return _context.CreateTransportMessage(topicArn, body);
         }
 
-        Task ModelContext.Publish(PublishRequest publishRequest, CancellationToken cancellationToken)
+        Task ModelContext.Publish(PublishRequest request, CancellationToken cancellationToken)
         {
-            return _context.Publish(publishRequest, cancellationToken);
+            return _context.Publish(request, cancellationToken);
         }
 
         Task ModelContext.DeleteMessage(string queueUrl, string receiptHandle, CancellationToken cancellationToken)

--- a/src/MassTransit.AmazonSqsTransport/Contexts/SharedModelContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/SharedModelContext.cs
@@ -1,0 +1,125 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService.Model;
+    using GreenPipes;
+    using GreenPipes.Payloads;
+    using Pipeline;
+    using Topology;
+
+
+    public class SharedModelContext :
+        ModelContext
+    {
+        readonly CancellationToken _cancellationToken;
+        readonly ModelContext _context;
+        readonly IPayloadCache _payloadCache;
+
+        public SharedModelContext(ModelContext context, CancellationToken cancellationToken)
+        {
+            _context = context;
+            _cancellationToken = cancellationToken;
+        }
+
+        public SharedModelContext(ModelContext context, IPayloadCache payloadCache, CancellationToken cancellationToken)
+        {
+            _context = context;
+            _payloadCache = payloadCache;
+            _cancellationToken = cancellationToken;
+        }
+
+        bool PipeContext.HasPayloadType(Type contextType)
+        {
+            if (_payloadCache != null)
+                return _payloadCache.HasPayloadType(contextType);
+
+            return _context.HasPayloadType(contextType);
+        }
+
+        bool PipeContext.TryGetPayload<TPayload>(out TPayload payload)
+        {
+            if (_payloadCache != null)
+                return _payloadCache.TryGetPayload(out payload);
+
+            return _context.TryGetPayload(out payload);
+        }
+
+        TPayload PipeContext.GetOrAddPayload<TPayload>(PayloadFactory<TPayload> payloadFactory)
+        {
+            if (_payloadCache != null)
+                return _payloadCache.GetOrAddPayload(payloadFactory);
+
+            return _context.GetOrAddPayload(payloadFactory);
+        }
+
+        T PipeContext.AddOrUpdatePayload<T>(PayloadFactory<T> addFactory, UpdatePayloadFactory<T> updateFactory)
+        {
+            return _context.AddOrUpdatePayload(addFactory, updateFactory);
+        }
+
+        ConnectionContext ModelContext.ConnectionContext => _context.ConnectionContext;
+
+        IAmazonSqsPublishTopology ModelContext.PublishTopology => _context.PublishTopology;
+
+        Task<string> ModelContext.GetTopic(string topicName)
+        {
+            return _context.GetTopic(topicName);
+        }
+
+        Task<string> ModelContext.GetQueue(string queueName)
+        {
+            return _context.GetQueue(queueName);
+        }
+
+        Task ModelContext.GetTopicSubscription(string topicName, string queueName)
+        {
+            return _context.GetTopicSubscription(topicName, queueName);
+        }
+
+        Task ModelContext.DeleteTopic(string topicName)
+        {
+            return _context.DeleteTopic(topicName);
+        }
+
+        Task ModelContext.DeleteQueue(string queueName)
+        {
+            return _context.DeleteQueue(queueName);
+        }
+
+        Task ModelContext.BasicConsume(string queueUrl, int prefetchCount, AmazonSqsBasicConsumer consumer)
+        {
+            return _context.BasicConsume(queueUrl, prefetchCount, consumer);
+        }
+
+        PublishRequest ModelContext.CreateTransportMessage(string topicArn, byte[] body)
+        {
+            return _context.CreateTransportMessage(topicArn, body);
+        }
+
+        Task ModelContext.Publish(PublishRequest publishRequest, CancellationToken cancellationToken)
+        {
+            return _context.Publish(publishRequest, cancellationToken);
+        }
+
+        Task ModelContext.DeleteMessage(string queueUrl, string receiptHandle, CancellationToken cancellationToken)
+        {
+            return _context.DeleteMessage(queueUrl, receiptHandle, cancellationToken);
+        }
+
+        CancellationToken PipeContext.CancellationToken => _cancellationToken;
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Contexts/TransportAmazonSqsSendContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/TransportAmazonSqsSendContext.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Contexts
+{
+    using System.Threading;
+    using Context;
+
+
+    public class TransportAmazonSqsSendContext<T> :
+        BaseSendContext<T>,
+        AmazonSqsSendContext<T>
+        where T : class
+    {
+        public TransportAmazonSqsSendContext(T message, CancellationToken cancellationToken)
+            : base(message, cancellationToken)
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsConnectException.cs
+++ b/src/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsConnectException.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Exceptions
+{
+    using System;
+    using System.Runtime.Serialization;
+
+
+    [Serializable]
+    public class AmazonSqsConnectException :
+        AmazonSqsTransportException
+    {
+        public AmazonSqsConnectException()
+        {
+        }
+
+        public AmazonSqsConnectException(string message)
+            : base(message)
+        {
+        }
+
+        public AmazonSqsConnectException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected AmazonSqsConnectException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsTransportConfigurationException.cs
+++ b/src/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsTransportConfigurationException.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Exceptions
+{
+    using System;
+    using System.Runtime.Serialization;
+
+
+    [Serializable]
+    public class AmazonSqsTransportConfigurationException :
+        AmazonSqsTransportException
+    {
+        public AmazonSqsTransportConfigurationException()
+        {
+        }
+
+        public AmazonSqsTransportConfigurationException(string message)
+            : base(message)
+        {
+        }
+
+        public AmazonSqsTransportConfigurationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected AmazonSqsTransportConfigurationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsTransportException.cs
+++ b/src/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsTransportException.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Exceptions
+{
+    using System;
+    using System.Runtime.Serialization;
+
+
+    [Serializable]
+    public class AmazonSqsTransportException :
+        MassTransitException
+    {
+        public AmazonSqsTransportException()
+        {
+        }
+
+        public AmazonSqsTransportException(string message)
+            : base(message)
+        {
+        }
+
+        public AmazonSqsTransportException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected AmazonSqsTransportException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/IAmazonSqsHost.cs
+++ b/src/MassTransit.AmazonSqsTransport/IAmazonSqsHost.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using System;
+    using Configuration;
+    using GreenPipes;
+    using Topology;
+    using Transport;
+
+
+    public interface IAmazonSqsHost :
+        IHost
+    {
+        IConnectionCache ConnectionCache { get; }
+
+        IRetryPolicy ConnectionRetryPolicy { get; }
+
+        AmazonSqsHostSettings Settings { get; }
+
+        new IAmazonSqsHostTopology Topology { get; }
+
+        /// <summary>
+        /// Create a temporary receive endpoint on the host, with a separate handle for stopping/removing the endpoint
+        /// </summary>
+        /// <param name="configure"></param>
+        /// <returns></returns>
+        HostReceiveEndpointHandle ConnectReceiveEndpoint(Action<IAmazonSqsReceiveEndpointConfigurator> configure = null);
+
+        /// <summary>
+        /// Create a receive endpoint on the host, with a separate handle for stopping/removing the endpoint
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <param name="configure"></param>
+        /// <returns></returns>
+        HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IAmazonSqsReceiveEndpointConfigurator> configure = null);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/IAmazonSqsHostControl.cs
+++ b/src/MassTransit.AmazonSqsTransport/IAmazonSqsHostControl.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using GreenPipes.Agents;
+    using Transports;
+
+
+    public interface IAmazonSqsHostControl :
+        IBusHostControl,
+        IAmazonSqsHost,
+        ISupervisor
+    {
+        void AddReceiveEndpoint(string endpointName, IReceiveEndpointControl receiveEndpoint);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>MassTransit.AmazonSQS</PackageId>
+    <Title>MassTransit.AmazonSQS</Title>
+    <Description>MassTransit ActiveMQ transport support; $(Description)</Description>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.AmazonSqsTransport.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.3" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.11" />
+    <PackageReference Include="GreenPipes" Version="2.1.1" />
+    <PackageReference Include="NewId" Version="3.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/MassTransit.AmazonSqsTransport/ModelContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/ModelContext.cs
@@ -16,9 +16,11 @@ namespace MassTransit.AmazonSqsTransport
     using System.Threading.Tasks;
     using Amazon.SimpleNotificationService.Model;
     using Amazon.SQS;
+    using Amazon.SQS.Model;
     using GreenPipes;
     using Pipeline;
     using Topology;
+    using Topology.Settings;
 
 
     public interface ModelContext :
@@ -41,11 +43,11 @@ namespace MassTransit.AmazonSqsTransport
 
         Task DeleteQueue(string queueName);
 
-        Task BasicConsume(string queueUrl, int prefetchCount, AmazonSqsBasicConsumer consumer);
+        Task BasicConsume(string queueUrl, ReceiveSettings receiveSettings, IBasicConsumer consumer);
 
         PublishRequest CreateTransportMessage(string topicArn, byte[] body);
 
-        Task Publish(PublishRequest publishRequest, CancellationToken cancellationToken = default(CancellationToken));
+        Task Publish(PublishRequest request, CancellationToken cancellationToken = default(CancellationToken));
 
         Task DeleteMessage(string queueUrl, string receiptHandle, CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/src/MassTransit.AmazonSqsTransport/ModelContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/ModelContext.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService.Model;
+    using Amazon.SQS;
+    using GreenPipes;
+    using Pipeline;
+    using Topology;
+
+
+    public interface ModelContext :
+        PipeContext
+    {
+        /// <summary>
+        /// The connection context for the model
+        /// </summary>
+        ConnectionContext ConnectionContext { get; }
+
+        IAmazonSqsPublishTopology PublishTopology { get; }
+
+        Task<string> GetTopic(string topicName);
+
+        Task<string> GetQueue(string queueName);
+
+        Task GetTopicSubscription(string topicName, string queueName);
+
+        Task DeleteTopic(string topicName);
+
+        Task DeleteQueue(string queueName);
+
+        Task BasicConsume(string queueUrl, int prefetchCount, AmazonSqsBasicConsumer consumer);
+
+        PublishRequest CreateTransportMessage(string topicArn, byte[] body);
+
+        Task Publish(PublishRequest publishRequest, CancellationToken cancellationToken = default(CancellationToken));
+
+        Task DeleteMessage(string queueUrl, string receiptHandle, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsBasicConsumer.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsBasicConsumer.cs
@@ -1,0 +1,218 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Pipeline
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Amazon.SQS.Model;
+    using Contexts;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using GreenPipes.Internals.Extensions;
+    using Logging;
+    using Topology;
+    using Transports;
+    using Transports.Metrics;
+
+
+    public interface IBasicConsumer
+    {
+        Task HandleMessage(Message message);
+    }
+
+    /// <summary>
+    /// Receives messages from AmazonSQS, pushing them to the InboundPipe of the service endpoint.
+    /// </summary>
+    public sealed class AmazonSqsBasicConsumer :
+        Supervisor,
+        IBasicConsumer,
+        DeliveryMetrics
+    {
+        readonly IDeadLetterTransport _deadLetterTransport;
+        readonly TaskCompletionSource<bool> _deliveryComplete;
+        readonly IErrorTransport _errorTransport;
+        readonly Uri _inputAddress;
+        readonly ILog _log = Logger.Get<AmazonSqsBasicConsumer>();
+        readonly ModelContext _model;
+        readonly string _queueUrl;
+        readonly ConcurrentDictionary<string, AmazonSqsReceiveContext> _pending;
+        readonly IReceiveObserver _receiveObserver;
+        readonly IPipe<ReceiveContext> _receivePipe;
+        readonly ReceiveSettings _receiveSettings;
+        readonly AmazonSqsReceiveEndpointContext _context;
+        readonly IDeliveryTracker _tracker;
+
+        /// <summary>
+        /// The basic consumer receives messages pushed from the broker.
+        /// </summary>
+        /// <param name="model">The model context for the consumer</param>
+        /// <param name="queueUrl"></param>
+        /// <param name="inputAddress">The input address for messages received by the consumer</param>
+        /// <param name="receivePipe">The receive pipe to dispatch messages</param>
+        /// <param name="receiveObserver">The observer for receive events</param>
+        /// <param name="context">The topology</param>
+        /// <param name="deadLetterTransport"></param>
+        /// <param name="errorTransport"></param>
+        public AmazonSqsBasicConsumer(ModelContext model, string queueUrl, Uri inputAddress, IPipe<ReceiveContext> receivePipe,
+            IReceiveObserver receiveObserver, AmazonSqsReceiveEndpointContext context,
+            IDeadLetterTransport deadLetterTransport, IErrorTransport errorTransport)
+        {
+            _model = model;
+            _queueUrl = queueUrl;
+            _inputAddress = inputAddress;
+            _receivePipe = receivePipe;
+            _receiveObserver = receiveObserver;
+            _context = context;
+            _deadLetterTransport = deadLetterTransport;
+            _errorTransport = errorTransport;
+
+            _tracker = new DeliveryTracker(HandleDeliveryComplete);
+
+            _receiveSettings = model.GetPayload<ReceiveSettings>();
+
+            _pending = new ConcurrentDictionary<string, AmazonSqsReceiveContext>();
+
+            _deliveryComplete = new TaskCompletionSource<bool>();
+
+            SetReady();
+        }
+
+        public async Task HandleMessage(Message message)
+        {
+            if (IsStopping)
+            {
+                await WaitAndAbandonMessage(message).ConfigureAwait(false);
+                return;
+            }
+
+            using (var delivery = _tracker.BeginDelivery())
+            {
+                var redelivered = message.Attributes.ContainsKey("ApproximateReceiveCount") && (int.TryParse(message.Attributes["ApproximateReceiveCount"], out var approximateReceiveCount) && approximateReceiveCount > 1);
+                var context = new AmazonSqsReceiveContext(_inputAddress, message, redelivered, _receiveObserver, _context);
+
+                context.GetOrAddPayload(() => _errorTransport);
+                context.GetOrAddPayload(() => _deadLetterTransport);
+
+                context.GetOrAddPayload(() => _receiveSettings);
+                context.GetOrAddPayload(() => _model);
+                context.GetOrAddPayload(() => _model.ConnectionContext);
+
+                try
+                {
+                    if (!_pending.TryAdd(message.MessageId, context))
+                        if (_log.IsErrorEnabled)
+                            _log.ErrorFormat("Duplicate BasicDeliver: {0}", message.MessageId);
+
+                    await _receiveObserver.PreReceive(context).ConfigureAwait(false);
+
+                    await _receivePipe.Send(context).ConfigureAwait(false);
+
+                    await context.CompleteTask.ConfigureAwait(false);
+
+                    // Acknowledge
+                    await _model.DeleteMessage(_queueUrl, message.ReceiptHandle);
+
+                    await _receiveObserver.PostReceive(context).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    await _receiveObserver.ReceiveFault(context, ex).ConfigureAwait(false);
+                    try
+                    {
+                        //_model.BasicNack(deliveryTag, false, true);
+                    }
+                    catch (Exception ackEx)
+                    {
+                        if (_log.IsErrorEnabled)
+                            _log.ErrorFormat("An error occurred trying to NACK a message with delivery tag {0}: {1}", message.MessageId, ackEx.ToString());
+                    }
+                }
+                finally
+                {
+                    _pending.TryRemove(message.MessageId, out _);
+
+                    context.Dispose();
+                }
+            }
+        }
+
+        long DeliveryMetrics.DeliveryCount => _tracker.DeliveryCount;
+
+        int DeliveryMetrics.ConcurrentDeliveryCount => _tracker.MaxConcurrentDeliveryCount;
+
+        void HandleDeliveryComplete()
+        {
+            if (IsStopping)
+            {
+                if (_log.IsDebugEnabled)
+                    _log.DebugFormat("Consumer shutdown completed: {0}", _context.InputAddress);
+
+                _deliveryComplete.TrySetResult(true);
+            }
+        }
+
+        async Task WaitAndAbandonMessage(Message message)
+        {
+            try
+            {
+                await _deliveryComplete.Task.ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                if (_log.IsErrorEnabled)
+                    _log.Debug("Shutting down, deliveryComplete Faulted: {_topology.InputAddress}", exception);
+            }
+        }
+
+        protected override async Task StopSupervisor(StopSupervisorContext context)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Stopping consumer: {0}", _context.InputAddress);
+
+            SetCompleted(ActiveAndActualAgentsCompleted(context));
+
+            await Completed.ConfigureAwait(false);
+        }
+
+        async Task ActiveAndActualAgentsCompleted(StopSupervisorContext context)
+        {
+            await Task.WhenAll(context.Agents.Select(x => Completed)).UntilCompletedOrCanceled(context.CancellationToken).ConfigureAwait(false);
+
+            if (_tracker.ActiveDeliveryCount > 0)
+            {
+                try
+                {
+                    await _deliveryComplete.Task.UntilCompletedOrCanceled(context.CancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    if (_log.IsWarnEnabled)
+                        _log.WarnFormat("Stop canceled waiting for message consumers to complete: {0}", _context.InputAddress);
+                }
+            }
+
+            //try
+            //{
+            //    _messageConsumer.Close();
+            //    _messageConsumer.Dispose();
+            //}
+            //catch (OperationCanceledException)
+            //{
+            //    if (_log.IsWarnEnabled)
+            //        _log.WarnFormat("Exception canceling the consumer: {0}", _context.InputAddress);
+            //}
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsConsumerFilter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsConsumerFilter.cs
@@ -1,0 +1,91 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Pipeline
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Contexts;
+    using Events;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using Logging;
+    using Topology;
+    using Transports;
+    using Transports.Metrics;
+
+
+    /// <summary>
+    /// A filter that uses the model context to create a basic consumer and connect it to the model
+    /// </summary>
+    public class AmazonSqsConsumerFilter :
+        Supervisor,
+        IFilter<ModelContext>
+    {
+        static readonly ILog _log = Logger.Get<AmazonSqsConsumerFilter>();
+        readonly IDeadLetterTransport _deadLetterTransport;
+        readonly IErrorTransport _errorTransport;
+        readonly IReceiveObserver _receiveObserver;
+        readonly IPipe<ReceiveContext> _receivePipe;
+        readonly AmazonSqsReceiveEndpointContext _context;
+        readonly IReceiveTransportObserver _transportObserver;
+
+        public AmazonSqsConsumerFilter(IPipe<ReceiveContext> receivePipe, IReceiveObserver receiveObserver, IReceiveTransportObserver transportObserver,
+            AmazonSqsReceiveEndpointContext context, IDeadLetterTransport deadLetterTransport, IErrorTransport errorTransport)
+        {
+            _receivePipe = receivePipe;
+            _receiveObserver = receiveObserver;
+            _transportObserver = transportObserver;
+            _context = context;
+            _deadLetterTransport = deadLetterTransport;
+            _errorTransport = errorTransport;
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+        }
+
+        async Task IFilter<ModelContext>.Send(ModelContext context, IPipe<ModelContext> next)
+        {
+            var receiveSettings = context.GetPayload<ReceiveSettings>();
+
+            var inputAddress = receiveSettings.GetInputAddress(context.ConnectionContext.HostSettings.HostAddress);
+
+            var queueUrl = await context.GetQueue(receiveSettings.EntityName).ConfigureAwait(false);
+
+            var consumer = new AmazonSqsBasicConsumer(context, queueUrl, inputAddress, _receivePipe, _receiveObserver, _context, _deadLetterTransport, _errorTransport);
+
+            await context.BasicConsume(queueUrl, receiveSettings.PrefetchCount, consumer).ConfigureAwait(false);
+
+            await consumer.Ready.ConfigureAwait(false);
+
+            Add(consumer);
+
+            await _transportObserver.Ready(new ReceiveTransportReadyEvent(inputAddress)).ConfigureAwait(false);
+
+            try
+            {
+                await consumer.Completed.ConfigureAwait(false);
+            }
+            finally
+            {
+                DeliveryMetrics metrics = consumer;
+                await _transportObserver.Completed(new ReceiveTransportCompletedEvent(inputAddress, metrics)).ConfigureAwait(false);
+
+                if (_log.IsDebugEnabled)
+                    _log.DebugFormat("Consumer completed: {0} received, {0} concurrent", metrics.DeliveryCount, metrics.ConcurrentDeliveryCount);
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsConsumerFilter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsConsumerFilter.cs
@@ -66,7 +66,7 @@ namespace MassTransit.AmazonSqsTransport.Pipeline
 
             var consumer = new AmazonSqsBasicConsumer(context, queueUrl, inputAddress, _receivePipe, _receiveObserver, _context, _deadLetterTransport, _errorTransport);
 
-            await context.BasicConsume(queueUrl, receiveSettings.PrefetchCount, consumer).ConfigureAwait(false);
+            await context.BasicConsume(queueUrl, receiveSettings, consumer).ConfigureAwait(false);
 
             await consumer.Ready.ConfigureAwait(false);
 

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/ConfigureTopologyContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/ConfigureTopologyContext.cs
@@ -1,0 +1,19 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Pipeline
+{
+    public interface ConfigureTopologyContext<T>
+        where T : class
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/ConfigureTopologyFilter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/ConfigureTopologyFilter.cs
@@ -1,0 +1,120 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Pipeline
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using GreenPipes;
+    using Logging;
+    using Topology;
+    using Topology.Builders;
+    using Topology.Entities;
+
+
+    /// <summary>
+    /// Configures the broker with the supplied topology once the model is created, to ensure
+    /// that the exchanges, queues, and bindings for the model are properly configured in AmazonSQS.
+    /// </summary>
+    public class ConfigureTopologyFilter<TSettings> :
+        IFilter<ModelContext>
+        where TSettings : class
+    {
+        readonly BrokerTopology _brokerTopology;
+        readonly ILog _log = Logger.Get<ConfigureTopologyFilter<TSettings>>();
+        readonly TSettings _settings;
+
+        public ConfigureTopologyFilter(TSettings settings, BrokerTopology brokerTopology)
+        {
+            _settings = settings;
+            _brokerTopology = brokerTopology;
+        }
+
+        async Task IFilter<ModelContext>.Send(ModelContext context, IPipe<ModelContext> next)
+        {
+            await context.OneTimeSetup<ConfigureTopologyContext<TSettings>>(async payload =>
+            {
+                await ConfigureTopology(context).ConfigureAwait(false);
+
+                context.GetOrAddPayload(() => _settings);
+            }).ConfigureAwait(false);
+
+            await next.Send(context).ConfigureAwait(false);
+
+            if (_settings is ReceiveSettings)
+                await DeleteAutoDelete(context).ConfigureAwait(false);
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateFilterScope("configureTopology");
+
+            _brokerTopology.Probe(scope);
+        }
+
+        async Task ConfigureTopology(ModelContext context)
+        {
+            await Task.WhenAll(_brokerTopology.Topics.Select(topic => Declare(context, topic))).ConfigureAwait(false);
+
+            await Task.WhenAll(_brokerTopology.Queues.Select(queue => Declare(context, queue))).ConfigureAwait(false);
+
+            await Task.WhenAll(_brokerTopology.TopicSubscriptions.Select(queue => Declare(context, queue))).ConfigureAwait(false);
+        }
+
+        async Task DeleteAutoDelete(ModelContext context)
+        {
+            await Task.WhenAll(_brokerTopology.Topics.Where(x => x.AutoDelete).Select(topic => Delete(context, topic))).ConfigureAwait(false);
+
+            await Task.WhenAll(_brokerTopology.Queues.Where(x => x.AutoDelete).Select(queue => Delete(context, queue))).ConfigureAwait(false);
+        }
+
+        Task Declare(ModelContext context, Topic topic)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Declare topic ({0})", topic);
+
+            return context.GetTopic(topic.EntityName);
+        }
+
+        Task Declare(ModelContext context, TopicSubscription subscription)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Binding topic ({0}) to queue ({1})", subscription.Source, subscription.Destination);
+
+            return context.GetTopicSubscription(subscription.Source.EntityName, subscription.Destination.EntityName);
+        }
+
+        Task Declare(ModelContext context, Queue queue)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Declare queue ({0})", queue);
+
+            return context.GetQueue(queue.EntityName);
+        }
+
+        Task Delete(ModelContext context, Topic topic)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Delete topic ({0})", topic);
+
+            return context.DeleteTopic(topic.EntityName);
+        }
+
+        Task Delete(ModelContext context, Queue queue)
+        {
+            if (_log.IsDebugEnabled)
+                _log.DebugFormat("Delete queue ({0})", queue);
+
+            return context.DeleteQueue(queue.EntityName);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/ReceiveModelFilter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/ReceiveModelFilter.cs
@@ -1,0 +1,62 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Pipeline
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Contexts;
+    using GreenPipes;
+
+
+    /// <summary>
+    /// Creates a receiving model context using the connection
+    /// </summary>
+    public class ReceiveModelFilter :
+        IFilter<ConnectionContext>
+    {
+        readonly IAmazonSqsHost _host;
+        readonly IPipe<ModelContext> _pipe;
+
+        public ReceiveModelFilter(IPipe<ModelContext> pipe, IAmazonSqsHost host)
+        {
+            _pipe = pipe;
+            _host = host;
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateFilterScope("receiveModel");
+
+            _pipe.Probe(scope);
+        }
+
+        async Task IFilter<ConnectionContext>.Send(ConnectionContext context, IPipe<ConnectionContext> next)
+        {
+            var amazonSqs = await context.CreateAmazonSqs().ConfigureAwait(false);
+            var amazonSns = await context.CreateAmazonSns().ConfigureAwait(false);
+
+            var modelContext = new AmazonSqsModelContext(context, amazonSqs, amazonSns, _host, context.CancellationToken);
+
+            try
+            {
+                await _pipe.Send(modelContext).ConfigureAwait(false);
+            }
+            finally
+            {
+                await modelContext.DisposeAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
+            await next.Send(context).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Testing/AmazonSqsTestHarness.cs
+++ b/src/MassTransit.AmazonSqsTransport/Testing/AmazonSqsTestHarness.cs
@@ -1,0 +1,164 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Testing
+{
+    using System;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SQS;
+    using Configuration;
+    using MassTransit.Testing;
+
+
+    public class AmazonSqsTestHarness :
+        BusTestHarness
+    {
+        Uri _hostAddress;
+        Uri _inputQueueAddress;
+
+        public AmazonSqsTestHarness(string inputQueueName = null)
+        {
+            Username = "admin";
+            Password = "admin";
+
+            InputQueueName = inputQueueName ?? "input_queue";
+
+            HostAddress = new Uri("amazonsqs://localhost/");
+        }
+
+        public Uri HostAddress
+        {
+            get => _hostAddress;
+            set
+            {
+                _hostAddress = value;
+                _inputQueueAddress = new Uri(HostAddress, InputQueueName);
+            }
+        }
+
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public string InputQueueName { get; }
+        public IAmazonSqsHost Host { get; private set; }
+
+        public override Uri InputQueueAddress => _inputQueueAddress;
+
+        public event Action<IAmazonSqsBusFactoryConfigurator> OnConfigureAmazonSqsBus;
+        public event Action<IAmazonSqsBusFactoryConfigurator, IAmazonSqsHost> OnConfigureAmazonSqsBusHost;
+        public event Action<IAmazonSqsReceiveEndpointConfigurator> OnConfigureAmazonSqsReceiveEndoint;
+        public event Action<IAmazonSqsHostConfigurator> OnConfigureAmazonSqsHost;
+        public event Action<IAmazonSQS, IAmazonSimpleNotificationService> OnCleanupVirtualHost;
+
+        protected virtual void ConfigureAmazonSqsBus(IAmazonSqsBusFactoryConfigurator configurator)
+        {
+            OnConfigureAmazonSqsBus?.Invoke(configurator);
+        }
+
+        protected virtual void ConfigureAmazonSqsBusHost(IAmazonSqsBusFactoryConfigurator configurator, IAmazonSqsHost host)
+        {
+            OnConfigureAmazonSqsBusHost?.Invoke(configurator, host);
+        }
+
+        protected virtual void ConfigureAmazonSqsReceiveEndpoint(IAmazonSqsReceiveEndpointConfigurator configurator)
+        {
+            OnConfigureAmazonSqsReceiveEndoint?.Invoke(configurator);
+        }
+
+        protected virtual void ConfigureAmazonSqsHost(IAmazonSqsHostConfigurator configurator)
+        {
+            OnConfigureAmazonSqsHost?.Invoke(configurator);
+        }
+
+        protected virtual void CleanupVirtualHost(IAmazonSQS amazonSqs, IAmazonSimpleNotificationService amazonSns)
+        {
+            OnCleanupVirtualHost?.Invoke(amazonSqs, amazonSns);
+        }
+
+        protected virtual IAmazonSqsHost ConfigureHost(IAmazonSqsBusFactoryConfigurator configurator)
+        {
+            return configurator.Host(HostAddress, h =>
+            {
+                h.AccessKey(Username);
+                h.SecretKey(Password);
+
+                ConfigureAmazonSqsHost(h);
+            });
+        }
+
+        protected override IBusControl CreateBus()
+        {
+            return MassTransit.Bus.Factory.CreateUsingAmazonSqs(x =>
+            {
+                Host = ConfigureHost(x);
+
+                CleanUpVirtualHost(Host);
+
+                ConfigureBus(x);
+
+                ConfigureAmazonSqsBus(x);
+
+                ConfigureAmazonSqsBusHost(x, Host);
+
+                x.ReceiveEndpoint(Host, InputQueueName, e =>
+                {
+                    ConfigureReceiveEndpoint(e);
+
+                    ConfigureAmazonSqsReceiveEndpoint(e);
+
+                    _inputQueueAddress = e.InputAddress;
+                });
+            });
+        }
+
+        void CleanUpVirtualHost(IAmazonSqsHost host)
+        {
+            try
+            {
+                using (var connection = host.Settings.CreateConnection())
+                {
+                    var amazonSqs = connection.CreateAmazonSqs();
+                    var amazonSns = connection.CreateAmazonSns();
+
+                    CleanUpQueue(amazonSqs, amazonSns, "input_queue");
+
+                    CleanUpQueue(amazonSqs, amazonSns, InputQueueName);
+
+                    CleanupVirtualHost(amazonSqs, amazonSns);
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception);
+            }
+        }
+
+        static void CleanUpQueue(IAmazonSQS amazonSqs, IAmazonSimpleNotificationService amazonSns, string queueName)
+        {
+            async Task CleanUpQueue(string queue)
+            {
+                var topicArn = (await amazonSns.CreateTopicAsync(queueName)).TopicArn;
+                await amazonSns.DeleteTopicAsync(topicArn);
+
+                var queueUrl = (await amazonSqs.GetQueueUrlAsync(queue)).QueueUrl;
+                await amazonSqs.DeleteQueueAsync(queueUrl);
+            }
+
+            Task.Run(async () =>
+            {
+                await CleanUpQueue(queueName).ConfigureAwait(false);
+                await CleanUpQueue($"{queueName}_skipped").ConfigureAwait(false);
+                await CleanUpQueue($"{queueName}_error").ConfigureAwait(false);
+            });
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/AmazonSqsEntityNameValidator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/AmazonSqsEntityNameValidator.cs
@@ -1,0 +1,50 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System.Text.RegularExpressions;
+    using Exceptions;
+    using MassTransit.Topology;
+
+
+    public class AmazonSqsEntityNameValidator :
+        IEntityNameValidator
+    {
+        static readonly Regex _regex = new Regex(@"^[A-Za-z0-9\-_\.:]+$", RegexOptions.Compiled);
+
+        public void ThrowIfInvalidEntityName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new AmazonSqsTransportConfigurationException("The entity name must not be null or empty");
+
+            var success = IsValidEntityName(name);
+            if (!success)
+            {
+                throw new AmazonSqsTransportConfigurationException("The entity name must be a sequence of these characters: letters, digits, hyphen, underscore, period, or colon.");
+            }
+        }
+
+        public bool IsValidEntityName(string name)
+        {
+            return _regex.Match(name).Success;
+        }
+
+        public static IEntityNameValidator Validator => Cached.EntityNameValidator;
+
+
+        static class Cached
+        {
+            internal static readonly IEntityNameValidator EntityNameValidator = new AmazonSqsEntityNameValidator();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/AmazonSqsHostEqualityComparer.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/AmazonSqsHostEqualityComparer.cs
@@ -1,0 +1,48 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System;
+    using System.Collections.Generic;
+
+
+    public sealed class AmazonSqsHostEqualityComparer :
+        IEqualityComparer<AmazonSqsHostSettings>
+    {
+        public static IEqualityComparer<AmazonSqsHostSettings> Default { get; } = new AmazonSqsHostEqualityComparer();
+
+        public bool Equals(AmazonSqsHostSettings x, AmazonSqsHostSettings y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (ReferenceEquals(x, null))
+                return false;
+
+            if (ReferenceEquals(y, null))
+                return false;
+
+            return string.Equals(x.Region.SystemName, y.Region.SystemName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(AmazonSqsHostSettings obj)
+        {
+            unchecked
+            {
+                var hashCode = obj.AccessKey?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ obj.Region?.GetHashCode() ?? 0;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/AmazonSqsBrokerTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/AmazonSqsBrokerTopology.cs
@@ -47,8 +47,8 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
 
             foreach (var queue in Queues)
             {
-                var exchangeScope = context.CreateScope("queue");
-                exchangeScope.Set(new
+                var queueScope = context.CreateScope("queue");
+                queueScope.Set(new
                 {
                     Name = queue.EntityName,
                     queue.Durable,
@@ -56,14 +56,13 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
                 });
             }
 
-            foreach (var binding in TopicSubscriptions)
+            foreach (var subscription in TopicSubscriptions)
             {
-                var exchangeScope = context.CreateScope("topicSubscription");
-                exchangeScope.Set(new
+                var subscriptionScope = context.CreateScope("topicSubscription");
+                subscriptionScope.Set(new
                 {
-                    Source = binding.Source.EntityName,
-                    Destination = binding.Destination.EntityName,
-                    RoutingKey = binding.Selector
+                    Source = subscription.Source.EntityName,
+                    Destination = subscription.Destination.EntityName
                 });
             }
         }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/AmazonSqsBrokerTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/AmazonSqsBrokerTopology.cs
@@ -1,0 +1,71 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Entities;
+    using GreenPipes;
+
+
+    public class AmazonSqsBrokerTopology :
+        BrokerTopology
+    {
+        public AmazonSqsBrokerTopology(IEnumerable<Topic> exchanges, IEnumerable<Queue> queues, IEnumerable<TopicSubscription> consumers)
+        {
+            Topics = exchanges.ToArray();
+            Queues = queues.ToArray();
+            TopicSubscriptions = consumers.ToArray();
+        }
+
+        public Topic[] Topics { get; }
+        public Queue[] Queues { get; }
+        public TopicSubscription[] TopicSubscriptions { get; }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            foreach (var topic in Topics)
+            {
+                var topicScope = context.CreateScope("topic");
+                topicScope.Set(new
+                {
+                    Name = topic.EntityName,
+                    topic.Durable,
+                    topic.AutoDelete
+                });
+            }
+
+            foreach (var queue in Queues)
+            {
+                var exchangeScope = context.CreateScope("queue");
+                exchangeScope.Set(new
+                {
+                    Name = queue.EntityName,
+                    queue.Durable,
+                    queue.AutoDelete
+                });
+            }
+
+            foreach (var binding in TopicSubscriptions)
+            {
+                var exchangeScope = context.CreateScope("topicSubscription");
+                exchangeScope.Set(new
+                {
+                    Source = binding.Source.EntityName,
+                    Destination = binding.Destination.EntityName,
+                    RoutingKey = binding.Selector
+                });
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopology.cs
@@ -1,0 +1,26 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using Entities;
+    using GreenPipes;
+
+
+    public interface BrokerTopology :
+        IProbeSite
+    {
+        Topic[] Topics { get; }
+        Queue[] Queues { get; }
+        TopicSubscription[] TopicSubscriptions { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopologyBuilder.cs
@@ -1,0 +1,70 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using System.Threading;
+    using Entities;
+    using MassTransit.Topology.Entities;
+
+
+    public abstract class BrokerTopologyBuilder
+    {
+        long _nextId;
+        protected NamedEntityCollection<TopicSubscriptionEntity, TopicSubscriptionHandle> TopicSubscriptions;
+        protected NamedEntityCollection<TopicEntity, TopicHandle> Topics;
+        protected NamedEntityCollection<QueueEntity, QueueHandle> Queues;
+
+        protected BrokerTopologyBuilder()
+        {
+            Topics = new NamedEntityCollection<TopicEntity, TopicHandle>(TopicEntity.EntityComparer, TopicEntity.NameComparer);
+            Queues = new NamedEntityCollection<QueueEntity, QueueHandle>(QueueEntity.QueueComparer, QueueEntity.NameComparer);
+            TopicSubscriptions = new NamedEntityCollection<TopicSubscriptionEntity, TopicSubscriptionHandle>(TopicSubscriptionEntity.EntityComparer, TopicSubscriptionEntity.NameComparer);
+        }
+
+        long GetNextId()
+        {
+            return Interlocked.Increment(ref _nextId);
+        }
+
+        public TopicHandle CreateTopic(string name, bool durable, bool autoDelete)
+        {
+            var id = GetNextId();
+
+            var exchange = new TopicEntity(id, name, durable, autoDelete);
+
+            return Topics.GetOrAdd(exchange);
+        }
+
+        public QueueHandle CreateQueue(string name, bool durable, bool autoDelete)
+        {
+            var id = GetNextId();
+
+            var queue = new QueueEntity(id, name, durable, autoDelete);
+
+            return Queues.GetOrAdd(queue);
+        }
+
+        public TopicSubscriptionHandle BindQueue(TopicHandle topic, QueueHandle queue, string selector)
+        {
+            var id = GetNextId();
+
+            var topicEntity = Topics.Get(topic);
+
+            var queueEntity = Queues.Get(queue);
+
+            var binding = new TopicSubscriptionEntity(id, topicEntity, queueEntity, selector);
+
+            return TopicSubscriptions.GetOrAdd(binding);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopologyBuilder.cs
@@ -40,21 +40,21 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
         {
             var id = GetNextId();
 
-            var exchange = new TopicEntity(id, name, durable, autoDelete);
+            var topicEntity = new TopicEntity(id, name, durable, autoDelete);
 
-            return Topics.GetOrAdd(exchange);
+            return Topics.GetOrAdd(topicEntity);
         }
 
         public QueueHandle CreateQueue(string name, bool durable, bool autoDelete)
         {
             var id = GetNextId();
 
-            var queue = new QueueEntity(id, name, durable, autoDelete);
+            var queueEntity = new QueueEntity(id, name, durable, autoDelete);
 
-            return Queues.GetOrAdd(queue);
+            return Queues.GetOrAdd(queueEntity);
         }
 
-        public TopicSubscriptionHandle BindQueue(TopicHandle topic, QueueHandle queue, string selector)
+        public TopicSubscriptionHandle CreateTopicSubscription(TopicHandle topic, QueueHandle queue)
         {
             var id = GetNextId();
 
@@ -62,7 +62,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
 
             var queueEntity = Queues.Get(queue);
 
-            var binding = new TopicSubscriptionEntity(id, topicEntity, queueEntity, selector);
+            var binding = new TopicSubscriptionEntity(id, topicEntity, queueEntity);
 
             return TopicSubscriptions.GetOrAdd(binding);
         }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/IPublishEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/IPublishEndpointBrokerTopologyBuilder.cs
@@ -1,0 +1,31 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using Entities;
+
+
+    /// <summary>
+    /// A builder for creating the topology when publishing a message
+    /// </summary>
+    public interface IPublishEndpointBrokerTopologyBuilder :
+        IBrokerTopologyBuilder
+    {
+        /// <summary>
+        /// The exchange to which the message is published
+        /// </summary>
+        TopicHandle Topic { get; set; }
+
+        IPublishEndpointBrokerTopologyBuilder CreateImplementedBuilder();
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/IReceiveEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/IReceiveEndpointBrokerTopologyBuilder.cs
@@ -1,0 +1,31 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using Entities;
+
+
+    /// <summary>
+    /// A unique builder context should be created for each specification, so that the items added
+    /// by it can be combined together into a group - so that if a subsequent specification yanks
+    /// something that conflicts, the system can yank the group or warn that it's impacted.
+    /// </summary>
+    public interface IReceiveEndpointBrokerTopologyBuilder :
+        IBrokerTopologyBuilder
+    {
+        /// <summary>
+        /// A handle to the consuming queue
+        /// </summary>
+        QueueHandle Queue { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
@@ -1,0 +1,86 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using Entities;
+
+
+    public class PublishEndpointBrokerTopologyBuilder :
+        BrokerTopologyBuilder,
+        IPublishEndpointBrokerTopologyBuilder
+    {
+        readonly PublishBrokerTopologyOptions _options;
+
+        public PublishEndpointBrokerTopologyBuilder(PublishBrokerTopologyOptions options = PublishBrokerTopologyOptions.FlattenHierarchy)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        /// The exchange to which the published message is sent
+        /// </summary>
+        public TopicHandle Topic { get; set; }
+
+        public IPublishEndpointBrokerTopologyBuilder CreateImplementedBuilder()
+        {
+            if (_options.HasFlag(PublishBrokerTopologyOptions.MaintainHierarchy))
+                return new ImplementedBuilder(this, _options);
+
+            return this;
+        }
+
+        public BrokerTopology BuildBrokerTopology()
+        {
+            return new AmazonSqsBrokerTopology(Topics, Queues, TopicSubscriptions);
+        }
+
+
+        protected class ImplementedBuilder :
+            IPublishEndpointBrokerTopologyBuilder
+        {
+            readonly IPublishEndpointBrokerTopologyBuilder _builder;
+            readonly PublishBrokerTopologyOptions _options;
+
+            public ImplementedBuilder(IPublishEndpointBrokerTopologyBuilder builder, PublishBrokerTopologyOptions options)
+            {
+                _builder = builder;
+                _options = options;
+            }
+
+            public TopicHandle Topic { get; set; }
+
+            public IPublishEndpointBrokerTopologyBuilder CreateImplementedBuilder()
+            {
+                if (_options.HasFlag(PublishBrokerTopologyOptions.MaintainHierarchy))
+                    return new ImplementedBuilder(this, _options);
+
+                return this;
+            }
+
+            public TopicHandle CreateTopic(string name, bool durable, bool autoDelete)
+            {
+                return _builder.CreateTopic(name, durable, autoDelete);
+            }
+
+            public QueueHandle CreateQueue(string name, bool durable, bool autoDelete)
+            {
+                return _builder.CreateQueue(name, durable, autoDelete);
+            }
+
+            public TopicSubscriptionHandle BindQueue(TopicHandle topic, QueueHandle queue, string selector)
+            {
+                return _builder.BindQueue(topic, queue, selector);
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
@@ -77,9 +77,9 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
                 return _builder.CreateQueue(name, durable, autoDelete);
             }
 
-            public TopicSubscriptionHandle BindQueue(TopicHandle topic, QueueHandle queue, string selector)
+            public TopicSubscriptionHandle CreateTopicSubscription(TopicHandle topic, QueueHandle queue)
             {
-                return _builder.BindQueue(topic, queue, selector);
+                return _builder.CreateTopicSubscription(topic, queue);
             }
         }
     }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/ReceiveEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/ReceiveEndpointBrokerTopologyBuilder.cs
@@ -1,0 +1,29 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using Entities;
+
+
+    public class ReceiveEndpointBrokerTopologyBuilder :
+        BrokerTopologyBuilder,
+        IReceiveEndpointBrokerTopologyBuilder
+    {
+        public QueueHandle Queue { get; set; }
+
+        public BrokerTopology BuildTopologyLayout()
+        {
+            return new AmazonSqsBrokerTopology(Topics, Queues, TopicSubscriptions);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/ReceiveEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/ReceiveEndpointBrokerTopologyBuilder.cs
@@ -19,6 +19,8 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
         BrokerTopologyBuilder,
         IReceiveEndpointBrokerTopologyBuilder
     {
+        public TopicHandle Topic { get; set; }
+
         public QueueHandle Queue { get; set; }
 
         public BrokerTopology BuildTopologyLayout()

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/TopologyLayoutExtensions.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/TopologyLayoutExtensions.cs
@@ -28,8 +28,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
 
             foreach (var consumer in layout.TopicSubscriptions)
             {
-                _log.InfoFormat("TopicSubscription: source {0}, destination: {1}, selector: {2}", consumer.Source.EntityName, consumer.Destination.EntityName,
-                    consumer.Selector);
+                _log.InfoFormat("TopicSubscription: source {0}, destination: {1}", consumer.Source.EntityName, consumer.Destination.EntityName);
             }
         }
     }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/TopologyLayoutExtensions.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/TopologyLayoutExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Builders
+{
+    using Logging;
+
+
+    public static class TopologyLayoutExtensions
+    {
+        static readonly ILog _log = Logger.Get<BrokerTopology>();
+
+        public static void LogResult(this BrokerTopology layout)
+        {
+            foreach (var topic in layout.Topics)
+            {
+                _log.InfoFormat("Topic: {0}, type: {1}, durable: {2}, auto-delete: {3}", topic.EntityName, topic.Durable, topic.AutoDelete);
+            }
+
+            foreach (var consumer in layout.TopicSubscriptions)
+            {
+                _log.InfoFormat("TopicSubscription: source {0}, destination: {1}, selector: {2}", consumer.Source.EntityName, consumer.Destination.EntityName,
+                    consumer.Selector);
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/EntityConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/EntityConfigurator.cs
@@ -1,0 +1,40 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
+{
+    using System.Collections.Generic;
+
+
+    public abstract class EntityConfigurator
+    {
+        protected EntityConfigurator(string entityName, bool durable = true, bool autoDelete = false)
+        {
+            EntityName = entityName;
+            Durable = durable;
+            AutoDelete = autoDelete;
+        }
+
+        public bool Durable { get; set; }
+        public bool AutoDelete { get; set; }
+        public string EntityName { get; }
+
+        protected virtual IEnumerable<string> GetQueryStringOptions()
+        {
+            if (!Durable)
+                yield return "durable=false";
+
+            if (AutoDelete)
+                yield return "autodelete=true";
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueBindingConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueBindingConfigurator.cs
@@ -23,7 +23,5 @@ namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
             : base(queueName, durable, autoDelete)
         {
         }
-
-        public string Selector { get; set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueBindingConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueBindingConfigurator.cs
@@ -1,0 +1,29 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
+{
+    using AmazonSqsTransport.Configuration;
+
+
+    public class QueueBindingConfigurator :
+        QueueConfigurator,
+        IQueueBindingConfigurator
+    {
+        public QueueBindingConfigurator(string queueName, bool durable, bool autoDelete)
+            : base(queueName, durable, autoDelete)
+        {
+        }
+
+        public string Selector { get; set; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
@@ -1,0 +1,36 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
+{
+    using AmazonSqsTransport.Configuration;
+    using Entities;
+
+
+    public class QueueConfigurator :
+        EntityConfigurator,
+        IQueueConfigurator,
+        Queue
+    {
+        public QueueConfigurator(string queueName, bool durable = true, bool autoDelete = false)
+            : base(queueName, durable, autoDelete)
+        {
+        }
+
+        public QueueConfigurator(Queue source)
+            : base(source.EntityName, source.Durable, source.AutoDelete)
+        {
+        }
+
+        public bool Lazy { get; set; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicBindingConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicBindingConfigurator.cs
@@ -1,0 +1,37 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
+{
+    using AmazonSqsTransport.Configuration;
+    using Entities;
+
+
+    public class TopicBindingConfigurator :
+        TopicConfigurator,
+        ITopicBindingConfigurator
+    {
+        public TopicBindingConfigurator(string topicName, bool durable = true, bool autoDelete = false, string selector = null)
+            : base(topicName, durable, autoDelete)
+        {
+            Selector = selector;
+        }
+
+        public TopicBindingConfigurator(Topic topic, string selector = null)
+            : base(topic)
+        {
+            Selector = selector;
+        }
+
+        public string Selector { get; set; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
@@ -1,0 +1,34 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
+{
+    using AmazonSqsTransport.Configuration;
+    using Entities;
+
+
+    public class TopicConfigurator :
+        EntityConfigurator,
+        ITopicConfigurator,
+        Topic
+    {
+        public TopicConfigurator(string topicName, bool durable = true, bool autoDelete = false)
+            : base(topicName, durable, autoDelete)
+        {
+        }
+
+        public TopicConfigurator(Topic source)
+            : base(source.EntityName, source.Durable, source.AutoDelete)
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicSubscriptionConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicSubscriptionConfigurator.cs
@@ -16,22 +16,18 @@ namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
     using Entities;
 
 
-    public class TopicBindingConfigurator :
+    public class TopicSubscriptionConfigurator :
         TopicConfigurator,
         ITopicBindingConfigurator
     {
-        public TopicBindingConfigurator(string topicName, bool durable = true, bool autoDelete = false, string selector = null)
+        public TopicSubscriptionConfigurator(string topicName, bool durable = true, bool autoDelete = false)
             : base(topicName, durable, autoDelete)
         {
-            Selector = selector;
         }
 
-        public TopicBindingConfigurator(Topic topic, string selector = null)
+        public TopicSubscriptionConfigurator(Topic topic)
             : base(topic)
         {
-            Selector = selector;
         }
-
-        public string Selector { get; set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsConsumeTopologyConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsConsumeTopologyConfigurator.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration
+{
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsConsumeTopologyConfigurator :
+        IConsumeTopologyConfigurator,
+        IAmazonSqsConsumeTopology
+    {
+        new IAmazonSqsMessageConsumeTopologyConfigurator<T> GetMessageTopology<T>()
+            where T : class;
+
+        void AddSpecification(IAmazonSqsConsumeTopologySpecification specification);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsConsumeTopologySpecification.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsConsumeTopologySpecification.cs
@@ -1,0 +1,24 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration
+{
+    using Builders;
+    using GreenPipes;
+
+
+    public interface IAmazonSqsConsumeTopologySpecification :
+        ISpecification
+    {
+        void Apply(IReceiveEndpointBrokerTopologyBuilder builder);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsMessageConsumeTopologyConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsMessageConsumeTopologyConfigurator.cs
@@ -1,0 +1,43 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration
+{
+    using System;
+    using AmazonSqsTransport.Configuration;
+    using Builders;
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsMessageConsumeTopologyConfigurator<TMessage> :
+        IMessageConsumeTopologyConfigurator<TMessage>,
+        IAmazonSqsMessageConsumeTopology<TMessage>
+        where TMessage : class
+    {
+        /// <summary>
+        /// Adds the exchange bindings for this message type
+        /// </summary>
+        /// <param name="configure">Configure the binding and the exchange</param>
+        void Bind(Action<ITopicBindingConfigurator> configure = null);
+    }
+
+
+    public interface IAmazonSqsMessageConsumeTopologyConfigurator :
+        IMessageConsumeTopologyConfigurator
+    {
+        /// <summary>
+        /// Apply the message topology to the builder
+        /// </summary>
+        /// <param name="builder"></param>
+        void Apply(IReceiveEndpointBrokerTopologyBuilder builder);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsMessagePublishTopologyConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsMessagePublishTopologyConfigurator.cs
@@ -1,0 +1,34 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration
+{
+    using AmazonSqsTransport.Configuration;
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsMessagePublishTopologyConfigurator<TMessage> :
+        IMessagePublishTopologyConfigurator<TMessage>,
+        IAmazonSqsMessagePublishTopology<TMessage>,
+        IAmazonSqsMessagePublishTopologyConfigurator
+        where TMessage : class
+    {
+    }
+
+
+    public interface IAmazonSqsMessagePublishTopologyConfigurator :
+        IMessagePublishTopologyConfigurator,
+        IAmazonSqsMessagePublishTopology,
+        ITopicConfigurator
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsMessageSendTopologyConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsMessageSendTopologyConfigurator.cs
@@ -1,0 +1,31 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration
+{
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsMessageSendTopologyConfigurator<TMessage> :
+        IMessageSendTopologyConfigurator<TMessage>,
+        IAmazonSqsMessageSendTopology<TMessage>,
+        IAmazonSqsMessageSendTopologyConfigurator
+        where TMessage : class
+    {
+    }
+
+
+    public interface IAmazonSqsMessageSendTopologyConfigurator :
+        IMessageSendTopologyConfigurator
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsPublishTopologyConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsPublishTopologyConfigurator.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration
+{
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsPublishTopologyConfigurator :
+        IPublishTopologyConfigurator,
+        IAmazonSqsPublishTopology
+    {
+        new IAmazonSqsMessagePublishTopologyConfigurator<T> GetMessageTopology<T>()
+            where T : class;
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsSendTopologyConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsSendTopologyConfigurator.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration
+{
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsSendTopologyConfigurator :
+        ISendTopologyConfigurator,
+        IAmazonSqsSendTopology
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/ConsumerConsumeTopologySpecification.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/ConsumerConsumeTopologySpecification.cs
@@ -1,0 +1,54 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Specifications
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Builders;
+    using Entities;
+    using Configurators;
+    using GreenPipes;
+
+
+    /// <summary>
+    /// Used to by a TopicSubscription virtual destination to the receive endpoint, via an additional message consumer
+    /// </summary>
+    public class ConsumerConsumeTopologySpecification :
+        TopicBindingConfigurator,
+        IAmazonSqsConsumeTopologySpecification
+    {
+        public ConsumerConsumeTopologySpecification(string topicName, bool durable = true, bool autoDelete = false)
+            : base(topicName, durable, autoDelete)
+        {
+        }
+
+        public ConsumerConsumeTopologySpecification(Topic topic)
+            : base(topic)
+        {
+        }
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
+        {
+            var topicHandle = builder.CreateTopic(EntityName, Durable, AutoDelete);
+
+            var queueHandle = builder.CreateQueue(builder.Queue.Queue.EntityName, Durable, AutoDelete);
+
+            var topicSubscriptionHandle = builder.BindQueue(topicHandle, queueHandle, Selector);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/ConsumerConsumeTopologySpecification.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/ConsumerConsumeTopologySpecification.cs
@@ -21,10 +21,10 @@ namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Specifications
 
 
     /// <summary>
-    /// Used to by a TopicSubscription virtual destination to the receive endpoint, via an additional message consumer
+    /// Used to by a TopicSubscription destination to the receive endpoint, via an additional message consumer
     /// </summary>
     public class ConsumerConsumeTopologySpecification :
-        TopicBindingConfigurator,
+        TopicSubscriptionConfigurator,
         IAmazonSqsConsumeTopologySpecification
     {
         public ConsumerConsumeTopologySpecification(string topicName, bool durable = true, bool autoDelete = false)
@@ -46,9 +46,10 @@ namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Specifications
         {
             var topicHandle = builder.CreateTopic(EntityName, Durable, AutoDelete);
 
-            var queueHandle = builder.CreateQueue(builder.Queue.Queue.EntityName, Durable, AutoDelete);
+            var builderQueue = builder.Queue.Queue;
+            var queueHandle = builder.CreateQueue(builderQueue.EntityName, builderQueue.Durable, builderQueue.AutoDelete);
 
-            var topicSubscriptionHandle = builder.BindQueue(topicHandle, queueHandle, Selector);
+            var topicSubscriptionHandle = builder.CreateTopicSubscription(topicHandle, queueHandle);
         }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/InvalidAmazonSqsConsumeTopologySpecification.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/InvalidAmazonSqsConsumeTopologySpecification.cs
@@ -1,0 +1,41 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Specifications
+{
+    using System.Collections.Generic;
+    using Builders;
+    using GreenPipes;
+
+
+    public class InvalidAmazonSqsConsumeTopologySpecification :
+        IAmazonSqsConsumeTopologySpecification
+    {
+        readonly string _key;
+        readonly string _message;
+
+        public InvalidAmazonSqsConsumeTopologySpecification(string key, string message)
+        {
+            _key = key;
+            _message = message;
+        }
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            yield return this.Failure(_key, _message);
+        }
+
+        public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
+        {
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/DeadLetterSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/DeadLetterSettings.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using Builders;
+
+
+    public interface DeadLetterSettings :
+        EntitySettings
+    {
+        /// <summary>
+        /// Return the BrokerTopology to apply at startup (to create exchange and queue if binding is specified)
+        /// </summary>
+        /// <returns></returns>
+        BrokerTopology GetBrokerTopology();
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/Queue.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/Queue.cs
@@ -31,10 +31,5 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         /// True if the queue should be deleted when the connection is closed
         /// </summary>
         bool AutoDelete { get; }
-
-        /// <summary>
-        /// True if the queue should limit broker memory usage
-        /// </summary>
-        bool Lazy { get; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/Queue.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/Queue.cs
@@ -1,0 +1,40 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    /// <summary>
+    /// The queue details used to declare the queue to AmazonSQS
+    /// </summary>
+    public interface Queue
+    {
+        /// <summary>
+        /// The queue name
+        /// </summary>
+        string EntityName { get; }
+
+        /// <summary>
+        /// True if the queue should be durable, and survive a broker restart
+        /// </summary>
+        bool Durable { get; }
+
+        /// <summary>
+        /// True if the queue should be deleted when the connection is closed
+        /// </summary>
+        bool AutoDelete { get; }
+
+        /// <summary>
+        /// True if the queue should limit broker memory usage
+        /// </summary>
+        bool Lazy { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueEntity.cs
@@ -1,0 +1,103 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+
+    public class QueueEntity :
+        Queue,
+        QueueHandle
+    {
+        public QueueEntity(long id, string name, bool durable, bool autoDelete, bool lazy = false)
+        {
+            Id = id;
+            EntityName = name;
+            Durable = durable;
+            AutoDelete = autoDelete;
+            Lazy = lazy;
+        }
+
+        public static IEqualityComparer<QueueEntity> NameComparer { get; } = new NameEqualityComparer();
+
+        public static IEqualityComparer<QueueEntity> QueueComparer { get; } = new QueueEntityEqualityComparer();
+
+        public string EntityName { get; }
+        public bool Durable { get; }
+        public bool AutoDelete { get; }
+        public bool Lazy { get; }
+        public long Id { get; }
+        public Queue Queue => this;
+
+        public override string ToString()
+        {
+            return string.Join(", ", new[]
+            {
+                $"name: {EntityName}",
+                Durable ? "durable" : "",
+                AutoDelete ? "auto-delete" : "",
+            }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        }
+
+
+        sealed class QueueEntityEqualityComparer : IEqualityComparer<QueueEntity>
+        {
+            public bool Equals(QueueEntity x, QueueEntity y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+                if (ReferenceEquals(x, null))
+                    return false;
+                if (ReferenceEquals(y, null))
+                    return false;
+                if (x.GetType() != y.GetType())
+                    return false;
+                return string.Equals(x.EntityName, y.EntityName) && x.Durable == y.Durable && x.AutoDelete == y.AutoDelete;
+            }
+
+            public int GetHashCode(QueueEntity obj)
+            {
+                unchecked
+                {
+                    var hashCode = obj.EntityName.GetHashCode();
+                    hashCode = (hashCode * 397) ^ obj.Durable.GetHashCode();
+                    hashCode = (hashCode * 397) ^ obj.AutoDelete.GetHashCode();
+                    return hashCode;
+                }
+            }
+        }
+
+
+        sealed class NameEqualityComparer : IEqualityComparer<QueueEntity>
+        {
+            public bool Equals(QueueEntity x, QueueEntity y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+                if (ReferenceEquals(x, null))
+                    return false;
+                if (ReferenceEquals(y, null))
+                    return false;
+                if (x.GetType() != y.GetType())
+                    return false;
+                return string.Equals(x.EntityName, y.EntityName);
+            }
+
+            public int GetHashCode(QueueEntity obj)
+            {
+                return obj.EntityName.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueEntity.cs
@@ -20,13 +20,12 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         Queue,
         QueueHandle
     {
-        public QueueEntity(long id, string name, bool durable, bool autoDelete, bool lazy = false)
+        public QueueEntity(long id, string name, bool durable, bool autoDelete)
         {
             Id = id;
             EntityName = name;
             Durable = durable;
             AutoDelete = autoDelete;
-            Lazy = lazy;
         }
 
         public static IEqualityComparer<QueueEntity> NameComparer { get; } = new NameEqualityComparer();
@@ -36,7 +35,6 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         public string EntityName { get; }
         public bool Durable { get; }
         public bool AutoDelete { get; }
-        public bool Lazy { get; }
         public long Id { get; }
         public Queue Queue => this;
 

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueHandle.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueHandle.cs
@@ -1,0 +1,23 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    using MassTransit.Topology.Entities;
+
+
+    public interface QueueHandle :
+        EntityHandle
+    {
+        Queue Queue { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/Topic.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/Topic.cs
@@ -1,0 +1,35 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    /// <summary>
+    /// The exchange details used to declare the exchange to AmazonSQS
+    /// </summary>
+    public interface Topic
+    {
+        /// <summary>
+        /// The exchange name
+        /// </summary>
+        string EntityName { get; }
+
+        /// <summary>
+        /// True if the exchange should be durable, and survive a broker restart
+        /// </summary>
+        bool Durable { get; }
+
+        /// <summary>
+        /// True if the exchange should be deleted when the connection is closed
+        /// </summary>
+        bool AutoDelete { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicEntity.cs
@@ -1,0 +1,110 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+
+    public class TopicEntity :
+        Topic,
+        TopicHandle
+    {
+        public TopicEntity(long id, string name, bool durable, bool autoDelete)
+        {
+            Id = id;
+            EntityName = name;
+            Durable = durable;
+            AutoDelete = autoDelete;
+        }
+
+        public static IEqualityComparer<TopicEntity> NameComparer { get; } = new NameEqualityComparer();
+
+        public static IEqualityComparer<TopicEntity> EntityComparer { get; } = new ExchangeEntityEqualityComparer();
+
+        public string EntityName { get; }
+        public bool Durable { get; }
+        public bool AutoDelete { get; }
+        public long Id { get; }
+        public Topic Topic => this;
+
+        public override string ToString()
+        {
+            return string.Join(", ", new[]
+            {
+                $"name: {EntityName}",
+                Durable ? "durable" : "",
+                AutoDelete ? "auto-delete" : ""
+            }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        }
+
+
+        sealed class NameEqualityComparer : IEqualityComparer<TopicEntity>
+        {
+            public bool Equals(TopicEntity x, TopicEntity y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return string.Equals(x.EntityName, y.EntityName);
+            }
+
+            public int GetHashCode(TopicEntity obj)
+            {
+                return obj.EntityName.GetHashCode();
+            }
+        }
+
+
+        sealed class ExchangeEntityEqualityComparer :
+            IEqualityComparer<TopicEntity>
+        {
+            public bool Equals(TopicEntity x, TopicEntity y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return string.Equals(x.EntityName, y.EntityName) && x.Durable == y.Durable && x.AutoDelete == y.AutoDelete;
+            }
+
+            public int GetHashCode(TopicEntity obj)
+            {
+                unchecked
+                {
+                    var hashCode = obj.EntityName.GetHashCode();
+                    hashCode = (hashCode * 397) ^ obj.Durable.GetHashCode();
+                    hashCode = (hashCode * 397) ^ obj.AutoDelete.GetHashCode();
+                    return hashCode;
+                }
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicEntity.cs
@@ -30,7 +30,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
 
         public static IEqualityComparer<TopicEntity> NameComparer { get; } = new NameEqualityComparer();
 
-        public static IEqualityComparer<TopicEntity> EntityComparer { get; } = new ExchangeEntityEqualityComparer();
+        public static IEqualityComparer<TopicEntity> EntityComparer { get; } = new TopicEntityEqualityComparer();
 
         public string EntityName { get; }
         public bool Durable { get; }
@@ -75,7 +75,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         }
 
 
-        sealed class ExchangeEntityEqualityComparer :
+        sealed class TopicEntityEqualityComparer :
             IEqualityComparer<TopicEntity>
         {
             public bool Equals(TopicEntity x, TopicEntity y)

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicHandle.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicHandle.cs
@@ -1,0 +1,23 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    using MassTransit.Topology.Entities;
+
+
+    public interface TopicHandle :
+        EntityHandle
+    {
+        Topic Topic { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscription.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscription.cs
@@ -13,23 +13,18 @@
 namespace MassTransit.AmazonSqsTransport.Topology.Entities
 {
     /// <summary>
-    /// The exchange to queue binding details to declare the binding to AmazonSQS
+    /// The topic to queue binding details to declare the binding to AmazonSQS
     /// </summary>
     public interface TopicSubscription
     {
         /// <summary>
-        /// The virtual topic
+        /// The topic
         /// </summary>
         Topic Source { get; }
 
         /// <summary>
-        /// The virtual topic consumer
+        /// The queue
         /// </summary>
         Queue Destination { get; }
-
-        /// <summary>
-        /// A routing key for the exchange binding
-        /// </summary>
-        string Selector { get; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscription.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscription.cs
@@ -1,0 +1,35 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    /// <summary>
+    /// The exchange to queue binding details to declare the binding to AmazonSQS
+    /// </summary>
+    public interface TopicSubscription
+    {
+        /// <summary>
+        /// The virtual topic
+        /// </summary>
+        Topic Source { get; }
+
+        /// <summary>
+        /// The virtual topic consumer
+        /// </summary>
+        Queue Destination { get; }
+
+        /// <summary>
+        /// A routing key for the exchange binding
+        /// </summary>
+        string Selector { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscriptionEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscriptionEntity.cs
@@ -23,10 +23,9 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         readonly QueueEntity _queue;
         readonly TopicEntity _topic;
 
-        public TopicSubscriptionEntity(long id, TopicEntity topic, QueueEntity queue, string selector)
+        public TopicSubscriptionEntity(long id, TopicEntity topic, QueueEntity queue)
         {
             Id = id;
-            Selector = selector;
             _topic = topic;
             _queue = queue;
         }
@@ -36,7 +35,6 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
 
         public Topic Source => _topic.Topic;
         public Queue Destination => _queue.Queue;
-        public string Selector { get; }
 
         public long Id { get; }
         public TopicSubscription TopicSubscription => this;
@@ -46,8 +44,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
             return string.Join(", ", new[]
             {
                 $"source: {Source.EntityName}",
-                $"destination: {Destination.EntityName}",
-                string.IsNullOrWhiteSpace(Selector) ? "" : $"selector: {Selector}"
+                $"destination: {Destination.EntityName}"
             }.Where(x => !string.IsNullOrWhiteSpace(x)));
         }
 
@@ -68,7 +65,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
                 if (x.GetType() != y.GetType())
                     return false;
 
-                return x._topic.Equals(y._topic) && x._queue.Equals(y._queue) && string.Equals(x.Selector, y.Selector);
+                return x._topic.Equals(y._topic) && x._queue.Equals(y._queue);
             }
 
             public int GetHashCode(TopicSubscriptionEntity obj)
@@ -77,8 +74,6 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
                 {
                     var hashCode = obj._topic.GetHashCode();
                     hashCode = (hashCode * 397) ^ obj._queue.GetHashCode();
-                    if (obj.Selector != null)
-                        hashCode = (hashCode * 397) ^ obj.Selector.GetHashCode();
 
                     return hashCode;
                 }
@@ -102,12 +97,12 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
                 if (x.GetType() != y.GetType())
                     return false;
 
-                return string.Equals(x._queue.EntityName, y._queue.EntityName);
+                return string.Equals(x._topic.EntityName, y._topic.EntityName);
             }
 
             public int GetHashCode(TopicSubscriptionEntity obj)
             {
-                return obj._queue.EntityName.GetHashCode();
+                return obj._topic.EntityName.GetHashCode();
             }
         }
     }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscriptionEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscriptionEntity.cs
@@ -1,0 +1,114 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+
+    public class TopicSubscriptionEntity :
+        TopicSubscription,
+        TopicSubscriptionHandle
+    {
+        readonly QueueEntity _queue;
+        readonly TopicEntity _topic;
+
+        public TopicSubscriptionEntity(long id, TopicEntity topic, QueueEntity queue, string selector)
+        {
+            Id = id;
+            Selector = selector;
+            _topic = topic;
+            _queue = queue;
+        }
+
+        public static IEqualityComparer<TopicSubscriptionEntity> NameComparer { get; } = new NameEqualityComparer();
+        public static IEqualityComparer<TopicSubscriptionEntity> EntityComparer { get; } = new ConsumerEntityEqualityComparer();
+
+        public Topic Source => _topic.Topic;
+        public Queue Destination => _queue.Queue;
+        public string Selector { get; }
+
+        public long Id { get; }
+        public TopicSubscription TopicSubscription => this;
+
+        public override string ToString()
+        {
+            return string.Join(", ", new[]
+            {
+                $"source: {Source.EntityName}",
+                $"destination: {Destination.EntityName}",
+                string.IsNullOrWhiteSpace(Selector) ? "" : $"selector: {Selector}"
+            }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        }
+
+
+        sealed class ConsumerEntityEqualityComparer : IEqualityComparer<TopicSubscriptionEntity>
+        {
+            public bool Equals(TopicSubscriptionEntity x, TopicSubscriptionEntity y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return x._topic.Equals(y._topic) && x._queue.Equals(y._queue) && string.Equals(x.Selector, y.Selector);
+            }
+
+            public int GetHashCode(TopicSubscriptionEntity obj)
+            {
+                unchecked
+                {
+                    var hashCode = obj._topic.GetHashCode();
+                    hashCode = (hashCode * 397) ^ obj._queue.GetHashCode();
+                    if (obj.Selector != null)
+                        hashCode = (hashCode * 397) ^ obj.Selector.GetHashCode();
+
+                    return hashCode;
+                }
+            }
+        }
+
+
+        sealed class NameEqualityComparer : IEqualityComparer<TopicSubscriptionEntity>
+        {
+            public bool Equals(TopicSubscriptionEntity x, TopicSubscriptionEntity y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return string.Equals(x._queue.EntityName, y._queue.EntityName);
+            }
+
+            public int GetHashCode(TopicSubscriptionEntity obj)
+            {
+                return obj._queue.EntityName.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscriptionHandle.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicSubscriptionHandle.cs
@@ -1,0 +1,11 @@
+namespace MassTransit.AmazonSqsTransport.Topology.Entities
+{
+    using MassTransit.Topology.Entities;
+
+
+    public interface TopicSubscriptionHandle :
+        EntityHandle
+    {
+        TopicSubscription TopicSubscription { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/EntitySettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/EntitySettings.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    public interface EntitySettings
+    {
+        /// <summary>
+        /// The entity name (either a topic or a queue)
+        /// </summary>
+        string EntityName { get; }
+
+        /// <summary>
+        /// True if messages should be persisted to disk for the queue
+        /// </summary>
+        bool Durable { get; }
+
+        /// <summary>
+        /// True if the queue/exchange should automatically be deleted
+        /// </summary>
+        bool AutoDelete { get; }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/ErrorSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/ErrorSettings.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using Builders;
+
+
+    public interface ErrorSettings :
+        EntitySettings
+    {
+        /// <summary>
+        /// Return the BrokerTopology to apply at startup (to create exchange and queue if binding is specified)
+        /// </summary>
+        /// <returns></returns>
+        BrokerTopology GetBrokerTopology();
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsConsumeTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsConsumeTopology.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System;
+    using AmazonSqsTransport.Configuration;
+    using Builders;
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsConsumeTopology :
+        IConsumeTopology
+    {
+        new IAmazonSqsMessageConsumeTopology<T> GetMessageTopology<T>()
+            where T : class;
+
+        /// <summary>
+        /// Apply the entire topology to the builder
+        /// </summary>
+        /// <param name="builder"></param>
+        void Apply(IReceiveEndpointBrokerTopologyBuilder builder);
+
+        /// <summary>
+        /// Bind an exchange, using the configurator
+        /// </summary>
+        /// <param name="topicName"></param>
+        /// <param name="configure"></param>
+        void Bind(string topicName, Action<ITopicBindingConfigurator> configure = null);
+
+        string CreateTemporaryQueueName(string prefix);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsHostTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsHostTopology.cs
@@ -1,0 +1,58 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System;
+    using AmazonSqsTransport.Configuration;
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsHostTopology :
+        IHostTopology
+    {
+        new IAmazonSqsPublishTopology PublishTopology { get; }
+
+        IAmazonSqsSendTopology SendTopology { get; }
+
+        /// <summary>
+        /// Returns the destination address for the specified exchange
+        /// </summary>
+        /// <param name="topicName"></param>
+        /// <param name="configure">Callback to configure exchange settings</param>
+        /// <returns></returns>
+        Uri GetDestinationAddress(string topicName, Action<ITopicConfigurator> configure = null);
+
+        /// <summary>
+        /// Returns the destination address for the specified message type
+        /// </summary>
+        /// <param name="messageType">The message type</param>
+        /// <param name="configure">Callback to configure exchange settings</param>
+        /// <returns></returns>
+        Uri GetDestinationAddress(Type messageType, Action<ITopicConfigurator> configure = null);
+
+        /// <summary>
+        /// Returns the settings for sending to the specified address. Will parse any arguments
+        /// off the query string to properly configure the settings, including exchange and queue
+        /// durability, etc.
+        /// </summary>
+        /// <param name="address">The AmazonSQS endpoint address</param>
+        /// <returns>The send settings for the address</returns>
+        SendSettings GetSendSettings(Uri address);
+
+        new IAmazonSqsMessagePublishTopology<T> Publish<T>()
+            where T : class;
+
+        new IAmazonSqsMessageSendTopology<T> Send<T>()
+            where T : class;
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsMessageConsumeTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsMessageConsumeTopology.cs
@@ -1,0 +1,23 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsMessageConsumeTopology<TMessage> :
+        IMessageConsumeTopology<TMessage>
+        where TMessage : class
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsMessagePublishTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsMessagePublishTopology.cs
@@ -1,0 +1,45 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using Builders;
+    using Entities;
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsMessagePublishTopology<TMessage> :
+        IMessagePublishTopology<TMessage>,
+        IAmazonSqsMessagePublishTopology
+        where TMessage : class
+    {
+        Topic Topic { get; }
+
+        /// <summary>
+        /// Returns the send settings for a publish endpoint, which are mostly unused now with topology
+        /// </summary>
+        /// <returns></returns>
+        SendSettings GetSendSettings();
+
+        BrokerTopology GetBrokerTopology(PublishBrokerTopologyOptions options = PublishBrokerTopologyOptions.MaintainHierarchy);
+    }
+
+
+    public interface IAmazonSqsMessagePublishTopology
+    {
+        /// <summary>
+        /// Apply the message topology to the builder, including any implemented types
+        /// </summary>
+        /// <param name="builder">The topology builder</param>
+        void Apply(IPublishEndpointBrokerTopologyBuilder builder);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsMessageSendTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsMessageSendTopology.cs
@@ -1,0 +1,23 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsMessageSendTopology<TMessage> :
+        IMessageSendTopology<TMessage>
+        where TMessage : class
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsPublishTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsPublishTopology.cs
@@ -1,0 +1,24 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsPublishTopology :
+        IPublishTopology
+    {
+        new IAmazonSqsMessagePublishTopology<T> GetMessageTopology<T>()
+            where T : class;
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsSendTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsSendTopology.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System;
+    using Configuration;
+    using MassTransit.Topology;
+
+
+    public interface IAmazonSqsSendTopology :
+        ISendTopology
+    {
+        new IAmazonSqsMessageSendTopologyConfigurator<T> GetMessageTopology<T>()
+            where T : class;
+
+        SendSettings GetSendSettings(Uri address);
+
+        /// <summary>
+        /// Return the error settings for the queue
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        ErrorSettings GetErrorSettings(EntitySettings settings);
+
+        /// <summary>
+        /// Return the dead letter settings for the queue
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        DeadLetterSettings GetDeadLetterSettings(EntitySettings settings);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
@@ -40,8 +40,7 @@ namespace MassTransit.AmazonSqsTransport.Topology
         /// </summary>
         /// <param name="topic"></param>
         /// <param name="queue"></param>
-        /// <param name="selector"></param>
         /// <returns></returns>
-        TopicSubscriptionHandle BindQueue(TopicHandle topic, QueueHandle queue, string selector);
+        TopicSubscriptionHandle CreateTopicSubscription(TopicHandle topic, QueueHandle queue);
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
@@ -1,0 +1,47 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using Entities;
+
+
+    public interface IBrokerTopologyBuilder
+    {
+        /// <summary>
+        /// Declares an exchange
+        /// </summary>
+        /// <param name="name">The topic name</param>
+        /// <param name="durable">A durable topic survives a broker restart</param>
+        /// <param name="autoDelete">Automatically delete if the broker connection is closed</param>
+        /// <returns>An entity handle used to reference the topic in subsequent calls</returns>
+        TopicHandle CreateTopic(string name, bool durable, bool autoDelete);
+
+        /// <summary>
+        /// Declares a queue
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="durable"></param>
+        /// <param name="autoDelete"></param>
+        /// <returns></returns>
+        QueueHandle CreateQueue(string name, bool durable, bool autoDelete);
+
+        /// <summary>
+        /// Binds an exchange to a queue, with the specified routing key and arguments
+        /// </summary>
+        /// <param name="topic"></param>
+        /// <param name="queue"></param>
+        /// <param name="selector"></param>
+        /// <returns></returns>
+        TopicSubscriptionHandle BindQueue(TopicHandle topic, QueueHandle queue, string selector);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/IMessageRoutingKeyFormatter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IMessageRoutingKeyFormatter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    public interface IMessageRoutingKeyFormatter<in TMessage>
+        where TMessage : class
+    {
+        string FormatRoutingKey(SendContext<TMessage> context);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/PublishBrokerTopologyOptions.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/PublishBrokerTopologyOptions.cs
@@ -1,0 +1,24 @@
+// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System;
+
+
+    [Flags]
+    public enum PublishBrokerTopologyOptions
+    {
+        FlattenHierarchy = 0,
+        MaintainHierarchy = 1
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System;
+
+
+    /// <summary>
+    /// Specify the receive settings for a receive transport
+    /// </summary>
+    public interface ReceiveSettings :
+        EntitySettings
+    {
+        /// <summary>
+        /// The number of unacknowledged messages to allow to be processed concurrently
+        /// </summary>
+        ushort PrefetchCount { get; }
+
+        /// <summary>
+        /// True if the queue receive should be exclusive and not shared
+        /// </summary>
+        bool Exclusive { get; }
+
+        string Selector { get; }
+
+        /// <summary>
+        /// If True, and a queue name is specified, if the queue exists and has messages, they are purged at startup
+        /// If the connection is reset, messages are not purged until the service is reset
+        /// </summary>
+        bool PurgeOnStartup { get; }
+
+        /// <summary>
+        /// Get the input address for the transport on the specified host
+        /// </summary>
+        Uri GetInputAddress(Uri hostAddress);
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
@@ -24,14 +24,9 @@ namespace MassTransit.AmazonSqsTransport.Topology
         /// <summary>
         /// The number of unacknowledged messages to allow to be processed concurrently
         /// </summary>
-        ushort PrefetchCount { get; }
+        int PrefetchCount { get; }
 
-        /// <summary>
-        /// True if the queue receive should be exclusive and not shared
-        /// </summary>
-        bool Exclusive { get; }
-
-        string Selector { get; }
+        int WaitTimeSeconds { get; }
 
         /// <summary>
         /// If True, and a queue name is specified, if the queue exists and has messages, they are purged at startup

--- a/src/MassTransit.AmazonSqsTransport/Topology/SendSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/SendSettings.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology
+{
+    using System;
+    using Builders;
+
+
+    public interface SendSettings :
+        EntitySettings
+    {
+        /// <summary>
+        /// Returns the send address for the settings
+        /// </summary>
+        /// <param name="hostAddress"></param>
+        /// <returns></returns>
+        Uri GetSendAddress(Uri hostAddress);
+
+        /// <summary>
+        /// Return the BrokerTopology to apply at startup (to create exchange and queue if binding is specified)
+        /// </summary>
+        /// <returns></returns>
+        BrokerTopology GetBrokerTopology();
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsDeadLetterSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsDeadLetterSettings.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Settings
+{
+    using Builders;
+    using Configuration.Configurators;
+
+
+    public class AmazonSqsDeadLetterSettings :
+        QueueBindingConfigurator,
+        DeadLetterSettings
+    {
+        public AmazonSqsDeadLetterSettings(EntitySettings source, string queueName)
+            : base(queueName, source.Durable, source.AutoDelete)
+        {
+        }
+
+        public BrokerTopology GetBrokerTopology()
+        {
+            var builder = new PublishEndpointBrokerTopologyBuilder();
+
+            builder.CreateQueue(EntityName, Durable, AutoDelete);
+
+            return builder.BuildBrokerTopology();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsErrorSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsErrorSettings.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Settings
+{
+    using Builders;
+    using Configuration.Configurators;
+
+
+    public class AmazonSqsErrorSettings :
+        QueueBindingConfigurator,
+        ErrorSettings
+    {
+        public AmazonSqsErrorSettings(EntitySettings source, string queueName)
+            : base(queueName, source.Durable, source.AutoDelete)
+        {
+        }
+
+        public BrokerTopology GetBrokerTopology()
+        {
+            var builder = new PublishEndpointBrokerTopologyBuilder();
+
+            builder.CreateQueue(EntityName, Durable, AutoDelete);
+
+            return builder.BuildBrokerTopology();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsReceiveSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsReceiveSettings.cs
@@ -1,0 +1,48 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Settings
+{
+    using System;
+    using Configuration.Configurators;
+
+
+    public class AmazonSqsReceiveSettings :
+        QueueBindingConfigurator,
+        ReceiveSettings
+    {
+        public AmazonSqsReceiveSettings(string queueName, bool durable, bool autoDelete)
+            : base(queueName, durable, autoDelete)
+        {
+            PrefetchCount = (ushort)Math.Min(Environment.ProcessorCount * 2, 10);
+        }
+
+        public ushort PrefetchCount { get; set; }
+
+        public bool Exclusive { get; set; }
+
+        public bool PurgeOnStartup { get; set; }
+
+        public Uri GetInputAddress(Uri hostAddress)
+        {
+            var builder = new UriBuilder(hostAddress);
+
+            builder.Path = builder.Path == "/"
+                ? $"/{EntityName}"
+                : $"/{string.Join("/", builder.Path.Trim('/'), EntityName)}";
+
+            builder.Query += string.Join("&", GetQueryStringOptions());
+
+            return builder.Uri;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsReceiveSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsReceiveSettings.cs
@@ -23,12 +23,13 @@ namespace MassTransit.AmazonSqsTransport.Topology.Settings
         public AmazonSqsReceiveSettings(string queueName, bool durable, bool autoDelete)
             : base(queueName, durable, autoDelete)
         {
-            PrefetchCount = (ushort)Math.Min(Environment.ProcessorCount * 2, 10);
+            PrefetchCount = Math.Min(Environment.ProcessorCount * 2, 10);
+            WaitTimeSeconds = 0;
         }
 
-        public ushort PrefetchCount { get; set; }
+        public int PrefetchCount { get; set; }
 
-        public bool Exclusive { get; set; }
+        public int WaitTimeSeconds { get; set; }
 
         public bool PurgeOnStartup { get; set; }
 

--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsSendSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsSendSettings.cs
@@ -1,0 +1,96 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Settings
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Builders;
+    using Configuration.Configurators;
+
+
+    public class AmazonSqsSendSettings :
+        TopicConfigurator,
+        SendSettings
+    {
+        bool _bindToQueue;
+        string _queueName;
+
+        public AmazonSqsSendSettings(string topicName, bool durable, bool autoDelete)
+            : base(topicName, durable, autoDelete)
+        {
+
+        }
+
+        public Uri GetSendAddress(Uri hostAddress)
+        {
+            var builder = new UriBuilder(hostAddress);
+
+            builder.Path = builder.Path == "/"
+                ? $"/{EntityName}"
+                : $"/{string.Join("/", builder.Path.Trim('/'), EntityName)}";
+
+            builder.Query += string.Join("&", GetQueryStringOptions());
+
+            return builder.Uri;
+        }
+
+        public BrokerTopology GetBrokerTopology()
+        {
+            var builder = new PublishEndpointBrokerTopologyBuilder();
+
+            builder.Topic = builder.CreateTopic(EntityName, Durable, AutoDelete);
+
+            if (_bindToQueue)
+            {
+                var queue = builder.CreateQueue(_queueName, Durable, AutoDelete);
+
+                builder.BindQueue(builder.Topic, queue, "");
+            }
+
+            return builder.BuildBrokerTopology();
+        }
+
+        public void BindToQueue(string queueName)
+        {
+            _bindToQueue = true;
+            _queueName = queueName;
+        }
+
+        protected override IEnumerable<string> GetQueryStringOptions()
+        {
+            foreach (var option in base.GetQueryStringOptions())
+                yield return option;
+
+            if (_bindToQueue)
+                yield return "bind=true";
+
+            if (!string.IsNullOrWhiteSpace(_queueName))
+                yield return "queue=" + WebUtility.UrlEncode(_queueName);
+        }
+
+        IEnumerable<string> GetSettingStrings()
+        {
+            if (Durable)
+                yield return "durable";
+
+            if (AutoDelete)
+                yield return "auto-delete";
+        }
+
+        public override string ToString()
+        {
+            return string.Join(", ", GetSettingStrings());
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsSendSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/AmazonSqsSendSettings.cs
@@ -55,7 +55,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Settings
             {
                 var queue = builder.CreateQueue(_queueName, Durable, AutoDelete);
 
-                builder.BindQueue(builder.Topic, queue, "");
+                builder.CreateTopicSubscription(builder.Topic, queue);
             }
 
             return builder.BuildBrokerTopology();

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsConsumeTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsConsumeTopology.cs
@@ -88,14 +88,14 @@ namespace MassTransit.AmazonSqsTransport.Topology.Topologies
             foreach (var c in host.MachineName)
                 if (char.IsLetterOrDigit(c))
                     sb.Append(c);
-                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                else if (c == '_' || c == '-')
                     sb.Append(c);
 
             sb.Append('-');
             foreach (var c in host.ProcessName)
                 if (char.IsLetterOrDigit(c))
                     sb.Append(c);
-                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                else if (c == '_' || c == '-')
                     sb.Append(c);
 
             sb.Append('-');

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsConsumeTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsConsumeTopology.cs
@@ -1,0 +1,121 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Topologies
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using AmazonSqsTransport.Configuration;
+    using Builders;
+    using Configuration;
+    using Configuration.Specifications;
+    using GreenPipes;
+    using MassTransit.Topology;
+    using MassTransit.Topology.Topologies;
+    using NewIdFormatters;
+    using Util;
+
+
+    public class AmazonSqsConsumeTopology :
+        ConsumeTopology,
+        IAmazonSqsConsumeTopologyConfigurator
+    {
+        static readonly INewIdFormatter _formatter = new ZBase32Formatter();
+        readonly IMessageTopology _messageTopology;
+        readonly IAmazonSqsPublishTopology _publishTopology;
+        readonly IList<IAmazonSqsConsumeTopologySpecification> _specifications;
+
+        public AmazonSqsConsumeTopology(IMessageTopology messageTopology, IAmazonSqsPublishTopology publishTopology)
+        {
+            _messageTopology = messageTopology;
+            _publishTopology = publishTopology;
+
+            _specifications = new List<IAmazonSqsConsumeTopologySpecification>();
+        }
+
+        IAmazonSqsMessageConsumeTopology<T> IAmazonSqsConsumeTopology.GetMessageTopology<T>()
+        {
+            return base.GetMessageTopology<T>() as IAmazonSqsMessageConsumeTopologyConfigurator<T>;
+        }
+
+        public void AddSpecification(IAmazonSqsConsumeTopologySpecification specification)
+        {
+            if (specification == null)
+                throw new ArgumentNullException(nameof(specification));
+
+            _specifications.Add(specification);
+        }
+
+        IAmazonSqsMessageConsumeTopologyConfigurator<T> IAmazonSqsConsumeTopologyConfigurator.GetMessageTopology<T>()
+        {
+            return base.GetMessageTopology<T>() as IAmazonSqsMessageConsumeTopologyConfigurator<T>;
+        }
+
+        public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
+        {
+            foreach (var specification in _specifications)
+                specification.Apply(builder);
+
+            ForEach<IAmazonSqsMessageConsumeTopologyConfigurator>(x => x.Apply(builder));
+        }
+
+        public void Bind(string topicName, Action<ITopicBindingConfigurator> configure = null)
+        {
+            var specification = new ConsumerConsumeTopologySpecification(topicName);
+
+            configure?.Invoke(specification);
+
+            _specifications.Add(specification);
+        }
+
+        public string CreateTemporaryQueueName(string prefix)
+        {
+            var sb = new StringBuilder(prefix);
+
+            var host = HostMetadataCache.Host;
+
+            foreach (var c in host.MachineName)
+                if (char.IsLetterOrDigit(c))
+                    sb.Append(c);
+                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                    sb.Append(c);
+
+            sb.Append('-');
+            foreach (var c in host.ProcessName)
+                if (char.IsLetterOrDigit(c))
+                    sb.Append(c);
+                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                    sb.Append(c);
+
+            sb.Append('-');
+            sb.Append(NewId.Next().ToString(_formatter));
+
+            return sb.ToString();
+        }
+
+        public override IEnumerable<ValidationResult> Validate()
+        {
+            return base.Validate().Concat(_specifications.SelectMany(x => x.Validate()));
+        }
+
+        protected override IMessageConsumeTopologyConfigurator CreateMessageTopology<T>(Type type)
+        {
+            var messageTopology = new AmazonSqsMessageConsumeTopology<T>(_messageTopology.GetMessageTopology<T>(), _publishTopology.GetMessageTopology<T>());
+
+            OnMessageTopologyCreated(messageTopology);
+
+            return messageTopology;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsHostTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsHostTopology.cs
@@ -1,0 +1,109 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Topologies
+{
+    using System;
+    using System.Text;
+    using AmazonSqsTransport.Configuration;
+    using AmazonSqsTransport.Configuration.Configuration;
+    using MassTransit.Topology.Topologies;
+    using Settings;
+    using Transports;
+    using Util;
+
+
+    public class AmazonSqsHostTopology :
+        HostTopology,
+        IAmazonSqsHostTopology
+    {
+        readonly Uri _hostAddress;
+        readonly IMessageNameFormatter _messageNameFormatter;
+        readonly IAmazonSqsTopologyConfiguration _topologyConfiguration;
+
+        public AmazonSqsHostTopology(IMessageNameFormatter messageNameFormatter, Uri hostAddress, IAmazonSqsTopologyConfiguration topologyConfiguration)
+            : base(topologyConfiguration)
+        {
+            _messageNameFormatter = messageNameFormatter;
+            _hostAddress = hostAddress;
+            _topologyConfiguration = topologyConfiguration;
+        }
+
+        IAmazonSqsPublishTopology IAmazonSqsHostTopology.PublishTopology => _topologyConfiguration.Publish;
+        IAmazonSqsSendTopology IAmazonSqsHostTopology.SendTopology => _topologyConfiguration.Send;
+
+        IAmazonSqsMessagePublishTopology<T> IAmazonSqsHostTopology.Publish<T>()
+        {
+            return _topologyConfiguration.Publish.GetMessageTopology<T>();
+        }
+
+        IAmazonSqsMessageSendTopology<T> IAmazonSqsHostTopology.Send<T>()
+        {
+            return _topologyConfiguration.Send.GetMessageTopology<T>();
+        }
+
+        public SendSettings GetSendSettings(Uri address)
+        {
+            return _topologyConfiguration.Send.GetSendSettings(address);
+        }
+
+        public Uri GetDestinationAddress(string topicName, Action<ITopicConfigurator> configure = null)
+        {
+            var sendSettings = new AmazonSqsSendSettings(topicName, true, false);
+
+            configure?.Invoke(sendSettings);
+
+            return sendSettings.GetSendAddress(_hostAddress);
+        }
+
+        public Uri GetDestinationAddress(Type messageType, Action<ITopicConfigurator> configure = null)
+        {
+            var isTemporary = TypeMetadataCache.IsTemporaryMessageType(messageType);
+
+            var durable = !isTemporary;
+            var autoDelete = isTemporary;
+
+            var name = _messageNameFormatter.GetMessageName(messageType).ToString();
+
+            var settings = new AmazonSqsSendSettings(name, durable, autoDelete);
+
+            configure?.Invoke(settings);
+
+            return settings.GetSendAddress(_hostAddress);
+        }
+
+        public override string CreateTemporaryQueueName(string prefix)
+        {
+            var sb = new StringBuilder(prefix);
+
+            var host = HostMetadataCache.Host;
+
+            foreach (var c in host.MachineName)
+                if (char.IsLetterOrDigit(c))
+                    sb.Append(c);
+                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                    sb.Append(c);
+
+            sb.Append('-');
+            foreach (var c in host.ProcessName)
+                if (char.IsLetterOrDigit(c))
+                    sb.Append(c);
+                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                    sb.Append(c);
+
+            sb.Append('-');
+            sb.Append(NewId.Next().ToString(Formatter));
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsHostTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsHostTopology.cs
@@ -90,14 +90,14 @@ namespace MassTransit.AmazonSqsTransport.Topology.Topologies
             foreach (var c in host.MachineName)
                 if (char.IsLetterOrDigit(c))
                     sb.Append(c);
-                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                else if (c == '_' || c == '-')
                     sb.Append(c);
 
             sb.Append('-');
             foreach (var c in host.ProcessName)
                 if (char.IsLetterOrDigit(c))
                     sb.Append(c);
-                else if (c == '.' || c == '_' || c == '-' || c == ':')
+                else if (c == '_' || c == '-')
                     sb.Append(c);
 
             sb.Append('-');

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessageConsumeTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessageConsumeTopology.cs
@@ -1,0 +1,78 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Topologies
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AmazonSqsTransport.Configuration;
+    using Builders;
+    using Configuration;
+    using Configuration.Specifications;
+    using GreenPipes;
+    using MassTransit.Topology;
+    using MassTransit.Topology.Topologies;
+    using Newtonsoft.Json.Linq;
+    using Util;
+
+
+    public class AmazonSqsMessageConsumeTopology<TMessage> :
+        MessageConsumeTopology<TMessage>,
+        IAmazonSqsMessageConsumeTopologyConfigurator<TMessage>,
+        IAmazonSqsMessageConsumeTopologyConfigurator
+        where TMessage : class
+    {
+        readonly IMessageTopology<TMessage> _messageTopology;
+        readonly IAmazonSqsMessagePublishTopology<TMessage> _publishTopology;
+        readonly IList<IAmazonSqsConsumeTopologySpecification> _specifications;
+        readonly string _consumerName;
+
+        public AmazonSqsMessageConsumeTopology(IMessageTopology<TMessage> messageTopology, IAmazonSqsMessagePublishTopology<TMessage> publishTopology)
+        {
+            _messageTopology = messageTopology;
+            _publishTopology = publishTopology;
+
+            _consumerName = $"TopicSubscription.{messageTopology.EntityName}";
+
+            _specifications = new List<IAmazonSqsConsumeTopologySpecification>();
+        }
+
+        bool IsBindableMessageType => typeof(JToken) != typeof(TMessage);
+
+        public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
+        {
+            foreach (var specification in _specifications)
+                specification.Apply(builder);
+        }
+
+        public void Bind(Action<ITopicBindingConfigurator> configure = null)
+        {
+            if (!IsBindableMessageType)
+            {
+                _specifications.Add(new InvalidAmazonSqsConsumeTopologySpecification(TypeMetadataCache<TMessage>.ShortName, "Is not a bindable message type"));
+                return;
+            }
+
+            var specification = new ConsumerConsumeTopologySpecification(_publishTopology.Topic);
+
+            configure?.Invoke(specification);
+
+            _specifications.Add(specification);
+        }
+
+        public override IEnumerable<ValidationResult> Validate()
+        {
+            return base.Validate().Concat(_specifications.SelectMany(x => x.Validate()));
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessageConsumeTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessageConsumeTopology.cs
@@ -35,14 +35,11 @@ namespace MassTransit.AmazonSqsTransport.Topology.Topologies
         readonly IMessageTopology<TMessage> _messageTopology;
         readonly IAmazonSqsMessagePublishTopology<TMessage> _publishTopology;
         readonly IList<IAmazonSqsConsumeTopologySpecification> _specifications;
-        readonly string _consumerName;
 
         public AmazonSqsMessageConsumeTopology(IMessageTopology<TMessage> messageTopology, IAmazonSqsMessagePublishTopology<TMessage> publishTopology)
         {
             _messageTopology = messageTopology;
             _publishTopology = publishTopology;
-
-            _consumerName = $"TopicSubscription.{messageTopology.EntityName}";
 
             _specifications = new List<IAmazonSqsConsumeTopologySpecification>();
         }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
@@ -38,7 +38,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Topologies
         {
             _messageTopology = messageTopology;
 
-            var topicName = messageTopology.EntityName;
+            var topicName = _messageTopology.EntityName;
 
             var temporary = TypeMetadataCache<TMessage>.IsTemporaryMessageType;
 

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
@@ -1,0 +1,135 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Topologies
+{
+    using System;
+    using System.Collections.Generic;
+    using AmazonSqsTransport.Configuration;
+    using Builders;
+    using Configuration;
+    using Configuration.Configurators;
+    using Entities;
+    using MassTransit.Topology;
+    using MassTransit.Topology.Topologies;
+    using Settings;
+    using Util;
+
+
+    public class AmazonSqsMessagePublishTopology<TMessage> :
+        MessagePublishTopology<TMessage>,
+        IAmazonSqsMessagePublishTopologyConfigurator<TMessage>
+        where TMessage : class
+    {
+        readonly TopicConfigurator _topic;
+        readonly IList<IAmazonSqsMessagePublishTopology> _implementedMessageTypes;
+        readonly IMessageTopology<TMessage> _messageTopology;
+
+        public AmazonSqsMessagePublishTopology(IMessageTopology<TMessage> messageTopology)
+        {
+            _messageTopology = messageTopology;
+
+            var topicName = messageTopology.EntityName;
+
+            var temporary = TypeMetadataCache<TMessage>.IsTemporaryMessageType;
+
+            var durable = !temporary;
+            var autoDelete = temporary;
+
+            _topic = new TopicConfigurator(topicName, durable, autoDelete);
+
+            _implementedMessageTypes = new List<IAmazonSqsMessagePublishTopology>();
+        }
+
+        public Topic Topic => _topic;
+
+        bool ITopicConfigurator.Durable
+        {
+            set => _topic.Durable = value;
+        }
+
+        bool ITopicConfigurator.AutoDelete
+        {
+            set => _topic.AutoDelete = value;
+        }
+
+        public override bool TryGetPublishAddress(Uri baseAddress, out Uri publishAddress)
+        {
+            publishAddress = GetSendSettings().GetSendAddress(baseAddress);
+            return true;
+        }
+
+        public void Apply(IPublishEndpointBrokerTopologyBuilder builder)
+        {
+            var topicHandle = builder.CreateTopic(_topic.EntityName, _topic.Durable, _topic.AutoDelete);
+
+            if (builder.Topic != null)
+            {
+                // builder.ExchangeBind(builder.Exchange, exchangeHandle, "", new Dictionary<string, object>());
+            }
+            else
+            {
+                // builder.Exchange = exchangeHandle;
+            }
+
+            foreach (IAmazonSqsMessagePublishTopology configurator in _implementedMessageTypes)
+                configurator.Apply(builder);
+        }
+
+        public SendSettings GetSendSettings()
+        {
+            return new AmazonSqsSendSettings(_topic.EntityName, _topic.Durable, _topic.AutoDelete);
+        }
+
+        public BrokerTopology GetBrokerTopology(PublishBrokerTopologyOptions options)
+        {
+            var builder = new PublishEndpointBrokerTopologyBuilder(options);
+
+            Apply(builder);
+
+            return builder.BuildBrokerTopology();
+        }
+
+        public void AddImplementedMessageConfigurator<T>(IAmazonSqsMessagePublishTopologyConfigurator<T> configurator, bool direct)
+            where T : class
+        {
+            var adapter = new ImplementedTypeAdapter<T>(configurator, direct);
+
+            _implementedMessageTypes.Add(adapter);
+        }
+
+
+        class ImplementedTypeAdapter<T> :
+            IAmazonSqsMessagePublishTopology
+            where T : class
+        {
+            readonly IAmazonSqsMessagePublishTopologyConfigurator<T> _configurator;
+            readonly bool _direct;
+
+            public ImplementedTypeAdapter(IAmazonSqsMessagePublishTopologyConfigurator<T> configurator, bool direct)
+            {
+                _configurator = configurator;
+                _direct = direct;
+            }
+
+            public void Apply(IPublishEndpointBrokerTopologyBuilder builder)
+            {
+                if (_direct)
+                {
+                    var implementedBuilder = builder.CreateImplementedBuilder();
+
+                    _configurator.Apply(implementedBuilder);
+                }
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessageSendTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessageSendTopology.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Topologies
+{
+    using Configuration;
+    using MassTransit.Topology.Topologies;
+
+
+    public class AmazonSqsMessageSendTopology<TMessage> :
+        MessageSendTopology<TMessage>,
+        IAmazonSqsMessageSendTopologyConfigurator<TMessage>
+        where TMessage : class
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsPublishTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsPublishTopology.cs
@@ -1,0 +1,80 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Topologies
+{
+    using System;
+    using Configuration;
+    using MassTransit.Topology;
+    using MassTransit.Topology.Topologies;
+    using Metadata;
+
+
+    public class AmazonSqsPublishTopology :
+        PublishTopology,
+        IAmazonSqsPublishTopologyConfigurator
+    {
+        readonly IMessageTopology _messageTopology;
+
+        public AmazonSqsPublishTopology(IMessageTopology messageTopology)
+        {
+            _messageTopology = messageTopology;
+        }
+
+        IAmazonSqsMessagePublishTopology<T> IAmazonSqsPublishTopology.GetMessageTopology<T>()
+        {
+            return GetMessageTopology<T>() as IAmazonSqsMessagePublishTopology<T>;
+        }
+
+        IAmazonSqsMessagePublishTopologyConfigurator<T> IAmazonSqsPublishTopologyConfigurator.GetMessageTopology<T>()
+        {
+            return GetMessageTopology<T>() as IAmazonSqsMessagePublishTopologyConfigurator<T>;
+        }
+
+        protected override IMessagePublishTopologyConfigurator CreateMessageTopology<T>(Type type)
+        {
+            var messageTopology = new AmazonSqsMessagePublishTopology<T>(_messageTopology.GetMessageTopology<T>());
+
+            var connector = new ImplementedMessageTypeConnector<T>(this, messageTopology);
+
+            ImplementedMessageTypeCache<T>.EnumerateImplementedTypes(connector);
+
+            OnMessageTopologyCreated(messageTopology);
+
+            return messageTopology;
+        }
+
+
+        class ImplementedMessageTypeConnector<TMessage> :
+            IImplementedMessageType
+            where TMessage : class
+        {
+            readonly AmazonSqsMessagePublishTopology<TMessage> _messagePublishTopologyConfigurator;
+            readonly IAmazonSqsPublishTopologyConfigurator _publishTopology;
+
+            public ImplementedMessageTypeConnector(IAmazonSqsPublishTopologyConfigurator publishTopology,
+                AmazonSqsMessagePublishTopology<TMessage> messagePublishTopologyConfigurator)
+            {
+                _publishTopology = publishTopology;
+                _messagePublishTopologyConfigurator = messagePublishTopologyConfigurator;
+            }
+
+            public void ImplementsMessageType<T>(bool direct)
+                where T : class
+            {
+                IAmazonSqsMessagePublishTopologyConfigurator<T> messageTopology = _publishTopology.GetMessageTopology<T>();
+
+                _messagePublishTopologyConfigurator.AddImplementedMessageConfigurator(messageTopology, direct);
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsSendTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsSendTopology.cs
@@ -1,0 +1,90 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Topology.Topologies
+{
+    using System;
+    using System.Net;
+    using Configuration;
+    using MassTransit.Topology;
+    using MassTransit.Topology.Topologies;
+    using Settings;
+    using Util;
+
+
+    public class AmazonSqsSendTopology :
+        SendTopology,
+        IAmazonSqsSendTopologyConfigurator
+    {
+        public AmazonSqsSendTopology(IEntityNameValidator validator)
+        {
+            EntityNameValidator = validator;
+        }
+
+        public IEntityNameValidator EntityNameValidator { get; }
+
+        IAmazonSqsMessageSendTopologyConfigurator<T> IAmazonSqsSendTopology.GetMessageTopology<T>()
+        {
+            IMessageSendTopologyConfigurator<T> configurator = base.GetMessageTopology<T>();
+
+            return configurator as IAmazonSqsMessageSendTopologyConfigurator<T>;
+        }
+
+        public SendSettings GetSendSettings(Uri address)
+        {
+            var name = address.AbsolutePath.Substring(1);
+            string[] pathSegments = name.Split('/');
+            if (pathSegments.Length == 2)
+                name = pathSegments[1];
+
+            if (name == "*")
+                throw new ArgumentException("Cannot send to a dynamic address");
+
+            EntityNameValidator.ThrowIfInvalidEntityName(name);
+
+            var isTemporary = address.Query.GetValueFromQueryString("temporary", false);
+
+            var durable = address.Query.GetValueFromQueryString("durable", !isTemporary);
+            var autoDelete = address.Query.GetValueFromQueryString("autodelete", isTemporary);
+
+            var settings = new AmazonSqsSendSettings(name, durable, autoDelete);
+
+            var bindToQueue = address.Query.GetValueFromQueryString("bind", false);
+            if (bindToQueue)
+            {
+                var queueName = WebUtility.UrlDecode(address.Query.GetValueFromQueryString("queue"));
+                settings.BindToQueue(queueName);
+            }
+
+            return settings;
+        }
+
+        public ErrorSettings GetErrorSettings(EntitySettings settings)
+        {
+            return new AmazonSqsErrorSettings(settings, settings.EntityName + "_error");
+        }
+
+        public DeadLetterSettings GetDeadLetterSettings(EntitySettings settings)
+        {
+            return new AmazonSqsDeadLetterSettings(settings, settings.EntityName + "_skipped");
+        }
+
+        protected override IMessageSendTopologyConfigurator CreateMessageTopology<T>(Type type)
+        {
+            var messageTopology = new AmazonSqsMessageSendTopology<T>();
+
+            OnMessageTopologyCreated(messageTopology);
+
+            return messageTopology;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsConnectionCache.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsConnectionCache.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using Topology;
+
+
+    public class AmazonSqsConnectionCache :
+        PipeContextSupervisor<ConnectionContext>,
+        IConnectionCache
+    {
+        readonly string _description;
+
+        public AmazonSqsConnectionCache(AmazonSqsHostSettings settings, IAmazonSqsHostTopology topology)
+            : base(new ConnectionContextFactory(settings, topology))
+        {
+            _description = settings.ToString();
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            if (HasContext)
+                context.Add("connected", true);
+        }
+
+        public override string ToString()
+        {
+            return _description;
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsDeadLetterTransport.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsDeadLetterTransport.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService.Model;
+    using GreenPipes;
+    using Transports;
+
+
+    public class AmazonSqsDeadLetterTransport :
+        AmazonSqsMoveTransport,
+        IDeadLetterTransport
+    {
+        public AmazonSqsDeadLetterTransport(string destination, IFilter<ModelContext> topologyFilter)
+            : base(destination, topologyFilter)
+        {
+        }
+
+        public Task Send(ReceiveContext context, string reason)
+        {
+            void PreSend(PublishRequest message, SendHeaders headers)
+            {
+                headers.Set(MessageHeaders.Reason, reason ?? "Unspecified");
+            }
+
+            return Move(context, PreSend);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsErrorTransport.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsErrorTransport.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService.Model;
+    using GreenPipes;
+    using Transports;
+
+
+    public class AmazonSqsErrorTransport :
+        AmazonSqsMoveTransport,
+        IErrorTransport
+    {
+        public AmazonSqsErrorTransport(string destination, IFilter<ModelContext> topologyFilter)
+            : base(destination, topologyFilter)
+        {
+        }
+
+        public Task Send(ExceptionReceiveContext context)
+        {
+            void PreSend(PublishRequest message, SendHeaders headers)
+            {
+                headers.SetExceptionHeaders(context.Exception, context.ExceptionTimestamp);
+            }
+
+            return Move(context, PreSend);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsHost.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsHost.cs
@@ -1,0 +1,206 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Configuration;
+    using Configuration.Builders;
+    using Configuration.Configuration;
+    using Configuration.Configurators;
+    using Events;
+    using Exceptions;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using MassTransit.Pipeline;
+    using MassTransit.Topology;
+    using Topology;
+    using Transports;
+
+
+    public class AmazonSqsHost :
+        Supervisor,
+        IAmazonSqsHostControl
+    {
+        readonly AmazonSqsHostSettings _settings;
+        readonly IAmazonSqsHostTopology _topology;
+        HostHandle _handle;
+
+        public AmazonSqsHost(IAmazonSqsBusConfiguration busConfiguration, AmazonSqsHostSettings settings, IAmazonSqsHostTopology topology)
+        {
+            _settings = settings;
+            _topology = topology;
+
+            ReceiveEndpoints = new ReceiveEndpointCollection();
+
+            ConnectionRetryPolicy = Retry.CreatePolicy(x =>
+            {
+                x.Handle<AmazonSqsTransportException>();
+
+                x.Exponential(1000, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(3));
+            });
+
+            ConnectionCache = new AmazonSqsConnectionCache(settings, _topology);
+
+            ReceiveEndpointFactory = new AmazonSqsReceiveEndpointFactory(busConfiguration, this);
+        }
+
+        public IAmazonSqsReceiveEndpointFactory ReceiveEndpointFactory { get; set; }
+
+        public IReceiveEndpointCollection ReceiveEndpoints { get; }
+
+        public IConnectionCache ConnectionCache { get; }
+        public IRetryPolicy ConnectionRetryPolicy { get; }
+        public AmazonSqsHostSettings Settings => _settings;
+        public IAmazonSqsHostTopology Topology => _topology;
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("host");
+            scope.Set(new
+            {
+                Type = "AmazonSQS",
+                _settings.Region,
+                _settings.AccessKey,
+                Password = new string('*', _settings.SecretKey.Length)
+            });
+
+            ConnectionCache.Probe(scope);
+
+            ReceiveEndpoints.Probe(scope);
+        }
+
+        public Uri Address => _settings.HostAddress;
+
+        IHostTopology IHost.Topology => _topology;
+
+        ConnectHandle IConsumeMessageObserverConnector.ConnectConsumeMessageObserver<T>(IConsumeMessageObserver<T> observer)
+        {
+            return ReceiveEndpoints.ConnectConsumeMessageObserver(observer);
+        }
+
+        ConnectHandle IConsumeObserverConnector.ConnectConsumeObserver(IConsumeObserver observer)
+        {
+            return ReceiveEndpoints.ConnectConsumeObserver(observer);
+        }
+
+        ConnectHandle IReceiveObserverConnector.ConnectReceiveObserver(IReceiveObserver observer)
+        {
+            return ReceiveEndpoints.ConnectReceiveObserver(observer);
+        }
+
+        ConnectHandle IReceiveEndpointObserverConnector.ConnectReceiveEndpointObserver(IReceiveEndpointObserver observer)
+        {
+            return ReceiveEndpoints.ConnectReceiveEndpointObserver(observer);
+        }
+
+        ConnectHandle IPublishObserverConnector.ConnectPublishObserver(IPublishObserver observer)
+        {
+            return ReceiveEndpoints.ConnectPublishObserver(observer);
+        }
+
+        ConnectHandle ISendObserverConnector.ConnectSendObserver(ISendObserver observer)
+        {
+            return ReceiveEndpoints.ConnectSendObserver(observer);
+        }
+
+        public async Task<HostHandle> Start()
+        {
+            if (_handle != null)
+                throw new MassTransitException($"The host was already started: {_settings}");
+
+            HostReceiveEndpointHandle[] handles = ReceiveEndpoints.StartEndpoints();
+
+            _handle = new Handle(handles, this, ConnectionCache);
+
+            return _handle;
+        }
+
+        public bool Matches(Uri address)
+        {
+            if (!address.Scheme.Equals("amazonsqs", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var settings = new AmazonSqsHostConfigurator(address).Settings;
+
+            return AmazonSqsHostEqualityComparer.Default.Equals(_settings, settings);
+        }
+
+        public HostReceiveEndpointHandle ConnectReceiveEndpoint(Action<IAmazonSqsReceiveEndpointConfigurator> configure = null)
+        {
+            return ConnectReceiveEndpoint(_topology.CreateTemporaryQueueName("endpoint"), configure);
+        }
+
+        public HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IAmazonSqsReceiveEndpointConfigurator> configure = null)
+        {
+            if (ReceiveEndpointFactory == null)
+                throw new ConfigurationException("The receive endpoint factory was not specified");
+
+            ReceiveEndpointFactory.CreateReceiveEndpoint(queueName, configure);
+
+            return ReceiveEndpoints.Start(queueName);
+        }
+
+        public void AddReceiveEndpoint(string endpointName, IReceiveEndpointControl receiveEndpoint)
+        {
+            ReceiveEndpoints.Add(endpointName, receiveEndpoint);
+        }
+
+
+        class Handle :
+            HostHandle
+        {
+            readonly IAgent _connectionCache;
+            readonly HostReceiveEndpointHandle[] _handles;
+            readonly AmazonSqsHost _host;
+
+            public Handle(HostReceiveEndpointHandle[] handles, AmazonSqsHost host, IAgent connectionCache)
+            {
+                _host = host;
+                _handles = handles;
+                _connectionCache = connectionCache;
+            }
+
+            Task<HostReady> HostHandle.Ready
+            {
+                get { return ReadyOrNot(_handles.Select(x => x.Ready)); }
+            }
+
+            async Task HostHandle.Stop(CancellationToken cancellationToken)
+            {
+                await Task.WhenAll(_handles.Select(x => x.StopAsync(cancellationToken))).ConfigureAwait(false);
+
+                await _host.Stop("Host Stopped", cancellationToken).ConfigureAwait(false);
+
+                await _connectionCache.Stop("Host stopped", cancellationToken).ConfigureAwait(false);
+            }
+
+            async Task<HostReady> ReadyOrNot(IEnumerable<Task<ReceiveEndpointReady>> endpoints)
+            {
+                Task<ReceiveEndpointReady>[] readyTasks = endpoints as Task<ReceiveEndpointReady>[] ?? endpoints.ToArray();
+
+                foreach (Task<ReceiveEndpointReady> ready in readyTasks)
+                    await ready.ConfigureAwait(false);
+
+                await _connectionCache.Ready.ConfigureAwait(false);
+
+                ReceiveEndpointReady[] endpointsReady = await Task.WhenAll(readyTasks).ConfigureAwait(false);
+
+                return new HostReadyEvent(_host.Address, endpointsReady);
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsModelCache.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsModelCache.cs
@@ -1,0 +1,35 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using GreenPipes;
+    using GreenPipes.Agents;
+
+
+    public class AmazonSqsModelCache :
+        PipeContextSupervisor<ModelContext>,
+        IModelCache
+
+    {
+        public AmazonSqsModelCache(IAmazonSqsHost host, IConnectionCache connectionCache)
+            : base(new ModelContextFactory(connectionCache, host))
+        {
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            if (HasContext)
+                context.Add("connected", true);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsMoveTransport.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsMoveTransport.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService.Model;
+    using Contexts;
+    using GreenPipes;
+
+
+    public class AmazonSqsMoveTransport
+    {
+        readonly string _destination;
+        readonly IFilter<ModelContext> _topologyFilter;
+
+        protected AmazonSqsMoveTransport(string destination, IFilter<ModelContext> topologyFilter)
+        {
+            _topologyFilter = topologyFilter;
+            _destination = destination;
+        }
+
+        protected async Task Move(ReceiveContext context, Action<PublishRequest, SendHeaders> preSend)
+        {
+            if (!context.TryGetPayload(out ModelContext modelContext))
+                throw new ArgumentException("The ReceiveContext must contain a BrokeredMessageContext (from Azure Service Bus)", nameof(context));
+
+            await _topologyFilter.Send(modelContext, Pipe.Empty<ModelContext>()).ConfigureAwait(false);
+
+            var topicArn = await modelContext.GetTopic(_destination).ConfigureAwait(false);
+            var message = modelContext.CreateTransportMessage(topicArn, context.GetBody());
+
+            if (context.TryGetPayload(out AmazonSqsMessageContext messageContext))
+                foreach (string key in messageContext.Attributes.Keys)
+                {
+                    message.MessageAttributes[key].StringValue = messageContext.Attributes[key].StringValue;
+                    message.MessageAttributes[key].BinaryValue = messageContext.Attributes[key].BinaryValue;
+                    message.MessageAttributes[key].DataType = messageContext.Attributes[key].DataType;
+                }
+
+            SendHeaders headers = new AmazonSnsHeaderAdapter(message.MessageAttributes);
+
+            headers.SetHostHeaders();
+
+            preSend(message, headers);
+
+            var task = Task.Run(() => modelContext.Publish(message));
+
+            context.AddPendingTask(task);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsReceiveTransport.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsReceiveTransport.cs
@@ -1,0 +1,163 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Contexts;
+    using Events;
+    using Exceptions;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using Logging;
+    using MassTransit.Pipeline.Observables;
+    using Policies;
+    using Topology;
+    using Transports;
+
+
+    public class AmazonSqsReceiveTransport :
+        Supervisor,
+        IReceiveTransport
+    {
+        static readonly ILog _log = Logger.Get<AmazonSqsReceiveTransport>();
+        readonly IPipe<ConnectionContext> _connectionPipe;
+        readonly IAmazonSqsHost _host;
+        readonly Uri _inputAddress;
+        readonly ReceiveObservable _receiveObservable;
+        readonly ReceiveTransportObservable _receiveTransportObservable;
+        readonly ReceiveSettings _settings;
+        readonly AmazonSqsReceiveEndpointContext _context;
+
+        public AmazonSqsReceiveTransport(IAmazonSqsHost host, ReceiveSettings settings, IPipe<ConnectionContext> connectionPipe,
+            AmazonSqsReceiveEndpointContext context, ReceiveObservable receiveObservable, ReceiveTransportObservable receiveTransportObservable)
+        {
+            _host = host;
+            _settings = settings;
+            _context = context;
+            _connectionPipe = connectionPipe;
+
+            _receiveObservable = receiveObservable;
+            _receiveTransportObservable = receiveTransportObservable;
+
+            _inputAddress = context.InputAddress;
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("transport");
+            scope.Add("type", "AmazonSQS");
+            scope.Set(_settings);
+            var topologyScope = scope.CreateScope("topology");
+            _context.BrokerTopology.Probe(topologyScope);
+        }
+
+        /// <summary>
+        /// Start the receive transport, returning a Task that can be awaited to signal the transport has
+        /// completely shutdown once the cancellation token is cancelled.
+        /// </summary>
+        /// <returns>A task that is completed once the transport is shut down</returns>
+        public ReceiveTransportHandle Start()
+        {
+            Task.Factory.StartNew(Receiver, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
+
+            return new Handle(this);
+        }
+
+        public ConnectHandle ConnectReceiveObserver(IReceiveObserver observer)
+        {
+            return _receiveObservable.Connect(observer);
+        }
+
+        public ConnectHandle ConnectReceiveTransportObserver(IReceiveTransportObserver observer)
+        {
+            return _receiveTransportObservable.Connect(observer);
+        }
+
+        public ConnectHandle ConnectPublishObserver(IPublishObserver observer)
+        {
+            return _context.ConnectPublishObserver(observer);
+        }
+
+        public ConnectHandle ConnectSendObserver(ISendObserver observer)
+        {
+            return _context.ConnectSendObserver(observer);
+        }
+
+        async Task Receiver()
+        {
+            while (!IsStopping)
+            {
+                try
+                {
+                    await _host.ConnectionRetryPolicy.Retry(async () =>
+                    {
+                        try
+                        {
+                            await _host.ConnectionCache.Send(_connectionPipe, Stopped).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                        }
+                        catch (Exception ex)
+                        {
+                            throw await ConvertToAmazonSqsConnectionException(ex, "ReceiveTransport Faulted, Restarting").ConfigureAwait(false);
+                        }
+                    }, Stopping);
+                }
+                catch
+                {
+                    // seriously, nothing to see here
+                }
+            }
+        }
+
+        async Task<AmazonSqsConnectException> ConvertToAmazonSqsConnectionException(Exception ex, string message)
+        {
+            if (_log.IsDebugEnabled)
+                _log.Debug(message, ex);
+
+            var exception = new AmazonSqsConnectException(message + _host.ConnectionCache, ex);
+
+            await NotifyFaulted(exception);
+
+            return exception;
+        }
+
+        Task NotifyFaulted(Exception exception)
+        {
+            if (_log.IsErrorEnabled)
+                _log.ErrorFormat("AmazonSQS Connect Failed: {0}", exception.Message);
+
+            return _receiveTransportObservable.Faulted(new ReceiveTransportFaultedEvent(_inputAddress, exception));
+        }
+
+
+        class Handle :
+            ReceiveTransportHandle
+        {
+            readonly IAgent _agent;
+
+            public Handle(IAgent agent)
+            {
+                _agent = agent;
+            }
+
+            Task ReceiveTransportHandle.Stop(CancellationToken cancellationToken)
+            {
+                return _agent.Stop("Stop Receive Transport", cancellationToken);
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsReceiveTransport.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsReceiveTransport.cs
@@ -112,7 +112,7 @@ namespace MassTransit.AmazonSqsTransport.Transport
                         }
                         catch (Exception ex)
                         {
-                            throw await ConvertToAmazonSqsConnectionException(ex, "ReceiveTransport Faulted, Restarting").ConfigureAwait(false);
+                            throw await ConvertToAmazonSqsConnectionException(ex, "ReceiveTransport Faulted, Restarting ").ConfigureAwait(false);
                         }
                     }, Stopping);
                 }

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsSendTransport.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsSendTransport.cs
@@ -1,0 +1,135 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService.Model;
+    using Contexts;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using GreenPipes.Internals.Extensions;
+    using MassTransit.Pipeline.Observables;
+    using Transports;
+
+    public class AmazonSqsSendTransport :
+        Supervisor,
+        ISendTransport
+    {
+        readonly string _entityName;
+        readonly IFilter<ModelContext> _filter;
+        readonly IPipeContextSource<ModelContext> _modelAgent;
+        readonly SendObservable _observers;
+
+        public AmazonSqsSendTransport(IAgent<ModelContext> modelAgent, IFilter<ModelContext> preSendFilter, string entityName)
+        {
+            _modelAgent = modelAgent;
+            _filter = preSendFilter;
+            _entityName = entityName;
+
+            _observers = new SendObservable();
+        }
+
+        async Task ISendTransport.Send<T>(T message, IPipe<SendContext<T>> pipe, CancellationToken cancellationToken)
+        {
+            if (IsStopped)
+                throw new TransportUnavailableException($"The send transport is stopped: {_entityName}");
+
+            IPipe<ModelContext> modelPipe = Pipe.New<ModelContext>(p =>
+            {
+                p.UseFilter(_filter);
+
+                p.UseExecuteAsync(async modelContext =>
+                {
+                    var topicArn = await modelContext.GetTopic(_entityName).ConfigureAwait(false);
+
+                    var sendContext = new TransportAmazonSqsSendContext<T>(message, cancellationToken);
+                    try
+                    {
+                        await pipe.Send(sendContext).ConfigureAwait(false);
+
+                        var transportMessage = modelContext.CreateTransportMessage(topicArn, sendContext.Body);
+
+                        KeyValuePair<string, object>[] headers = sendContext.Headers.GetAll()
+                            .Where(x => x.Value != null && (x.Value is string || x.Value.GetType().GetTypeInfo().IsValueType))
+                            .ToArray();
+
+                        foreach (KeyValuePair<string, object> header in headers)
+                        {
+                            if (transportMessage.MessageAttributes.ContainsKey(header.Key))
+                                continue;
+
+                            transportMessage.MessageAttributes[header.Key].StringValue = header.Value.ToString();
+                        }
+
+                        transportMessage.MessageAttributes.Add("Content-Type", new MessageAttributeValue
+                        {
+                            DataType = "String",
+                            StringValue = sendContext.ContentType.MediaType
+                        });
+
+                        if (sendContext.MessageId.HasValue)
+                            transportMessage.MessageAttributes.Add("MessageId", new MessageAttributeValue
+                            {
+                                DataType = "String",
+                                StringValue = sendContext.MessageId.ToString()
+                            });
+
+                        if (sendContext.CorrelationId.HasValue)
+                            transportMessage.MessageAttributes.Add("CorrelationId", new MessageAttributeValue
+                            {
+                                DataType = "String",
+                                StringValue = sendContext.CorrelationId.ToString()
+                            });
+
+                        if (sendContext.TimeToLive.HasValue)
+                            transportMessage.MessageAttributes.Add("TimeToLive", new MessageAttributeValue
+                            {
+                                DataType = "Number",
+                                StringValue = sendContext.TimeToLive.Value.Milliseconds.ToString()
+                            });
+
+                        await _observers.PreSend(sendContext).ConfigureAwait(false);
+
+                        var publishTask = Task.Run(() => modelContext.Publish(transportMessage, sendContext.CancellationToken), sendContext.CancellationToken);
+
+                        await publishTask.UntilCompletedOrCanceled(sendContext.CancellationToken).ConfigureAwait(false);
+
+                        sendContext.LogSent();
+
+                        await _observers.PostSend(sendContext).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        sendContext.LogFaulted(ex);
+
+                        await _observers.SendFault(sendContext, ex).ConfigureAwait(false);
+
+                        throw;
+                    }
+                });
+            });
+
+            await _modelAgent.Send(modelPipe, cancellationToken).ConfigureAwait(false);
+        }
+
+        public ConnectHandle ConnectSendObserver(ISendObserver observer)
+        {
+            return _observers.Connect(observer);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/ConnectionContextFactory.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/ConnectionContextFactory.cs
@@ -1,0 +1,91 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Contexts;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using Logging;
+    using Topology;
+
+
+    public class ConnectionContextFactory :
+        IPipeContextFactory<ConnectionContext>
+    {
+        static readonly ILog _log = Logger.Get<ConnectionContextFactory>();
+        readonly string _description;
+        readonly AmazonSqsHostSettings _settings;
+        readonly IAmazonSqsHostTopology _topology;
+
+        public ConnectionContextFactory(AmazonSqsHostSettings settings, IAmazonSqsHostTopology topology)
+        {
+            _settings = settings;
+            _topology = topology;
+
+            _description = settings.ToString();
+        }
+
+        IPipeContextAgent<ConnectionContext> IPipeContextFactory<ConnectionContext>.CreateContext(ISupervisor supervisor)
+        {
+            IAsyncPipeContextAgent<ConnectionContext> asyncContext = supervisor.AddAsyncContext<ConnectionContext>();
+
+            var context = Task.Factory.StartNew(() => CreateConnection(asyncContext, supervisor), supervisor.Stopping, TaskCreationOptions.None,
+                    TaskScheduler.Default)
+                .Unwrap();
+
+            return asyncContext;
+        }
+
+        IActivePipeContextAgent<ConnectionContext> IPipeContextFactory<ConnectionContext>.CreateActiveContext(ISupervisor supervisor,
+            PipeContextHandle<ConnectionContext> context, CancellationToken cancellationToken)
+        {
+            return supervisor.AddActiveContext(context, CreateSharedConnection(context.Context, cancellationToken));
+        }
+
+        async Task<ConnectionContext> CreateSharedConnection(Task<ConnectionContext> context, CancellationToken cancellationToken)
+        {
+            var connectionContext = await context.ConfigureAwait(false);
+
+            var sharedConnection = new SharedConnectionContext(connectionContext, cancellationToken);
+
+            return sharedConnection;
+        }
+
+        async Task<ConnectionContext> CreateConnection(IAsyncPipeContextAgent<ConnectionContext> asyncContext, IAgent supervisor)
+        {
+            IConnection connection = null;
+            try
+            {
+                if (supervisor.Stopping.IsCancellationRequested)
+                    throw new OperationCanceledException($"The connection is stopping and cannot be used: {_description}");
+
+                connection = _settings.CreateConnection();
+
+                var connectionContext = new AmazonSqsConnectionContext(connection, _settings, _topology, _description, supervisor.Stopped);
+                connectionContext.GetOrAddPayload(() => _settings);
+
+                await asyncContext.Created(connectionContext).ConfigureAwait(false);
+
+                return connectionContext;
+            }
+            catch (OperationCanceledException)
+            {
+                await asyncContext.CreateCanceled().ConfigureAwait(false);
+                throw;
+            }
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/IConnectionCache.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/IConnectionCache.cs
@@ -1,0 +1,25 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using GreenPipes.Agents;
+
+
+    /// <summary>
+    /// Attaches a connection context to the value (shared, of course)
+    /// </summary>
+    public interface IConnectionCache :
+        ISupervisor<ConnectionContext>
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/IModelCache.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/IModelCache.cs
@@ -1,0 +1,25 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using GreenPipes.Agents;
+
+
+    /// <summary>
+    /// Creates and caches a model on the connection
+    /// </summary>
+    public interface IModelCache :
+        ISupervisor<ModelContext>
+    {
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/ModelContextFactory.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/ModelContextFactory.cs
@@ -1,0 +1,98 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Contexts;
+    using GreenPipes;
+    using GreenPipes.Agents;
+    using Logging;
+
+
+    public class ModelContextFactory :
+        IPipeContextFactory<ModelContext>
+    {
+        static readonly ILog _log = Logger.Get<ModelContextFactory>();
+        readonly IConnectionCache _connectionCache;
+        readonly IAmazonSqsHost _host;
+
+        public ModelContextFactory(IConnectionCache connectionCache, IAmazonSqsHost host)
+        {
+            _connectionCache = connectionCache;
+            _host = host;
+        }
+
+        IPipeContextAgent<ModelContext> IPipeContextFactory<ModelContext>.CreateContext(ISupervisor supervisor)
+        {
+            IAsyncPipeContextAgent<ModelContext> asyncContext = supervisor.AddAsyncContext<ModelContext>();
+
+            CreateModel(asyncContext, supervisor.Stopped);
+
+            return asyncContext;
+        }
+
+        IActivePipeContextAgent<ModelContext> IPipeContextFactory<ModelContext>.CreateActiveContext(ISupervisor supervisor,
+            PipeContextHandle<ModelContext> context, CancellationToken cancellationToken)
+        {
+            return supervisor.AddActiveContext(context, CreateSharedSession(context.Context, cancellationToken));
+        }
+
+        async Task<ModelContext> CreateSharedSession(Task<ModelContext> context, CancellationToken cancellationToken)
+        {
+            var modelContext = await context.ConfigureAwait(false);
+
+            return new SharedModelContext(modelContext, cancellationToken);
+        }
+
+        void CreateModel(IAsyncPipeContextAgent<ModelContext> asyncContext, CancellationToken cancellationToken)
+        {
+            IPipe<ConnectionContext> connectionPipe = Pipe.ExecuteAsync<ConnectionContext>(async connectionContext =>
+            {
+                if (_log.IsDebugEnabled)
+                    _log.DebugFormat("Creating model: {0}", connectionContext.Description);
+
+                try
+                {
+                    var amazonSqs = await connectionContext.CreateAmazonSqs().ConfigureAwait(false);
+                    var amazonSns = await connectionContext.CreateAmazonSns().ConfigureAwait(false);
+
+                    var modelContext = new AmazonSqsModelContext(connectionContext, amazonSqs, amazonSns, _host, cancellationToken);
+
+                    await asyncContext.Created(modelContext).ConfigureAwait(false);
+
+                    await asyncContext.Completed.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    await asyncContext.CreateCanceled().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    await asyncContext.CreateFaulted(exception).ConfigureAwait(false);
+                }
+            });
+
+            var connectionTask = _connectionCache.Send(connectionPipe, cancellationToken);
+
+            Task NotifyCreateCanceled(Task task) => asyncContext.CreateCanceled();
+
+            connectionTask.ContinueWith(NotifyCreateCanceled, TaskContinuationOptions.OnlyOnCanceled);
+
+            Task NotifyCreateFaulted(Task task) => asyncContext.CreateFaulted(task.Exception);
+
+            connectionTask.ContinueWith(NotifyCreateFaulted, TaskContinuationOptions.OnlyOnFaulted);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/PublishTransportProvider.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/PublishTransportProvider.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Threading.Tasks;
+    using GreenPipes.Agents;
+    using Pipeline;
+    using Topology;
+    using Transports;
+
+
+    public class PublishTransportProvider :
+        IPublishTransportProvider
+    {
+        readonly IAmazonSqsHostControl _host;
+        readonly IAmazonSqsPublishTopology _publishTopology;
+
+        public PublishTransportProvider(IAmazonSqsHostControl host, IAmazonSqsPublishTopology publishTopology)
+        {
+            _publishTopology = publishTopology;
+            _host = host;
+        }
+
+        public Task<ISendTransport> GetPublishTransport<T>(Uri publishAddress)
+            where T : class
+        {
+            IAmazonSqsMessagePublishTopology<T> publishTopology = _publishTopology.GetMessageTopology<T>();
+
+            var sendSettings = publishTopology.GetSendSettings();
+
+            IAgent<ModelContext> modelAgent = GetModelAgent();
+
+            var configureTopologyFilter = new ConfigureTopologyFilter<SendSettings>(sendSettings, publishTopology.GetBrokerTopology());
+
+            var sendTransport = new AmazonSqsSendTransport(modelAgent, configureTopologyFilter, sendSettings.EntityName);
+            sendTransport.Add(modelAgent);
+
+            _host.Add(sendTransport);
+
+            return Task.FromResult<ISendTransport>(sendTransport);
+        }
+
+        protected virtual IAgent<ModelContext> GetModelAgent()
+        {
+            return new AmazonSqsModelCache(_host, _host.ConnectionCache);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/SendTransportProvider.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/SendTransportProvider.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using System;
+    using System.Threading.Tasks;
+    using Configuration.Configuration;
+    using GreenPipes.Agents;
+    using Pipeline;
+    using Topology;
+    using Transports;
+
+
+    public class SendTransportProvider :
+        ISendTransportProvider
+    {
+        readonly IAmazonSqsBusConfiguration _busConfiguration;
+
+        public SendTransportProvider(IAmazonSqsBusConfiguration busConfiguration)
+        {
+            _busConfiguration = busConfiguration;
+        }
+
+        Task<ISendTransport> ISendTransportProvider.GetSendTransport(Uri address)
+        {
+            return Task.FromResult(GetSendTransport(address));
+        }
+
+        ISendTransport GetSendTransport(Uri address)
+        {
+            if (!_busConfiguration.TryGetHost(address, out var hostConfiguration))
+                throw new EndpointNotFoundException($"The host was not found for the specified address: {address}");
+
+            var host = hostConfiguration.Host;
+
+            var settings = host.Topology.SendTopology.GetSendSettings(address);
+
+            IAgent<ModelContext> modelAgent = GetModelAgent(host);
+
+            var configureTopologyFilter = new ConfigureTopologyFilter<SendSettings>(settings, settings.GetBrokerTopology());
+
+            var transport = new AmazonSqsSendTransport(modelAgent, configureTopologyFilter, settings.EntityName);
+            transport.Add(modelAgent);
+
+            host.Add(transport);
+
+            return transport;
+        }
+
+        protected virtual IAgent<ModelContext> GetModelAgent(IAmazonSqsHost host)
+        {
+            return new AmazonSqsModelCache(host, host.ConnectionCache);
+        }
+    }
+}

--- a/src/MassTransit.sln
+++ b/src/MassTransit.sln
@@ -145,7 +145,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.DapperIntegrati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.LamarIntegration", "Containers\MassTransit.LamarIntegration\MassTransit.LamarIntegration.csproj", "{19B5094E-076C-432F-84DB-1BFD475A6E8E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Automatonymous.LamarIntegration", "Containers\MassTransit.Automatonymous.LamarIntegration\MassTransit.Automatonymous.LamarIntegration.csproj", "{BB8C090E-0474-4F0E-B745-D7594F801B3A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Automatonymous.LamarIntegration", "Containers\MassTransit.Automatonymous.LamarIntegration\MassTransit.Automatonymous.LamarIntegration.csproj", "{BB8C090E-0474-4F0E-B745-D7594F801B3A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AmazonSqsTransport", "MassTransit.AmazonSqsTransport\MassTransit.AmazonSqsTransport.csproj", "{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AmazonSqsTransport.Tests", "MassTransit.AmazonSqsTransport.Tests\MassTransit.AmazonSqsTransport.Tests.csproj", "{C7188986-F31F-46ED-8F1C-047E9A7E8A52}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -766,6 +770,30 @@ Global
 		{BB8C090E-0474-4F0E-B745-D7594F801B3A}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
 		{BB8C090E-0474-4F0E-B745-D7594F801B3A}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
 		{BB8C090E-0474-4F0E-B745-D7594F801B3A}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Debug|x86.Build.0 = Debug|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Release|x86.ActiveCfg = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.Release|x86.Build.0 = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Debug|x86.Build.0 = Debug|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.Release|x86.Build.0 = Release|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.ReleaseUnsigned|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -823,9 +851,11 @@ Global
 		{F84D81B1-C33D-420C-849F-EA422D87807F} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
 		{19B5094E-076C-432F-84DB-1BFD475A6E8E} = {6C61507E-FF16-45C8-8FE4-350069D9B4C1}
 		{BB8C090E-0474-4F0E-B745-D7594F801B3A} = {6C61507E-FF16-45C8-8FE4-350069D9B4C1}
+		{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
+		{C7188986-F31F-46ED-8F1C-047E9A7E8A52} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35
 		SolutionGuid = {43D3A7D5-0945-435E-8D03-1E631E5CDBA8}
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
I have started working on an additional transport using Amazon SNS (topic/exchange) and SQS (queue), its a combination of ActiveMQ and RabbitMQ transport,

Still early days, but would to get some early feedback.

![image](https://user-images.githubusercontent.com/1691062/43045138-2ce3bce2-8df6-11e8-9d89-75f18ba91b97.png)

## Testing locally (need docker environment)
- `git clone https://github.com/localstack/localstack`
- `docker-compose up -d`

## Testing with AWS
- Change your aws credentials in [here](https://github.com/MassTransit/MassTransit/pull/1166/files#diff-b5c51c603d76895f530f9711ea3dab78R121)
### Minimum IAM permissions needed
 - **SNS** `CreateTopic`, `DeleteTopic`, `Subscribe`, `Publish`
 - **SQS** `CreateQueue`, `DeleteQueue`, `SendMessage`, `ReceiveMessage`, `DeleteMessage`

## Configure_Specs are green 

<img width="709" alt="screen shot 2018-07-26 at 8 00 33 am" src="https://user-images.githubusercontent.com/1691062/43230022-230cdeae-90aa-11e8-80d0-f849f816f28a.png">

## ErrorQueue_Specs needs some work.
