### PR TITLE
Add automatonymous integration overloads using datetimes for specifying the delays

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration/ScheduleTimeProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ScheduleTimeProvider.cs
@@ -1,0 +1,27 @@
+// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace Automatonymous
+{
+    using System;
+
+
+    public delegate DateTime ScheduleTimeProvider<in TInstance>(ConsumeEventContext<TInstance> context);
+
+
+    public delegate DateTime ScheduleTimeProvider<in TInstance, in TData>(ConsumeEventContext<TInstance, TData> context)
+        where TData : class;
+
+
+    public delegate DateTime ScheduleTimeProvider<in TInstance, in TData, in TException>(ConsumeExceptionEventContext<TInstance, TData, TException> context)
+        where TData : class;
+}

--- a/src/MassTransit.AutomatonymousIntegration/SchedulerExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/SchedulerExtensions.cs
@@ -37,6 +37,14 @@ namespace Automatonymous
         }
 
         public static EventActivityBinder<TInstance> Schedule<TInstance, TMessage>(this EventActivityBinder<TInstance> source,
+            Schedule<TInstance, TMessage> schedule, TMessage message, ScheduleTimeProvider<TInstance> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TMessage>(x => message, schedule, timeProvider));
+        }
+
+        public static EventActivityBinder<TInstance> Schedule<TInstance, TMessage>(this EventActivityBinder<TInstance> source,
             Schedule<TInstance, TMessage> schedule, TMessage message, Action<SendContext> contextCallback)
             where TInstance : class, SagaStateMachineInstance
             where TMessage : class
@@ -50,6 +58,14 @@ namespace Automatonymous
             where TMessage : class
         {
             return source.Add(new ScheduleActivity<TInstance, TMessage>(x => message, schedule, contextCallback, delayProvider));
+        }
+
+        public static EventActivityBinder<TInstance> Schedule<TInstance, TMessage>(this EventActivityBinder<TInstance> source,
+            Schedule<TInstance, TMessage> schedule, TMessage message, Action<SendContext> contextCallback, ScheduleTimeProvider<TInstance> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TMessage>(x => message, schedule, contextCallback, timeProvider));
         }
 
         public static EventActivityBinder<TInstance> Schedule<TInstance, TMessage>(this EventActivityBinder<TInstance> source,
@@ -69,6 +85,14 @@ namespace Automatonymous
         }
 
         public static EventActivityBinder<TInstance> Schedule<TInstance, TMessage>(this EventActivityBinder<TInstance> source,
+            Schedule<TInstance, TMessage> schedule, EventMessageFactory<TInstance, TMessage> messageFactory, ScheduleTimeProvider<TInstance> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TMessage>(messageFactory, schedule, timeProvider));
+        }
+
+        public static EventActivityBinder<TInstance> Schedule<TInstance, TMessage>(this EventActivityBinder<TInstance> source,
             Schedule<TInstance, TMessage> schedule, EventMessageFactory<TInstance, TMessage> messageFactory, Action<SendContext> contextCallback)
             where TInstance : class, SagaStateMachineInstance
             where TMessage : class
@@ -83,6 +107,15 @@ namespace Automatonymous
             where TMessage : class
         {
             return source.Add(new ScheduleActivity<TInstance, TMessage>(messageFactory, schedule, contextCallback, delayProvider));
+        }
+
+        public static EventActivityBinder<TInstance> Schedule<TInstance, TMessage>(this EventActivityBinder<TInstance> source,
+            Schedule<TInstance, TMessage> schedule, EventMessageFactory<TInstance, TMessage> messageFactory, Action<SendContext> contextCallback,
+            ScheduleTimeProvider<TInstance> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TMessage>(messageFactory, schedule, contextCallback, timeProvider));
         }
 
         public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
@@ -106,6 +139,16 @@ namespace Automatonymous
 
         public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
             this EventActivityBinder<TInstance, TData> source, Schedule<TInstance, TMessage> schedule, TMessage message,
