### PR TITLE
Add Flakey Test Category for specific SignalR Test

### DIFF
--- a/src/MassTransit.SignalR.Tests/HubLifeTimeManagerTests.cs
+++ b/src/MassTransit.SignalR.Tests/HubLifeTimeManagerTests.cs
@@ -115,6 +115,7 @@
 
         #region From Scaleout
         [Test]
+        [Category("Flakey")]
         public async Task DisconnectConnectionRemovesConnectionFromGroup()
         {
             using (var client = new TestClient())


### PR DESCRIPTION
- I had noticed this when working on the cake build, this sometimes failed
I added a delay,hoping it would help, but it is intermittent. Running in Visual Studio
it passes 100% of the time.