### PR TITLE
Expose messages so we can use array methods instead of for loops

### DIFF
--- a/src/MassTransit/Batch.cs
+++ b/src/MassTransit/Batch.cs
@@ -13,6 +13,7 @@
 namespace MassTransit
 {
     using System;
+    using System.Collections.Generic;
 
 
     /// <summary>
@@ -37,7 +38,7 @@ namespace MassTransit
         /// <summary>
         /// Returns all messages from batch
         /// </summary>
-        ConsumeContext<T>[] Messages { get; }
+        IEnumerable<ConsumeContext<T>> Messages { get; }
 
         /// <summary>
         /// Returns the message at the specified index

--- a/src/MassTransit/Batch.cs
+++ b/src/MassTransit/Batch.cs
@@ -33,6 +33,11 @@ namespace MassTransit
         /// When the last message in this batch was received
         /// </summary>
         DateTime LastMessageReceived { get; }
+        
+        /// <summary>
+        /// Returns all messages from batch
+        /// </summary>
+        ConsumeContext<T>[] Messages { get; }
 
         /// <summary>
         /// Returns the message at the specified index

--- a/src/MassTransit/Pipeline/ConsumerFactories/BatchConsumer.cs
+++ b/src/MassTransit/Pipeline/ConsumerFactories/BatchConsumer.cs
@@ -163,6 +163,8 @@ namespace MassTransit.Pipeline.ConsumerFactories
             public DateTime FirstMessageReceived { get; }
             public DateTime LastMessageReceived { get; }
 
+            public ConsumeContext<TMessage>[] Messages => _messages;
+
             public ConsumeContext<TMessage> this[int index] => _messages[index];
 
             public int Length => _messages.Length;

--- a/src/MassTransit/Pipeline/ConsumerFactories/BatchConsumer.cs
+++ b/src/MassTransit/Pipeline/ConsumerFactories/BatchConsumer.cs
@@ -163,7 +163,7 @@ namespace MassTransit.Pipeline.ConsumerFactories
             public DateTime FirstMessageReceived { get; }
             public DateTime LastMessageReceived { get; }
 
-            public ConsumeContext<TMessage>[] Messages => _messages;
+            public IEnumerable<ConsumeContext<TMessage>> Messages => _messages;
 
             public ConsumeContext<TMessage> this[int index] => _messages[index];
 


### PR DESCRIPTION
We have a use case that we want to filter out messages. We use it to save heartbeats into a DB. The case can be that there are messages with the same id but a different timestamp. We only want to save the latest. 

Instead of looping over everything we can just use the array immediately and apply some LINQ statements.