### PR TITLE
Removed exception.GetBaseException() from FaultExceptionInfo.ctor

### DIFF
--- a/src/MassTransit/Events/FaultExceptionInfo.cs
+++ b/src/MassTransit/Events/FaultExceptionInfo.cs
@@ -25,8 +25,6 @@ namespace MassTransit.Events
             if (exception == null)
                 throw new ArgumentNullException(nameof(exception));
 
-            exception = exception.GetBaseException() ?? exception;
-
             ExceptionType = TypeMetadataCache.GetShortName(exception.GetType());
             InnerException = exception.InnerException != null
                 ? new FaultExceptionInfo(exception.InnerException)


### PR DESCRIPTION
Fixes #1348.
Exception.GetBaseException returns the deepest InnerException. I can't say why we need this behavior, so I removed it.
With this change [my simple tests ](https://github.com/GreenKn1ght/MT.FaultExceptionInfo.Tests) completed successfully.

