### PR TITLE
- move endpoint configuration into bus factory configuration

### DIFF
--- a/src/MassTransit.Azure.ServiceBus.Core/Hosting/ServiceBusServiceConfigurator.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Hosting/ServiceBusServiceConfigurator.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Azure.ServiceBus.Core.Hosting
 {
@@ -130,6 +130,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Hosting
         public void ConfigureSend(Action<ISendPipeConfigurator> callback)
         {
             _configurator.ConfigureSend(callback);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            _configurator.MapEndpoint(type,uri);
         }
 
         public void ConfigurePublish(Action<IPublishPipeConfigurator> callback)

--- a/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusServiceConfigurator.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Hosting/ServiceBusServiceConfigurator.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Hosting
 {
@@ -130,6 +130,11 @@ namespace MassTransit.AzureServiceBusTransport.Hosting
         public void ConfigureSend(Action<ISendPipeConfigurator> callback)
         {
             _configurator.ConfigureSend(callback);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            _configurator.MapEndpoint(type,uri);
         }
 
         public void ConfigurePublish(Action<IPublishPipeConfigurator> callback)

--- a/src/MassTransit.HttpTransport/Transport/HttpResponseSendEndpointProvider.cs
+++ b/src/MassTransit.HttpTransport/Transport/HttpResponseSendEndpointProvider.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.HttpTransport.Transport
 {
@@ -57,6 +57,11 @@ namespace MassTransit.HttpTransport.Transport
             }
 
             return _sendEndpointProvider.GetSendEndpoint(address);
+        }
+
+        public Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            return _sendEndpointProvider.GetSendEndpoint(type);
         }
 
         public ConnectHandle ConnectSendObserver(ISendObserver observer)

--- a/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqServiceConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Hosting/RabbitMqServiceConfigurator.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.RabbitMqTransport.Hosting
 {
@@ -133,6 +133,11 @@ namespace MassTransit.RabbitMqTransport.Hosting
         public void ConfigureSend(Action<ISendPipeConfigurator> callback)
         {
             _configurator.ConfigureSend(callback);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            _configurator.MapEndpoint(type, uri);
         }
 
         public void ConfigurePublish(Action<IPublishPipeConfigurator> callback)

--- a/src/MassTransit.TestFramework/TestConsumeContext.cs
+++ b/src/MassTransit.TestFramework/TestConsumeContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.TestFramework
 {
@@ -215,6 +215,11 @@ namespace MassTransit.TestFramework
             throw new NotImplementedException();
         }
 
+        public Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
         public async Task NotifyConsumed<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType) where T : class
         {
         }
@@ -248,7 +253,7 @@ namespace MassTransit.TestFramework
     }
 
 
-    public class TestReceiveContext : 
+    public class TestReceiveContext :
         BaseReceiveContext
     {
         public TestReceiveContext(Uri sourceAddress)

--- a/src/MassTransit.Tests/SendByConvention_Specs.cs
+++ b/src/MassTransit.Tests/SendByConvention_Specs.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests
 {
@@ -37,6 +37,36 @@ namespace MassTransit.Tests
             _handled = Handled<NastyMessage>(configurator);
 
             EndpointConvention.Map<NastyMessage>(configurator.InputAddress);
+        }
+
+
+        class NastyMessage
+        {
+            public string Value { get; set; }
+        }
+    }
+
+
+    [TestFixture]
+    public class SendByBusFactoryConvention_Specs :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_send_by_convention_to_the_input_queue()
+        {
+            var endpoint = await Bus.GetSendEndpoint<NastyMessage>();
+            await endpoint.Send(new NastyMessage {Value = "Hello"});
+
+            await _handled;
+        }
+
+        Task<ConsumeContext<NastyMessage>> _handled;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _handled = Handled<NastyMessage>(configurator);
+
+            configurator.MapEndpoint<NastyMessage>(configurator.InputAddress);
         }
 
 
@@ -82,6 +112,7 @@ namespace MassTransit.Tests
             DateTime Timestamp { get; }
         }
     }
