### PR TITLE
Changing EF to use a scope-focused DbContext factory

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration.Tests/NHibernateFactory_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/NHibernateFactory_Specs.cs
@@ -113,6 +113,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
                 _machine = new TestStateMachine();
                 _sessionFactory = new SQLiteSessionFactoryProvider(typeof(InstanceMap))
                     .GetSessionFactory();
+
                 _repository = new NHibernateSagaRepository<Instance>(_sessionFactory);
 
                 configurator.StateMachineSaga(_machine, _repository);
@@ -192,6 +193,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
                 _machine = new TestStateMachine();
                 _sessionFactory = new SQLiteSessionFactoryProvider(typeof(InstanceMap))
                     .GetSessionFactory();
+
                 _repository = new NHibernateSagaRepository<Instance>(_sessionFactory);
 
                 configurator.StateMachineSaga(_machine, _repository);
@@ -292,8 +294,9 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         {
             public When_pre_inserting_in_an_invalid_state_with_ef()
             {
-                SagaDbContextFactory sagaDbContextFactory =
-                    () => new SagaDbContext<Instance, EntityFrameworkInstanceMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString());
+                ISagaDbContextFactory<Instance> sagaDbContextFactory = new DelegateSagaDbContextFactory<Instance>(
+                    () => new SagaDbContext<Instance, EntityFrameworkInstanceMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString()));
+
                 _repository = new EntityFrameworkSagaRepository<Instance>(sagaDbContextFactory);
             }
 

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
@@ -30,7 +30,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         InMemoryTestFixture
     {
         ChoirStateMachine _machine;
-        readonly SagaDbContextFactory _sagaDbContextFactory;
+        readonly ISagaDbContextFactory<ChoirState> _sagaDbContextFactory;
         readonly Lazy<ISagaRepository<ChoirState>> _repository;
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -42,14 +42,14 @@ namespace MassTransit.AutomatonymousIntegration.Tests
 
         public When_using_EntityFrameworkConcurrencyFail()
         {
-            _sagaDbContextFactory =
-                () => new SagaDbContext<ChoirState, EntityFrameworkChoirStateMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString());
+            _sagaDbContextFactory = new DelegateSagaDbContextFactory<ChoirState>(
+                () => new SagaDbContext<ChoirState, EntityFrameworkChoirStateMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString()));
             _repository = new Lazy<ISagaRepository<ChoirState>>(() => new EntityFrameworkSagaRepository<ChoirState>(_sagaDbContextFactory, optimistic: true));
         }
 
         async Task<ChoirState> GetSaga(Guid id)
         {
-            using (var dbContext = _sagaDbContextFactory())
+            using (var dbContext = _sagaDbContextFactory.Create())
             {
                 return await dbContext.Set<ChoirState>().SingleOrDefaultAsync(x => x.CorrelationId == id);
             }

--- a/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
+++ b/src/MassTransit.AutomatonymousIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
@@ -32,7 +32,7 @@ namespace MassTransit.AutomatonymousIntegration.Tests
         InMemoryTestFixture
     {
         ChoirStateMachine _machine;
-        readonly SagaDbContextFactory _sagaDbContextFactory;
+        readonly ISagaDbContextFactory<ChoirState> _sagaDbContextFactory;
         readonly Lazy<ISagaRepository<ChoirState>> _repository;
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -49,14 +49,14 @@ namespace MassTransit.AutomatonymousIntegration.Tests
 
         public When_using_EntityFrameworkConcurrencyOptimistic()
         {
-            _sagaDbContextFactory =
-                () => new SagaDbContext<ChoirState, EntityFrameworkChoirStateMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString());
+            _sagaDbContextFactory = new DelegateSagaDbContextFactory<ChoirState>(
+                () => new SagaDbContext<ChoirState, EntityFrameworkChoirStateMap>(SagaDbContextFactoryProvider.GetLocalDbConnectionString()));
             _repository = new Lazy<ISagaRepository<ChoirState>>(() => new EntityFrameworkSagaRepository<ChoirState>(_sagaDbContextFactory, optimistic: true));
         }
 
         async Task<ChoirState> GetSaga(Guid id)
         {
-            using (var dbContext = _sagaDbContextFactory())
+            using (var dbContext = _sagaDbContextFactory.Create())
             {
                 return await dbContext.Set<ChoirState>().SingleOrDefaultAsync(x => x.CorrelationId == id);
             }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SagaLocator_Specs.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SagaLocator_Specs.cs
@@ -1,44 +1,52 @@
-﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+﻿// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests
 {
     using System;
     using System.Threading.Tasks;
-
-    using MassTransit.EntityFrameworkCoreIntegration.Saga;
     using MassTransit.Saga;
-    using MassTransit.TestFramework;
     using MassTransit.Tests.Saga;
     using MassTransit.Tests.Saga.Messages;
-
     using Microsoft.EntityFrameworkCore;
-    using Microsoft.EntityFrameworkCore.Infrastructure;
-
     using NUnit.Framework;
-
+    using Saga;
     using Shouldly;
+    using TestFramework;
     using Testing;
 
 
-    [TestFixture, Category("Integration")]
+    [TestFixture]
+    [Category("Integration")]
     public class Locating_an_existing_ef_saga :
         InMemoryTestFixture
     {
         [Test]
         public async Task A_correlated_message_should_find_the_correct_saga()
         {
-            Guid sagaId = NewId.NextGuid();
+            var sagaId = NewId.NextGuid();
             var message = new InitiateSimpleSaga(sagaId);
 
-            await this.InputQueueSendEndpoint.Send(message);
+            await InputQueueSendEndpoint.Send(message);
 
-            Guid? foundId = await this._sagaRepository.Value.ShouldContainSaga(message.CorrelationId, this.TestTimeout);
+            Guid? foundId = await _sagaRepository.Value.ShouldContainSaga(message.CorrelationId, TestTimeout);
 
             foundId.HasValue.ShouldBe(true);
 
-            var nextMessage = new CompleteSimpleSaga { CorrelationId = sagaId };
+            var nextMessage = new CompleteSimpleSaga {CorrelationId = sagaId};
 
-            await this.InputQueueSendEndpoint.Send(nextMessage);
+            await InputQueueSendEndpoint.Send(nextMessage);
 
-            foundId = await this._sagaRepository.Value.ShouldContainSaga(x => x.CorrelationId == sagaId && x.Completed, this.TestTimeout);
+            foundId = await _sagaRepository.Value.ShouldContainSaga(x => x.CorrelationId == sagaId && x.Completed, TestTimeout);
 
             foundId.HasValue.ShouldBe(true);
         }
@@ -46,12 +54,12 @@
         [Test]
         public async Task An_initiating_message_should_start_the_saga()
         {
-            Guid sagaId = NewId.NextGuid();
+            var sagaId = NewId.NextGuid();
             var message = new InitiateSimpleSaga(sagaId);
 
-            await this.InputQueueSendEndpoint.Send(message);
+            await InputQueueSendEndpoint.Send(message);
 
-            Guid? foundId = await this._sagaRepository.Value.ShouldContainSaga(message.CorrelationId, this.TestTimeout);
+            Guid? foundId = await _sagaRepository.Value.ShouldContainSaga(message.CorrelationId, TestTimeout);
 
             foundId.HasValue.ShouldBe(true);
         }
@@ -66,19 +74,19 @@
             // dotnet ef migrations add --context "SagaDbContext``2" Init  -v
             var contextFactory = new ContextFactory();
 
-            using (var context = contextFactory.CreateDbContext(Array.Empty<string>()))
+            using (SagaDbContext<SimpleSaga, SimpleSagaMap> context = contextFactory.CreateDbContext(Array.Empty<string>()))
             {
                 context.Database.Migrate();
             }
 
-            this._sagaDbContextFactory = () => contextFactory.CreateDbContext(Array.Empty<string>());
-            this._sagaRepository = new Lazy<ISagaRepository<SimpleSaga>>(() => 
-                new EntityFrameworkSagaRepository<SimpleSaga>(this._sagaDbContextFactory));
+            _sagaDbContextFactory = () => contextFactory.CreateDbContext(Array.Empty<string>());
+            _sagaRepository = new Lazy<ISagaRepository<SimpleSaga>>(() =>
+                new EntityFrameworkSagaRepository<SimpleSaga>(_sagaDbContextFactory));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
-            configurator.Saga(this._sagaRepository.Value);
+            configurator.Saga(_sagaRepository.Value);
         }
     }
 }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreMetadataHelper.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreMetadataHelper.cs
@@ -1,26 +1,42 @@
-﻿namespace MassTransit.EntityFrameworkCoreIntegration
+﻿// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration
 {
-    using Microsoft.EntityFrameworkCore;
-    using Microsoft.EntityFrameworkCore.Metadata;
     using System;
     using System.Collections.Concurrent;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata;
 
-    public class EntityFrameworkMetadataHelper : IRelationalEntityMetadataHelper
+
+    public class EntityFrameworkMetadataHelper :
+        IRelationalEntityMetadataHelper
     {
         protected static readonly ConcurrentDictionary<Type, string> TableNames = new ConcurrentDictionary<Type, string>();
 
-        protected string SchemaTableFormat { get; }
-        protected string DefaultSchema { get; }
-        protected Func<IEntityType, IRelationalEntityTypeAnnotations> RelationalEntityTypeAnnotations { get; }
-
-        public EntityFrameworkMetadataHelper(string schemaTableFormat = "{0}.{1}", string defaultSchema = "dbo", Func<IEntityType, IRelationalEntityTypeAnnotations> relationalEntityTypeAnnotations = null)
+        public EntityFrameworkMetadataHelper(string schemaTableFormat = "{0}.{1}", string defaultSchema = "dbo",
+            Func<IEntityType, IRelationalEntityTypeAnnotations> relationalEntityTypeAnnotations = null)
         {
             SchemaTableFormat = schemaTableFormat;
             DefaultSchema = defaultSchema;
             RelationalEntityTypeAnnotations = relationalEntityTypeAnnotations ?? GetRelationalEntityTypeAnnotations;
         }
 
-        public virtual string GetTableName<T>(DbContext context) where T : class
+        protected string SchemaTableFormat { get; }
+        protected string DefaultSchema { get; }
+        protected Func<IEntityType, IRelationalEntityTypeAnnotations> RelationalEntityTypeAnnotations { get; }
+
+        public virtual string GetTableName<T>(DbContext context)
+            where T : class
         {
             var t = typeof(T);
 
@@ -31,20 +47,14 @@
                 var sql = GetRelationalEntityTypeAnnotations(context.Model.FindEntityType(t));
                 var sqlSchema = sql.Schema;
                 if (string.IsNullOrEmpty(sqlSchema))
-                {
                     sqlSchema = DefaultSchema;
-                }
 
                 result = string.Format(SchemaTableFormat, sqlSchema, sql.TableName);
 
                 if (!string.IsNullOrWhiteSpace(result))
-                {
                     TableNames.TryAdd(t, result);
-                }
                 else
-                {
                     throw new MassTransitException("Couldn't determine table and schema name (using model metadata).");
-                }
             }
 
             return result;

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/ISagaDbContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/ISagaDbContextFactory.cs
@@ -1,0 +1,47 @@
+// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration
+{
+    using MassTransit.Saga;
+    using Microsoft.EntityFrameworkCore;
+
+
+    /// <summary>
+    /// Creates a DbContext for the saga repository
+    /// </summary>
+    /// <typeparam name="TSaga"></typeparam>
+    public interface ISagaDbContextFactory<TSaga>
+        where TSaga : class, ISaga
+    {
+        /// <summary>
+        /// Create a standalone DbContext
+        /// </summary>
+        /// <returns></returns>
+        DbContext Create();
+
+        /// <summary>
+        /// Create a scoped DbContext within the lifetime scope of the saga repository
+        /// </summary>
+        /// <param name="context"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        DbContext CreateScoped<T>(ConsumeContext<T> context)
+            where T : class;
+
+        /// <summary>
+        /// Release the DbContext once it is no longer needed
+        /// </summary>
+        /// <param name="dbContext"></param>
+        void Release(DbContext dbContext);
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
@@ -16,12 +16,12 @@
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.EntityFrameworkIntegration.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="GreenPipes" Version="2.1.3"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.4"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4"/>
-        <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
-        <ProjectReference Include="..\..\MassTransit\MassTransit.csproj"/>
+        <PackageReference Include="GreenPipes" Version="2.1.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />
+        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+        <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Saga/DelegateSagaDbContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Saga/DelegateSagaDbContextFactory.cs
@@ -1,0 +1,47 @@
+// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Saga
+{
+    using System;
+    using MassTransit.Saga;
+    using Microsoft.EntityFrameworkCore;
+
+
+    public class DelegateSagaDbContextFactory<TSaga> :
+        ISagaDbContextFactory<TSaga>
+        where TSaga : class, ISaga
+    {
+        readonly Func<DbContext> _dbContextFactory;
+
+        public DelegateSagaDbContextFactory(Func<DbContext> dbContextFactory)
+        {
+            _dbContextFactory = dbContextFactory;
+        }
+
+        public DbContext Create()
+        {
+            return _dbContextFactory();
+        }
+
+        public DbContext CreateScoped<T>(ConsumeContext<T> context)
+            where T : class
+        {
+            return _dbContextFactory();
+        }
+
+        public void Release(DbContext dbContext)
+        {
+            dbContext.Dispose();
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SagaLocator_Specs.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration.Tests/SagaLocator_Specs.cs
@@ -28,7 +28,7 @@
 
             foundId.HasValue.ShouldBe(true);
 
-            var nextMessage = new CompleteSimpleSaga { CorrelationId = sagaId };
+            var nextMessage = new CompleteSimpleSaga {CorrelationId = sagaId};
 
             await InputQueueSendEndpoint.Send(nextMessage);
 
@@ -50,19 +50,20 @@
             foundId.HasValue.ShouldBe(true);
         }
 
-        readonly SagaDbContextFactory sagaDbContextFactory;
+        readonly ISagaDbContextFactory<SimpleSaga> _sagaDbContextFactory;
         readonly Lazy<ISagaRepository<SimpleSaga>> _sagaRepository;
 
         public Locating_an_existing_ef_saga()
         {
-            sagaDbContextFactory = () => new SagaDbContext<SimpleSaga, SimpleSagaMap>(LocalDbConnectionStringProvider.GetLocalDbConnectionString());
-            _sagaRepository = new Lazy<ISagaRepository<SimpleSaga>>(() => new EntityFrameworkSagaRepository<SimpleSaga>(sagaDbContextFactory));
+            _sagaDbContextFactory = new DelegateSagaDbContextFactory<SimpleSaga>(() =>
+                new SagaDbContext<SimpleSaga, SimpleSagaMap>(LocalDbConnectionStringProvider.GetLocalDbConnectionString()));
+
+            _sagaRepository = new Lazy<ISagaRepository<SimpleSaga>>(() => new EntityFrameworkSagaRepository<SimpleSaga>(_sagaDbContextFactory));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
             configurator.Saga(_sagaRepository.Value);
         }
-
     }
 }

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
@@ -16,16 +16,16 @@
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MassTransit.EntityFrameworkIntegration.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="EntityFramework" Version="6.2.0"/>
-        <PackageReference Include="GreenPipes" Version="2.1.3"/>
-        <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
-        <Reference Include="System"/>
-        <Reference Include="System.ComponentModel.DataAnnotations"/>
-        <Reference Include="System.Core"/>
-        <Reference Include="System.Data.DataSetExtensions"/>
-        <Reference Include="System.Data"/>
-        <Reference Include="System.Xml"/>
-        <ProjectReference Include="..\..\MassTransit\MassTransit.csproj"/>
+        <PackageReference Include="EntityFramework" Version="6.2.0" />
+        <PackageReference Include="GreenPipes" Version="2.1.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+        <Reference Include="System" />
+        <Reference Include="System.ComponentModel.DataAnnotations" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data.DataSetExtensions" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
+        <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/DelegateSagaDbContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/Saga/DelegateSagaDbContextFactory.cs
@@ -1,0 +1,47 @@
+// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkIntegration.Saga
+{
+    using System;
+    using System.Data.Entity;
+    using MassTransit.Saga;
+
+
+    public class DelegateSagaDbContextFactory<TSaga> :
+        ISagaDbContextFactory<TSaga>
+        where TSaga : class, ISaga
+    {
+        readonly Func<DbContext> _dbContextFactory;
+
+        public DelegateSagaDbContextFactory(Func<DbContext> dbContextFactory)
+        {
+            _dbContextFactory = dbContextFactory;
+        }
+
+        public DbContext Create()
+        {
+            return _dbContextFactory();
+        }
+
+        public DbContext CreateScoped<T>(ConsumeContext<T> context)
+            where T : class
+        {
+            return _dbContextFactory();
+        }
+
+        public void Release(DbContext dbContext)
+        {
+            dbContext.Dispose();
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaDbContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/SagaDbContextFactory.cs
@@ -13,10 +13,35 @@
 namespace MassTransit.EntityFrameworkIntegration
 {
     using System.Data.Entity;
+    using MassTransit.Saga;
 
 
     /// <summary>
-    /// Factory method for creating new database context connections.
+    /// Creates a DbContext for the saga repository
     /// </summary>
-    public delegate DbContext SagaDbContextFactory();
+    /// <typeparam name="TSaga"></typeparam>
+    public interface ISagaDbContextFactory<TSaga>
+        where TSaga : class, ISaga
+    {
+        /// <summary>
+        /// Create a standalone DbContext
+        /// </summary>
+        /// <returns></returns>
+        DbContext Create();
+
+        /// <summary>
+        /// Create a scoped DbContext within the lifetime scope of the saga repository
+        /// </summary>
+        /// <param name="context"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        DbContext CreateScoped<T>(ConsumeContext<T> context)
+            where T : class;
+
+        /// <summary>
+        /// Release the DbContext once it is no longer needed
+        /// </summary>
+        /// <param name="dbContext"></param>
+        void Release(DbContext dbContext);
+    }
 }


### PR DESCRIPTION
The current DbContext creation with EF doesn't allow a way to resolve from a scoped lifecycle.