### PR TITLE
Activemq failover

### DIFF
--- a/src/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
+++ b/src/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
@@ -115,6 +115,10 @@ namespace MassTransit.ActiveMqTransport.Tests
     [TestFixture]
     public class Configuring_ActiveMQ
     {
+        const string TestBrokerHost = "b-15a8b984-a883-4143-a4e7-8f97bc5db37d-1.mq.us-east-2.amazonaws.com";
+        const string TestUsername = "masstransit-build";
+        const string TestPassword = "build-Br0k3r";
+
         [Test]
         public async Task Should_succeed_and_connect_when_properly_configured()
         {
@@ -124,10 +128,10 @@ namespace MassTransit.ActiveMqTransport.Tests
 
             var busControl = Bus.Factory.CreateUsingActiveMq(cfg =>
             {
-                var host = cfg.Host("b-15a8b984-a883-4143-a4e7-8f97bc5db37d-1.mq.us-east-2.amazonaws.com", 61617, h =>
+                var host = cfg.Host(TestBrokerHost, 61617, h =>
                 {
-                    h.Username("masstransit-build");
-                    h.Password("build-Br0k3r");
+                    h.Username(TestUsername);
+                    h.Password(TestPassword);
 
                     h.UseSsl();
                 });
@@ -167,10 +171,10 @@ namespace MassTransit.ActiveMqTransport.Tests
         {
             var bus = Bus.Factory.CreateUsingActiveMq(sbc =>
             {
-                var host = sbc.Host("b-15a8b984-a883-4143-a4e7-8f97bc5db37d-1.mq.us-east-2.amazonaws.com", 61617, h =>
+                var host = sbc.Host(TestBrokerHost, 61617, h =>
                 {
-                    h.Username("masstransit-build");
-                    h.Password("build-Br0k3r");
+                    h.Username(TestUsername);
+                    h.Password(TestPassword);
 
                     h.UseSsl();
                 });
@@ -278,10 +282,10 @@ namespace MassTransit.ActiveMqTransport.Tests
         {
             var busControl = Bus.Factory.CreateUsingActiveMq(cfg =>
             {
-                cfg.Host("b-15a8b984-a883-4143-a4e7-8f97bc5db37d-1.mq.us-east-2.amazonaws.com", 61617, h =>
+                cfg.Host(TestBrokerHost, 61617, h =>
                 {
-                    h.Username("masstransit-build");
-                    h.Password("build-Br0k3r");
+                    h.Username(TestUsername);
+                    h.Password(TestPassword);
 
                     h.UseSsl();
                 });

--- a/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ActiveMqHostConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ActiveMqHostConfigurator.cs
@@ -68,5 +68,18 @@ namespace MassTransit.ActiveMqTransport.Configurators
             if (_settings.Port == 61616)
                 _settings.Port = 61617;
         }
+
+        public void FailoverHosts(string[] hosts)
+        {
+            _settings.FailoverHosts = hosts;
+        }
+
+        public void TransportOptions(Dictionary<string, string> options)
+        {
+            foreach (KeyValuePair<string, string> option in options)
+            {
+                _settings.TransportOptions[option.Key] = option.Value;
+            }
+        }
     }
 }

--- a/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ActiveMqHostConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ActiveMqHostConfigurator.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.ActiveMqTransport.Configurators
 {
     using System;
+    using System.Collections.Generic;
 
 
     public class ActiveMqHostConfigurator :
@@ -30,6 +31,11 @@ namespace MassTransit.ActiveMqTransport.Configurators
                 Host = address.Host,
                 Username = "",
                 Password = "",
+                TransportOptions = new Dictionary<string, string>()
+                {
+                    { "wireFormat.tightEncodingEnabled", "true" },
+                    { "nms.AsyncSend", "true" }
+                }
             };
 
             _settings.Port = !address.IsDefaultPort ? address.Port : 61616;

--- a/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -34,7 +34,7 @@ namespace MassTransit.ActiveMqTransport.Configurators
         public Dictionary<string, string> TransportOptions { get; set; }
 
         public string Host { get; set; }
-        public int Port { get; set; } = 61616;
+        public int Port { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public bool UseSsl { get; set; }

--- a/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs
@@ -13,18 +13,16 @@
 namespace MassTransit.ActiveMqTransport.Configurators
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Apache.NMS;
-    using Apache.NMS.ActiveMQ;
-    using Apache.NMS.ActiveMQ.Transport;
-    using Apache.NMS.ActiveMQ.Transport.Tcp;
-    using Apache.NMS.ActiveMQ.Util;
 
 
     public class ConfigurationHostSettings :
         ActiveMqHostSettings
     {
-        readonly Lazy<Uri> _hostAddress;
         readonly Lazy<Uri> _brokerAddress;
+        readonly Lazy<Uri> _hostAddress;
 
         public ConfigurationHostSettings()
         {
@@ -32,8 +30,11 @@ namespace MassTransit.ActiveMqTransport.Configurators
             _brokerAddress = new Lazy<Uri>(FormatBrokerAddress);
         }
 
+        public string[] FailoverHosts { get; set; }
+        public Dictionary<string, string> TransportOptions { get; set; }
+
         public string Host { get; set; }
-        public int Port { get; set; }
+        public int Port { get; set; } = 61616;
         public string Username { get; set; }
         public string Password { get; set; }
         public bool UseSsl { get; set; }
@@ -43,26 +44,8 @@ namespace MassTransit.ActiveMqTransport.Configurators
 
         public IConnection CreateConnection()
         {
-            ITransport transport;
-            if (UseSsl)
-            {
-                var sslTransportFactory = new SslTransportFactory
-                {
-                    SslProtocol = "Tls"
-                };
-
-                transport = sslTransportFactory.CreateTransport(BrokerAddress);
-            }
-            else
-            {
-                transport = TransportFactory.CreateTransport(BrokerAddress);
-            }
-
-            return new Connection(BrokerAddress, transport, new IdGenerator())
-            {
-                UserName = Username,
-                Password = Password
-            };
+            var factory = new NMSConnectionFactory(BrokerAddress);
+            return factory.CreateConnection(Username, Password);
         }
 
         Uri FormatHostAddress()
@@ -80,16 +63,42 @@ namespace MassTransit.ActiveMqTransport.Configurators
 
         Uri FormatBrokerAddress()
         {
-            // create broker URI: http://activemq.apache.org/nms/activemq-uri-configuration.html
-            var builder = new UriBuilder
-            {
-                Scheme = UseSsl ? "ssl" : "tcp",
-                Host = Host,
-                Port = Port,
-                Query = "wireFormat.tightEncodingEnabled=true&nms.AsyncSend=true"
-            };
+            var scheme = UseSsl ? "ssl" : "tcp";
+            var queryPart = GetQueryString();
 
-            return builder.Uri;
+            // create broker URI: http://activemq.apache.org/nms/activemq-uri-configuration.html
+            if (FailoverHosts?.Length > 0)
+            {
+                var failoverPart = string.Join(",", FailoverHosts
+                    .Select(failoverHost => new UriBuilder
+                        {
+                            Scheme = scheme,
+                            Host = failoverHost,
+                            Port = Port
+                        }.Uri.ToString()
+                    ));
+
+                
+                return new Uri($"activemq:failover:({failoverPart}){queryPart}");
+            }
+
+
+            var uri = new Uri($"activemq:{scheme}://{Host}:{Port}{queryPart}");
+            return uri;
+        }
+
+        string GetQueryString()
+        {
+            var queryPart = string.Empty;
+            if (TransportOptions?.Count > 0)
+            {
+                var queryString = string.Join("&", TransportOptions
+                    .Select(pair => $"{pair.Key}={pair.Value}"));
+
+                queryString = $"?{queryString}";
+            }
+
+            return queryPart;
         }
 
         public override string ToString()

--- a/src/MassTransit.ActiveMqTransport/Configuration/IActiveMqHostConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Configuration/IActiveMqHostConfigurator.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.ActiveMqTransport
 {
+    using System.Collections.Generic;
+
+
     public interface IActiveMqHostConfigurator
     {
         /// <summary>
@@ -27,5 +30,17 @@ namespace MassTransit.ActiveMqTransport
         void Password(string password);
 
         void UseSsl();
+
+        /// <summary>
+        /// Sets a list of hosts to enable the failover transport
+        /// </summary>
+        /// <param name="hosts"></param>
+        void FailoverHosts(string[] hosts);
+
+        /// <summary>
+        /// Sets options on the underlying NMS transport
+        /// </summary>
+        /// <param name="options"></param>
+        void TransportOptions(Dictionary<string, string> options);
     }
 }


### PR DESCRIPTION
This change exposes the ActiveMQ NMS client failover mechanism. All the tests are passing that connect to a local broker. I apparently can't reach your AWS MQ resource, but I did test it with some I created an it's working. This will address #1241. 
