### PR TITLE
QuartzIntegrationExtensions.UseInMemoryScheduler with ISchedulerFactory

### DIFF
--- a/src/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
+++ b/src/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
@@ -30,6 +30,17 @@ namespace MassTransit
                 throw new ArgumentNullException(nameof(configurator));
 
             ISchedulerFactory schedulerFactory = new StdSchedulerFactory();
+            return configurator.UseInMemoryScheduler(schedulerFactory, queueName);
+        }
+
+        public static Uri UseInMemoryScheduler(this IBusFactoryConfigurator configurator, ISchedulerFactory schedulerFactory, string queueName = "quartz")
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+
+            if (schedulerFactory == null)
+                throw new ArgumentNullException(nameof(schedulerFactory));
+
             var scheduler = TaskUtil.Await(() => schedulerFactory.GetScheduler());
 
             Uri inputAddress = null;


### PR DESCRIPTION
Hi.

We need to configure the Quarts from within the C# code. Can we have a overload of UseInMemoryScheduler which takes the ISchedulerFactory as a parameter?

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
