### PR TITLE
Remove forcing AMQP protocol

### DIFF
--- a/src/MassTransit.Azure.ServiceBus.Core/ServiceBusHost.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/ServiceBusHost.cs
@@ -210,7 +210,7 @@ namespace MassTransit.Azure.ServiceBus.Core
             {
                 TokenProvider = settings.TokenProvider,
                 OperationTimeout = settings.OperationTimeout,
-                TransportType = TransportType.Amqp
+                TransportType = settings.TransportType
             };
 
             return mfs;


### PR DESCRIPTION
AMQP is forced even if you want to use "AmqpWebSockets" transport type.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
