### PR TITLE
Added support for Queue, Topic, QueueSubscription and TopicSubscription attributes for SQS/SNS

### DIFF
--- a/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Builders/AmazonSqsReceiveEndpointBuilder.cs
@@ -66,7 +66,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Builders
         {
             var builder = new ReceiveEndpointBrokerTopologyBuilder();
 
-            builder.Queue = builder.CreateQueue(settings.EntityName, settings.Durable, settings.AutoDelete, settings.Attributes);
+            builder.Queue = builder.CreateQueue(settings.EntityName, settings.Durable, settings.AutoDelete, settings.QueueAttributes, settings.QueueSubscriptionAttributes);
 
             _configuration.Topology.Consume.Apply(builder);
 

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
@@ -152,7 +152,8 @@
             set => _settings.PurgeOnStartup = value;
         }
 
-        public IDictionary<string, object> Attributes => _settings.Attributes;
+        public IDictionary<string, object> QueueAttributes => _settings.QueueAttributes;
+        public IDictionary<string, object> QueueSubscriptionAttributes => _settings.QueueSubscriptionAttributes;
 
         public void Subscribe(string topicName, Action<ITopicSubscriptionConfigurator> configure = null)
         {

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
@@ -87,7 +87,8 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
             set => _settings.PurgeOnStartup = value;
         }
 