+
 
     [TestFixture]
     public class Conventional_polymorphic_base_class :

--- a/src/MassTransit.WebJobs.ServiceBusIntegration/Contexts/WebJobMessageReceiverEndpointContext.cs
+++ b/src/MassTransit.WebJobs.ServiceBusIntegration/Contexts/WebJobMessageReceiverEndpointContext.cs
@@ -1,17 +1,19 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.WebJobs.ServiceBusIntegration.Contexts
 {
+    using System;
+    using System.Collections.Generic;
     using System.Threading;
     using Context;
     using Logging;
@@ -28,6 +30,7 @@ namespace MassTransit.WebJobs.ServiceBusIntegration.Contexts
         readonly CancellationToken _cancellationToken;
         readonly ILog _log;
         readonly IPublishTopology _publishTopology;
+        readonly IReadOnlyDictionary<Type, Uri> _endpointMapping;
 
         public WebJobMessageReceiverEndpointContext(IReceiveEndpointConfiguration configuration, ILog log, IBinder binder, CancellationToken cancellationToken)
             : base(configuration)
@@ -37,13 +40,14 @@ namespace MassTransit.WebJobs.ServiceBusIntegration.Contexts
             _log = log;
 
             _publishTopology = configuration.Topology.Publish;
+            _endpointMapping = configuration.Topology.Send.EndpointMapping;
         }
 
         protected override ISendEndpointProvider CreateSendEndpointProvider()
         {
             ISendTransportProvider sendTransportProvider = new ServiceBusAttributeSendTransportProvider(_binder, _log, _cancellationToken);
 
-            return new SendEndpointProvider(sendTransportProvider, SendObservers, Serializer, InputAddress, SendPipe);
+            return new SendEndpointProvider(sendTransportProvider, SendObservers, Serializer, InputAddress, SendPipe, _endpointMapping);
         }
 
         protected override IPublishEndpointProvider CreatePublishEndpointProvider()

--- a/src/MassTransit/Clients/Contexts/BusClientFactoryContext.cs
+++ b/src/MassTransit/Clients/Contexts/BusClientFactoryContext.cs
@@ -45,6 +45,11 @@ namespace MassTransit.Clients.Contexts
             return _bus.GetSendEndpoint(address);
         }
 
+        public Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            return _bus.GetSendEndpoint(type);
+        }
+
         public Uri ResponseAddress => _bus.Address;
 
         public IPublishEndpoint PublishEndpoint => _bus;

--- a/src/MassTransit/Clients/Contexts/ReceiveEndpointClientFactoryContext.cs
+++ b/src/MassTransit/Clients/Contexts/ReceiveEndpointClientFactoryContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Clients.Contexts
 {
@@ -47,6 +47,11 @@ namespace MassTransit.Clients.Contexts
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {
             return _receiveEndpoint.GetSendEndpoint(address);
+        }
+
+        public Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            return _receiveEndpoint.GetSendEndpoint(type);
         }
 
         public Uri ResponseAddress { get; }

--- a/src/MassTransit/Configuration/BusConfigurators/BusFactoryConfigurator.cs
+++ b/src/MassTransit/Configuration/BusConfigurators/BusFactoryConfigurator.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.BusConfigurators
 {
@@ -76,6 +76,11 @@ namespace MassTransit.BusConfigurators
                 throw new ArgumentNullException(nameof(callback));
 
             callback(_configuration.Send.Configurator);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            _configuration.Topology.Send.MapEndpoint(type, uri);
         }
 
         public void ConfigurePublish(Action<IPublishPipeConfigurator> callback)

--- a/src/MassTransit/Configuration/Configuration/EndpointConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/EndpointConfiguration.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Configuration
 {
@@ -134,6 +134,11 @@ namespace MassTransit.Configuration
                 throw new ArgumentNullException(nameof(callback));
 
             callback(Send.Configurator);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            Topology.Send.MapEndpoint(type, uri);
         }
 
         public void ConfigureReceive(Action<IReceivePipeConfigurator> callback)

