### PR TITLE
(POC) Implemented sns to sns subscriptions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _book
 .vscode
 **/.idea/
 appsettings.Development.json
+/src/MassTransit.AmazonSqsTransport/*.zip

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+nuget="src/.nuget/nuget.exe"
+if [ ! -f "$nuget" ]
+then
+    msbuild src/.nuget/NuGet.targets -Target:RestorePackages
+fi
+
+gitlink="src/packages/gitlink/lib/net45/GitLink.exe"
+if [ ! -f "$gitlink" ]
+then
+    mono "$nuget" Install gitlink -Source "https://www.nuget.org/api/v2/" -OutputDirectory "./src/packages" -ExcludeVersion
+fi
+
+fake="src/packages/FAKE/tools/fake.exe"
+if [ ! -f "$fake" ]
+then
+    mono "$nuget" Install FAKE -Source "https://www.nuget.org/api/v2/" -OutputDirectory "./src/packages" -ExcludeVersion
+fi
+
+mono "$fake" build.fsx $1

--- a/src/MassTransit.AmazonSqsTransport.Tests/Configure_Specs.cs
+++ b/src/MassTransit.AmazonSqsTransport.Tests/Configure_Specs.cs
@@ -16,6 +16,7 @@ namespace MassTransit.AmazonSqsTransport.Tests
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using Configuration;
@@ -213,6 +214,7 @@ namespace MassTransit.AmazonSqsTransport.Tests
                     h.SecretKey("admin");
                     h.Config(new AmazonSimpleNotificationServiceConfig { ServiceURL = "http://docker.localhost:4575" });
                     h.Config(new AmazonSQSConfig { ServiceURL = "http://docker.localhost:4576" });
+                    h.Config(new AmazonLambdaConfig { ServiceURL = "http://docker.localhost:4574" });
                 });
             });
 

--- a/src/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
+++ b/src/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription.Tests/MassTransit.AmazonSqsTransport.TopicSubscription.Tests.csproj
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription.Tests/MassTransit.AmazonSqsTransport.TopicSubscription.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription.Tests/MassTransit.AmazonSqsTransport.TopicSubscription.Tests.csproj
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription.Tests/MassTransit.AmazonSqsTransport.TopicSubscription.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.0.0" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="nsubstitute" Version="3.1.0" />
+    <PackageReference Include="Shouldly" Version="3.0.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MassTransit.AmazonSqsTransport.TopicSubscription\MassTransit.AmazonSqsTransport.TopicSubscription.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription.Tests/TopicSubscriptionTests.cs
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription.Tests/TopicSubscriptionTests.cs
@@ -1,0 +1,48 @@
+namespace MassTransit.AmazonSqsTransport.TopicSubscription.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Amazon.Lambda.SNSEvents;
+    using Amazon.SimpleNotificationService;
+    using Amazon.SimpleNotificationService.Model;
+    using NSubstitute;
+    using Shouldly;
+    using Xunit;
+
+
+    public class TopicSubscriptionTests
+    {
+        [Fact]
+        public void FunctionTest()
+        {
+            var client = Substitute.For<IAmazonSimpleNotificationService>();
+
+            var topicSubscription = new TopicSubscription(client);
+
+            var snsEvent = new SNSEvent
+            {
+                Records = new [] {
+                    new SNSEvent.SNSRecord
+                    {
+                        EventSource = Guid.NewGuid().ToString(),
+                        EventSubscriptionArn = Guid.NewGuid().ToString(),
+                        Sns = new SNSEvent.SNSMessage
+                        {
+                            MessageAttributes = new Dictionary<string, SNSEvent.MessageAttribute>(),
+                            Message = $"Test {Guid.NewGuid()}"
+                        }
+                    }
+                }
+            };
+
+            Func<Task> request = () => topicSubscription.Handler(snsEvent);
+
+            request.ShouldNotThrow();
+
+            client
+                .Received()
+                .PublishAsync(Arg.Any<PublishRequest>());
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+        <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.4.0" />
         <PackageReference Include="Amazon.Lambda.SNSEvents" Version="1.0.0" />
         <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.2.1" />
     </ItemGroup>

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <AWSProjectType>Lambda</AWSProjectType>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+        <AWSProjectType>Lambda</AWSProjectType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+        <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.4.0" />
+        <PackageReference Include="Amazon.Lambda.SNSEvents" Version="1.0.0" />
+        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.2.1" />
+    </ItemGroup>
+
+</Project>

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/MassTransit.AmazonSqsTransport.TopicSubscription.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
-        <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.4.0" />
         <PackageReference Include="Amazon.Lambda.SNSEvents" Version="1.0.0" />
         <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.2.1" />
     </ItemGroup>

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/TopicSubscription.cs
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/TopicSubscription.cs
@@ -1,6 +1,4 @@
-﻿[assembly: Amazon.Lambda.Core.LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
-
-namespace MassTransit.AmazonSqsTransport.TopicSubscription
+﻿namespace MassTransit.AmazonSqsTransport.TopicSubscription
 {
     using System;
     using System.Collections.Generic;
@@ -38,7 +36,7 @@ namespace MassTransit.AmazonSqsTransport.TopicSubscription
         }
 
         public Dictionary<string, MessageAttributeValue> Map(IDictionary<string, SNSEvent.MessageAttribute> attributes) =>
-            attributes.ToDictionary(
+            attributes?.ToDictionary(
                 x => x.Key,
                 x => new MessageAttributeValue
                 {

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/TopicSubscription.cs
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/TopicSubscription.cs
@@ -1,4 +1,6 @@
-﻿namespace MassTransit.AmazonSqsTransport.TopicSubscription
+﻿[assembly: Amazon.Lambda.Core.LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace MassTransit.AmazonSqsTransport.TopicSubscription
 {
     using System;
     using System.Collections.Generic;

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/TopicSubscription.cs
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/TopicSubscription.cs
@@ -1,0 +1,49 @@
+﻿[assembly: Amazon.Lambda.Core.LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace MassTransit.AmazonSqsTransport.TopicSubscription
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService;
+    using Amazon.Lambda.SNSEvents;
+    using Amazon.SimpleNotificationService.Model;
+
+
+    public class TopicSubscription
+    {
+        readonly IAmazonSimpleNotificationService _client;
+
+        public TopicSubscription() : this(new AmazonSimpleNotificationServiceClient()) {}
+
+        public TopicSubscription(IAmazonSimpleNotificationService client)
+        {
+            _client = client ?? new AmazonSimpleNotificationServiceClient();
+        }
+
+        public async Task Handler(SNSEvent snsEvent)
+        {
+            foreach (var record in snsEvent.Records)
+            {
+                var snsRecord = record.Sns;
+
+                await _client.PublishAsync(new PublishRequest
+                {
+                    Message = snsRecord.Message,
+                    MessageAttributes = Map(snsRecord.MessageAttributes),
+                    TopicArn = Environment.GetEnvironmentVariable("PUBLISH_TOPIC_ARN")
+                });
+            }
+        }
+
+        public Dictionary<string, MessageAttributeValue> Map(IDictionary<string, SNSEvent.MessageAttribute> attributes) =>
+            attributes.ToDictionary(
+                x => x.Key,
+                x => new MessageAttributeValue
+                {
+                    DataType = x.Value.Type,
+                    StringValue = x.Value.Value
+                });
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport.TopicSubscription/aws-lambda-tools-defaults.json
+++ b/src/MassTransit.AmazonSqsTransport.TopicSubscription/aws-lambda-tools-defaults.json
@@ -1,0 +1,19 @@
+﻿{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile":"",
+  "region" : "",
+  "configuration": "Release",
+  "framework": "netcoreapp2.1",
+  "function-runtime": "dotnetcore2.1",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "MassTransit.AmazonSqsTransport.TopicSubscription::MassTransit.AmazonSqsTransport.TopicSubscription.TopicSubscription::Handler"
+}

--- a/src/MassTransit.AmazonSqsTransport/AmazonSqsHostSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/AmazonSqsHostSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
@@ -37,6 +37,11 @@ namespace MassTransit.AmazonSqsTransport
         ///     MAYBE this should be a SecureString instead of a regular string
         /// </summary>
         string SecretKey { get; }
+
+        /// <summary>
+        ///     The executionRoleArn for creating aws lambda function.
+        /// </summary>
+        string ExecutionRoleArn { get; }
 
         Uri HostAddress { get; }
 

--- a/src/MassTransit.AmazonSqsTransport/ClientContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/ClientContext.cs
@@ -37,6 +37,8 @@ namespace MassTransit.AmazonSqsTransport
 
         Task CreateQueueSubscription(string topicName, string queueName);
 
+        Task CreateTopicSubscription(string sourceName, string destinationName);
+
         Task DeleteTopic(string topicName);
 
         Task DeleteQueue(string queueName);
@@ -52,6 +54,7 @@ namespace MassTransit.AmazonSqsTransport
         Task SendMessage(SendMessageRequest request, CancellationToken cancellationToken);
 
         Task DeleteMessage(string queueUrl, string receiptHandle, CancellationToken cancellationToken = default);
+
         Task PurgeQueue(string queueName, CancellationToken cancellationToken);
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsHostConfigurationExtensions.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsHostConfigurationExtensions.cs
@@ -10,10 +10,12 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
-namespace MassTransit.AmazonSqsTransport.Configuration
+namespace MassTransit
 {
     using System;
-    using Configurators;
+    using AmazonSqsTransport;
+    using AmazonSqsTransport.Configuration;
+    using AmazonSqsTransport.Configuration.Configurators;
 
 
     public static class AmazonSqsHostConfigurationExtensions

--- a/src/MassTransit.AmazonSqsTransport/Configuration/BusFactoryConfiguratorExtensions.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/BusFactoryConfiguratorExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
@@ -10,9 +10,11 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
-namespace MassTransit.AmazonSqsTransport.Configuration
+namespace MassTransit
 {
     using System;
+    using AmazonSqsTransport;
+    using AmazonSqsTransport.Configuration;
 
 
     public static class BusFactoryConfiguratorExtensions

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsHostConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsHostConfigurator.cs
@@ -14,6 +14,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
 {
     using System;
     using Amazon;
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using Exceptions;
@@ -36,6 +37,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
                 Region = regionEndpoint,
                 AccessKey = "",
                 SecretKey = "",
+                ExecutionRoleArn = "",
                 AmazonSqsConfig = new AmazonSQSConfig { RegionEndpoint = regionEndpoint },
                 AmazonSnsConfig = new AmazonSimpleNotificationServiceConfig { RegionEndpoint = regionEndpoint },
             };
@@ -62,6 +64,11 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
             _settings.SecretKey = secretKey;
         }
 
+        public void ExecutionRoleArn(string executionRoleArn)
+        {
+            _settings.ExecutionRoleArn = executionRoleArn;
+        }
+
         public void Config(AmazonSQSConfig config)
         {
             _settings.AmazonSqsConfig = config;
@@ -70,6 +77,11 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
         public void Config(AmazonSimpleNotificationServiceConfig config)
         {
             _settings.AmazonSnsConfig = config;
+        }
+
+        public void Config(AmazonLambdaConfig config)
+        {
+            _settings.AmazonLambdaConfig = config;
         }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -14,6 +14,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
 {
     using System;
     using Amazon;
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using Transport;
@@ -23,25 +24,31 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
         AmazonSqsHostSettings
     {
         readonly Lazy<Uri> _hostAddress;
-        
+
         public ConfigurationHostSettings()
         {
             _hostAddress = new Lazy<Uri>(FormatHostAddress);
         }
 
         public RegionEndpoint Region { get; set; }
+
         public string AccessKey { get; set; }
+
         public string SecretKey { get; set; }
+
+        public string ExecutionRoleArn { get; set; }
 
         public AmazonSQSConfig AmazonSqsConfig { get; set; }
 
         public AmazonSimpleNotificationServiceConfig AmazonSnsConfig { get; set; }
 
+        public AmazonLambdaConfig AmazonLambdaConfig { get; set; }
+
         public Uri HostAddress => _hostAddress.Value;
 
         public IConnection CreateConnection()
         {
-            return new Connection(AccessKey, SecretKey, Region, AmazonSqsConfig, AmazonSnsConfig);
+            return new Connection(AccessKey, SecretKey, Region, AmazonSqsConfig, AmazonSnsConfig, AmazonLambdaConfig);
         }
 
         Uri FormatHostAddress()

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsHostConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsHostConfigurator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AmazonSqsTransport.Configuration
 {
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
 
@@ -31,6 +32,12 @@ namespace MassTransit.AmazonSqsTransport.Configuration
         void SecretKey(string secretKey);
 
         /// <summary>
+        /// Sets the exectionRoleArn for the connection to AmazonLambda
+        /// </summary>
+        /// <param name="executionRoleArn"></param>
+        void ExecutionRoleArn(string executionRoleArn);
+
+        /// <summary>
         /// Sets the default config for the connection to AmazonSQS
         /// </summary>
         /// <param name="config"></param>
@@ -41,5 +48,11 @@ namespace MassTransit.AmazonSqsTransport.Configuration
         /// </summary>
         /// <param name="config"></param>
         void Config(AmazonSimpleNotificationServiceConfig config);
+
+        /// <summary>
+        /// Sets the default config for the connection to AmazonLambda
+        /// </summary>
+        /// <param name="config"></param>
+        void Config(AmazonLambdaConfig config);
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/ConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/ConnectionContext.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -14,6 +14,7 @@ namespace MassTransit.AmazonSqsTransport
 {
     using System;
     using System.Threading.Tasks;
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using GreenPipes;
@@ -57,5 +58,11 @@ namespace MassTransit.AmazonSqsTransport
         /// </summary>
         /// <returns></returns>
         Task<IAmazonSimpleNotificationService> CreateAmazonSns();
+
+        /// <summary>
+        /// Create a model on the connection
+        /// </summary>
+        /// <returns></returns>
+        Task<IAmazonLambda> CreateAmazonLambda();
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsClientContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsClientContext.cs
@@ -16,6 +16,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -39,6 +40,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
         IAsyncDisposable
     {
         static readonly ILog _log = Logger.Get<AmazonSqsClientContext>();
+        static readonly Stream _topicSubscriptionZipFile = Assembly.GetEntryAssembly().GetManifestResourceStream("EmbeddedResource.MassTransit.AmazonSqsTransport.TopicSubscription.zip");
 
         readonly ConnectionContext _connectionContext;
         readonly IAmazonSqsHost _host;
@@ -78,6 +80,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
 
             _amazonSqs?.Dispose();
             _amazonSns?.Dispose();
+            _amazonLambda?.Dispose();
 
             return GreenPipes.Util.TaskUtil.Completed;
         }
@@ -139,26 +142,36 @@ namespace MassTransit.AmazonSqsTransport.Contexts
             var sourceArn = results[0];
             var destinationArn = results[1];
 
-            var request = new CreateFunctionRequest();
-            request.Code = new FunctionCode
+            using (var stream = new MemoryStream())
             {
-                S3Bucket = "masstransit-amazonsqs-transport-topicsubscription",
-                S3Key = "deploy.zip"
-            };
-            request.Runtime = Runtime.Dotnetcore21;
-            request.Handler = "MassTransit.AmazonSqsTransport.TopicSubscription::MassTransit.AmazonSqsTransport.TopicSubscription.TopicSubscription::Handler";
-            request.FunctionName = $"MassTransit-Subscription-{sourceName}-{destinationName}";
-            request.Environment.Variables.Add("PUBLISH_TOPIC_ARN", destinationArn);
-            request.Role = "ExecutionRoleARN";
+                await _topicSubscriptionZipFile.CopyToAsync(stream);
 
-            var response = await _amazonLambda.CreateFunctionAsync(request).ConfigureAwait(false);
+                var request = new CreateFunctionRequest
+                {
+                    Code = new FunctionCode {ZipFile = stream},
+                    Runtime = Runtime.Dotnetcore21,
+                    Handler = "MassTransit.AmazonSqsTransport.TopicSubscription::MassTransit.AmazonSqsTransport.TopicSubscription.TopicSubscription::Handler",
+                    FunctionName = $"MassTransit-Subscription-{sourceName}-{destinationName}",
+                    Role = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+                    Environment = new Amazon.Lambda.Model.Environment {Variables = {{"PUBLISH_TOPIC_ARN", destinationArn}}},
+                };
 
-            await _amazonSns.SubscribeAsync(new SubscribeRequest
-            {
-                TopicArn = sourceArn,
-                Endpoint = response.FunctionArn,
-                Protocol = "lambda"
-            }).ConfigureAwait(false);
+                var response = await _amazonLambda.CreateFunctionAsync(request).ConfigureAwait(false);
+
+                await _amazonLambda.AddPermissionAsync(new Amazon.Lambda.Model.AddPermissionRequest
+                {
+                    FunctionName = response.FunctionName,
+                    Action = "sns:Publish",
+                    SourceArn = destinationArn
+                });
+
+                await _amazonSns.SubscribeAsync(new SubscribeRequest
+                {
+                    TopicArn = sourceArn,
+                    Endpoint = response.FunctionArn,
+                    Protocol = "lambda"
+                }).ConfigureAwait(false);
+            }
         }
 
         async Task ClientContext.DeleteTopic(string topicName)

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsClientContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsClientContext.cs
@@ -153,7 +153,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
                     Runtime = Runtime.Dotnetcore21,
                     Handler = "MassTransit.AmazonSqsTransport.TopicSubscription::MassTransit.AmazonSqsTransport.TopicSubscription.TopicSubscription::Handler",
                     FunctionName = functionName,
-                    Role = "arn:aws:iam::134693456886:role/AWSLambdaSNSExecutionRole",
+                    Role = _host.Settings.ExecutionRoleArn,
                     Environment = new Amazon.Lambda.Model.Environment {Variables = {{"PUBLISH_TOPIC_ARN", destinationArn}}},
                     Timeout = 30,
                     MemorySize = 256

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
@@ -1,11 +1,11 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -15,6 +15,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using GreenPipes;
@@ -57,6 +58,11 @@ namespace MassTransit.AmazonSqsTransport.Contexts
         public Task<IAmazonSimpleNotificationService> CreateAmazonSns()
         {
             return Task.Factory.StartNew(() => Connection.CreateAmazonSnsClient(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
+        }
+
+        public Task<IAmazonLambda> CreateAmazonLambda()
+        {
+            return Task.Factory.StartNew(() => Connection.CreateAmazonLambdaClient(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
         }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Contexts/SharedClientContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/SharedClientContext.cs
@@ -91,6 +91,11 @@ namespace MassTransit.AmazonSqsTransport.Contexts
             return _context.CreateQueueSubscription(topicName, queueName);
         }
 
+        public Task CreateTopicSubscription(string sourceName, string destinationName)
+        {
+            return _context.CreateTopicSubscription(sourceName, destinationName);
+        }
+
         Task ClientContext.DeleteTopic(string topicName)
         {
             return _context.DeleteTopic(topicName);

--- a/src/MassTransit.AmazonSqsTransport/Contexts/SharedConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/SharedConnectionContext.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -15,6 +15,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using GreenPipes;
@@ -70,6 +71,11 @@ namespace MassTransit.AmazonSqsTransport.Contexts
         Task<IAmazonSimpleNotificationService> ConnectionContext.CreateAmazonSns()
         {
             return _context.CreateAmazonSns();
+        }
+
+        public Task<IAmazonLambda> CreateAmazonLambda()
+        {
+            return _context.CreateAmazonLambda();
         }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="MassTransit.AmazonSqsTransport.TopicSubscription.zip" />
-    <EmbeddedResource Include="MassTransit.AmazonSqsTransport.TopicSubscription.zip">
+    <EmbeddedResource Include="../../build_artifacts/MassTransit.AmazonSqsTransport.TopicSubscription.zip">
       <LogicalName>MassTransit.AmazonSqsTransport.TopicSubscription.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -13,6 +13,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.AmazonSqsTransport.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.16.6" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.1.14" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.3.22" />
     <PackageReference Include="GreenPipes" Version="2.1.3" />

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -23,4 +23,8 @@
   <ItemGroup>
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="MassTransit.AmazonSqsTransport.TopicSubscription.zip" />
+    <EmbeddedResource Include="MassTransit.AmazonSqsTransport.TopicSubscription.zip"></EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -25,6 +25,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="MassTransit.AmazonSqsTransport.TopicSubscription.zip" />
-    <EmbeddedResource Include="MassTransit.AmazonSqsTransport.TopicSubscription.zip"></EmbeddedResource>
+    <EmbeddedResource Include="MassTransit.AmazonSqsTransport.TopicSubscription.zip">
+      <LogicalName>MassTransit.AmazonSqsTransport.TopicSubscription.zip</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -3,13 +3,13 @@
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>MassTransit.AmazonSQS</PackageId>
     <Title>MassTransit.AmazonSQS</Title>
-    <Description>MassTransit ActiveMQ transport support; $(Description)</Description>
+    <Description>MassTransit AmazonSQS transport support; $(Description)</Description>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.AmazonSqsTransport.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/ReceiveClientFilter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/ReceiveClientFilter.cs
@@ -44,8 +44,9 @@ namespace MassTransit.AmazonSqsTransport.Pipeline
         {
             var amazonSqs = await context.CreateAmazonSqs().ConfigureAwait(false);
             var amazonSns = await context.CreateAmazonSns().ConfigureAwait(false);
+            var amazonLambda = await context.CreateAmazonLambda().ConfigureAwait(false);
 
-            var modelContext = new AmazonSqsClientContext(context, amazonSqs, amazonSns, _host, context.CancellationToken);
+            var modelContext = new AmazonSqsClientContext(context, amazonSqs, amazonSns, amazonLambda, _host, context.CancellationToken);
 
             try
             {

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/IPublishEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/IPublishEndpointBrokerTopologyBuilder.cs
@@ -1,11 +1,11 @@
 // Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -24,7 +24,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
         /// <summary>
         /// The exchange to which the message is published
         /// </summary>
-        TopicHandle Topic { get; }
+        TopicHandle Topic { get; set; }
 
         IPublishEndpointBrokerTopologyBuilder CreateImplementedBuilder();
     }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
@@ -50,6 +50,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
         {
             readonly IPublishEndpointBrokerTopologyBuilder _builder;
             readonly PublishBrokerTopologyOptions _options;
+            TopicHandle _topic;
 
             public ImplementedBuilder(IPublishEndpointBrokerTopologyBuilder builder, PublishBrokerTopologyOptions options)
             {
@@ -57,11 +58,22 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
                 _options = options;
             }
 
-            public TopicHandle Topic { get; set; }
+            public TopicHandle Topic
+            {
+                get => _topic;
+                set
+                {
+                    _topic = value;
+                    if (_builder.Topic != null)
+                    {
+                        _builder.CreateTopicSubscription(_builder.Topic, _topic);
+                    }
+                }
+            }
 
             public IPublishEndpointBrokerTopologyBuilder CreateImplementedBuilder()
             {
-                if (_options.HasFlag(PublishBrokerTopologyOptions.MaintainHierarchy))
+                if (_options.HasFlag(PublishBrokerTopologyOptions.FlattenHierarchy))
                     return new ImplementedBuilder(this, _options);
 
                 return this;

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/ConsumerConsumeTopologySpecification.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Specifications/ConsumerConsumeTopologySpecification.cs
@@ -46,7 +46,7 @@ namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Specifications
         {
             var topicHandle = builder.CreateTopic(EntityName, Durable, AutoDelete);
 
-            var topicSubscriptionHandle = builder.CreateQueueSubscription(topicHandle, builder.Queue);
+            builder.CreateQueueSubscription(topicHandle, builder.Queue);
         }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
@@ -73,13 +73,9 @@ namespace MassTransit.AmazonSqsTransport.Topology.Topologies
             var topicHandle = builder.CreateTopic(_topic.EntityName, _topic.Durable, _topic.AutoDelete);
 
             if (builder.Topic != null)
-            {
-                // builder.ExchangeBind(builder.Exchange, exchangeHandle, "", new Dictionary<string, object>());
-            }
+                builder.CreateTopicSubscription(builder.Topic, topicHandle);
             else
-            {
-                // builder.Exchange = exchangeHandle;
-            }
+                builder.Topic = topicHandle;
 
             foreach (IAmazonSqsMessagePublishTopology configurator in _implementedMessageTypes)
                 configurator.Apply(builder);

--- a/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsHost.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/AmazonSqsHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
@@ -75,7 +75,8 @@ namespace MassTransit.AmazonSqsTransport.Transport
                 Type = "AmazonSQS",
                 _settings.Region,
                 _settings.AccessKey,
-                Password = new string('*', _settings.SecretKey.Length)
+                Password = new string('*', _settings.SecretKey.Length),
+                _settings.ExecutionRoleArn
             });
 
             ConnectionCache.Probe(scope);

--- a/src/MassTransit.AmazonSqsTransport/Transport/ClientContextFactory.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/ClientContextFactory.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -67,8 +67,9 @@ namespace MassTransit.AmazonSqsTransport.Transport
                 {
                     var amazonSqs = await connectionContext.CreateAmazonSqs().ConfigureAwait(false);
                     var amazonSns = await connectionContext.CreateAmazonSns().ConfigureAwait(false);
+                    var amazonLambda = await connectionContext.CreateAmazonLambda().ConfigureAwait(false);
 
-                    var modelContext = new AmazonSqsClientContext(connectionContext, amazonSqs, amazonSns, _host, cancellationToken);
+                    var modelContext = new AmazonSqsClientContext(connectionContext, amazonSqs, amazonSns, amazonLambda, _host, cancellationToken);
 
                     await asyncContext.Created(modelContext).ConfigureAwait(false);
 

--- a/src/MassTransit.AmazonSqsTransport/Transport/Connection.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/Connection.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.AmazonSqsTransport.Transport
 {
     using Amazon;
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
 
@@ -24,14 +25,19 @@ namespace MassTransit.AmazonSqsTransport.Transport
         readonly AmazonSimpleNotificationServiceConfig _amazonSnsConfig;
         readonly AmazonSQSConfig _amazonSqsConfig;
         readonly string _secretKey;
+        readonly AmazonLambdaConfig _amazonLambdaConfig;
 
-        public Connection(string accessKey, string secretKey, RegionEndpoint regionEndpoint = null, AmazonSQSConfig amazonSqsConfig = null,
-            AmazonSimpleNotificationServiceConfig amazonSnsConfig = null)
+        public Connection(string accessKey, string secretKey,
+            RegionEndpoint regionEndpoint = null,
+            AmazonSQSConfig amazonSqsConfig = null,
+            AmazonSimpleNotificationServiceConfig amazonSnsConfig = null,
+            AmazonLambdaConfig amazonLambdaConfig = null)
         {
             _accessKey = accessKey;
             _secretKey = secretKey;
             _amazonSqsConfig = amazonSqsConfig ?? new AmazonSQSConfig {RegionEndpoint = regionEndpoint ?? RegionEndpoint.USEast1};
             _amazonSnsConfig = amazonSnsConfig ?? new AmazonSimpleNotificationServiceConfig {RegionEndpoint = regionEndpoint ?? RegionEndpoint.USEast1};
+            _amazonLambdaConfig = amazonLambdaConfig ?? new AmazonLambdaConfig {RegionEndpoint = regionEndpoint ?? RegionEndpoint.USEast1};
         }
 
         public IAmazonSQS CreateAmazonSqsClient()
@@ -42,6 +48,11 @@ namespace MassTransit.AmazonSqsTransport.Transport
         public IAmazonSimpleNotificationService CreateAmazonSnsClient()
         {
             return new AmazonSimpleNotificationServiceClient(_accessKey, _secretKey, _amazonSnsConfig);
+        }
+
+        public IAmazonLambda CreateAmazonLambdaClient()
+        {
+            return new AmazonLambdaClient(_accessKey, _secretKey, _amazonLambdaConfig);
         }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Transport/IConnection.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/IConnection.cs
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AmazonSqsTransport.Transport
 {
+    using Amazon.Lambda;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
 
@@ -21,5 +22,7 @@ namespace MassTransit.AmazonSqsTransport.Transport
         IAmazonSQS CreateAmazonSqsClient();
 
         IAmazonSimpleNotificationService CreateAmazonSnsClient();
+
+        IAmazonLambda CreateAmazonLambdaClient();
     }
 }

--- a/src/MassTransit.sln
+++ b/src/MassTransit.sln
@@ -149,17 +149,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Automatonymous.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AmazonSqsTransport", "MassTransit.AmazonSqsTransport\MassTransit.AmazonSqsTransport.csproj", "{EDC2B3F1-BAC0-440E-AE97-28F691E2F75D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AmazonSqsTransport.Tests", "MassTransit.AmazonSqsTransport.Tests\MassTransit.AmazonSqsTransport.Tests.csproj", "{C7188986-F31F-46ED-8F1C-047E9A7E8A52}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AmazonSqsTransport.Tests", "MassTransit.AmazonSqsTransport.Tests\MassTransit.AmazonSqsTransport.Tests.csproj", "{C7188986-F31F-46ED-8F1C-047E9A7E8A52}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Azure.ServiceBus.Core", "MassTransit.Azure.ServiceBus.Core\MassTransit.Azure.ServiceBus.Core.csproj", "{8B7B39F7-FE78-47F6-8A7D-DF2374175E50}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Azure.ServiceBus.Core", "MassTransit.Azure.ServiceBus.Core\MassTransit.Azure.ServiceBus.Core.csproj", "{8B7B39F7-FE78-47F6-8A7D-DF2374175E50}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Azure.ServiceBus.Core.Tests", "MassTransit.Azure.ServiceBus.Core.Tests\MassTransit.Azure.ServiceBus.Core.Tests.csproj", "{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Azure.ServiceBus.Core.Tests", "MassTransit.Azure.ServiceBus.Core.Tests\MassTransit.Azure.ServiceBus.Core.Tests.csproj", "{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AspNetCoreIntegration", "Containers\MassTransit.AspNetCoreIntegration\MassTransit.AspNetCoreIntegration.csproj", "{D7451A10-796F-497C-AC49-5C07BD6A2BCC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AspNetCoreIntegration", "Containers\MassTransit.AspNetCoreIntegration\MassTransit.AspNetCoreIntegration.csproj", "{D7451A10-796F-497C-AC49-5C07BD6A2BCC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Transports.Tests", "MassTransit.Transports.Tests\MassTransit.Transports.Tests.csproj", "{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Transports.Tests", "MassTransit.Transports.Tests\MassTransit.Transports.Tests.csproj", "{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AmazonSqsTransport.TopicSubscription", "MassTransit.AmazonSqsTransport.TopicSubscription\MassTransit.AmazonSqsTransport.TopicSubscription.csproj", "{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AmazonSqsTransport.TopicSubscription", "MassTransit.AmazonSqsTransport.TopicSubscription\MassTransit.AmazonSqsTransport.TopicSubscription.csproj", "{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AmazonSqsTransport.TopicSubscription.Tests", "MassTransit.AmazonSqsTransport.TopicSubscription.Tests\MassTransit.AmazonSqsTransport.TopicSubscription.Tests.csproj", "{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -828,18 +830,6 @@ Global
 		{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
 		{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
 		{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|x86.Build.0 = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|x86.ActiveCfg = Release|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|x86.Build.0 = Release|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|Any CPU.ActiveCfg = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -852,6 +842,18 @@ Global
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.Release|x86.Build.0 = Release|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
 		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -864,6 +866,18 @@ Global
 		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
 		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
 		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Debug|x86.Build.0 = Debug|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Release|x86.ActiveCfg = Release|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.Release|x86.Build.0 = Release|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -925,9 +939,10 @@ Global
 		{C7188986-F31F-46ED-8F1C-047E9A7E8A52} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{8B7B39F7-FE78-47F6-8A7D-DF2374175E50} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
-		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC} = {6C61507E-FF16-45C8-8FE4-350069D9B4C1}
+		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
+		{3D2F62DA-9B2E-4AC0-B45A-99CF13240C60} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {43D3A7D5-0945-435E-8D03-1E631E5CDBA8}

--- a/src/MassTransit.sln
+++ b/src/MassTransit.sln
@@ -159,6 +159,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AspNetCoreInteg
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Transports.Tests", "MassTransit.Transports.Tests\MassTransit.Transports.Tests.csproj", "{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AmazonSqsTransport.TopicSubscription", "MassTransit.AmazonSqsTransport.TopicSubscription\MassTransit.AmazonSqsTransport.TopicSubscription.csproj", "{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -850,6 +852,18 @@ Global
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Debug|x86.Build.0 = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Release|x86.ActiveCfg = Release|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.Release|x86.Build.0 = Release|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.ReleaseUnsigned|Any CPU.ActiveCfg = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -913,6 +927,7 @@ Global
 		{1AEF94BE-7A9A-4E2C-BE6C-D31A38A139DD} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{9C0F8E16-564A-4DA9-A8E0-12FA31B172B7} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{D7451A10-796F-497C-AC49-5C07BD6A2BCC} = {6C61507E-FF16-45C8-8FE4-350069D9B4C1}
+		{474E82C5-AAFB-4E5A-824E-1FE3420FCB99} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {43D3A7D5-0945-435E-8D03-1E631E5CDBA8}


### PR DESCRIPTION
### This is just a proof of concept and any feedback is appreciated.

Think I have figured out how to create sns to sns subscription making use of lambda function which re-publishes the sns notification, similar to rabbit exchange to exchange bindings.

### Requirements
- `dotnet tool install -g Amazon.Lambda.Tools`
- `dotnet lambda package -pl .\src\MassTransit.AmazonSqsTransport.TopicSubscription -o .\src\MassTransit\src\MassTransit.AmazonSqsTransport\MassTransit.AmazonSqsTransport.TopicSubscription.zip`

### Remaining issues
- [x] Figure out how to package the lambda function into a zip during build.
- [ ] How to name the lambda function.
