### PR TITLE
Fix DocumentDb Race Condition and Tests

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration.Tests/Storage2Spec_Types.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/Storage2Spec_Types.cs
@@ -14,8 +14,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
 {
     using System;
     using Automatonymous;
-    using Saga;
-    using Newtonsoft.Json;
+    using DocumentDbIntegration;
 
     public class RehersalBegins
     {
@@ -47,7 +46,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
     }
 
     public class ChoirState :
-        SagaStateMachineInstance
+        SagaStateMachineInstance, IVersionedSaga
     {
         protected ChoirState()
         {
@@ -60,8 +59,8 @@ namespace MassTransit.AutomatonymousIntegration.Tests
 
         public string CurrentState { get; set; }
         public int Harmony { get; set; }
-        [JsonProperty("id")]
         public Guid CorrelationId { get; set; }
+        public string ETag { get; set; }
         public byte[] RowVersion { get; set; }
         public string BassName { get; set; }
         public string BaritoneName { get; set; }

--- a/src/MassTransit.AutomatonymousIntegration.Tests/StorageSpec_Types.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/StorageSpec_Types.cs
@@ -14,6 +14,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
 {
     using System;
     using Automatonymous;
+    using DocumentDbIntegration;
     using Newtonsoft.Json;
 
 
@@ -38,7 +39,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
     }
 
 
-    public class ShoppingChore :
+    public class ShoppingChore : IVersionedSaga,
         SagaStateMachineInstance
     {
         protected ShoppingChore()
@@ -54,8 +55,11 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         public int Everything { get; set; }
         public bool Screwed { get; set; }
 
-        [JsonProperty(PropertyName = "id")]
+        [JsonProperty("id")]
         public Guid CorrelationId { get; set; }
+
+        [JsonProperty("_etag")]
+        public string ETag { get; set; }
     }
 
 

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/Data/SimpleSagaResource.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/Data/SimpleSagaResource.cs
@@ -8,7 +8,7 @@
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
 
-    public class SimpleSaga :
+    public class SimpleSagaResource : Resource,
         InitiatedBy<InitiateSimpleSaga>,
         Orchestrates<CompleteSimpleSaga>,
         Observes<ObservableSagaMessage, SimpleSaga>,
@@ -30,11 +30,8 @@
             return Task.FromResult(0);
         }
 
+        [JsonProperty("id")]
         public Guid CorrelationId { get; set; }
-
-        public string ETag { get; set; }
-
-        public string Username { get; set; }
 
         public Task Consume(ConsumeContext<ObservableSagaMessage> message)
         {

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaConsumeContextTestsForPopContext.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaConsumeContextTestsForPopContext.cs
@@ -33,7 +33,7 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
         public void GivenADocumentDbSagaConsumeContext_WhenPoppingContext()
         {
             var documentDbSagaConsumeContext = new DocumentDbSagaConsumeContext<SimpleSaga, InitiateSimpleSaga>(It.IsAny<IDocumentClient>(),It.IsAny<string>(), It.IsAny<string>(),
-                Mock.Of<ConsumeContext<InitiateSimpleSaga>>(), Mock.Of<SimpleSaga>());
+                Mock.Of<ConsumeContext<InitiateSimpleSaga>>(), It.IsAny<SimpleSaga>());
 
             _context = documentDbSagaConsumeContext.PopContext<InitiateSimpleSaga>();
         }

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaConsumeContextTestsForSetCompleted.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaConsumeContextTestsForSetCompleted.cs
@@ -31,7 +31,7 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
         [Test]
         public async Task ThenSagaDoesNotExistInRepository()
         {
-            var saga = await SagaRepository.Instance.GetSaga(_saga.CorrelationId);
+            var saga = await SagaRepository.Instance.GetSaga<SimpleSaga>(_saga.CorrelationId, true);
 
             Assert.That(saga, Is.Null);
         }
@@ -44,7 +44,7 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
         {
             _saga = new SimpleSaga {CorrelationId = Guid.NewGuid()};
 
-            await SagaRepository.Instance.InsertSaga(_saga);
+            await SagaRepository.Instance.InsertSaga(_saga, true);
 
             _documentDbSagaConsumeContext =
                 new DocumentDbSagaConsumeContext<SimpleSaga, InitiateSimpleSaga>(SagaRepository.Instance.Client, SagaRepository.DatabaseName, SagaRepository.CollectionName,

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForProbing.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForProbing.cs
@@ -44,7 +44,7 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
             _probeContext = new Mock<ProbeContext>();
             _probeContext.Setup(m => m.CreateScope("sagaRepository")).Returns(_scope.Object);
 
-            var repository = new DocumentDbSagaRepository<SimpleSaga>(SagaRepository.Instance.Client, SagaRepository.DatabaseName, SagaRepository.CollectionName, null);
+            var repository = new DocumentDbSagaRepository<SimpleSagaResource>(SagaRepository.Instance.Client, SagaRepository.DatabaseName);
 
             repository.Probe(_probeContext.Object);
         }

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendQueryWhenSagaNotFound.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendQueryWhenSagaNotFound.cs
@@ -30,28 +30,28 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
         [Test]
         public void ThenMissingPipeCalled()
         {
-            _sagaPolicy.Verify(x => x.Missing(_sagaQueryConsumeContext.Object, It.IsAny<MissingPipe<SimpleSaga, InitiateSimpleSaga>>()), Times.Once);
+            _sagaPolicy.Verify(x => x.Missing(_sagaQueryConsumeContext.Object, It.IsAny<MissingPipe<SimpleSagaResource, InitiateSimpleSaga>>()), Times.Once);
         }
 
         [Test]
         public void ThenSagaNotSentToInstance()
         {
-            _sagaPolicy.Verify(x => x.Existing(It.IsAny<DocumentDbSagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>(), _nextPipe.Object), Times.Never);
+            _sagaPolicy.Verify(x => x.Existing(It.IsAny<DocumentDbSagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>(), _nextPipe.Object), Times.Never);
         }
 
-        Mock<ISagaPolicy<SimpleSaga, InitiateSimpleSaga>> _sagaPolicy;
-        Mock<SagaQueryConsumeContext<SimpleSaga, InitiateSimpleSaga>> _sagaQueryConsumeContext;
-        Mock<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>> _nextPipe;
+        Mock<ISagaPolicy<SimpleSagaResource, InitiateSimpleSaga>> _sagaPolicy;
+        Mock<SagaQueryConsumeContext<SimpleSagaResource, InitiateSimpleSaga>> _sagaQueryConsumeContext;
+        Mock<IPipe<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>> _nextPipe;
 
         [OneTimeSetUp]
         public async Task GivenADocumentDbSagaRepository_WhenSendingQueryAndSagaNotFound()
         {
-            _sagaQueryConsumeContext = new Mock<SagaQueryConsumeContext<SimpleSaga, InitiateSimpleSaga>>();
+            _sagaQueryConsumeContext = new Mock<SagaQueryConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>();
             _sagaQueryConsumeContext.Setup(x => x.Query.FilterExpression).Returns(x => x.CorrelationId == Guid.NewGuid());
-            _sagaPolicy = new Mock<ISagaPolicy<SimpleSaga, InitiateSimpleSaga>>();
-            _nextPipe = new Mock<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>>();
+            _sagaPolicy = new Mock<ISagaPolicy<SimpleSagaResource, InitiateSimpleSaga>>();
+            _nextPipe = new Mock<IPipe<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>>();
 
-            var repository = new DocumentDbSagaRepository<SimpleSaga>(SagaRepository.Instance.Client, SagaRepository.DatabaseName, SagaRepository.CollectionName, null);
+            var repository = new DocumentDbSagaRepository<SimpleSagaResource>(SagaRepository.Instance.Client, SagaRepository.DatabaseName, SagaRepository.CollectionName);
 
             await repository.SendQuery(_sagaQueryConsumeContext.Object, _sagaPolicy.Object, _nextPipe.Object);
         }

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendingWhenCorrelationIdNull.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendingWhenCorrelationIdNull.cs
@@ -39,12 +39,12 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
             var context = new Mock<ConsumeContext<InitiateSimpleSaga>>();
             context.Setup(x => x.CorrelationId).Returns(default(Guid?));
 
-            var repository = new DocumentDbSagaRepository<SimpleSaga>(Mock.Of<IDocumentClient>(), "sagaTest", "sagas", null);
+            var repository = new DocumentDbSagaRepository<SimpleSagaResource>(Mock.Of<IDocumentClient>(), "sagaTest");
 
             try
             {
-                await repository.Send(context.Object, Mock.Of<ISagaPolicy<SimpleSaga, InitiateSimpleSaga>>(),
-                    Mock.Of<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>>());
+                await repository.Send(context.Object, Mock.Of<ISagaPolicy<SimpleSagaResource, InitiateSimpleSaga>>(),
+                    Mock.Of<IPipe<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>>());
             }
             catch (SagaException exception)
             {

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendingWhenInstanceNotFound.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendingWhenInstanceNotFound.cs
@@ -29,13 +29,13 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
         [Test]
         public void ThenMissingPipeInvokedOnPolicy()
         {
-            _policy.Verify(m => m.Missing(_context.Object, It.IsAny<MissingPipe<SimpleSaga, InitiateSimpleSaga>>()));
+            _policy.Verify(m => m.Missing(_context.Object, It.IsAny<MissingPipe<SimpleSagaResource, InitiateSimpleSaga>>()));
         }
 
-        Mock<ISagaPolicy<SimpleSaga, InitiateSimpleSaga>> _policy;
+        Mock<ISagaPolicy<SimpleSagaResource, InitiateSimpleSaga>> _policy;
         Mock<ConsumeContext<InitiateSimpleSaga>> _context;
-        SimpleSaga _nullSimpleSaga;
-        Mock<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>> _nextPipe;
+        SimpleSagaResource _nullSimpleSaga;
+        Mock<IPipe<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>> _nextPipe;
 
         [OneTimeSetUp]
         public async Task GivenADocumentDbSagaRepository_WhenSendingAndInstanceNotFound()
@@ -46,12 +46,12 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
 
             _nullSimpleSaga = null;
 
-            _policy = new Mock<ISagaPolicy<SimpleSaga, InitiateSimpleSaga>>();
+            _policy = new Mock<ISagaPolicy<SimpleSagaResource, InitiateSimpleSaga>>();
             _policy.Setup(x => x.PreInsertInstance(_context.Object, out _nullSimpleSaga)).Returns(false);
 
-            _nextPipe = new Mock<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>>();
+            _nextPipe = new Mock<IPipe<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>>();
 
-            var repository = new DocumentDbSagaRepository<SimpleSaga>(SagaRepository.Instance.Client, SagaRepository.DatabaseName, SagaRepository.CollectionName, null);
+            var repository = new DocumentDbSagaRepository<SimpleSagaResource>(SagaRepository.Instance.Client, SagaRepository.DatabaseName);
 
             await repository.Send(_context.Object, _policy.Object, _nextPipe.Object);
         }

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendingWhenInstanceNotReturnedFromPolicy.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/DocumentDbSagaRepositoryTestsForSendingWhenInstanceNotReturnedFromPolicy.cs
@@ -49,15 +49,15 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
             Assert.That(etagGuid != Guid.Empty, Is.True);
         }
 
-        Mock<ISagaPolicy<SimpleSaga, InitiateSimpleSaga>> _policy;
+        Mock<ISagaPolicy<SimpleSagaResource, InitiateSimpleSaga>> _policy;
         Mock<ConsumeContext<InitiateSimpleSaga>> _context;
-        SimpleSaga _nullSimpleSaga;
+        SimpleSagaResource _nullSimpleSaga;
         Guid _correlationId;
         CancellationToken _cancellationToken;
-        Mock<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>> _nextPipe;
-        SimpleSaga _simpleSaga;
+        Mock<IPipe<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>> _nextPipe;
+        SimpleSagaResource _simpleSaga;
         Mock<IDocumentDbSagaConsumeContextFactory> _sagaConsumeContextFactory;
-        Mock<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>> _sagaConsumeContext;
+        Mock<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>> _sagaConsumeContext;
 
         [OneTimeSetUp]
         public async Task GivenADocumentDbSagaRepository_WhenSendingAndInstanceNotReturnedFromPolicy()
@@ -71,24 +71,24 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
 
             _nullSimpleSaga = null;
 
-            _policy = new Mock<ISagaPolicy<SimpleSaga, InitiateSimpleSaga>>();
+            _policy = new Mock<ISagaPolicy<SimpleSagaResource, InitiateSimpleSaga>>();
             _policy.Setup(x => x.PreInsertInstance(_context.Object, out _nullSimpleSaga)).Returns(false);
 
-            _nextPipe = new Mock<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>>();
+            _nextPipe = new Mock<IPipe<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>>();
 
-            _simpleSaga = new SimpleSaga {CorrelationId = _correlationId};
+            _simpleSaga = new SimpleSagaResource { CorrelationId = _correlationId};
 
-            _sagaConsumeContext = new Mock<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>();
+            _sagaConsumeContext = new Mock<SagaConsumeContext<SimpleSagaResource, InitiateSimpleSaga>>();
             _sagaConsumeContext.Setup(x => x.CorrelationId).Returns(_correlationId);
 
             _sagaConsumeContextFactory = new Mock<IDocumentDbSagaConsumeContextFactory>();
             _sagaConsumeContextFactory.Setup(
-                    m => m.Create(It.IsAny<IDocumentClient>(),It.IsAny<string>(), It.IsAny<string>(), _context.Object, It.Is<SimpleSaga>(x => x.CorrelationId == _correlationId), true))
+                    m => m.Create(It.IsAny<IDocumentClient>(),It.IsAny<string>(), It.IsAny<string>(), _context.Object, It.Is<SimpleSagaResource>(x => x.CorrelationId == _correlationId), true, null))
                 .Returns(_sagaConsumeContext.Object);
 
-            await SagaRepository.Instance.InsertSaga(_simpleSaga);
+            await SagaRepository.Instance.InsertSaga(_simpleSaga, true);
 
-            var repository = new DocumentDbSagaRepository<SimpleSaga>(SagaRepository.Instance.Client, SagaRepository.DatabaseName, SagaRepository.CollectionName, _sagaConsumeContextFactory.Object);
+            var repository = new DocumentDbSagaRepository<SimpleSagaResource>(SagaRepository.Instance.Client, SagaRepository.DatabaseName, SagaRepository.CollectionName, _sagaConsumeContextFactory.Object, null);
 
             await repository.Send(_context.Object, _policy.Object, _nextPipe.Object);
         }

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/MissingPipeTestsForProbing.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/MissingPipeTestsForProbing.cs
@@ -36,7 +36,7 @@
             _nextPipe = new Mock<IPipe<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>>();
 
             _pipe = new MissingPipe<SimpleSaga, InitiateSimpleSaga>(Mock.Of<IDocumentClient>(), SagaRepository.DatabaseName, SagaRepository.CollectionName, _nextPipe.Object,
-                Mock.Of<IDocumentDbSagaConsumeContextFactory>(), new RequestOptions());
+                Mock.Of<IDocumentDbSagaConsumeContextFactory>(), null);
         }
     }
 }

