### PR TITLE
Move StopOperation into finally block

### DIFF
--- a/src/MassTransit.ApplicationInsights/ApplicationInsightsFilter.cs
+++ b/src/MassTransit.ApplicationInsights/ApplicationInsightsFilter.cs
@@ -70,7 +70,7 @@ namespace MassTransit.ApplicationInsights
                 {
                     await next.Send(context).ConfigureAwait(false);
 
-                    _telemetryClient.StopOperation(operation);
+                    operation.Telemetry.Success = true;
                 }
                 catch (Exception ex)
                 {
@@ -79,6 +79,10 @@ namespace MassTransit.ApplicationInsights
                     operation.Telemetry.Success = false;
 
                     throw;
+                }
+                finally
+                {
+                     _telemetryClient.StopOperation(operation);
                 }
             }
         }


### PR DESCRIPTION
I've just moved AI StopOperation to finally block, based on MS docs for queues: 
https://docs.microsoft.com/en-us/azure/application-insights/application-insights-custom-operations-tracking#queue-instrumentation