### PR TITLE
Add StringDecimalConverter to default Serializer converters.

### DIFF
--- a/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
@@ -508,4 +508,31 @@ namespace MassTransit.Tests.Serialization
         {
         }
     }
+
+
+    public class When_serializing_decimals
+    {
+        [Test]
+        public void Should_deserialize_correctly()
+        {
+            // arrange
+            var message = new MessageA
+            {
+                Decimal = decimal.MaxValue
+            };
+
+            // act, assert
+            var serializedMessage = JsonConvert.SerializeObject(message, MassTransit.Serialization.JsonMessageSerializer.SerializerSettings);
+            serializedMessage.ShouldNotBeNull();
+
+            var deserializedMessage = JsonConvert.DeserializeObject<MessageA>(serializedMessage, MassTransit.Serialization.JsonMessageSerializer.DeserializerSettings);
+            deserializedMessage.ShouldNotBeNull();
+            deserializedMessage.Decimal.ShouldBe(message.Decimal);
+        }
+
+        class MessageA
+        {
+            public decimal Decimal { get; set; }
+        }
+    }
 }

--- a/src/MassTransit/Serialization/JsonMessageSerializer.cs
+++ b/src/MassTransit/Serialization/JsonMessageSerializer.cs
@@ -74,6 +74,7 @@ namespace MassTransit.Serialization
             {
                 new ByteArrayConverter(),
                 new MessageDataJsonConverter(),
+                new StringDecimalConverter()
             }),
         };
 


### PR DESCRIPTION
Add StringDecimalConverter to default Serializer converters to match Deserializer converters. Decimals across full range and precision now serialize/deserialize correctly.

New test added to verify change.