--- a/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/MissingPipeTestsForSendingWhenProxyCompleted.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration.Tests/Saga/MissingPipeTestsForSendingWhenProxyCompleted.cs
@@ -56,9 +56,9 @@ namespace MassTransit.DocumentDbIntegration.Tests.Saga
             _consumeContextFactory = new Mock<IDocumentDbSagaConsumeContextFactory>();
             _mockDocumentClient = new Mock<IDocumentClient>();
             _context = new Mock<SagaConsumeContext<SimpleSaga, InitiateSimpleSaga>>();
-            _consumeContextFactory.Setup(m => m.Create(_mockDocumentClient.Object, "","", _context.Object, _context.Object.Saga, false)).Returns(_proxy.Object);
+            _consumeContextFactory.Setup(m => m.Create(_mockDocumentClient.Object, "","", _context.Object, It.IsAny<SimpleSaga>(), false, null)).Returns(_proxy.Object);
 
-            _pipe = new MissingPipe<SimpleSaga, InitiateSimpleSaga>(_mockDocumentClient.Object, "","", _nextPipe.Object, _consumeContextFactory.Object, new RequestOptions());
+            _pipe = new MissingPipe<SimpleSaga, InitiateSimpleSaga>(_mockDocumentClient.Object, "","", _nextPipe.Object, _consumeContextFactory.Object, null);
 
             TaskUtil.Await(() => _pipe.Send(_context.Object));
         }