--- a/src/MassTransit/Configuration/Configuration/ReceiveEndpointConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/ReceiveEndpointConfiguration.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Configuration
 {
@@ -128,6 +128,11 @@ namespace MassTransit.Configuration
         public void ConfigureSend(Action<ISendPipeConfigurator> callback)
         {
             _configuration.ConfigureSend(callback);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            _configuration.MapEndpoint(type, uri);
         }
 
         public void ConfigurePublish(Action<IPublishPipeConfigurator> callback)

--- a/src/MassTransit/Configuration/EndpointSpecifications/ReceiveSpecification.cs
+++ b/src/MassTransit/Configuration/EndpointSpecifications/ReceiveSpecification.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.EndpointSpecifications
 {
@@ -102,7 +102,6 @@ namespace MassTransit.EndpointSpecifications
             Configuration.Consume.Configurator.HandlerConfigured(configurator);
         }
 
-
         public void ConfigurePublish(Action<IPublishPipeConfigurator> callback)
         {
             if (callback == null)
@@ -117,6 +116,11 @@ namespace MassTransit.EndpointSpecifications
                 throw new ArgumentNullException(nameof(callback));
 
             callback(Configuration.Send.Configurator);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            Configuration.MapEndpoint(type, uri);
         }
 
         public void AddEndpointSpecification(IReceiveEndpointSpecification specification)

--- a/src/MassTransit/Configuration/ISendPipelineConfigurator.cs
+++ b/src/MassTransit/Configuration/ISendPipelineConfigurator.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
@@ -22,5 +22,28 @@ namespace MassTransit
         /// </summary>
         /// <param name="callback"></param>
         void ConfigureSend(Action<ISendPipeConfigurator> callback);
+
+        /// <summary>
+        /// Map message type endpoint with uri
+        /// </summary>
+        /// <param name="type">Message type</param>
+        /// <param name="uri">Uri</param>
+        void MapEndpoint(Type type, Uri uri);
+    }
+
+
+    public static class SendPipelineConfiguratorExtensions
+    {
+        /// <summary>
+        /// Map message type endpoint with uri
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="uri">Uri</param>
+        /// <typeparam name="T">Message type</typeparam>
+        public static void MapEndpoint<T>(this ISendPipelineConfigurator configurator, Uri uri)
+            where T : class
+        {
+            configurator.MapEndpoint(typeof(T), uri);
+        }
     }
 }

--- a/src/MassTransit/Configuration/ManagementEndpointConfigurator.cs
+++ b/src/MassTransit/Configuration/ManagementEndpointConfigurator.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
@@ -79,6 +79,11 @@ namespace MassTransit
         void ISendPipelineConfigurator.ConfigureSend(Action<ISendPipeConfigurator> callback)
         {
             _configurator.ConfigureSend(callback);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            _configurator.MapEndpoint(type, uri);
         }
 
         void IPublishPipelineConfigurator.ConfigurePublish(Action<IPublishPipeConfigurator> callback)

--- a/src/MassTransit/Context/BaseConsumeContext.cs
+++ b/src/MassTransit/Context/BaseConsumeContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Context
 {
@@ -238,6 +238,13 @@ namespace MassTransit.Context
         public virtual async Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {
             var sendEndpoint = await _receiveContext.SendEndpointProvider.GetSendEndpoint(address).ConfigureAwait(false);
+
+            return new ConsumeSendEndpoint(sendEndpoint, this, ConsumeTask);
+        }
+
+        public async Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            var sendEndpoint = await _receiveContext.SendEndpointProvider.GetSendEndpoint(type).ConfigureAwait(false);
 
             return new ConsumeSendEndpoint(sendEndpoint, this, ConsumeTask);
         }

