### PR TITLE
New filter ApplicationInsightsPublishFilter

### DIFF
--- a/src/MassTransit.ApplicationInsights.Tests/ApplicationInsightsPublishFilter_Specs.cs
+++ b/src/MassTransit.ApplicationInsights.Tests/ApplicationInsightsPublishFilter_Specs.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.ApplicationInsights.Tests
+{
+    using GreenPipes;
+    using Microsoft.ApplicationInsights;
+    using Moq;
+    using NUnit.Framework;
+    using System.Threading.Tasks;
+
+    public class ApplicationInsightsPublishFilter_Specs
+    {
+        [Test]
+        public async Task Should_send_context_to_next_pipe()
+        {
+            bool configureOperationHasBeenCalled = false;
+
+            var mockPublishContext = new Mock<PublishContext>();
+            var filter = new ApplicationInsightsPublishFilter<PublishContext>(new TelemetryClient(), ((holder, context) => configureOperationHasBeenCalled = true));
+
+            var mockPipe = new Mock<IPipe<PublishContext>>();
+            await filter.Send(mockPublishContext.Object, mockPipe.Object);
+
+            Assert.IsTrue(configureOperationHasBeenCalled);
+            mockPipe.Verify(action => action.Send(mockPublishContext.Object), Times.Once);
+        }
+    }
+}

--- a/src/MassTransit.ApplicationInsights.Tests/Configure_Specs.cs
+++ b/src/MassTransit.ApplicationInsights.Tests/Configure_Specs.cs
@@ -22,7 +22,7 @@ namespace MassTransit.ApplicationInsights.Tests
     public class Configure_Specs
     {
         [Test]
-        public void Test()
+        public void Bus_should_be_created_when_use_ApplicationInsights_extension()
         {
             var telemetryClient = new TelemetryClient();
 
@@ -55,13 +55,10 @@ namespace MassTransit.ApplicationInsights.Tests
         }
 
         [Test]
-        public void Should_add_an_ApplicationInsightsPublishFilter_to_the_pipe_configurator()
+        public void Should_call_ConfigurePublish_on_the_given_pipeline_configurator()
         {
             // Arrange.
             var pipelineConfiguratorMock = new Mock<IPublishPipelineConfigurator>();
-
-            pipelineConfiguratorMock.Setup(c => c.ConfigurePublish(It.IsAny<Action<IPublishPipeConfigurator>>()));
-
             var pipelineConfigurator = pipelineConfiguratorMock.Object;
             var telemetryClient = new TelemetryClient();
 

--- a/src/MassTransit.ApplicationInsights.Tests/MassTransit.ApplicationInsights.Tests.csproj
+++ b/src/MassTransit.ApplicationInsights.Tests/MassTransit.ApplicationInsights.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="2.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />

--- a/src/MassTransit.ApplicationInsights/ApplicationInsightsMiddlewareConfiguratorExtensions.cs
+++ b/src/MassTransit.ApplicationInsights/ApplicationInsightsMiddlewareConfiguratorExtensions.cs
@@ -35,5 +35,38 @@ namespace MassTransit.ApplicationInsights
         {
             configurator.AddPipeSpecification(new ApplicationInsightsSpecification<T>(telemetryClient, configureOperation));
         }
+
+        /// <summary>
+        /// Add support for ApplicationInsights to the pipeline, which will be used to track all message publication.
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="telemetryClient">Telemetry client</param>
+        /// <param name="configureOperation">Add additional information to operation</param>
+        /// <typeparam name="T"></typeparam>
+        public static void UseApplicationInsightsOnPublish<T>(this IPipeConfigurator<T> configurator,
+            TelemetryClient telemetryClient,
+            Action<IOperationHolder<DependencyTelemetry>, T> configureOperation = null)
+            where T : class, PublishContext
+        {
+
+            configurator.AddPipeSpecification(new ApplicationInsightsPublishSpecification<T>(telemetryClient, configureOperation));
+        }
+
+        /// <summary>
+        /// Add support for ApplicationInsights to the pipeline, which will be used to track all message publication.
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="telemetryClient">Telemetry client</param>
+        /// <param name="configureOperation">Add additional information to operation</param>
+        public static void UseApplicationInsightsOnPublish(this IPublishPipelineConfigurator configurator,
+            TelemetryClient telemetryClient,
+            Action<IOperationHolder<DependencyTelemetry>, PublishContext> configureOperation = null)
+        {
+            configurator.ConfigurePublish(pipeConfigurator =>
+            {
+                var specification = new ApplicationInsightsPublishSpecification<PublishContext>(telemetryClient, configureOperation);
+                pipeConfigurator.AddPipeSpecification(specification);
+            });
+        }
     }
 }

