### PR TITLE
Update StringDecimalConverter.cs

### DIFF
--- a/src/MassTransit/Serialization/JsonConverters/StringDecimalConverter.cs
+++ b/src/MassTransit/Serialization/JsonConverters/StringDecimalConverter.cs
@@ -27,7 +27,7 @@ namespace MassTransit.Serialization.JsonConverters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            string text = Convert.ToString(value);
+            string text = Convert.ToString(value, CultureInfo.InvariantCulture);
             if (string.IsNullOrEmpty(text))
                 text = "";
 


### PR DESCRIPTION
My current culture is nl-BE. If I have a decimal value, for example: 12.345 the stringvalue will be 12,345 after serialization... When deserialize the value is 12345. The decimal seperator is seen as a thousand separator in the 'Invariant Culture'.

Simple test:
![screenshot](https://user-images.githubusercontent.com/1420161/50692056-e7825b80-1032-11e9-961f-e18f44ad7de6.PNG)




 
