### PR TITLE
Add SourceLink support and consolidate some csproj properties

### DIFF
--- a/src/Containers/MassTransit.AutofacIntegration/MassTransit.AutofacIntegration.csproj
+++ b/src/Containers/MassTransit.AutofacIntegration/MassTransit.AutofacIntegration.csproj
@@ -3,7 +3,6 @@
     <RootNamespace>MassTransit.AutofacIntegration</RootNamespace>
     <AssemblyName>MassTransit.AutofacIntegration</AssemblyName>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Containers/MassTransit.Automatonymous.AutofacIntegration/MassTransit.Automatonymous.AutofacIntegration.csproj
+++ b/src/Containers/MassTransit.Automatonymous.AutofacIntegration/MassTransit.Automatonymous.AutofacIntegration.csproj
@@ -3,7 +3,6 @@
     <RootNamespace>MassTransit.AutomatonymousAutofacIntegration</RootNamespace>
     <AssemblyName>MassTransit.Automatonymous.AutofacIntegration</AssemblyName>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Containers/MassTransit.Automatonymous.ExtensionsDependencyInjectionIntegration/MassTransit.Automatonymous.ExtensionsDependencyInjectionIntegration.csproj
+++ b/src/Containers/MassTransit.Automatonymous.ExtensionsDependencyInjectionIntegration/MassTransit.Automatonymous.ExtensionsDependencyInjectionIntegration.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>MassTransit.AutomatonymousExtensions.DependencyInjectionIntegration</AssemblyName>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Containers/MassTransit.Automatonymous.LamarIntegration/MassTransit.Automatonymous.LamarIntegration.csproj
+++ b/src/Containers/MassTransit.Automatonymous.LamarIntegration/MassTransit.Automatonymous.LamarIntegration.csproj
@@ -3,7 +3,6 @@
     <RootNamespace>MassTransit.AutomatonymousLamarIntegration</RootNamespace>
     <AssemblyName>MassTransit.Automatonymous.LamarIntegration</AssemblyName>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.Automatonymous.Lamar</PackageId>

--- a/src/Containers/MassTransit.Automatonymous.StructureMapIntegration/MassTransit.Automatonymous.StructureMapIntegration.csproj
+++ b/src/Containers/MassTransit.Automatonymous.StructureMapIntegration/MassTransit.Automatonymous.StructureMapIntegration.csproj
@@ -3,7 +3,6 @@
     <RootNamespace>MassTransit.AutomatonymousStructureMapIntegration</RootNamespace>
     <AssemblyName>MassTransit.Automatonymous.StructureMapIntegration</AssemblyName>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.Automatonymous.StructureMap</PackageId>

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/MassTransit.ExtensionsDependencyInjectionIntegration.csproj
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/MassTransit.ExtensionsDependencyInjectionIntegration.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>MassTransit.Extensions.DependencyInjectionIntegration</AssemblyName>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Containers/MassTransit.LamarIntegration/MassTransit.LamarIntegration.csproj
+++ b/src/Containers/MassTransit.LamarIntegration/MassTransit.LamarIntegration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.Lamar</PackageId>

--- a/src/Containers/MassTransit.NinjectIntegration/MassTransit.NinjectIntegration.csproj
+++ b/src/Containers/MassTransit.NinjectIntegration/MassTransit.NinjectIntegration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Containers/MassTransit.SimpleInjectorIntegration/MassTransit.SimpleInjectorIntegration.csproj
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/MassTransit.SimpleInjectorIntegration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Containers/MassTransit.StructureMapIntegration/MassTransit.StructureMapIntegration.csproj
+++ b/src/Containers/MassTransit.StructureMapIntegration/MassTransit.StructureMapIntegration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.StructureMap</PackageId>

--- a/src/Containers/MassTransit.UnityIntegration/MassTransit.UnityIntegration.csproj
+++ b/src/Containers/MassTransit.UnityIntegration/MassTransit.UnityIntegration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Containers/MassTransit.WindsorIntegration/MassTransit.WindsorIntegration.csproj
+++ b/src/Containers/MassTransit.WindsorIntegration/MassTransit.WindsorIntegration.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,24 +3,39 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-  <Title>MassTransit</Title>
+    <Title>MassTransit</Title>
     <Product>MassTransit</Product>
     <Description>MassTransit is a message-based distributed application framework for .NET http://masstransit-project.com</Description>
     <PackageProjectUrl>https://github.com/MassTransit/MassTransit</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/MassTransit/MassTransit/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/MassTransit/MassTransit</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageTags>MassTransit</PackageTags>
     <Authors>Chris Patterson;Dru Sellers;Travis Smith</Authors>
     <Copyright>Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.</Copyright>
     <WarningLevel>4</WarningLevel>
     <NoWarn>1587,1591,1998,3008,3001</NoWarn>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <LangVersion>latest</LangVersion>
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>portable</DebugType>
+
+    <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
+
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>full</DebugType>
     <DefineConstants>DEBUG;TRACE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <Optimize>true</Optimize>
     <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Loggers/MassTransit.ExtensionsLoggingIntegration/MassTransit.ExtensionsLoggingIntegration.csproj
+++ b/src/Loggers/MassTransit.ExtensionsLoggingIntegration/MassTransit.ExtensionsLoggingIntegration.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>MassTransit.ExtensionsLoggingIntegration</AssemblyName>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Loggers/MassTransit.Log4NetIntegration/MassTransit.Log4NetIntegration.csproj
+++ b/src/Loggers/MassTransit.Log4NetIntegration/MassTransit.Log4NetIntegration.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>MassTransit.Log4NetIntegration</AssemblyName>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Loggers/MassTransit.NLogIntegration/MassTransit.NLogIntegration.csproj
+++ b/src/Loggers/MassTransit.NLogIntegration/MassTransit.NLogIntegration.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>MassTransit.NLogIntegration</AssemblyName>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Loggers/MassTransit.SerilogIntegration/MassTransit.SerilogIntegration.csproj
+++ b/src/Loggers/MassTransit.SerilogIntegration/MassTransit.SerilogIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/MassTransit.ActiveMqTransport.Tests/MassTransit.ActiveMqTransport.Tests.csproj
+++ b/src/MassTransit.ActiveMqTransport.Tests/MassTransit.ActiveMqTransport.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="2.1.3" />