-        public IDictionary<string, object> Attributes => _settings.Attributes;
+        public IDictionary<string, object> QueueAttributes => _settings.QueueAttributes;
+        public IDictionary<string, object> QueueSubscriptionAttributes => _settings.QueueSubscriptionAttributes;
 
         public IAmazonSqsHost Host(AmazonSqsHostSettings settings)
         {

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IQueueConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IQueueConfigurator.cs
@@ -34,6 +34,11 @@ namespace MassTransit.AmazonSqsTransport.Configuration
         /// <summary>
         /// Specify optional <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html">attributes</see> for the queue.  
         /// </summary>
-        IDictionary<string, object> Attributes { get; }
+        IDictionary<string, object> QueueAttributes { get; }
+
+        /// <summary>
+        /// Additional <see href="https://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html">attributes</see> for the queue's subscription.
+        /// </summary>
+        IDictionary<string, object> QueueSubscriptionAttributes { get; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/ITopicConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/ITopicConfigurator.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AmazonSqsTransport.Configuration
 {
+    using System.Collections.Generic;
+
+
     /// <summary>
     /// Configures an exchange for AmazonSQS
     /// </summary>
@@ -27,5 +30,15 @@ namespace MassTransit.AmazonSqsTransport.Configuration
         /// Specify that the queue (and the exchange of the same name) should be created as auto-delete
         /// </summary>
         bool AutoDelete { set; }
+
+        /// <summary>
+        /// Additional <see href="https://docs.aws.amazon.com/sns/latest/api/API_SetTopicAttributes.html">attributes</see> for the topic.
+        /// </summary>
+        IDictionary<string, object> TopicAttributes { get; }
+
+        /// <summary>
+        /// Additional <see href="https://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html">attributes</see> for the topic's subscription.
+        /// </summary>
+        IDictionary<string, object> TopicSubscriptionAttributes { get; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/BrokerTopologyBuilder.cs
@@ -39,20 +39,20 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
             return Interlocked.Increment(ref _nextId);
         }
 
-        public TopicHandle CreateTopic(string name, bool durable, bool autoDelete)
+        public TopicHandle CreateTopic(string name, bool durable, bool autoDelete, IDictionary<string, object> topicAttributes = null, IDictionary<string, object> topicSubscriptionAttributes = null)
         {
             var id = GetNextId();
 
-            var topicEntity = new TopicEntity(id, name, durable, autoDelete);
+            var topicEntity = new TopicEntity(id, name, durable, autoDelete, topicAttributes, topicSubscriptionAttributes);
 
             return Topics.GetOrAdd(topicEntity);
         }
 
-        public QueueHandle CreateQueue(string name, bool durable, bool autoDelete, IDictionary<string, object> attributes = null)
+        public QueueHandle CreateQueue(string name, bool durable, bool autoDelete, IDictionary<string, object> queueAttributes = null, IDictionary<string, object> queueSubscriptionAttributes = null)
         {
             var id = GetNextId();
 
-            var queueEntity = new QueueEntity(id, name, durable, autoDelete, attributes);
+            var queueEntity = new QueueEntity(id, name, durable, autoDelete, queueAttributes, queueSubscriptionAttributes);
 
             return Queues.GetOrAdd(queueEntity);
         }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Builders/PublishEndpointBrokerTopologyBuilder.cs
@@ -68,14 +68,14 @@ namespace MassTransit.AmazonSqsTransport.Topology.Builders
                 return this;
             }
 
-            public TopicHandle CreateTopic(string name, bool durable, bool autoDelete)
+            public TopicHandle CreateTopic(string name, bool durable, bool autoDelete, IDictionary<string, object> topicAttributes = null, IDictionary<string, object> topicSubscriptionAttributes = null)
             {
-                return _builder.CreateTopic(name, durable, autoDelete);
+                return _builder.CreateTopic(name, durable, autoDelete, topicAttributes, topicSubscriptionAttributes);
             }
 
-            public QueueHandle CreateQueue(string name, bool durable, bool autoDelete, IDictionary<string, object> attributes = null)
+            public QueueHandle CreateQueue(string name, bool durable, bool autoDelete, IDictionary<string, object> queueAttributes = null, IDictionary<string, object> queueSubscriptionAttributes = null)
             {
-                return _builder.CreateQueue(name, durable, autoDelete, attributes);
+                return _builder.CreateQueue(name, durable, autoDelete, queueAttributes, queueSubscriptionAttributes);
             }
 
             public QueueSubscriptionHandle CreateQueueSubscription(TopicHandle topic, QueueHandle queue)

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/QueueConfigurator.cs
@@ -22,18 +22,21 @@ namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
         IQueueConfigurator,
         Queue
     {
-        protected QueueConfigurator(string queueName, bool durable = true, bool autoDelete = false, IDictionary<string, object> attributes = null)
+        protected QueueConfigurator(string queueName, bool durable = true, bool autoDelete = false, IDictionary<string, object> queueAttributes = null, IDictionary<string, object> queueSubscriptionAttributes = null)
             : base(queueName, durable, autoDelete)
         {
-            Attributes = attributes ?? new Dictionary<string, object>();
+            QueueAttributes = queueAttributes ?? new Dictionary<string, object>();
+            QueueSubscriptionAttributes = queueSubscriptionAttributes ?? new Dictionary<string, object>();
         }
 
         public QueueConfigurator(Queue source)
             : base(source.EntityName, source.Durable, source.AutoDelete)
         {
-            Attributes = source.Attributes;
+            QueueAttributes = source.QueueAttributes;
+            QueueSubscriptionAttributes = source.QueueSubscriptionAttributes;
         }
 
-        public IDictionary<string, object> Attributes { get; set; }
+        public IDictionary<string, object> QueueAttributes { get; set; }
+        public IDictionary<string, object> QueueSubscriptionAttributes { get; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/Configurators/TopicConfigurator.cs
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
 {
+    using System.Collections.Generic;
     using AmazonSqsTransport.Configuration;
     using Entities;
 
@@ -21,14 +22,20 @@ namespace MassTransit.AmazonSqsTransport.Topology.Configuration.Configurators
         ITopicConfigurator,
         Topic
     {
-        public TopicConfigurator(string topicName, bool durable = true, bool autoDelete = false)
+        public TopicConfigurator(string topicName, bool durable = true, bool autoDelete = false, IDictionary<string, object> topicAttributes = null, IDictionary<string, object> topicSubscriptionAttributes = null)
             : base(topicName, durable, autoDelete)
         {
+            TopicAttributes = topicAttributes ?? new Dictionary<string, object>();
+            TopicSubscriptionAttributes = topicSubscriptionAttributes ?? new Dictionary<string, object>();
         }
 
         public TopicConfigurator(Topic source)
             : base(source.EntityName, source.Durable, source.AutoDelete)
         {
+            TopicAttributes = source.TopicAttributes;
         }
+
+        public IDictionary<string, object> TopicAttributes { get; set; }
+        public IDictionary<string, object> TopicSubscriptionAttributes { get; set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/Queue.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/Queue.cs
@@ -38,6 +38,11 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         /// <summary>
         /// Additional <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html">attributes</see> for the queue.
         /// </summary>
-        IDictionary<string, object> Attributes { get; }
+        IDictionary<string, object> QueueAttributes { get; }
+
+        /// <summary>
+        /// Additional <see href="https://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html">attributes</see> for the queue's subscription.
+        /// </summary>
+        IDictionary<string, object> QueueSubscriptionAttributes { get; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/QueueEntity.cs
@@ -20,13 +20,14 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         Queue,
         QueueHandle
     {
-        public QueueEntity(long id, string name, bool durable, bool autoDelete, IDictionary<string, object> attributes = null)
+        public QueueEntity(long id, string name, bool durable, bool autoDelete, IDictionary<string, object> queueAttributes = null, IDictionary<string, object> queueSubscriptionAttributes = null)
         {
             Id = id;
             EntityName = name;
             Durable = durable;
             AutoDelete = autoDelete;
-            Attributes = attributes ?? new Dictionary<string, object>();
+            QueueAttributes = queueAttributes ?? new Dictionary<string, object>();
+            QueueSubscriptionAttributes = queueSubscriptionAttributes ?? new Dictionary<string, object>();
         }
 
         public static IEqualityComparer<QueueEntity> NameComparer { get; } = new NameEqualityComparer();
@@ -37,7 +38,8 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         public bool Durable { get; }
         public bool AutoDelete { get; }
         public long Id { get; }
-        public IDictionary<string, object> Attributes { get; }
+        public IDictionary<string, object> QueueAttributes { get; }
+        public IDictionary<string, object> QueueSubscriptionAttributes { get; }
         public Queue Queue => this;
 
         public override string ToString()
@@ -47,7 +49,8 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
                 $"name: {EntityName}",
                 Durable ? "durable" : "",
                 AutoDelete ? "auto-delete" : "",
-                Attributes.Any() ? $"attributes: {string.Join(";", Attributes.Select(a => $"{a.Key}={a.Value}"))}" : ""
+                QueueAttributes.Any() ? $"attributes: {string.Join(";", QueueAttributes.Select(a => $"{a.Key}={a.Value}"))}" : "",
+                QueueSubscriptionAttributes.Any() ? $"subscription-attributes: {string.Join(";", QueueSubscriptionAttributes.Select(a => $"{a.Key}={a.Value}"))}" : ""
             }.Where(x => !string.IsNullOrWhiteSpace(x)));
         }
 

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/Topic.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/Topic.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AmazonSqsTransport.Topology.Entities
 {
+    using System.Collections.Generic;
+
+
     /// <summary>
     /// The exchange details used to declare the exchange to AmazonSQS
     /// </summary>
@@ -31,5 +34,15 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         /// True if the exchange should be deleted when the connection is closed
         /// </summary>
         bool AutoDelete { get; }
+
+        /// <summary>
+        /// Additional <see href="https://docs.aws.amazon.com/sns/latest/api/API_SetTopicAttributes.html">attributes</see> for the topic.
+        /// </summary>
+        IDictionary<string, object> TopicAttributes { get; }
+
+        /// <summary>
+        /// Additional <see href="https://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html">attributes</see> for the topic's subscription.
+        /// </summary>
+        IDictionary<string, object> TopicSubscriptionAttributes { get; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicEntity.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Entities/TopicEntity.cs
@@ -20,12 +20,16 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         Topic,
         TopicHandle
     {
-        public TopicEntity(long id, string name, bool durable, bool autoDelete)
+        public TopicEntity(long id, string name, bool durable, bool autoDelete, IDictionary<string, object> topicAttributes = null, IDictionary<string, object> topicSubscriptionAttributes = null)
         {
             Id = id;
             EntityName = name;
             Durable = durable;
             AutoDelete = autoDelete;
+            TopicAttributes = topicAttributes ?? new Dictionary<string, object>();
+            TopicSubscriptionAttributes = topicSubscriptionAttributes ?? new Dictionary<string, object>();
+
+            EnsureRawDeliveryIsSet();
         }
 
         public static IEqualityComparer<TopicEntity> NameComparer { get; } = new NameEqualityComparer();
@@ -36,6 +40,8 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
         public bool Durable { get; }
         public bool AutoDelete { get; }
         public long Id { get; }
+        public IDictionary<string, object> TopicAttributes { get; }
+        public IDictionary<string, object> TopicSubscriptionAttributes { get; }
         public Topic Topic => this;
 
         public override string ToString()
@@ -44,8 +50,15 @@ namespace MassTransit.AmazonSqsTransport.Topology.Entities
             {
                 $"name: {EntityName}",
                 Durable ? "durable" : "",
-                AutoDelete ? "auto-delete" : ""
+                AutoDelete ? "auto-delete" : "",
+                TopicAttributes.Any() ? $"attributes: {string.Join(";", TopicAttributes.Select(a => $"{a.Key}={a.Value}"))}" : "",
+                TopicSubscriptionAttributes.Any() ? $"subscription-attributes: {string.Join(";", TopicSubscriptionAttributes.Select(a => $"{a.Key}={a.Value}"))}" : ""
             }.Where(x => !string.IsNullOrWhiteSpace(x)));
+        }
+
+        private void EnsureRawDeliveryIsSet()
+        {
+            TopicSubscriptionAttributes["RawMessageDelivery"] = true;
         }
 
 

--- a/src/MassTransit.AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
@@ -24,8 +24,10 @@ namespace MassTransit.AmazonSqsTransport.Topology
         /// <param name="name">The topic name</param>
         /// <param name="durable">A durable topic survives a broker restart</param>
         /// <param name="autoDelete">Automatically delete if the broker connection is closed</param>
+        /// <param name="topicAttributes"></param>
+        /// <param name="topicSubscriptionAttributes"></param>
         /// <returns>An entity handle used to reference the topic in subsequent calls</returns>
-        TopicHandle CreateTopic(string name, bool durable, bool autoDelete);
+        TopicHandle CreateTopic(string name, bool durable, bool autoDelete, IDictionary<string, object> topicAttributes = null, IDictionary<string, object> topicSubscriptionAttributes = null);
 
         /// <summary>
         /// Declares a queue
@@ -33,9 +35,10 @@ namespace MassTransit.AmazonSqsTransport.Topology
         /// <param name="name"></param>
         /// <param name="durable"></param>
         /// <param name="autoDelete"></param>
-        /// <param name="attributes"></param>
+        /// <param name="queueAttributes"></param>
+        /// <param name="queueSubscriptionAttributes"></param>
         /// <returns></returns>
-        QueueHandle CreateQueue(string name, bool durable, bool autoDelete, IDictionary<string, object> attributes = null);
+        QueueHandle CreateQueue(string name, bool durable, bool autoDelete, IDictionary<string, object> queueAttributes = null, IDictionary<string, object> queueSubscriptionAttributes = null);
 
         /// <summary>
         /// Create a subscription on a topic to a queue

--- a/src/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
@@ -38,7 +38,12 @@ namespace MassTransit.AmazonSqsTransport.Topology
         /// <summary>
         /// Additional <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html">attributes</see> for the queue.
         /// </summary>
-        IDictionary<string, object> Attributes { get; }
+        IDictionary<string, object> QueueAttributes { get; }
+
+        /// <summary>
+        /// Additional <see href="https://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html">attributes</see> for the queue's subscription.
+        /// </summary>
+        IDictionary<string, object> QueueSubscriptionAttributes { get; }
 
         /// <summary>
         /// Get the input address for the transport on the specified host

--- a/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Topologies/AmazonSqsMessagePublishTopology.cs
@@ -62,6 +62,9 @@ namespace MassTransit.AmazonSqsTransport.Topology.Topologies
             set => _topic.AutoDelete = value;
         }
 
+        IDictionary<string, object> ITopicConfigurator.TopicAttributes => _topic.TopicAttributes;
+        IDictionary<string, object> ITopicConfigurator.TopicSubscriptionAttributes => _topic.TopicSubscriptionAttributes;
+
         public override bool TryGetPublishAddress(Uri baseAddress, out Uri publishAddress)
         {
             publishAddress = GetPublishSettings().GetSendAddress(baseAddress);


### PR DESCRIPTION
This PR adds ability to setup extra attributes in AWS infrastructure. As existing `.Attributes` haven't been published yet I think its rename to `.QueueAttributes` shouldn't be considered a BC?
