### PR TITLE
- allow to generate sendEndpoint using HostAddress

### DIFF
--- a/src/MassTransit.HttpTransport/Transport/HttpResponseSendEndpointProvider.cs
+++ b/src/MassTransit.HttpTransport/Transport/HttpResponseSendEndpointProvider.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.HttpTransport.Transport
 {
@@ -42,6 +42,8 @@ namespace MassTransit.HttpTransport.Transport
             _observers = new SendObservable();
             _sendEndpointProvider = sendEndpointProvider;
         }
+
+        public Uri HostAddress => _sendEndpointProvider.HostAddress;
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {

--- a/src/MassTransit.TestFramework/TestConsumeContext.cs
+++ b/src/MassTransit.TestFramework/TestConsumeContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.TestFramework
 {
@@ -152,10 +152,10 @@ namespace MassTransit.TestFramework
 
         public void AddConsumeTask(Task task)
         {
-
         }
 
-        public Task RespondAsync<T>(T message) where T : class
+        public Task RespondAsync<T>(T message)
+            where T : class
         {
             throw new NotImplementedException();
         }
@@ -165,27 +165,32 @@ namespace MassTransit.TestFramework
             throw new NotImplementedException();
         }
 
-        public Task RespondAsync<T>(object values) where T : class
+        public Task RespondAsync<T>(object values)
+            where T : class
         {
             throw new NotImplementedException();
         }
 
-        public Task RespondAsync<T>(object values, IPipe<SendContext<T>> sendPipe) where T : class
+        public Task RespondAsync<T>(object values, IPipe<SendContext<T>> sendPipe)
+            where T : class
         {
             throw new NotImplementedException();
         }
 
-        public Task RespondAsync<T>(object values, IPipe<SendContext> sendPipe) where T : class
+        public Task RespondAsync<T>(object values, IPipe<SendContext> sendPipe)
+            where T : class
         {
             throw new NotImplementedException();
         }
 
-        public Task RespondAsync<T>(T message, IPipe<SendContext<T>> sendPipe) where T : class
+        public Task RespondAsync<T>(T message, IPipe<SendContext<T>> sendPipe)
+            where T : class
         {
             throw new NotImplementedException();
         }
 
-        public Task RespondAsync<T>(T message, IPipe<SendContext> sendPipe) where T : class
+        public Task RespondAsync<T>(T message, IPipe<SendContext> sendPipe)
+            where T : class
         {
             throw new NotImplementedException();
         }
@@ -205,17 +210,21 @@ namespace MassTransit.TestFramework
             throw new NotImplementedException();
         }
 
-        public void Respond<T>(T message) where T : class
+        public void Respond<T>(T message)
+            where T : class
         {
             throw new NotImplementedException();
         }
+
+        public Uri HostAddress => throw new NotImplementedException();
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {
             throw new NotImplementedException();
         }
 
-        public async Task NotifyConsumed<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType) where T : class
+        public async Task NotifyConsumed<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType)
+            where T : class
         {
         }
 
@@ -248,7 +257,7 @@ namespace MassTransit.TestFramework
     }
 
 
-    public class TestReceiveContext : 
+    public class TestReceiveContext :
         BaseReceiveContext
     {
         public TestReceiveContext(Uri sourceAddress)

--- a/src/MassTransit.Tests/SendReceive_Specs.cs
+++ b/src/MassTransit.Tests/SendReceive_Specs.cs
@@ -1,17 +1,18 @@
 // Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests
 {
+    using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using Shouldly;
@@ -39,7 +40,7 @@ namespace MassTransit.Tests
         {
             Task<ConsumeContext<IMessageA>> handler = SubscribeHandler<IMessageA>();
 
-            await BusSendEndpoint.Send<IMessageA>(new {});
+            await BusSendEndpoint.Send<IMessageA>(new { });
 
             await handler;
         }
@@ -109,6 +110,29 @@ namespace MassTransit.Tests
             var consumeContext = await handler;
 
             consumeContext.RequestId.ShouldBe(requestId);
+        }
+    }
+
+
+    public class Send_message_using_endpoint_provider :
+        InMemoryTestFixture
+    {
+        Task<ConsumeContext<PingMessage>> _consumer;
+        Uri _address;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            base.ConfigureInMemoryReceiveEndpoint(configurator);
+            _consumer = HandledByConsumer<PingMessage>(configurator);
+            _address = configurator.InputAddress;
+        }
+
+        [Test]
+        public async Task Should_succeed()
+        {
+            var endpoint = await Bus.GetHostSendEndpoint(_address);
+            await endpoint.Send(new PingMessage());
+            await _consumer;
         }
     }
 }