--- a/src/Persistence/MassTransit.DocumentDbIntegration/IVersionedSaga.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration/IVersionedSaga.cs
@@ -1,0 +1,9 @@
+﻿namespace MassTransit.DocumentDbIntegration
+{
+    using MassTransit.Saga;
+
+    public interface IVersionedSaga : ISaga
+    {
+        string ETag { get; }
+    }
+}

--- a/src/Persistence/MassTransit.DocumentDbIntegration/JsonSerializerSettingsExtensions.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration/JsonSerializerSettingsExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace MassTransit.DocumentDbIntegration
+{
+    using Newtonsoft.Json;
+
+    public static class JsonSerializerSettingsExtensions
+    {
+        public static JsonSerializerSettings GetSagaRenameSettings<TSaga>() where TSaga : class, IVersionedSaga
+        {
+            var resolver = new PropertyRenameSerializerContractResolver();
+            resolver.RenameProperty(typeof(TSaga), "CorrelationId", "id");
+            resolver.RenameProperty(typeof(TSaga), "ETag", "_etag");
+
+            return new JsonSerializerSettings
+            {
+                ContractResolver = resolver
+            };
+        }
+    }
+}

--- a/src/Persistence/MassTransit.DocumentDbIntegration/MassTransit.DocumentDbIntegration.csproj
+++ b/src/Persistence/MassTransit.DocumentDbIntegration/MassTransit.DocumentDbIntegration.csproj
@@ -31,5 +31,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.10" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Persistence/MassTransit.DocumentDbIntegration/PropertyRenameSerializerContractResolver.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration/PropertyRenameSerializerContractResolver.cs
@@ -10,15 +10,14 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-
-
 namespace MassTransit.DocumentDbIntegration
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+
     public class PropertyRenameSerializerContractResolver : DefaultContractResolver
     {
         readonly Dictionary<Type, Dictionary<string, string>> _renames;

--- a/src/Persistence/MassTransit.DocumentDbIntegration/Saga/Context/DocumentDbSagaConsumeContextFactory.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration/Saga/Context/DocumentDbSagaConsumeContextFactory.cs
@@ -13,20 +13,18 @@
 
 namespace MassTransit.DocumentDbIntegration.Saga.Context
 {
-    using MassTransit.Saga;
     using Microsoft.Azure.Documents;
-    using Microsoft.Azure.Documents.Client;
-
+    using Newtonsoft.Json;
 
     public class DocumentDbSagaConsumeContextFactory :
         IDocumentDbSagaConsumeContextFactory
     {
         public SagaConsumeContext<TSaga, TMessage> Create<TSaga, TMessage>(IDocumentClient client, string databaseName, string collectionName,
-            ConsumeContext<TMessage> message, TSaga instance, bool existing = true)
-            where TSaga : class, ISaga
+            ConsumeContext<TMessage> message, TSaga instance, bool existing = true, JsonSerializerSettings jsonSerializerSettings = null)
+            where TSaga : class, IVersionedSaga
             where TMessage : class
         {
-            return new DocumentDbSagaConsumeContext<TSaga, TMessage>(client, databaseName, collectionName, message, instance, existing);
+            return new DocumentDbSagaConsumeContext<TSaga, TMessage>(client, databaseName, collectionName, message, instance, existing, jsonSerializerSettings);
         }
     }
 }

