### PR TITLE
Appinsights property name collision

### DIFF
--- a/src/MassTransit.ApplicationInsights.Tests/CopyPropertiesTelemetryInitializer.cs
+++ b/src/MassTransit.ApplicationInsights.Tests/CopyPropertiesTelemetryInitializer.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.ApplicationInsights.Tests
+{
+    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    internal class CopyPropertiesTelemetryInitializer : ITelemetryInitializer
+    {
+        private IDictionary<string, string> Properties { get; }
+
+        public CopyPropertiesTelemetryInitializer(ISupportProperties source)
+        {
+            Properties = source.Properties;
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            var itemWithProperties = (ISupportProperties)telemetry;
+            foreach (var property in Properties)
+            {
+                itemWithProperties.Properties.Add(property);
+            }
+        }
+    }
+}

--- a/src/MassTransit.ApplicationInsights/Pipeline/ApplicationInsightsConsumeFilter.cs
+++ b/src/MassTransit.ApplicationInsights/Pipeline/ApplicationInsightsConsumeFilter.cs
@@ -67,25 +67,25 @@ namespace MassTransit.ApplicationInsights.Pipeline
 
             using (IOperationHolder<RequestTelemetry> operation = _telemetryClient.StartOperation(requestTelemetry))
             {
-                operation.Telemetry.Properties.Add(MessageType, TypeMetadataCache<T>.ShortName);
+                operation.Telemetry.Properties[MessageType] = TypeMetadataCache<T>.ShortName;
 
                 if (context.MessageId.HasValue)
-                    operation.Telemetry.Properties.Add(MessageId, context.MessageId.Value.ToString());
+                    operation.Telemetry.Properties[MessageId] = context.MessageId.Value.ToString();
 
                 if (context.ConversationId.HasValue)
-                    operation.Telemetry.Properties.Add(ConversationId, context.ConversationId.Value.ToString());
+                    operation.Telemetry.Properties[ConversationId] = context.ConversationId.Value.ToString();
 
                 if (context.CorrelationId.HasValue)
-                    operation.Telemetry.Properties.Add(CorrelationId, context.CorrelationId.Value.ToString());
+                    operation.Telemetry.Properties[CorrelationId] = context.CorrelationId.Value.ToString();
 
                 if (context.DestinationAddress != null)
-                    operation.Telemetry.Properties.Add(DestinationAddress, context.DestinationAddress.ToString());
+                    operation.Telemetry.Properties[DestinationAddress] = context.DestinationAddress.ToString();
 
                 if (context.ReceiveContext.InputAddress != null)
-                    operation.Telemetry.Properties.Add(InputAddress, context.ReceiveContext.InputAddress.ToString());
+                    operation.Telemetry.Properties[InputAddress] = context.ReceiveContext.InputAddress.ToString();
 
                 if (context.RequestId.HasValue)
-                    operation.Telemetry.Properties.Add(RequestId, context.RequestId.Value.ToString());
+                    operation.Telemetry.Properties[RequestId] = context.RequestId.Value.ToString();
 
                 _configureOperation?.Invoke(operation, context);
 

--- a/src/MassTransit.ApplicationInsights/Pipeline/ApplicationInsightsPublishFilter.cs
+++ b/src/MassTransit.ApplicationInsights/Pipeline/ApplicationInsightsPublishFilter.cs
@@ -70,22 +70,22 @@ namespace MassTransit.ApplicationInsights.Pipeline
                 context.Headers.Set(_telemetryHeaderRootKey, operation.Telemetry.Context.Operation.Id);
                 context.Headers.Set(_telemetryHeaderParentKey, operation.Telemetry.Id);
 
-                operation.Telemetry.Properties.Add(MessageType, TypeMetadataCache<T>.ShortName);
+                operation.Telemetry.Properties[MessageType] = TypeMetadataCache<T>.ShortName;
 
                 if (context.MessageId.HasValue)
-                    operation.Telemetry.Properties.Add(MessageId, context.MessageId.Value.ToString());
+                    operation.Telemetry.Properties[MessageId] = context.MessageId.Value.ToString();
 
                 if (context.ConversationId.HasValue)
-                    operation.Telemetry.Properties.Add(ConversationId, context.ConversationId.Value.ToString());
+                    operation.Telemetry.Properties[ConversationId] = context.ConversationId.Value.ToString();
 
                 if (context.CorrelationId.HasValue)
-                    operation.Telemetry.Properties.Add(CorrelationId, context.CorrelationId.Value.ToString());
+                    operation.Telemetry.Properties[CorrelationId] = context.CorrelationId.Value.ToString();
 
                 if (context.DestinationAddress != null)
-                    operation.Telemetry.Properties.Add(DestinationAddress, context.DestinationAddress.ToString());
+                    operation.Telemetry.Properties[DestinationAddress] = context.DestinationAddress.ToString();
 
                 if (context.RequestId.HasValue)
-                    operation.Telemetry.Properties.Add(RequestId, context.RequestId.Value.ToString());
+                    operation.Telemetry.Properties[RequestId] = context.RequestId.Value.ToString();
 
                 try
                 {

--- a/src/MassTransit.ApplicationInsights/Pipeline/ApplicationInsightsSendFilter.cs
+++ b/src/MassTransit.ApplicationInsights/Pipeline/ApplicationInsightsSendFilter.cs
@@ -70,22 +70,22 @@ namespace MassTransit.ApplicationInsights.Pipeline
                 context.Headers.Set(_telemetryHeaderRootKey, operation.Telemetry.Context.Operation.Id);
                 context.Headers.Set(_telemetryHeaderParentKey, operation.Telemetry.Id);
 
-                operation.Telemetry.Properties.Add(MessageType, TypeMetadataCache<T>.ShortName);
+                operation.Telemetry.Properties[MessageType] = TypeMetadataCache<T>.ShortName;
 
                 if (context.MessageId.HasValue)
-                    operation.Telemetry.Properties.Add(MessageId, context.MessageId.Value.ToString());
+                    operation.Telemetry.Properties[MessageId] = context.MessageId.Value.ToString();
 
                 if (context.ConversationId.HasValue)
-                    operation.Telemetry.Properties.Add(ConversationId, context.ConversationId.Value.ToString());
+                    operation.Telemetry.Properties[ConversationId] = context.ConversationId.Value.ToString();
 
                 if (context.CorrelationId.HasValue)
-                    operation.Telemetry.Properties.Add(CorrelationId, context.CorrelationId.Value.ToString());
+                    operation.Telemetry.Properties[CorrelationId] = context.CorrelationId.Value.ToString();
 
                 if (context.DestinationAddress != null)
-                    operation.Telemetry.Properties.Add(DestinationAddress, context.DestinationAddress.ToString());
+                    operation.Telemetry.Properties[DestinationAddress] = context.DestinationAddress.ToString();
 
                 if (context.RequestId.HasValue)
-                    operation.Telemetry.Properties.Add(RequestId, context.RequestId.Value.ToString());
+                    operation.Telemetry.Properties[RequestId] = context.RequestId.Value.ToString();
 
                 try
                 {


### PR DESCRIPTION
This PR aims to fix #1359 by ensuring MassTransit overwrites already set properties.

I believe this is a better situation than to fail logging, or to fail processing because of a logging process.