+            ScheduleTimeProvider<TInstance, TData> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TData : class
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(x => message, schedule, timeProvider));
+        }
+
+        public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
+            this EventActivityBinder<TInstance, TData> source, Schedule<TInstance, TMessage> schedule, TMessage message,
             Action<SendContext> contextCallback)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
@@ -122,6 +165,16 @@ namespace Automatonymous
             where TMessage : class
         {
             return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(x => message, schedule, contextCallback, delayProvider));
+        }
+
+        public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
+            this EventActivityBinder<TInstance, TData> source, Schedule<TInstance, TMessage> schedule, TMessage message,
+            Action<SendContext> contextCallback, ScheduleTimeProvider<TInstance, TData> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TData : class
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(x => message, schedule, contextCallback, timeProvider));
         }
 
         public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
@@ -146,6 +199,16 @@ namespace Automatonymous
 
         public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
             this EventActivityBinder<TInstance, TData> source, Schedule<TInstance, TMessage> schedule,
+            EventMessageFactory<TInstance, TData, TMessage> messageFactory, ScheduleTimeProvider<TInstance, TData> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TData : class
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(messageFactory, schedule, timeProvider));
+        }
+
+        public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
+            this EventActivityBinder<TInstance, TData> source, Schedule<TInstance, TMessage> schedule,
             EventMessageFactory<TInstance, TData, TMessage> messageFactory,
             Action<SendContext> contextCallback)
             where TInstance : class, SagaStateMachineInstance
@@ -164,6 +227,17 @@ namespace Automatonymous
             where TMessage : class
         {
             return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(messageFactory, schedule, contextCallback, delayProvider));
+        }
+
+        public static EventActivityBinder<TInstance, TData> Schedule<TInstance, TData, TMessage>(
+            this EventActivityBinder<TInstance, TData> source, Schedule<TInstance, TMessage> schedule,
+            EventMessageFactory<TInstance, TData, TMessage> messageFactory,
+            Action<SendContext> contextCallback, ScheduleTimeProvider<TInstance, TData> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TData : class
+            where TMessage : class
+        {
+            return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(messageFactory, schedule, contextCallback, timeProvider));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
@@ -189,6 +263,17 @@ namespace Automatonymous
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
+            ScheduleTimeProvider<TInstance, TData, TException> timeProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TData : class
+            where TException : Exception
+            where TMessage : class
+        {
+            return source.Add(new FaultedScheduleActivity<TInstance, TData, TException, TMessage>(x => message, schedule, timeProvider));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
             Action<SendContext> contextCallback)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
@@ -201,6 +286,17 @@ namespace Automatonymous
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
             Action<SendContext> contextCallback, ScheduleDelayProvider<TInstance, TData, TException> delayProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TData : class
+            where TException : Exception
+            where TMessage : class
+        {
+            return source.Add(new FaultedScheduleActivity<TInstance, TData, TException, TMessage>(x => message, schedule, contextCallback, delayProvider));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
+            Action<SendContext> contextCallback, ScheduleTimeProvider<TInstance, TData, TException> delayProvider)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -224,6 +320,18 @@ namespace Automatonymous
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule,
             EventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
             Action<SendContext> contextCallback, ScheduleDelayProvider<TInstance, TData, TException> delayProvider)
+            where TInstance : class, SagaStateMachineInstance
+            where TData : class
+            where TException : Exception
+            where TMessage : class
+        {
+            return source.Add(new FaultedScheduleActivity<TInstance, TData, TException, TMessage>(messageFactory, schedule, contextCallback, delayProvider));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule,
+            EventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
+            Action<SendContext> contextCallback, ScheduleTimeProvider<TInstance, TData, TException> delayProvider)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception


### PR DESCRIPTION
This is related to #1355.
This PR exposes overloads in the automatonymous integration in order to be able to send in an actual DateTime instead of only a TimeSpan. 