--- a/src/MassTransit/Context/BaseReceiveEndpointContext.cs
+++ b/src/MassTransit/Context/BaseReceiveEndpointContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Context
 {
@@ -39,6 +39,7 @@ namespace MassTransit.Context
         readonly ReceiveObservable _receiveObservers;
         readonly ReceiveTransportObservable _transportObservers;
         readonly ReceiveEndpointObservable _endpointObservers;
+        readonly ISendTopologyConfigurator _sendTopology;
 
         protected BaseReceiveEndpointContext(IReceiveEndpointConfiguration configuration)
         {
@@ -46,6 +47,7 @@ namespace MassTransit.Context
             HostAddress = configuration.HostAddress;
 
             _publishTopology = configuration.Topology.Publish;
+            _sendTopology = configuration.Topology.Send;
 
             SendObservers = new SendObservable();
             PublishObservers = new PublishObservable();
@@ -113,7 +115,7 @@ namespace MassTransit.Context
 
         protected virtual ISendEndpointProvider CreateSendEndpointProvider()
         {
-            return new SendEndpointProvider(_sendTransportProvider.Value, SendObservers, Serializer, InputAddress, SendPipe);
+            return new SendEndpointProvider(_sendTransportProvider.Value, SendObservers, Serializer, InputAddress, SendPipe, _sendTopology.EndpointMapping);
         }
 
         protected virtual IPublishEndpointProvider CreatePublishEndpointProvider()

--- a/src/MassTransit/Context/MessageConsumeContext.cs
+++ b/src/MassTransit/Context/MessageConsumeContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Context
 {
@@ -155,6 +155,11 @@ namespace MassTransit.Context
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             return _context.GetSendEndpoint(address);
+        }
+
+        Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Type type)
+        {
+            return _context.GetSendEndpoint(type);
         }
 
         ReceiveContext ConsumeContext.ReceiveContext => _context.ReceiveContext;

--- a/src/MassTransit/Courier/Hosts/HostCompensateActivityContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostCompensateActivityContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Courier.Hosts
 {
@@ -109,6 +109,11 @@ namespace MassTransit.Courier.Hosts
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             return _context.GetSendEndpoint(address);
+        }
+
+        Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Type type)
+        {
+            return _context.GetSendEndpoint(type);
         }
 
         Guid CompensateContext.TrackingNumber => _context.TrackingNumber;

--- a/src/MassTransit/Courier/Hosts/HostCompensateContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostCompensateContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Courier.Hosts
 {
@@ -172,6 +172,12 @@ namespace MassTransit.Courier.Hosts
         {
             // TODO intercept to ensure SourceAddress is right, but it should be based on the InputAddress
             return _context.GetSendEndpoint(address);
+        }
+
+        public Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            // TODO intercept to ensure SourceAddress is right, but it should be based on the InputAddress
+            return _context.GetSendEndpoint(type);
         }
 
         public ConnectHandle ConnectPublishObserver(IPublishObserver observer)

--- a/src/MassTransit/Courier/Hosts/HostExecuteActivityContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostExecuteActivityContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Courier.Hosts
 {
@@ -194,6 +194,11 @@ namespace MassTransit.Courier.Hosts
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             return _consumeContext.GetSendEndpoint(address);
+        }
+
+        Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Type type)
+        {
+            return _consumeContext.GetSendEndpoint(type);
         }
 
         TActivity ExecuteActivityContext<TActivity, TArguments>.Activity => _activity;

