### PR TITLE
Adding extension for ConfigureConsumers to allow registration of cons…

### DIFF
--- a/src/Containers/MassTransit.AutofacIntegration/AutofacRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/AutofacRegistrationExtensions.cs
@@ -73,6 +73,19 @@ namespace MassTransit
         }
 
         /// <summary>
+        /// Configure a consumer on the receive endpoint, with the type of consumer.
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="consumerType"></param>
+        /// <param name="context"></param>
+        public static void ConfigureConsumer(this IReceiveEndpointConfigurator configurator, Type consumerType,
+            IComponentContext context)
+        {
+            var registration = context.Resolve<IRegistration>();
+            registration.ConfigureConsumer(consumerType, configurator);
+        }
+
+        /// <summary>
         /// Configure all registered consumers on the receive endpoint
         /// </summary>
         /// <param name="configurator"></param>

--- a/src/Containers/MassTransit.LamarIntegration/LamarReceiveEndpointExtensions.cs
+++ b/src/Containers/MassTransit.LamarIntegration/LamarReceiveEndpointExtensions.cs
@@ -56,6 +56,12 @@ namespace MassTransit
             configurator.Consumer(consumerFactory, configure);
         }
 
+        public static void Consumer(this IReceiveEndpointConfigurator configurator, IContainer container, Type consumerType)
+        {
+            var registration = container.GetInstance<IRegistration>();
+            registration.ConfigureConsumer(consumerType, configurator);
+        }
+
         /// <summary>
         /// Registers a saga using the container that has the repository resolved from the container
         /// </summary>

--- a/src/Containers/MassTransit.NinjectIntegration/NinjectExtensions.cs
+++ b/src/Containers/MassTransit.NinjectIntegration/NinjectExtensions.cs
@@ -84,6 +84,12 @@ namespace MassTransit
             configure?.Invoke(configurator);
         }
 
+        public static void Consumer(this IReceiveEndpointConfigurator configurator, IKernel kernel, Type consumerType)
+        {
+            var registration = kernel.Get<IRegistration>();
+            registration.ConfigureConsumer(consumerType, configurator);
+        }
+
         public static void Consumer<T>(this IReceiveEndpointConfigurator configurator, IKernel kernel, Action<IConsumerConfigurator<T>> configure = null)
             where T : class, IConsumer
         {

--- a/src/Containers/MassTransit.SimpleInjectorIntegration/SimpleInjectorExtensions.cs
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/SimpleInjectorExtensions.cs
@@ -60,6 +60,12 @@ namespace MassTransit
             configurator.Consumer(consumerFactory, configure);
         }
 
+        public static void Consumer(this IReceiveEndpointConfigurator configurator, Container container, Type consumerType)
+        {
+            var registration = container.GetInstance<IRegistration>();
+            registration.ConfigureConsumer(consumerType, configurator);
+        }
+
         public static void Saga<T>(this IReceiveEndpointConfigurator configurator, Container container, Action<ISagaConfigurator<T>> configure = null)
             where T : class, ISaga
         {

--- a/src/Containers/MassTransit.StructureMapIntegration/StructureMapReceiveEndpointExtensions.cs
+++ b/src/Containers/MassTransit.StructureMapIntegration/StructureMapReceiveEndpointExtensions.cs
@@ -51,6 +51,18 @@ namespace MassTransit
         }
 
         /// <summary>
+        /// Registers a consumer given the type of consumer
+        /// </summary>
+        /// <param name="configurator">The service bus configurator</param>
+        /// <param name="context">The LifetimeScope of the container</param>
+        /// <param name="consumerType">The consumer type</param>
+        public static void Consumer(this IReceiveEndpointConfigurator configurator, IContext context, Type consumerType)
+        {
+            var registration = context.GetInstance<IRegistration>();
+            registration.ConfigureConsumer(consumerType, configurator);
+        }
+
+        /// <summary>
         /// Registers a consumer given the lifetime scope specified
         /// </summary>
         /// <typeparam name="T">The consumer type</typeparam>

--- a/src/Containers/MassTransit.UnityIntegration/UnityExtensions.cs
+++ b/src/Containers/MassTransit.UnityIntegration/UnityExtensions.cs
@@ -58,6 +58,12 @@ namespace MassTransit
             configurator.Consumer(consumerFactory, configure);
         }
 
+        public static void Consumer(this IReceiveEndpointConfigurator configurator, IUnityContainer container, Type consumerType)
+        {
+            var registration = container.Resolve<IRegistration>();
+            registration.ConfigureConsumer(consumerType, configurator);
+        }
+
         public static void Saga<T>(this IReceiveEndpointConfigurator configurator, IUnityContainer container, Action<ISagaConfigurator<T>> configure = null)
             where T : class, ISaga
         {

--- a/src/Containers/MassTransit.WindsorIntegration/WindsorReceiveEndpointExtensions.cs
+++ b/src/Containers/MassTransit.WindsorIntegration/WindsorReceiveEndpointExtensions.cs
@@ -41,7 +41,7 @@ namespace MassTransit
             var consumerFactory = new ScopeConsumerFactory<T>(scopeProvider);
 
             configurator.Consumer(consumerFactory, configure);
-        }
+        }        
 
         /// <summary>
         /// Registers a consumer given the lifetime scope specified
@@ -58,6 +58,18 @@ namespace MassTransit
             RegisterScopedContextProviderIfNotPresent(container);
 
             Consumer(configurator, container.Kernel, configure);
+        }
+
+        /// <summary>
+        /// Registers a consumer given the type of the consumer
+        /// </summary>
+        /// <param name="configurator">The service bus configureator</param>
+        /// <param name="kernel"></param>
+        /// <param name="consumerType">The consumer type</param>
+        public static void Consumer(this IReceiveEndpointConfigurator configurator, IKernel kernel, Type consumerType)
+        {
+            var registration = kernel.Resolve<IRegistration>();
+            registration.ConfigureConsumer(consumerType, configurator);
         }
 
         /// <summary>


### PR DESCRIPTION
…umer by using the type of the consumer.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
I created an assembly scanner extension to get params for Assemblies and then scanned those assemblies for any types that declared IConsumer<>.  Then based on a convention it would auto register all endpoints with the type of the consumer that i found during the assembly scan.  I'll be posting another pull request that has the assembly scanning extension that allows for an easier auto config

The convention used was say i have a consumer
namespace Bicycle.Orders {
           public class OrderPlacedConsumer : IConsumer<OrderPlacedEvent>
           {
              /// interesting code here
            }
}

and OrderPlacedEvent was defined in another Library (or same library doesn't matter)

namespace Bicycle.Domain.Events {
      public class OrderPlacedEvent {
          /// interesting code here
     }
}

The AutoConfigureEndpoints extension (that will be submitted in another pull request) will register an endpoint

///Somewhere in Assembly scanning process
var consumerType = typeof(OrderPlacedConsumer)

///then later
cfg.ReceiveEndpoint("Bicycle.Orders.OrderPlacedConsumer.OrderPlacedEvent", g => 
{
      g.ConfigureConsumer(consumerType);
}

I'm posting the screenshot for the RabbitMQ version of the AutoConfigure extension method, hoping to add this for all other transports.

![image](https://user-images.githubusercontent.com/7133386/53519766-a25e3100-3a99-11e9-9211-7166fbd14c76.png)






