### PR TITLE
Make Servicebus settings configurable for .net core test project

### DIFF
--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/AzureServiceBusTestFixture.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/AzureServiceBusTestFixture.cs
@@ -32,7 +32,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
         public AzureServiceBusTestFixture(string inputQueueName = null, Uri serviceUri = null, ServiceBusTokenProviderSettings settings = null)
             : this(new AzureServiceBusTestHarness(
-                serviceUri ?? AzureServiceBusEndpointUriCreator.Create("masstransit-build", "MassTransit.AzureServiceBusTransport.Tests"),
+                serviceUri ?? AzureServiceBusEndpointUriCreator.Create(Configuration.ServiceNamespace, "MassTransit.Azure.ServiceBus.Core.Tests"),
                 settings?.KeyName ?? ((ServiceBusTokenProviderSettings)new TestAzureServiceBusAccountSettings()).KeyName,
                 settings?.SharedAccessKey ?? ((ServiceBusTokenProviderSettings)new TestAzureServiceBusAccountSettings()).SharedAccessKey,
                 inputQueueName))

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/BasicAzureServiceBusAccountSettings.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/BasicAzureServiceBusAccountSettings.cs
@@ -15,11 +15,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
     using System;
     using Microsoft.Azure.ServiceBus.Primitives;
 
-    public class BasicAzureServiceBusAccountSettings : 
+    public class BasicAzureServiceBusAccountSettings :
         ServiceBusTokenProviderSettings
     {
-        const string KeyName = "MassTransitBuild";
-        const string SharedAccessKey = "AVoxltiFrIsOQsdlCgtbLtVGjcEpXH/9ZM1q/55xjoM=";
+        static readonly string KeyName = Configuration.KeyName;
+        static readonly string SharedAccessKey = Configuration.SharedAccessKey;
         readonly TokenScope _tokenScope;
         readonly TimeSpan _tokenTimeToLive;
 

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/Basic_Specs.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/Basic_Specs.cs
@@ -42,7 +42,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         }
 
         public Sending_a_message_to_a_basic_endpoint()
-            : base("input_queue", AzureServiceBusEndpointUriCreator.Create("masstransit-basic", "MassTransit.AzureServiceBusTransport.Tests"),
+            : base("input_queue", AzureServiceBusEndpointUriCreator.Create(Configuration.ServiceNamespace, "MassTransit.Azure.ServiceBus.Core.Tests"),
                 new BasicAzureServiceBusAccountSettings())
         {
         }

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/Configuration.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/Configuration.cs
@@ -1,0 +1,20 @@
+﻿namespace MassTransit.Azure.ServiceBus.Core.Tests
+{
+    using NUnit.Framework;
+
+    internal static class Configuration
+    {
+        public static string KeyName =>
+            TestContext.Parameters.Exists(nameof(KeyName))
+                ? TestContext.Parameters.Get(nameof(KeyName))
+                : "MassTransitBuild";
+        public static string ServiceNamespace =>
+            TestContext.Parameters.Exists(nameof(ServiceNamespace))
+                ? TestContext.Parameters.Get(nameof(ServiceNamespace))
+                : "masstransit-build";
+        public static string SharedAccessKey =>
+            TestContext.Parameters.Exists(nameof(SharedAccessKey))
+                ? TestContext.Parameters.Get(nameof(SharedAccessKey))
+                : "xsvaZOKYkX8JI5N+spLCkI9iu102jLhWFJrf0LmNPMw=";
+    }
+}

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/ConfiguringAzure_Specs.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/ConfiguringAzure_Specs.cs
@@ -32,11 +32,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             public async Task Should_support_the_new_syntax()
             {
                 ServiceBusTokenProviderSettings settings = new TestAzureServiceBusAccountSettings();
-                var serviceBusNamespace = "masstransit-build";
+                var serviceBusNamespace = Configuration.ServiceNamespace;
 
                 Uri serviceUri = AzureServiceBusEndpointUriCreator.Create(
                     serviceBusNamespace, 
-                    "MassTransit.AzureServiceBusTransport.Tests"
+                    "MassTransit.Azure.ServiceBus.Core.Tests"
                 );
 
                 var completed = new TaskCompletionSource<A>();
@@ -94,7 +94,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             {
                 ServiceBusTokenProviderSettings settings = new TestAzureServiceBusAccountSettings();
 
-                var serviceBusNamespace = "masstransit-build";
+                var serviceBusNamespace = Configuration.ServiceNamespace;
 
                 Uri serviceUri = new Uri($"sb://{serviceBusNamespace}.servicebus.windows.net/Test.Namespace");
 

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/TestAzureServiceBusAccountSettings.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/TestAzureServiceBusAccountSettings.cs
@@ -19,8 +19,8 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
     public class TestAzureServiceBusAccountSettings :
         ServiceBusTokenProviderSettings
     {
-        const string KeyName = "MassTransitBuild";
-        const string SharedAccessKey = "xsvaZOKYkX8JI5N+spLCkI9iu102jLhWFJrf0LmNPMw=";
+        static readonly string KeyName = Configuration.KeyName;
+        static readonly string SharedAccessKey = Configuration.SharedAccessKey;
         readonly TokenScope _tokenScope;
         readonly TimeSpan _tokenTimeToLive;
 

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/TwoScopeAzureServiceBusTestFixture.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/TwoScopeAzureServiceBusTestFixture.cs
@@ -28,7 +28,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
         public TwoScopeAzureServiceBusTestFixture()
         {
-            _secondServiceUri = AzureServiceBusEndpointUriCreator.Create("masstransit-build", "MassTransit.Tests.SecondService");
+            _secondServiceUri = AzureServiceBusEndpointUriCreator.Create(Configuration.ServiceNamespace, "MassTransit.Tests.SecondService");
         }
 
         Uri _secondInputQueueAddress;

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/Verify_account_settings.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/Verify_account_settings.cs
@@ -46,8 +46,8 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
                 };
 
                 var serviceUri = AzureServiceBusEndpointUriCreator.Create(
-                    "masstransit-build",
-                    "MassTransit.AzureServiceBusTransport.Tests"
+                    Configuration.ServiceNamespace,
+                    "MassTransit.Azure.ServiceBus.Core.Tests"
                 );
 
                 var namespaceManager = new NamespaceManager(serviceUri, namespaceSettings);
@@ -119,7 +119,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             Task CreateHostQueue(ITokenProvider tokenProvider)
             {
                 var serviceUri = AzureServiceBusEndpointUriCreator.Create(
-                    "masstransit-build",
+                    Configuration.ServiceNamespace,
                     Environment.MachineName
                 );
 


### PR DESCRIPTION
The Azure Service Bus settings for the Azure Service Bus Core tests are hard-coded and this bus is not accessible for external developers. This PR makes the settings configurable by providing them in a .runsettings file. This allows external developers to configure their own service bus and run the tests. If none is provided or if the settings are not present, the same values from the original code are returned, so no change to the current build pipeline should be needed when merging this PR.

Example: default.runsettings

```xml
<?xml version="1.0" encoding="utf-8"?>
<RunSettings>
  <!-- Parameters used by tests at runtime -->
  <TestRunParameters>
    <Parameter name="ServiceNamespace" value="masstransit-build" />
    <Parameter name="KeyName" value="MassTransitBuild" />
    <Parameter name="SharedAccessKey" value="xsvaZOKYkX8JI5N+spLCkI9iu102jLhWFJrf0LmNPMw="/>
  </TestRunParameters>
</RunSettings>
```