--- a/src/MassTransit.ApplicationInsights/ApplicationInsightsPublishFilter.cs
+++ b/src/MassTransit.ApplicationInsights/ApplicationInsightsPublishFilter.cs
@@ -1,0 +1,87 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.ApplicationInsights
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using GreenPipes;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    public class ApplicationInsightsPublishFilter<T> : IFilter<T> where T : class, PublishContext
+    {
+        const string MessageId = nameof(MessageId);
+        const string ConversationId = nameof(ConversationId);
+        const string CorrelationId = nameof(CorrelationId);
+        const string RequestId = nameof(RequestId);
+
+        const string StepName = "MassTransit:Publisher";
+
+        readonly TelemetryClient _telemetryClient;
+        readonly Action<IOperationHolder<DependencyTelemetry>, T> _configureOperation;
+
+        public ApplicationInsightsPublishFilter(TelemetryClient telemetryClient, Action<IOperationHolder<DependencyTelemetry>, T> configureOperation)
+        {
+            _telemetryClient = telemetryClient;
+            _configureOperation = configureOperation;
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            context.CreateFilterScope(nameof(ApplicationInsightsPublishFilter<T>));
+        }
+
+        public async Task Send(T context, IPipe<T> next)
+        {
+            var contextType = context.GetType();
+            var messageType = contextType.GetGenericArguments().FirstOrDefault();
+
+            using (var operation = _telemetryClient.StartOperation<DependencyTelemetry>($"{StepName} {messageType?.FullName ?? "Unknown"}"))
+            {
+                if (context.MessageId.HasValue)
+                    operation.Telemetry.Properties.Add(MessageId, context.MessageId.Value.ToString());
+
+                if (context.ConversationId.HasValue)
+                    operation.Telemetry.Properties.Add(ConversationId, context.ConversationId.Value.ToString());
+
+                if (context.CorrelationId.HasValue)
+                    operation.Telemetry.Properties.Add(CorrelationId, context.CorrelationId.Value.ToString());
+
+                if (context.RequestId.HasValue)
+                    operation.Telemetry.Properties.Add(RequestId, context.RequestId.Value.ToString());
+
+                _configureOperation?.Invoke(operation, context);
+
+                try
+                {
+                    await next.Send(context).ConfigureAwait(false);
+
+                }
+                catch (Exception e)
+                {
+                    _telemetryClient.TrackException(e, operation.Telemetry.Properties);
+
+                    operation.Telemetry.Success = false;
+
+                    throw;
+                }
+                finally
+                {
+                    _telemetryClient.StopOperation(operation);
+                }
+            }
+        }
+    }
+}

--- a/src/MassTransit.ApplicationInsights/ApplicationInsightsPublishSpecification.cs
+++ b/src/MassTransit.ApplicationInsights/ApplicationInsightsPublishSpecification.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.ApplicationInsights
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using GreenPipes;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    public class ApplicationInsightsPublishSpecification<T> : IPipeSpecification<T> where T : class, PublishContext
+    {
+        readonly TelemetryClient _telemetryClient;
+        readonly Action<IOperationHolder<DependencyTelemetry>, T> _configureOperation;
+
+        public ApplicationInsightsPublishSpecification(TelemetryClient telemetryClient, Action<IOperationHolder<DependencyTelemetry>, T> configureOperation)
+        {
+            _telemetryClient = telemetryClient;
+            _configureOperation = configureOperation;
+        }
+
+        public void Apply(IPipeBuilder<T> builder)
+        {
+            builder.AddFilter(new ApplicationInsightsPublishFilter<T>(_telemetryClient, _configureOperation));
+        }
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+    }
+}


### PR DESCRIPTION
Added a new filter named `ApplicationInsightsPublishFilter` to allow the tracking of publications as Application Insights dependency telemetries.

Notes:
* The filter is heavily inspired by the existing filter `ApplicationInsightsFilter` that tracks message consumptions as request telemetries, maybe there are things that could be factorized.
* Ideally, the existing filter `ApplicationInsightsFilter` could be renamed `ApplicationInsightsConsumeFilter`, but that would be a breaking change.
* The name of the dependency telemetries tracked in App Insights follows the pattern `"MassTransit:Publisher MessageNamespace.MyMessageType"`. To obtain the message type, I extract the first generic argument from the type of the context. I'm not sure if this is the best way to do it.