### PR TITLE
Changing namespace separate so as to not conflict with virtual topic consumer prefix wildcards

### DIFF
--- a/src/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
+++ b/src/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
@@ -23,6 +23,7 @@ namespace MassTransit.ActiveMqTransport.Tests
     using NUnit.Framework;
     using TestFramework.Messages;
     using Testing;
+    using Topology.Topologies;
 
 
     [TestFixture]
@@ -222,6 +223,14 @@ namespace MassTransit.ActiveMqTransport.Tests
             await busControl.StartAsync(new CancellationTokenSource(10000).Token);
 
             await busControl.StopAsync(new CancellationTokenSource(10000).Token);
+        }
+
+        [Test]
+        public async Task Pub_Sub_Queue_Names_Should_Not_Contain_Periods()
+        {
+            var consumeTopology = new ActiveMqConsumeTopology(null, null);
+            var queueName = consumeTopology.CreateTemporaryQueueName("bus.test");
+            Assert.That(queueName, Does.Not.Contain('.'));
         }
 
         [Test]

--- a/src/MassTransit.ActiveMqTransport/ActiveMqMessageNameFormatter.cs
+++ b/src/MassTransit.ActiveMqTransport/ActiveMqMessageNameFormatter.cs
@@ -23,7 +23,7 @@ namespace MassTransit.ActiveMqTransport
 
         public ActiveMqMessageNameFormatter()
         {
-            _formatter = new DefaultMessageNameFormatter("::", "--", "_", "-");
+            _formatter = new DefaultMessageNameFormatter("::", "--", ".", "-");
         }
 
         public MessageName GetMessageName(Type type)

--- a/src/MassTransit.ActiveMqTransport/ActiveMqMessageNameFormatter.cs
+++ b/src/MassTransit.ActiveMqTransport/ActiveMqMessageNameFormatter.cs
@@ -23,7 +23,7 @@ namespace MassTransit.ActiveMqTransport
 
         public ActiveMqMessageNameFormatter()
         {
-            _formatter = new DefaultMessageNameFormatter("::", "--", ".", "-");
+            _formatter = new DefaultMessageNameFormatter("::", "--", "_", "-");
         }
 
         public MessageName GetMessageName(Type type)

--- a/src/MassTransit.ActiveMqTransport/Topology/Topologies/ActiveMqConsumeTopology.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/Topologies/ActiveMqConsumeTopology.cs
@@ -82,6 +82,12 @@ namespace MassTransit.ActiveMqTransport.Topology.Topologies
                 _specifications.Add(new InvalidActiveMqConsumeTopologySpecification("Bind", $"Only virtual topics can be bound: {topicName}"));
         }
 
+        public override string CreateTemporaryQueueName(string tag)
+        {
+            var result = base.CreateTemporaryQueueName(tag);
+            return new string(result.Where(c => c != '.').ToArray());
+        }
+
         public override IEnumerable<ValidationResult> Validate()
         {
             return base.Validate().Concat(_specifications.SelectMany(x => x.Validate()));


### PR DESCRIPTION
There are some receive endpoints that we define as follows:

```
var host = cfg.Host(hostSettings);
cfg.ReceiveEndpoint(host, rcvCfg =>
{
    rcvCfg.Consumer<IConsumer<SecurityGroupChanged>>(context);
    rcvCfg.Consumer<IConsumer<UserChanged>>(context);
    rcvCfg.Consumer<IConsumer<InstanceUserChanged>>(context);
    rcvCfg.Consumer<IConsumer<InstanceChanged>>(context);
});
```

So more pub sub style. The problem, however, is that MassTransit generates the following virtual topic and associated consumer queue, as an example:

VirtualTopic.REFS.Platform.Instances.Interfaces.DomainEvents.SecurityGroupChanged
Consumer.endpoint-EC2AMAZ-KFCBO2P-REFS.Platform.Instances-ab4yyyn5ihfq6krjbdmjtt17dn.VirtualTopic.REFS.Platform.Instances.Interfaces.DomainEvents.SecurityGroupChanged

The default virtual destination defaults, which MassTransit is expecting are as follows:

`VirtualTopic.>` (this matches all topics prefixed with `VirtualTopic.`)
`Consumer.*.VirtualTopic.>` <-- this is the issue

The `.` is a path separator in ActiveMQ. The `*` wildcard only matches a single path. There is no good documentation that points to this, but we tested this by hand with ActiveMQ to validate that. As such, that generated consumer name has the namespace of the .NET type using `.` as the separator, which also being the ActiveMQ path separator, causes the consumer queue prefix match to fail. Hence this long explanation for a one character change.



