### PR TITLE
Make Azure Service Bus test settings configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ src/SolutionVersion.cs
 tests
 doc/build/*
 *.[lm]df
+*.runsettings
 
 # osx noise
 .DS_Store

--- a/src/MassTransit.AzureServiceBusTransport.Tests/AzureServiceBusTestFixture.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/AzureServiceBusTestFixture.cs
@@ -32,7 +32,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
 
         public AzureServiceBusTestFixture(string inputQueueName = null, Uri serviceUri = null, ServiceBusTokenProviderSettings settings = null)
             : this(new AzureServiceBusTestHarness(
-                serviceUri ?? ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build", "MassTransit.AzureServiceBusTransport.Tests"),
+                serviceUri ?? ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace, "MassTransit.AzureServiceBusTransport.Tests"),
                 settings?.KeyName ?? ((ServiceBusTokenProviderSettings)new TestAzureServiceBusAccountSettings()).KeyName,
                 settings?.SharedAccessKey ?? ((ServiceBusTokenProviderSettings)new TestAzureServiceBusAccountSettings()).SharedAccessKey,
                 inputQueueName))

--- a/src/MassTransit.AzureServiceBusTransport.Tests/Configuration.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/Configuration.cs
@@ -1,0 +1,20 @@
+﻿namespace MassTransit.AzureServiceBusTransport.Tests
+{
+    using NUnit.Framework;
+
+    internal static class Configuration
+    {
+        public static string KeyName =>
+            TestContext.Parameters.Exists(nameof(KeyName))
+                ? TestContext.Parameters.Get(nameof(KeyName))
+                : "MassTransitBuild";
+        public static string ServiceNamespace =>
+            TestContext.Parameters.Exists(nameof(ServiceNamespace))
+                ? TestContext.Parameters.Get(nameof(ServiceNamespace))
+                : "masstransit-build";
+        public static string SharedAccessKey =>
+            TestContext.Parameters.Exists(nameof(SharedAccessKey))
+                ? TestContext.Parameters.Get(nameof(SharedAccessKey))
+                : "xsvaZOKYkX8JI5N+spLCkI9iu102jLhWFJrf0LmNPMw=";
+    }
+}

--- a/src/MassTransit.AzureServiceBusTransport.Tests/ConfiguringAzure_Specs.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/ConfiguringAzure_Specs.cs
@@ -33,7 +33,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
             {
                 ServiceBusTokenProviderSettings settings = new TestAzureServiceBusAccountSettings();
 
-                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build",
+                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace,
                     "MassTransit.AzureServiceBusTransport.Tests");
 
                 var completed = new TaskCompletionSource<A>();
@@ -83,7 +83,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
             {
                 ServiceBusTokenProviderSettings settings = new TestAzureServiceBusAccountSettings();
 
-                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build",
+                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace,
                     "MassTransit.AzureServiceBusTransport.Tests");
 
                 var completed = new TaskCompletionSource<A>();
@@ -141,7 +141,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
             {
                 ServiceBusTokenProviderSettings settings = new TestAzureServiceBusAccountSettings();
 
-                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build",
+                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace,
                     "Test.Namespace");
 
                // serviceUri = new Uri(serviceUri.ToString().Trim('/'));

--- a/src/MassTransit.AzureServiceBusTransport.Tests/TestAzureServiceBusAccountSettings.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/TestAzureServiceBusAccountSettings.cs
@@ -19,8 +19,8 @@ namespace MassTransit.AzureServiceBusTransport.Tests
     public class TestAzureServiceBusAccountSettings :
         ServiceBusTokenProviderSettings
     {
-        const string KeyName = "MassTransitBuild";
-        const string SharedAccessKey = "xsvaZOKYkX8JI5N+spLCkI9iu102jLhWFJrf0LmNPMw=";
+        static readonly string KeyName = Configuration.KeyName;
+        static readonly string SharedAccessKey = Configuration.SharedAccessKey;
         readonly TokenScope _tokenScope;
         readonly TimeSpan _tokenTimeToLive;
 

--- a/src/MassTransit.AzureServiceBusTransport.Tests/TwoScopeAzureServiceBusTestFixture.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/TwoScopeAzureServiceBusTestFixture.cs
@@ -28,7 +28,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
 
         public TwoScopeAzureServiceBusTestFixture()
         {
-            _secondServiceUri = ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build", "MassTransit.Tests.SecondService");
+            _secondServiceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace, "MassTransit.Tests.SecondService");
         }
 
         Uri _secondInputQueueAddress;

--- a/src/MassTransit.AzureServiceBusTransport.Tests/Verify_account_settings.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/Verify_account_settings.cs
@@ -38,7 +38,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
 
                 TokenProvider tokenProvider = provider.GetTokenProvider();
 
-                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build",
+                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace,
                     "MassTransit.AzureServiceBusTransport.Tests");
                 var namespaceManager = new NamespaceManager(serviceUri, tokenProvider);
                 CreateQueue(namespaceManager, serviceUri, "TestClient");
@@ -59,7 +59,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
 
                 MessagingFactory factory =
                     MessagingFactory.Create(
-                        ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build", Environment.MachineName), mfs);
+                        ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace, Environment.MachineName), mfs);
 
                 MessageReceiver receiver = await factory.CreateMessageReceiverAsync("Control");
                 receiver.PrefetchCount = 100;
@@ -119,7 +119,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
 
             void CreateHostQueue(TokenProvider tokenProvider)
             {
-                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", "masstransit-build",
+                Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace,
                     Environment.MachineName);
                 var namespaceManager = new NamespaceManager(serviceUri, tokenProvider);
                 CreateQueue(namespaceManager, serviceUri, "Control");


### PR DESCRIPTION
The Azure Service Bus settings for the Azure Service Bus tests are hard-coded and this bus is not accessible for external developers. This PR makes the settings configurable by providing them in a [.runsettings](https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file) file. This allows external developers to configure their own service bus and run the tests. If none is provided or if the settings are not present, the same values from the original code are returned, so no change to the current build pipeline should be needed when merging this PR.

Example: default.runsettings
```xml
<?xml version="1.0" encoding="utf-8"?>
<RunSettings>
  <!-- Parameters used by tests at runtime -->
  <TestRunParameters>
    <Parameter name="ServiceNamespace" value="masstransit-build" />
    <Parameter name="KeyName" value="MassTransitBuild" />
    <Parameter name="SharedAccessKey" value="xsvaZOKYkX8JI5N+spLCkI9iu102jLhWFJrf0LmNPMw="/>
  </TestRunParameters>
</RunSettings>
```