### PR TITLE
Better exception when cyclic graph detect and concurrency protections

### DIFF
--- a/src/MassTransit/Transports/InMemory/GraphValidation/CyclicGraphException.cs
+++ b/src/MassTransit/Transports/InMemory/GraphValidation/CyclicGraphException.cs
@@ -1,0 +1,41 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Transports.InMemory.GraphValidation
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    public class CyclicGraphException :
+        MassTransitException
+    {
+        public CyclicGraphException()
+        {
+        }
+
+        public CyclicGraphException(string message)
+            : base(message)
+        {
+        }
+
+        public CyclicGraphException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected CyclicGraphException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/MassTransit/Transports/InMemory/GraphValidation/DependencyGraph.cs
+++ b/src/MassTransit/Transports/InMemory/GraphValidation/DependencyGraph.cs
@@ -58,7 +58,7 @@ namespace MassTransit.Transports.InMemory.GraphValidation
                 message.Append(")");
             }
 
-            throw new InvalidOperationException("The dependency graph contains cycles: " + message);
+            throw new CyclicGraphException("The dependency graph contains cycles: " + message);
         }
     }
 }


### PR DESCRIPTION
This fixes issues that I discovered when I was running highly concurrent tests and they were building a lot of in memory transports. The exception told that graph was cyclic when in fact the inner exception told that there was a concurrent modification.

```
System.InvalidOperationException: The exchange binding would create a cycle in the messaging fabric. ---> System.InvalidOperationException: Collection was modified; enumeration operation may not execute.

at System.Collections.Generic.HashSet`1.Enumerator.MoveNext()
at MassTransit.Transports.InMemory.Fabric.MessageFabric.ValidateBinding(IMessageSink`1 destination, IInMemoryExchange sourceExchange)
--- End of inner exception stack trace ---
at MassTransit.Transports.InMemory.Fabric.MessageFabric.ValidateBinding(IMessageSink`1 destination, IInMemoryExchange sourceExchange)
at MassTransit.Transports.InMemory.Fabric.MessageFabric.ExchangeBind(String source, String destination)
at MassTransit.Transports.InMemory.Topology.Builders.PublishEndpointTopologyBuilder.ImplementedBuilder.set_ExchangeName(String value)
at MassTransit.Transports.InMemory.Topology.Topologies.InMemoryMessagePublishTopology`1.Apply(IInMemoryPublishTopologyBuilder builder)
at MassTransit.Transports.InMemory.Topology.Topologies.InMemoryMessagePublishTopology`1.TypeAdapter`1.Apply(IInMemoryPublishTopologyBuilder builder)
at MassTransit.Transports.InMemory.Topology.Topologies.InMemoryMessagePublishTopology`1.Apply(IInMemoryPublishTopologyBuilder builder)
at MassTransit.Transports.InMemory.InMemoryPublishTransportProvider.GetPublishTransport[T](Uri publishAddress)
at MassTransit.Transports.PublishEndpointProvider.<CreateSendEndpoint>d__14`1.MoveNext()
```

I've modified acyclic check to throw typed exception that can be handled on caller side and also using separate list instances to traverse instead of enumerables that might change mid-traversal.