--- a/src/Persistence/MassTransit.DocumentDbIntegration/Saga/Context/IDocumentDbSagaConsumeContextFactory.cs
+++ b/src/Persistence/MassTransit.DocumentDbIntegration/Saga/Context/IDocumentDbSagaConsumeContextFactory.cs
@@ -1,15 +1,13 @@
 namespace MassTransit.DocumentDbIntegration.Saga.Context
 {
-    using MassTransit.Saga;
     using Microsoft.Azure.Documents;
-    using Microsoft.Azure.Documents.Client;
-
+    using Newtonsoft.Json;
 
     public interface IDocumentDbSagaConsumeContextFactory
     {
         SagaConsumeContext<TSaga, TMessage> Create<TSaga, TMessage>(IDocumentClient client, string databaseName, string collectionName,
-            ConsumeContext<TMessage> message, TSaga instance, bool existing = true)
-            where TSaga : class, ISaga
+            ConsumeContext<TMessage> message, TSaga instance, bool existing = true, JsonSerializerSettings jsonSerializerSettings = null)
+            where TSaga : class, IVersionedSaga
             where TMessage : class;
     }
 }


### PR DESCRIPTION
Here's the fix for #1174 

This also fixes an additional bug found which is mentioned in the discussion of that same issue which was introduced with the JsonProperty("id") refactor.

I left in the PropertyRenameResolver, and updated the documentation to explain the limitation if using, and offer alternatives to allow usage of any query expression with Document Db.