--- a/src/MassTransit.WebJobs.ServiceBusIntegration/Contexts/WebJobMessageReceiverEndpointContext.cs
+++ b/src/MassTransit.WebJobs.ServiceBusIntegration/Contexts/WebJobMessageReceiverEndpointContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.WebJobs.ServiceBusIntegration.Contexts
 {
@@ -43,7 +43,7 @@ namespace MassTransit.WebJobs.ServiceBusIntegration.Contexts
         {
             ISendTransportProvider sendTransportProvider = new ServiceBusAttributeSendTransportProvider(_binder, _log, _cancellationToken);
 
-            return new SendEndpointProvider(sendTransportProvider, SendObservers, Serializer, InputAddress, SendPipe);
+            return new SendEndpointProvider(sendTransportProvider, HostAddress, SendObservers, Serializer, InputAddress, SendPipe);
         }
 
         protected override IPublishEndpointProvider CreatePublishEndpointProvider()

--- a/src/MassTransit/Clients/Contexts/BusClientFactoryContext.cs
+++ b/src/MassTransit/Clients/Contexts/BusClientFactoryContext.cs
@@ -40,6 +40,8 @@ namespace MassTransit.Clients.Contexts
             return _bus.ConnectSendObserver(observer);
         }
 
+        public Uri HostAddress => _bus.HostAddress;
+
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {
             return _bus.GetSendEndpoint(address);

--- a/src/MassTransit/Clients/Contexts/ReceiveEndpointClientFactoryContext.cs
+++ b/src/MassTransit/Clients/Contexts/ReceiveEndpointClientFactoryContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Clients.Contexts
 {
@@ -43,6 +43,8 @@ namespace MassTransit.Clients.Contexts
         {
             return _receiveEndpoint.ConnectSendObserver(observer);
         }
+
+        public Uri HostAddress => _receiveEndpoint.HostAddress;
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {

--- a/src/MassTransit/Context/BaseConsumeContext.cs
+++ b/src/MassTransit/Context/BaseConsumeContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Context
 {
@@ -234,6 +234,8 @@ namespace MassTransit.Context
         {
             AddConsumeTask(RespondAsync(message));
         }
+
+        public Uri HostAddress => _receiveContext.SendEndpointProvider.HostAddress;
 
         public virtual async Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {

--- a/src/MassTransit/Context/BaseReceiveEndpointContext.cs
+++ b/src/MassTransit/Context/BaseReceiveEndpointContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Context
 {
@@ -113,7 +113,7 @@ namespace MassTransit.Context
 
         protected virtual ISendEndpointProvider CreateSendEndpointProvider()
         {
-            return new SendEndpointProvider(_sendTransportProvider.Value, SendObservers, Serializer, InputAddress, SendPipe);
+            return new SendEndpointProvider(_sendTransportProvider.Value, HostAddress, SendObservers, Serializer, InputAddress, SendPipe);
         }
 
         protected virtual IPublishEndpointProvider CreatePublishEndpointProvider()

--- a/src/MassTransit/Context/MessageConsumeContext.cs
+++ b/src/MassTransit/Context/MessageConsumeContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Context
 {
@@ -151,6 +151,8 @@ namespace MassTransit.Context
         {
             return _context.ConnectSendObserver(observer);
         }
+
+        public Uri HostAddress => _context.HostAddress;
 
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {

--- a/src/MassTransit/Courier/Hosts/HostCompensateActivityContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostCompensateActivityContext.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Courier.Hosts
 {
@@ -105,6 +105,8 @@ namespace MassTransit.Courier.Hosts
         {
             return _context.Publish<T>(values, publishPipe, cancellationToken);
         }
+
+        Uri ISendEndpointProvider.HostAddress => _context.HostAddress;
 
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {

--- a/src/MassTransit/Courier/Hosts/HostCompensateContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostCompensateContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Courier.Hosts
 {
@@ -168,7 +168,9 @@ namespace MassTransit.Courier.Hosts
             return new FailedCompensationResult<TLog>(this, _publisher, _compensateLog, _routingSlip, exception);
         }
 
-        public Task<ISendEndpoint> GetSendEndpoint(Uri address)
+        Uri ISendEndpointProvider.HostAddress => _context.HostAddress;
+
+        Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             // TODO intercept to ensure SourceAddress is right, but it should be based on the InputAddress
             return _context.GetSendEndpoint(address);

--- a/src/MassTransit/Courier/Hosts/HostExecuteActivityContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostExecuteActivityContext.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Courier.Hosts
 {
@@ -190,6 +190,8 @@ namespace MassTransit.Courier.Hosts
         {
             return _context.Publish<T>(values, publishPipe, cancellationToken);
         }
+
+        Uri ISendEndpointProvider.HostAddress => _context.HostAddress;
 
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {

--- a/src/MassTransit/Courier/Hosts/HostExecuteContext.cs
+++ b/src/MassTransit/Courier/Hosts/HostExecuteContext.cs
@@ -281,6 +281,8 @@ namespace MassTransit.Courier.Hosts
             return Faulted(exception);
         }
 
+        Uri ISendEndpointProvider.HostAddress => _context.HostAddress;
+
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             return _context.GetSendEndpoint(address);

--- a/src/MassTransit/EndpointConventionExtensions.cs
+++ b/src/MassTransit/EndpointConventionExtensions.cs
@@ -1,18 +1,19 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using GreenPipes;

--- a/src/MassTransit/ISendEndpointProvider.cs
+++ b/src/MassTransit/ISendEndpointProvider.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
@@ -26,10 +26,28 @@ namespace MassTransit
         ISendObserverConnector
     {
         /// <summary>
+        /// Host Address
+        /// </summary>
+        Uri HostAddress { get; }
+
+        /// <summary>
         /// Return the send endpoint for the specified address
         /// </summary>
         /// <param name="address">The endpoint address</param>
-        /// <returns>The send endpoint</returns>
+        /// <returns>The send endpoint <see cref="ISendEndpoint"/></returns>
         Task<ISendEndpoint> GetSendEndpoint(Uri address);
+    }
+
+
+    public static class SendEndpointProviderExtensions
+    {
+        /// <summary>
+        /// Return the send endpoint for the specified address using HostAddress as a base
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="address">The endpoint address</param>
+        /// <returns>The send endpoint <see cref="ISendEndpoint"/></returns>
+        public static Task<ISendEndpoint> GetHostSendEndpoint(this ISendEndpointProvider provider, Uri address) =>
+            provider.GetSendEndpoint(new Uri(provider.HostAddress, address));
     }
 }

--- a/src/MassTransit/MassTransitBus.cs
+++ b/src/MassTransit/MassTransitBus.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit
 {
@@ -117,6 +117,8 @@ namespace MassTransit
         public Uri Address { get; }
 
         public IBusTopology Topology { get; }
+
+        Uri ISendEndpointProvider.HostAddress => _sendEndpointProvider.HostAddress;
 
         Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {

--- a/src/MassTransit/Transports/ReceiveEndpoint.cs
+++ b/src/MassTransit/Transports/ReceiveEndpoint.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Transports
 {
@@ -24,7 +24,7 @@ namespace MassTransit.Transports
     /// <summary>
     /// A receive endpoint is called by the receive transport to push messages to consumers.
     /// The receive endpoint is where the initial deserialization occurs, as well as any additional
-    /// filters on the receive context. 
+    /// filters on the receive context.
     /// </summary>
     public class ReceiveEndpoint :
         IReceiveEndpointControl
@@ -97,7 +97,9 @@ namespace MassTransit.Transports
             return _receiveTransport.ConnectSendObserver(observer);
         }
 
-        public Task<ISendEndpoint> GetSendEndpoint(Uri address)
+        Uri ISendEndpointProvider.HostAddress => _context.SendEndpointProvider.HostAddress;
+
+        Task<ISendEndpoint> ISendEndpointProvider.GetSendEndpoint(Uri address)
         {
             return _context.SendEndpointProvider.GetSendEndpoint(address);
         }

--- a/src/MassTransit/Transports/SendEndpointProvider.cs
+++ b/src/MassTransit/Transports/SendEndpointProvider.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Transports
 {
@@ -29,8 +29,10 @@ namespace MassTransit.Transports
         readonly Uri _sourceAddress;
         readonly ISendTransportProvider _transportProvider;
 
-        public SendEndpointProvider(ISendTransportProvider transportProvider, SendObservable observers, IMessageSerializer serializer, Uri sourceAddress, ISendPipe sendPipe)
+        public SendEndpointProvider(ISendTransportProvider transportProvider, Uri hostAddress, SendObservable observers, IMessageSerializer serializer,
+            Uri sourceAddress, ISendPipe sendPipe)
         {
+            HostAddress = hostAddress;
             _transportProvider = transportProvider;
             _serializer = serializer;
             _sourceAddress = sourceAddress;
@@ -39,6 +41,8 @@ namespace MassTransit.Transports
             _cache = new SendEndpointCache<Uri>();
             _observers = observers;
         }
+
+        public Uri HostAddress { get; }
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri address)
         {


### PR DESCRIPTION
this commit will add ability to use `HostAddress` as a base for send endpoint. It could be situation where u are using secret manager and u don't know the base endpoint but u know queue names