--- a/src/MassTransit/Courier/Hosts/HostExecuteContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostExecuteContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Courier.Hosts
 {
@@ -166,6 +166,7 @@ namespace MassTransit.Courier.Hosts
         {
             if (log == null)
                 throw new ArgumentNullException(nameof(log));
+
             if (variables == null)
                 throw new ArgumentNullException(nameof(variables));
 
@@ -180,6 +181,7 @@ namespace MassTransit.Courier.Hosts
         {
             if (log == null)
                 throw new ArgumentNullException(nameof(log));
+
             if (variables == null)
                 throw new ArgumentNullException(nameof(variables));
 
@@ -202,6 +204,7 @@ namespace MassTransit.Courier.Hosts
         {
             if (log == null)
                 throw new ArgumentNullException(nameof(log));
+
             if (buildItinerary == null)
                 throw new ArgumentNullException(nameof(buildItinerary));
 
@@ -216,8 +219,10 @@ namespace MassTransit.Courier.Hosts
         {
             if (log == null)
                 throw new ArgumentNullException(nameof(log));
+
             if (variables == null)
                 throw new ArgumentNullException(nameof(variables));
+
             if (buildItinerary == null)
                 throw new ArgumentNullException(nameof(buildItinerary));
 
@@ -233,8 +238,10 @@ namespace MassTransit.Courier.Hosts
         {
             if (log == null)
                 throw new ArgumentNullException(nameof(log));
+
             if (variables == null)
                 throw new ArgumentNullException(nameof(variables));
+
             if (buildItinerary == null)
                 throw new ArgumentNullException(nameof(buildItinerary));
 
@@ -284,6 +291,11 @@ namespace MassTransit.Courier.Hosts
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             return _context.GetSendEndpoint(address);
+        }
+
+        Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Type type)
+        {
+            return _context.GetSendEndpoint(type);
         }
 
         ConnectHandle IPublishObserverConnector.ConnectPublishObserver(IPublishObserver observer)

--- a/src/MassTransit/EndpointConvention.cs
+++ b/src/MassTransit/EndpointConvention.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
     using System;
 
 
+    [Obsolete("Use ISendPipelineConfigurator.MapEndpoint instead")]
     public static class EndpointConvention
     {
         /// <summary>

--- a/src/MassTransit/EndpointConventionExtensions.cs
+++ b/src/MassTransit/EndpointConventionExtensions.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
@@ -21,6 +21,18 @@ namespace MassTransit
 
     public static class EndpointConventionExtensions
     {
+        /// <summary>
+        /// Get SendEndpoint for specific message type
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Task<ISendEndpoint> GetSendEndpoint<T>(this ISendEndpointProvider provider)
+            where T : class
+        {
+            return provider.GetSendEndpoint(typeof(T));
+        }
+
         /// <summary>
         /// Send a message
         /// </summary>

--- a/src/MassTransit/ISendEndpointProvider.cs
+++ b/src/MassTransit/ISendEndpointProvider.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
@@ -31,5 +31,12 @@ namespace MassTransit
         /// <param name="address">The endpoint address</param>
         /// <returns>The send endpoint</returns>
         Task<ISendEndpoint> GetSendEndpoint(Uri address);
+
+        /// <summary>
+        /// Return the send endpoint for the specified address
+        /// </summary>
+        /// <param name="type">Message Type</param>
+        /// <returns>The send endpoint</returns>
+        Task<ISendEndpoint> GetSendEndpoint(Type type);
     }
 }

--- a/src/MassTransit/MassTransitBus.cs
+++ b/src/MassTransit/MassTransitBus.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
@@ -121,6 +121,11 @@ namespace MassTransit
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             return _sendEndpointProvider.GetSendEndpoint(address);
+        }
+
+        Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Type type)
+        {
+            return _sendEndpointProvider.GetSendEndpoint(type);
         }
 
         public async Task<BusHandle> StartAsync(CancellationToken cancellationToken)

--- a/src/MassTransit/Topology/Configuration/ISendTopologyConfigurator.cs
+++ b/src/MassTransit/Topology/Configuration/ISendTopologyConfigurator.cs
@@ -1,17 +1,19 @@
 // Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Topology
 {
+    using System;
+    using System.Collections.Generic;
     using GreenPipes;
 
 
@@ -33,5 +35,8 @@ namespace MassTransit.Topology
         /// <param name="topology">The topology</param>
         void AddMessageSendTopology<T>(IMessageSendTopology<T> topology)
             where T : class;
+
+        IReadOnlyDictionary<Type, Uri> EndpointMapping { get; }
+        void MapEndpoint(Type type, Uri uri);
     }
 }

--- a/src/MassTransit/Topology/ISendTopology.cs
+++ b/src/MassTransit/Topology/ISendTopology.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Topology
 {

--- a/src/MassTransit/Transports/ReceiveEndpoint.cs
+++ b/src/MassTransit/Transports/ReceiveEndpoint.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Transports
 {
@@ -24,7 +24,7 @@ namespace MassTransit.Transports
     /// <summary>
     /// A receive endpoint is called by the receive transport to push messages to consumers.
     /// The receive endpoint is where the initial deserialization occurs, as well as any additional
-    /// filters on the receive context. 
+    /// filters on the receive context.
     /// </summary>
     public class ReceiveEndpoint :
         IReceiveEndpointControl
@@ -100,6 +100,11 @@ namespace MassTransit.Transports
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {
             return _context.SendEndpointProvider.GetSendEndpoint(address);
+        }
+
+        public Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            return _context.SendEndpointProvider.GetSendEndpoint(type);
         }
 
         public IPublishEndpoint CreatePublishEndpoint(Uri sourceAddress, ConsumeContext context = null)

--- a/src/MassTransit/Transports/SendEndpointProvider.cs
+++ b/src/MassTransit/Transports/SendEndpointProvider.cs
@@ -1,22 +1,24 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Transports
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using GreenPipes;
     using Pipeline;
     using Pipeline.Observables;
+    using Util;
 
 
     public class SendEndpointProvider :
@@ -25,16 +27,19 @@ namespace MassTransit.Transports
         readonly ISendEndpointCache<Uri> _cache;
         readonly SendObservable _observers;
         readonly ISendPipe _sendPipe;
+        readonly IReadOnlyDictionary<Type, Uri> _endpointMapping;
         readonly IMessageSerializer _serializer;
         readonly Uri _sourceAddress;
         readonly ISendTransportProvider _transportProvider;
 
-        public SendEndpointProvider(ISendTransportProvider transportProvider, SendObservable observers, IMessageSerializer serializer, Uri sourceAddress, ISendPipe sendPipe)
+        public SendEndpointProvider(ISendTransportProvider transportProvider, SendObservable observers, IMessageSerializer serializer, Uri sourceAddress,
+            ISendPipe sendPipe, IReadOnlyDictionary<Type, Uri> endpointMapping)
         {
             _transportProvider = transportProvider;
             _serializer = serializer;
             _sourceAddress = sourceAddress;
             _sendPipe = sendPipe;
+            _endpointMapping = endpointMapping;
 
             _cache = new SendEndpointCache<Uri>();
             _observers = observers;
@@ -42,6 +47,14 @@ namespace MassTransit.Transports
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {
+            return _cache.GetSendEndpoint(address, CreateSendEndpoint);
+        }
+
+        public Task<ISendEndpoint> GetSendEndpoint(Type type)
+        {
+            if (!_endpointMapping.TryGetValue(type, out var address))
+                throw new ArgumentException($"A convention for the message type {TypeMetadataCache.GetShortName(type)} was not found");
+
             return _cache.GetSendEndpoint(address, CreateSendEndpoint);
         }
 

--- a/src/MassTransit/Turnout/Configuration/TurnoutServiceSpecification.cs
+++ b/src/MassTransit/Turnout/Configuration/TurnoutServiceSpecification.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Turnout.Configuration
 {
@@ -118,6 +118,11 @@ namespace MassTransit.Turnout.Configuration
         void ISendPipelineConfigurator.ConfigureSend(Action<ISendPipeConfigurator> callback)
         {
             _configurator.ConfigureSend(callback);
+        }
+
+        public void MapEndpoint(Type type, Uri uri)
+        {
+            _configurator.MapEndpoint(type, uri);
         }
 
         void IPublishPipelineConfigurator.ConfigurePublish(Action<IPublishPipeConfigurator> callback)


### PR DESCRIPTION
this will help us avoid of using static `EndpointConvetion` and use endpoint mapping via bus instance