--- a/src/MassTransit.ActiveMqTransport/MassTransit.ActiveMqTransport.csproj
+++ b/src/MassTransit.ActiveMqTransport/MassTransit.ActiveMqTransport.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>

--- a/src/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
+++ b/src/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="2.1.3" />

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>

--- a/src/MassTransit.ApplicationInsights.Tests/MassTransit.ApplicationInsights.Tests.csproj
+++ b/src/MassTransit.ApplicationInsights.Tests/MassTransit.ApplicationInsights.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MassTransit.ApplicationInsights\MassTransit.ApplicationInsights.csproj" />

--- a/src/MassTransit.ApplicationInsights/MassTransit.ApplicationInsights.csproj
+++ b/src/MassTransit.ApplicationInsights/MassTransit.ApplicationInsights.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
-    <LangVersion>7.1</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/MassTransit.AutomatonymousIntegration/MassTransit.AutomatonymousIntegration.csproj
+++ b/src/MassTransit.AutomatonymousIntegration/MassTransit.AutomatonymousIntegration.csproj
@@ -3,10 +3,8 @@
     <RootNamespace>Automatonymous</RootNamespace>
     <AssemblyName>MassTransit.AutomatonymousIntegration</AssemblyName>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.Automatonymous</PackageId>

--- a/src/MassTransit.Azure.ServiceBus.Core/MassTransit.Azure.ServiceBus.Core.csproj
+++ b/src/MassTransit.Azure.ServiceBus.Core/MassTransit.Azure.ServiceBus.Core.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
-    <LangVersion>7.2</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/MassTransit.AzureServiceBusTransport/MassTransit.AzureServiceBusTransport.csproj
+++ b/src/MassTransit.AzureServiceBusTransport/MassTransit.AzureServiceBusTransport.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
-    <LangVersion>7.1</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/MassTransit.Futures.Tests/MassTransit.Futures.Tests.csproj
+++ b/src/MassTransit.Futures.Tests/MassTransit.Futures.Tests.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>MassTransit.Futures.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
     <TargetFrameworks>net452</TargetFrameworks>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="2.1.3" />

--- a/src/MassTransit.Futures/MassTransit.Futures.csproj
+++ b/src/MassTransit.Futures/MassTransit.Futures.csproj
@@ -5,7 +5,6 @@
     <IsPackable>false</IsPackable>
     <TargetFrameworks>net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="2.1.3" />

--- a/src/MassTransit.Host.Quartz/MassTransit.Host.Quartz.csproj
+++ b/src/MassTransit.Host.Quartz/MassTransit.Host.Quartz.csproj
@@ -4,8 +4,6 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="MassTransit.Host.*.config">

--- a/src/MassTransit.HttpTransport/MassTransit.HttpTransport.csproj
+++ b/src/MassTransit.HttpTransport/MassTransit.HttpTransport.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.Http</PackageId>

--- a/src/MassTransit.QuartzIntegration/MassTransit.QuartzIntegration.csproj
+++ b/src/MassTransit.QuartzIntegration/MassTransit.QuartzIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/MassTransit.QuartzService/MassTransit.QuartzService.csproj
+++ b/src/MassTransit.QuartzService/MassTransit.QuartzService.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>net452</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="log4net.config">

--- a/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
+++ b/src/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="2.1.3" />

--- a/src/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
+++ b/src/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
-    <LangVersion>7.1</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/MassTransit.Reactive/MassTransit.Reactive.csproj
+++ b/src/MassTransit.Reactive/MassTransit.Reactive.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/MassTransit.WebJobs.ServiceBusIntegration/MassTransit.WebJobs.ServiceBusIntegration.csproj
+++ b/src/MassTransit.WebJobs.ServiceBusIntegration/MassTransit.WebJobs.ServiceBusIntegration.csproj
@@ -4,7 +4,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.WebJobs.ServiceBus</PackageId>

--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
-    <LangVersion>7.2</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Persistence/MassTransit.DapperIntegration/MassTransit.DapperIntegration.csproj
+++ b/src/Persistence/MassTransit.DapperIntegration/MassTransit.DapperIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <!--<SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>-->
   </PropertyGroup>

--- a/src/Persistence/MassTransit.DocumentDbIntegration/MassTransit.DocumentDbIntegration.csproj
+++ b/src/Persistence/MassTransit.DocumentDbIntegration/MassTransit.DocumentDbIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
@@ -4,7 +4,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.EntityFramework</PackageId>

--- a/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
+++ b/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.Marten</PackageId>

--- a/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.MongoDb</PackageId>

--- a/src/Persistence/MassTransit.NHibernateIntegration/MassTransit.NHibernateIntegration.csproj
+++ b/src/Persistence/MassTransit.NHibernateIntegration/MassTransit.NHibernateIntegration.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Persistence/MassTransit.RedisIntegration/MassTransit.RedisIntegration.csproj
+++ b/src/Persistence/MassTransit.RedisIntegration/MassTransit.RedisIntegration.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>portable</DebugType>
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.Redis</PackageId>


### PR DESCRIPTION
This adds SourceLink support and consolidates some csproj properties that are scattered to all files. Also packing .pdb files as part of NuGet package to get line numbers for errors.