### PR TITLE
Remove superfluous NetMessagingFactoryCache

### DIFF
--- a/src/MassTransit.AzureServiceBusTransport/IServiceBusHost.cs
+++ b/src/MassTransit.AzureServiceBusTransport/IServiceBusHost.cs
@@ -42,11 +42,6 @@ namespace MassTransit.AzureServiceBusTransport
         IMessagingFactoryCache MessagingFactoryCache { get; }
 
         /// <summary>
-        /// The messaging factory cache for NET-TCP (may be the same as above, depending upon configuration)
-        /// </summary>
-        IMessagingFactoryCache NetMessagingFactoryCache { get; }
-
-        /// <summary>
         /// The namespace cache for operating on the service bus namespace (management)
         /// </summary>
         INamespaceCache NamespaceCache { get; }


### PR DESCRIPTION
The ServiceBusHost has two MessagingFactoryCaches. One specifically
forced to be configured to use the NetMessaging TransportType. This is
odd as the "normal" MessagingFactoryCache will get the correct settings
depending on the transporttype NetMessaging or Amqp. Also the
NetMessagingFactoryCache is not used anywhere, so it can be removed
safely.