### PR TITLE
Make DeployAsync an extension method

### DIFF
--- a/src/MassTransit/BusControlExtensions.cs
+++ b/src/MassTransit/BusControlExtensions.cs
@@ -91,7 +91,7 @@ namespace MassTransit
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static async Task DeployAsync(IBusControl bus, CancellationToken cancellationToken = default)
+        public static async Task DeployAsync(this IBusControl bus, CancellationToken cancellationToken = default)
         {
             if (bus == null)
                 throw new ArgumentNullException(nameof(bus));


### PR DESCRIPTION
Pretty simple change - just adds `this` to the `DeployAsync` method so that it can be used from the `IBusControl` context.

Thanks!