### PR TITLE
Hosting for ASP.NET Core

### DIFF
--- a/src/Containers/MassTransit.AspNetCoreIntegration/MassTransit.AspNetCoreIntegration.csproj
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/MassTransit.AspNetCoreIntegration.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>MassTransit.AspNetCoreIntegration</RootNamespace>
+    <AssemblyName>MassTransit.AspNetCoreIntegration</AssemblyName>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>portable</DebugType>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\MassTransit.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>MassTransit.AspNetCore</PackageId>
+    <Title>MassTransit.AspNetCore</Title>
+    <Description>MassTransit hosting for ASP.NET Core; $(Description)</Description>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.AspNetCoreIntegration.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
+    <ProjectReference Include="..\MassTransit.ExtensionsDependencyInjectionIntegration\MassTransit.ExtensionsDependencyInjectionIntegration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Containers/MassTransit.AspNetCoreIntegration/MassTransitHostedService.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/MassTransitHostedService.cs
@@ -1,0 +1,39 @@
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AspNetCoreIntegration
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Hosting;
+
+
+    public class MassTransitHostedService : IHostedService
+    {
+        readonly IBusControl _bus;
+
+        public MassTransitHostedService(IBusControl bus)
+        {
+            _bus = bus;
+        }
+        
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return _bus.StartAsync(cancellationToken);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return _bus.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Containers/MassTransit.AspNetCoreIntegration/ServiceCollectionExtensions.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/ServiceCollectionExtensions.cs
@@ -1,0 +1,79 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+
+namespace MassTransit.AspNetCoreIntegration
+{
+    using System;
+    using ExtensionsDependencyInjectionIntegration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Hosting;
+
+
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Register and hosts the resolved bus with all required interfaces.
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <param name="createBus">Bus factory that loads consumers and sagas from IServiceProvider</param>
+        /// <returns></returns>
+        public static IServiceCollection AddMassTransit(this IServiceCollection services, Func<IServiceProvider, IBusControl> createBus)
+        {
+            services.TryAddSingleton(createBus);
+            services.TryAddSingleton<IBus>(p => p.GetRequiredService<IBusControl>());
+            services.TryAddSingleton<IPublishEndpoint>(p => p.GetRequiredService<IBusControl>());
+            services.TryAddSingleton<ISendEndpointProvider>(p => p.GetRequiredService<IBusControl>());
+
+            services.AddSingleton<IHostedService>(p => new MassTransitHostedService(p.GetRequiredService<IBusControl>()));
+
+            return services;
+        }
+
+        /// <summary>
+        /// Register and hosts the resolved bus with all required interfaces.
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <param name="createBus">Bus factory that loads consumers and sagas from IServiceProvider</param>
+        /// <param name="configure">Use MassTransit DI extensions for IServiceCollection to register consumers and sagas</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static IServiceCollection AddMassTransit(this IServiceCollection services, Func<IServiceProvider, IBusControl> createBus,
+            Action<IServiceCollectionConfigurator> configure)
+        {
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            services.AddMassTransit(configure);
+            services.AddMassTransit(createBus);
+            
+            return services;
+        }
+
+        /// <summary>
+        /// Register and hosts a given bus instance with all required interfaces.
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <param name="bus">The bus instance</param>
+        /// <returns></returns>
+        public static IServiceCollection AddMassTransit(this IServiceCollection services, IBusControl bus)
+        {
+            services.TryAddSingleton(bus);
+            services.TryAddSingleton<IBus>(bus);
+            services.TryAddSingleton<IPublishEndpoint>(bus);
+            services.TryAddSingleton<ISendEndpointProvider>(bus);
+
+            return services;
+        }
+    }
+}

--- a/src/MassTransit.sln
+++ b/src/MassTransit.sln
@@ -155,6 +155,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Azure.ServiceBu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Azure.ServiceBus.Core.Tests", "MassTransit.Azure.ServiceBus.Core.Tests\MassTransit.Azure.ServiceBus.Core.Tests.csproj", "{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AspNetCoreIntegration", "Containers\MassTransit.AspNetCoreIntegration\MassTransit.AspNetCoreIntegration.csproj", "{D7451A10-796F-497C-AC49-5C07BD6A2BCC}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Transports.Tests", "MassTransit.Transports.Tests\MassTransit.Transports.Tests.csproj", "{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}"
 EndProject
 Global
@@ -836,6 +838,18 @@ Global
 		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
 		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
 		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Debug|x86.Build.0 = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Release|x86.Build.0 = Release|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -898,6 +912,7 @@ Global
 		{8B7B39F7-FE78-47F6-8A7D-DF2374175E50} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
+		{D7451A10-796F-497C-AC49-5C07BD6A2BCC} = {6C61507E-FF16-45C8-8FE4-350069D9B4C1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {43D3A7D5-0945-435E-8D03-1E631E5CDBA8}


### PR DESCRIPTION
The existing MS DI integration is a bit confusing. Usually, when third-party packages have `services.AddSomething` extensions, it means that everything will be properly registered. However, the existing `AddMassTransit` extension only allows registering consumers and sagas.

This package is less for DI but more for a better integration with ASP.NET Core, including the hosting. It allows registering and hosting the resolved instance, which uses the existing `AddMassTransit`, or a pre-made bus instance, when consumers are configured without the container, or using a resolved instance if consumers are added to the container differently, or the existing `AddMassTransit` has already been called.

If it gets accepted, I will write the documentation.