### PR TITLE
Fix Uninstall for CosmosDb Emulator

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,9 @@ nuget:
 install:
   # Appveyor images now have cosmosdb installed (https://help.appveyor.com/discussions/problems/7950-unable-to-laucnh-cosmosdb-emulator), but
   # because it's an old version, we have to uninstall it, and install the latest
-  - ps: |
-      Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-      Uninstall-CosmosDbEmulator -RemoveData
+  - wmic product where name="Azure Cosmos DB Emulator" call uninstall
+  # Weird, the emulator seems to have 2 versions installed, 1.20.108.4 and 2.1.2, so we use different uninstall command above
+  # also could be useful: https://github.com/appveyor-tests/CosmosDb
   # this nice little snippit is from here: https://medium.com/@nick.chapsas/testing-your-cosmosdb-c-code-and-automating-it-with-appveyor-7df2da50a4b4
   - ps: "Start-Sleep -s 30"
   - ps: "Invoke-WebRequest -Uri 'https://aka.ms/cosmosdb-emulator' -OutFile 'cosmos-db.msi'\ncmd /c start /wait msiexec /i cosmos-db.msi /qn /quiet /norestart /log install.log  \nSet-Content -Value '\"C:\\Program Files\\Azure Cosmos DB Emulator\\CosmosDB.Emulator.exe\" /NoUI /NoExplorer /NoFirewall' -Path .\\startCosmosDb.cmd\nStart-Process -FilePath .\\startCosmosDb.cmd\n\n$attempt = 0\n$max = 8\nwhile(!$client.Connected -and $attempt -lt $max) {\n  try {    \n    $client = New-Object System.Net.Sockets.TcpClient([System.Net.Sockets.AddressFamily]::InterNetwork)\n    $attempt++; $client.Connect(\"127.0.0.1\", 8081); write-host \"CosmosDB started\"\n  }\n  catch {    \n    if($attempt -eq $max) {\n      write-host \"CosmosDB was not started\"; $client.Close(); return\n      }  \n    [int]$sleepTime = 5*$attempt\n    write-host \"CosmosDB is not started. Retry after $sleepTime seconds...\"\n    sleep $sleepTime;\n    $client.Close()        \n  }  \n}"


### PR DESCRIPTION
The uninstall command was failing, so we use a tweaked command.