### PR TITLE
AppInsights - Updating configure operation invoke to run before context headers are set

### DIFF
--- a/src/MassTransit.ApplicationInsights.Tests/ApplicationInsightsPublishFilter_Specs.cs
+++ b/src/MassTransit.ApplicationInsights.Tests/ApplicationInsightsPublishFilter_Specs.cs
@@ -68,6 +68,35 @@ namespace MassTransit.ApplicationInsights.Tests
         }
 
         [Test]
+        public async Task Should_use_updated_telemetryId_and_parent_id_on_context_headers_using_configure_op()
+        {
+            // Arrange.
+            var operationId = Guid.NewGuid().ToString();
+            var parentId = Guid.NewGuid().ToString();
+            var rootKeyHeaderName = "RootKey";
+            var parentKeyHeaderName = "ParentKey";
+
+            var mockPublishContext = new Mock<PublishContext>();
+            mockPublishContext.Setup(c => c.Headers).Returns(_mockHeaders.Object);
+
+            _mockHeaders.Setup(x => x.Set(It.IsAny<string>(), It.IsAny<string>()));
+
+            var filter = new ApplicationInsightsPublishFilter<PublishContext>(new TelemetryClient(),
+                                                                              (holder, context) =>
+                                                                              {
+                                                                                  holder.Telemetry.Context.Operation.Id = operationId;
+                                                                                  holder.Telemetry.Id = parentId;
+                                                                              }, rootKeyHeaderName, parentKeyHeaderName);
+
+            // Act.
+            await filter.Send(mockPublishContext.Object, new Mock<IPipe<PublishContext>>().Object);
+
+            // Assert.
+            _mockHeaders.Verify(x => x.Set(rootKeyHeaderName, operationId), Times.Once);
+            _mockHeaders.Verify(x => x.Set(parentKeyHeaderName, parentId), Times.Once);
+        }
+
+        [Test]
         public async Task Should_add_the_expected_properties_to_the_dependency_telemetry()
         {
             // Arrange.

--- a/src/MassTransit.ApplicationInsights/ApplicationInsightsPublishFilter.cs
+++ b/src/MassTransit.ApplicationInsights/ApplicationInsightsPublishFilter.cs
@@ -68,6 +68,8 @@ namespace MassTransit.ApplicationInsights
 
             using (IOperationHolder<DependencyTelemetry> operation = _telemetryClient.StartOperation(telemetry))
             {
+                _configureOperation?.Invoke(operation, context);
+
                 context.Headers.Set(_telemetryHeaderRootKey, operation.Telemetry.Context.Operation.Id);
                 context.Headers.Set(_telemetryHeaderParentKey, operation.Telemetry.Id);
 
@@ -87,8 +89,6 @@ namespace MassTransit.ApplicationInsights
 
                 if (context.RequestId.HasValue)
                     operation.Telemetry.Properties.Add(RequestId, context.RequestId.Value.ToString());
-
-                _configureOperation?.Invoke(operation, context);
 
                 try
                 {

--- a/src/MassTransit.ApplicationInsights/ApplicationInsightsSendFilter.cs
+++ b/src/MassTransit.ApplicationInsights/ApplicationInsightsSendFilter.cs
@@ -67,6 +67,8 @@ namespace MassTransit.ApplicationInsights
 
             using (IOperationHolder<DependencyTelemetry> operation = _telemetryClient.StartOperation(requestTelemetry))
             {
+                _configureOperation?.Invoke(operation, context);
+
                 context.Headers.Set(_telemetryHeaderRootKey, operation.Telemetry.Context.Operation.Id);
                 context.Headers.Set(_telemetryHeaderParentKey, operation.Telemetry.Id);
 
@@ -86,8 +88,6 @@ namespace MassTransit.ApplicationInsights
 
                 if (context.RequestId.HasValue)
                     operation.Telemetry.Properties.Add(RequestId, context.RequestId.Value.ToString());
-
-                _configureOperation?.Invoke(operation, context);
 
                 try
                 {


### PR DESCRIPTION
As discussed on gitter - this allows for updated op Ids sent in from ASP.NET to be sent through to consumers.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
