### PR TITLE
Support scheduling from WhenEnter/Catch blocks

### DIFF
--- a/src/MassTransit.AutomatonymousIntegration/Activities/FaultedPublishActivity.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Activities/FaultedPublishActivity.cs
@@ -5,6 +5,81 @@ namespace Automatonymous.Activities
     using GreenPipes;
     using MassTransit;
 
+    public class FaultedPublishActivity<TInstance, TException, TMessage> :
+        Activity<TInstance>
+        where TInstance : SagaStateMachineInstance
+        where TMessage : class
+        where TException : Exception
+    {
+        readonly AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> _asyncMessageFactory;
+        readonly EventExceptionMessageFactory<TInstance, TException, TMessage> _messageFactory;
+        readonly IPipe<PublishContext<TMessage>> _publishPipe;
+
+        public FaultedPublishActivity(EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<PublishContext<TMessage>> contextCallback)
+            : this(contextCallback)
+        {
+            _messageFactory = messageFactory;
+        }
+
+        public FaultedPublishActivity(AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<PublishContext<TMessage>> contextCallback)
+            : this(contextCallback)
+        {
+            _asyncMessageFactory = messageFactory;
+        }
+
+        FaultedPublishActivity(Action<PublishContext<TMessage>> contextCallback)
+        {
+            _publishPipe = contextCallback != null ? Pipe.Execute(contextCallback) : Pipe.Empty<PublishContext<TMessage>>();
+        }
+
+        void Visitable.Accept(StateMachineVisitor inspector)
+        {
+            inspector.Visit(this);
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<T>(BehaviorExceptionContext<TInstance, T> context,
+            Behavior<TInstance> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                await exceptionContext.Publish(message, _publishPipe).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+
+        async Task Activity<TInstance>.Faulted<T, TOtherException>(BehaviorExceptionContext<TInstance, T, TOtherException> context, Behavior<TInstance, T> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                await exceptionContext.Publish(message, _publishPipe).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("publish-faulted");
+            _publishPipe.Probe(scope);
+        }
+    }
 
     public class FaultedPublishActivity<TInstance, TData, TException, TMessage> :
         Activity<TInstance, TData>

--- a/src/MassTransit.AutomatonymousIntegration/Activities/FaultedRequestActivity.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Activities/FaultedRequestActivity.cs
@@ -15,6 +15,93 @@ namespace Automatonymous.Activities
     using System;
     using System.Threading.Tasks;
 
+    public class FaultedRequestActivity<TInstance, TException, TRequest, TResponse> :
+        RequestActivityImpl<TInstance, TRequest, TResponse>,
+        Activity<TInstance>
+        where TInstance : class, SagaStateMachineInstance
+        where TException : Exception
+        where TRequest : class
+        where TResponse : class
+    {
+        readonly EventExceptionMessageFactory<TInstance, TException, TRequest> _messageFactory;
+        readonly AsyncEventExceptionMessageFactory<TInstance, TException, TRequest> _asyncMessageFactory;
+        readonly ServiceAddressExceptionProvider<TInstance, TException> _serviceAddressProvider;
+
+        public FaultedRequestActivity(Request<TInstance, TRequest, TResponse> request,
+            EventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            : base(request)
+        {
+            _messageFactory = messageFactory;
+            _serviceAddressProvider = context => request.Settings.ServiceAddress;
+        }
+
+        public FaultedRequestActivity(Request<TInstance, TRequest, TResponse> request,
+            ServiceAddressExceptionProvider<TInstance, TException> serviceAddressProvider,
+            EventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            : base(request)
+        {
+            _messageFactory = messageFactory;
+            _serviceAddressProvider = context => serviceAddressProvider(context) ?? request.Settings.ServiceAddress;
+        }
+
+        public FaultedRequestActivity(Request<TInstance, TRequest, TResponse> request,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            : base(request)
+        {
+            _asyncMessageFactory = messageFactory;
+            _serviceAddressProvider = context => request.Settings.ServiceAddress;
+        }
+
+        public FaultedRequestActivity(Request<TInstance, TRequest, TResponse> request,
+            ServiceAddressExceptionProvider<TInstance, TException> serviceAddressProvider,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            : base(request)
+        {
+            _asyncMessageFactory = messageFactory;
+            _serviceAddressProvider = context => serviceAddressProvider(context) ?? request.Settings.ServiceAddress;
+        }
+
+        public void Accept(StateMachineVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<T>(BehaviorExceptionContext<TInstance, T> context, Behavior<TInstance> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+                var serviceAddress = _serviceAddressProvider(exceptionContext);
+
+                await SendRequest(context, exceptionContext, message, serviceAddress).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+
+        async Task Activity<TInstance>.Faulted<T, TOtherException>(BehaviorExceptionContext<TInstance, T, TOtherException> context, Behavior<TInstance, T> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+                var serviceAddress = _serviceAddressProvider(exceptionContext);
+
+                await SendRequest(context, exceptionContext, message, serviceAddress).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+    }
 
     public class FaultedRequestActivity<TInstance, TData, TException, TRequest, TResponse> :
         RequestActivityImpl<TInstance, TRequest, TResponse>,
@@ -27,7 +114,7 @@ namespace Automatonymous.Activities
     {
         readonly EventExceptionMessageFactory<TInstance, TData, TException, TRequest> _messageFactory;
         readonly AsyncEventExceptionMessageFactory<TInstance, TData, TException, TRequest> _asyncMessageFactory;
-        readonly ServiceAddressProvider<TInstance, TData, TException> _serviceAddressProvider;
+        readonly ServiceAddressExceptionProvider<TInstance, TData, TException> _serviceAddressProvider;
 
         public FaultedRequestActivity(Request<TInstance, TRequest, TResponse> request,
             EventExceptionMessageFactory<TInstance, TData, TException, TRequest> messageFactory)
@@ -38,7 +125,7 @@ namespace Automatonymous.Activities
         }
 
         public FaultedRequestActivity(Request<TInstance, TRequest, TResponse> request,
-            ServiceAddressProvider<TInstance, TData, TException> serviceAddressProvider,
+            ServiceAddressExceptionProvider<TInstance, TData, TException> serviceAddressProvider,
             EventExceptionMessageFactory<TInstance, TData, TException, TRequest> messageFactory)
             : base(request)
         {
@@ -55,7 +142,7 @@ namespace Automatonymous.Activities
         }
 
         public FaultedRequestActivity(Request<TInstance, TRequest, TResponse> request,
-            ServiceAddressProvider<TInstance, TData, TException> serviceAddressProvider,
+            ServiceAddressExceptionProvider<TInstance, TData, TException> serviceAddressProvider,
             AsyncEventExceptionMessageFactory<TInstance, TData, TException, TRequest> messageFactory)
             : base(request)
         {
@@ -73,8 +160,7 @@ namespace Automatonymous.Activities
             return next.Execute(context);
         }
 
-        public async Task Faulted<T>(BehaviorExceptionContext<TInstance, TData, T> context, Behavior<TInstance, TData> next)
-            where T : Exception
+        async Task Activity<TInstance, TData>.Faulted<T>(BehaviorExceptionContext<TInstance, TData, T> context, Behavior<TInstance, TData> next)
         {
             if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TData, TException> exceptionContext))
             {

--- a/src/MassTransit.AutomatonymousIntegration/Activities/FaultedRespondActivity.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Activities/FaultedRespondActivity.cs
@@ -6,6 +6,81 @@ namespace Automatonymous.Activities
     using MassTransit;
 
 
+    public class FaultedRespondActivity<TInstance, TException, TMessage> :
+        Activity<TInstance>
+        where TInstance : SagaStateMachineInstance
+        where TMessage : class
+        where TException : Exception
+    {
+        readonly AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> _asyncMessageFactory;
+        readonly EventExceptionMessageFactory<TInstance, TException, TMessage> _messageFactory;
+        readonly IPipe<SendContext<TMessage>> _responsePipe;
+
+        public FaultedRespondActivity(EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(contextCallback)
+        {
+            _messageFactory = messageFactory;
+        }
+
+        public FaultedRespondActivity(AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(contextCallback)
+        {
+            _asyncMessageFactory = messageFactory;
+        }
+
+        FaultedRespondActivity(Action<SendContext<TMessage>> contextCallback)
+        {
+            _responsePipe = contextCallback != null ? Pipe.Execute(contextCallback) : Pipe.Empty<SendContext<TMessage>>();
+        }
+
+        void Visitable.Accept(StateMachineVisitor inspector)
+        {
+            inspector.Visit(this);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("respond-faulted");
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<T>(BehaviorExceptionContext<TInstance, T> context,
+            Behavior<TInstance> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                await exceptionContext.RespondAsync(message, _responsePipe).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+
+        async Task Activity<TInstance>.Faulted<T, TOtherException>(BehaviorExceptionContext<TInstance, T, TOtherException> context, Behavior<TInstance, T> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                await exceptionContext.RespondAsync(message, _responsePipe).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+    }
+
     public class FaultedRespondActivity<TInstance, TData, TException, TMessage> :
         Activity<TInstance, TData>
         where TInstance : SagaStateMachineInstance

--- a/src/MassTransit.AutomatonymousIntegration/Activities/FaultedScheduleActivity.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Activities/FaultedScheduleActivity.cs
@@ -6,6 +6,109 @@
     using MassTransit;
     using MassTransit.Scheduling;
 
+    public class FaultedScheduleActivity<TInstance, TException, TMessage> :
+        Activity<TInstance>
+        where TInstance : class, SagaStateMachineInstance
+        where TException : Exception
+        where TMessage : class
+    {
+        readonly AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> _asyncMessageFactory;
+        readonly EventExceptionMessageFactory<TInstance, TException, TMessage> _messageFactory;
+        readonly Schedule<TInstance, TMessage> _schedule;
+        readonly IPipe<SendContext<TMessage>> _sendPipe;
+        readonly ScheduleTimeExceptionProvider<TInstance, TException> _timeProvider;
+
+        public FaultedScheduleActivity(EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Schedule<TInstance, TMessage> schedule, ScheduleTimeExceptionProvider<TInstance, TException> timeProvider,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(schedule, timeProvider, contextCallback)
+        {
+            _messageFactory = messageFactory;
+        }
+
+        public FaultedScheduleActivity(AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Schedule<TInstance, TMessage> schedule, ScheduleTimeExceptionProvider<TInstance, TException> timeProvider,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(schedule, timeProvider, contextCallback)
+        {
+            _asyncMessageFactory = messageFactory;
+        }
+
+        FaultedScheduleActivity(Schedule<TInstance, TMessage> schedule, ScheduleTimeExceptionProvider<TInstance, TException> timeProvider,
+            Action<SendContext<TMessage>> contextCallback)
+        {
+            _schedule = schedule;
+            _timeProvider = timeProvider;
+            _sendPipe = contextCallback != null ? Pipe.Execute(contextCallback) : Pipe.Empty<SendContext<TMessage>>();
+        }
+
+        void Visitable.Accept(StateMachineVisitor inspector)
+        {
+            inspector.Visit(this);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("schedule-faulted");
+            _sendPipe.Probe(scope);
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<T>(BehaviorExceptionContext<TInstance, T> context, Behavior<TInstance> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                if (!exceptionContext.TryGetPayload(out MessageSchedulerContext schedulerContext))
+                    throw new ContextException("The scheduler context could not be retrieved.");
+
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                var scheduledTime = _timeProvider(exceptionContext);
+
+                ScheduledMessage<TMessage> scheduledMessage = await schedulerContext.ScheduleSend(scheduledTime, message, _sendPipe).ConfigureAwait(false);
+
+                Guid? previousTokenId = _schedule.GetTokenId(context.Instance);
+                if (previousTokenId.HasValue)
+                    await schedulerContext.CancelScheduledSend(exceptionContext.ReceiveContext.InputAddress, previousTokenId.Value).ConfigureAwait(false);
+
+                _schedule?.SetTokenId(context.Instance, scheduledMessage.TokenId);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+
+        async Task Activity<TInstance>.Faulted<T, TOtherException>(BehaviorExceptionContext<TInstance, T, TOtherException> context, Behavior<TInstance, T> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                if (!exceptionContext.TryGetPayload(out MessageSchedulerContext schedulerContext))
+                    throw new ContextException("The scheduler context could not be retrieved.");
+
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                var scheduledTime = _timeProvider(exceptionContext);
+
+                ScheduledMessage<TMessage> scheduledMessage = await schedulerContext.ScheduleSend(scheduledTime, message, _sendPipe).ConfigureAwait(false);
+
+                Guid? previousTokenId = _schedule.GetTokenId(context.Instance);
+                if (previousTokenId.HasValue)
+                    await schedulerContext.CancelScheduledSend(exceptionContext.ReceiveContext.InputAddress, previousTokenId.Value).ConfigureAwait(false);
+
+                _schedule?.SetTokenId(context.Instance, scheduledMessage.TokenId);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+    }
 
     public class FaultedScheduleActivity<TInstance, TData, TException, TMessage> :
         Activity<TInstance, TData>
@@ -18,10 +121,10 @@
         readonly EventExceptionMessageFactory<TInstance, TData, TException, TMessage> _messageFactory;
         readonly Schedule<TInstance, TMessage> _schedule;
         readonly IPipe<SendContext<TMessage>> _sendPipe;
-        readonly ScheduleTimeProvider<TInstance, TData, TException> _timeProvider;
+        readonly ScheduleTimeExceptionProvider<TInstance, TData, TException> _timeProvider;
 
         public FaultedScheduleActivity(EventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
-            Schedule<TInstance, TMessage> schedule, ScheduleTimeProvider<TInstance, TData, TException> timeProvider,
+            Schedule<TInstance, TMessage> schedule, ScheduleTimeExceptionProvider<TInstance, TData, TException> timeProvider,
             Action<SendContext<TMessage>> contextCallback)
             : this(schedule, timeProvider, contextCallback)
         {
@@ -29,14 +132,14 @@
         }
 
         public FaultedScheduleActivity(AsyncEventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
-            Schedule<TInstance, TMessage> schedule, ScheduleTimeProvider<TInstance, TData, TException> timeProvider,
+            Schedule<TInstance, TMessage> schedule, ScheduleTimeExceptionProvider<TInstance, TData, TException> timeProvider,
             Action<SendContext<TMessage>> contextCallback)
             : this(schedule, timeProvider, contextCallback)
         {
             _asyncMessageFactory = messageFactory;
         }
 
-        FaultedScheduleActivity(Schedule<TInstance, TMessage> schedule, ScheduleTimeProvider<TInstance, TData, TException> timeProvider,
+        FaultedScheduleActivity(Schedule<TInstance, TMessage> schedule, ScheduleTimeExceptionProvider<TInstance, TData, TException> timeProvider,
             Action<SendContext<TMessage>> contextCallback)
         {
             _schedule = schedule;

--- a/src/MassTransit.AutomatonymousIntegration/Activities/FaultedSendActivity.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Activities/FaultedSendActivity.cs
@@ -5,6 +5,116 @@ namespace Automatonymous.Activities
     using GreenPipes;
     using MassTransit;
 
+    public class FaultedSendActivity<TInstance, TException, TMessage> :
+        Activity<TInstance>
+        where TInstance : SagaStateMachineInstance
+        where TMessage : class
+        where TException : Exception
+    {
+        readonly AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> _asyncMessageFactory;
+        readonly DestinationAddressProvider<TInstance> _destinationAddressProvider;
+        readonly EventExceptionMessageFactory<TInstance, TException, TMessage> _messageFactory;
+        readonly IPipe<SendContext<TMessage>> _sendPipe;
+
+        public FaultedSendActivity(DestinationAddressProvider<TInstance> destinationAddressProvider,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(messageFactory, contextCallback)
+        {
+            _destinationAddressProvider = destinationAddressProvider;
+        }
+
+        public FaultedSendActivity(DestinationAddressProvider<TInstance> destinationAddressProvider,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(messageFactory, contextCallback)
+        {
+            _destinationAddressProvider = destinationAddressProvider;
+        }
+
+        public FaultedSendActivity(EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(contextCallback)
+        {
+            _messageFactory = messageFactory;
+        }
+
+        public FaultedSendActivity(AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback)
+            : this(contextCallback)
+        {
+            _asyncMessageFactory = messageFactory;
+        }
+
+        FaultedSendActivity(Action<SendContext<TMessage>> contextCallback)
+        {
+            _sendPipe = contextCallback != null ? Pipe.Execute(contextCallback) : Pipe.Empty<SendContext<TMessage>>();
+        }
+
+        void Visitable.Accept(StateMachineVisitor inspector)
+        {
+            inspector.Visit(this);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("send-faulted");
+            _sendPipe.Probe(scope);
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<T>(BehaviorExceptionContext<TInstance, T> context,
+            Behavior<TInstance> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                if (_destinationAddressProvider != null)
+                {
+                    var destinationAddress = _destinationAddressProvider(exceptionContext.Instance);
+
+                    var endpoint = await exceptionContext.GetSendEndpoint(destinationAddress).ConfigureAwait(false);
+
+                    await endpoint.Send(message, _sendPipe).ConfigureAwait(false);
+                }
+                else
+                    await exceptionContext.Send(message, _sendPipe).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+
+        async Task Activity<TInstance>.Faulted<T, TOtherException>(BehaviorExceptionContext<TInstance, T, TOtherException> context, Behavior<TInstance, T> next)
+        {
+            if (context.TryGetExceptionContext(out ConsumeExceptionEventContext<TInstance, TException> exceptionContext))
+            {
+                var message = _messageFactory?.Invoke(exceptionContext) ?? await _asyncMessageFactory(exceptionContext).ConfigureAwait(false);
+
+                if (_destinationAddressProvider != null)
+                {
+                    var destinationAddress = _destinationAddressProvider(exceptionContext.Instance);
+
+                    var endpoint = await exceptionContext.GetSendEndpoint(destinationAddress).ConfigureAwait(false);
+
+                    await endpoint.Send(message, _sendPipe).ConfigureAwait(false);
+                }
+                else
+                    await exceptionContext.Send(message, _sendPipe).ConfigureAwait(false);
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+    }
 
     public class FaultedSendActivity<TInstance, TData, TException, TMessage> :
         Activity<TInstance, TData>

--- a/src/MassTransit.AutomatonymousIntegration/AsyncEventExceptionMessageFactory.cs
+++ b/src/MassTransit.AutomatonymousIntegration/AsyncEventExceptionMessageFactory.cs
@@ -3,6 +3,18 @@ namespace Automatonymous
     using System;
     using System.Threading.Tasks;
 
+    /// <summary>
+    /// Returns a message from an event exception
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <typeparam name="TException"></typeparam>
+    /// <typeparam name="TMessage"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate Task<TMessage> AsyncEventExceptionMessageFactory<in TInstance, in TException, TMessage>(
+        ConsumeExceptionEventContext<TInstance, TException> context)
+        where TException : Exception;
+
 
     /// <summary>
     /// Returns a message from an event exception

--- a/src/MassTransit.AutomatonymousIntegration/ConsumeExceptionEventContext.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ConsumeExceptionEventContext.cs
@@ -14,6 +14,17 @@ namespace Automatonymous
 {
     using MassTransit;
 
+    /// <summary>
+    /// Combines the consumption of an event in a state machine with the consumer context of the receiving endpoint.
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <typeparam name="TException"></typeparam>
+    public interface ConsumeExceptionEventContext<out TInstance, out TException> :
+        EventContext<TInstance>,
+        ConsumeContext
+    {
+        TException Exception { get; }
+    }
 
     /// <summary>
     /// Combines the consumption of an event in a state machine with the consumer context of the receiving endpoint.

--- a/src/MassTransit.AutomatonymousIntegration/ContextExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ContextExtensions.cs
@@ -40,6 +40,25 @@ namespace Automatonymous
             return new AutomatonymousConsumeEventContext<TInstance>(context, consumeContext);
         }
 
+        public static bool TryGetExceptionContext<TInstance, TException>(
+            this BehaviorContext<TInstance> context, out ConsumeExceptionEventContext<TInstance, TException> exceptionContext)
+            where TException : Exception
+        {
+            var behaviorExceptionContext = context as BehaviorExceptionContext<TInstance, TException>;
+            if (behaviorExceptionContext != null)
+            {
+                ConsumeContext consumeContext;
+                if (!context.TryGetPayload(out consumeContext))
+                    throw new ContextException("The consume context could not be retrieved.");
+
+                exceptionContext = new AutomatonymousConsumeExceptionEventContext<TInstance, TException>(behaviorExceptionContext, consumeContext);
+                return true;
+            }
+
+            exceptionContext = null;
+            return false;
+        }
+
         public static bool TryGetExceptionContext<TInstance, TData, TException>(
             this BehaviorContext<TInstance, TData> context, out ConsumeExceptionEventContext<TInstance, TData, TException> exceptionContext)
             where TData : class

--- a/src/MassTransit.AutomatonymousIntegration/Contexts/AutomatonymousConsumeExceptionEventContext.cs
+++ b/src/MassTransit.AutomatonymousIntegration/Contexts/AutomatonymousConsumeExceptionEventContext.cs
@@ -15,6 +15,19 @@ namespace Automatonymous.Contexts
     using System;
     using MassTransit;
 
+    public class AutomatonymousConsumeExceptionEventContext<TInstance, TException> :
+        AutomatonymousConsumeEventContext<TInstance>,
+        ConsumeExceptionEventContext<TInstance, TException>
+        where TException : Exception
+    {
+        public AutomatonymousConsumeExceptionEventContext(BehaviorExceptionContext<TInstance, TException> context, ConsumeContext consumeContext)
+            : base(context, consumeContext)
+        {
+            Exception = context.Exception;
+        }
+
+        public TException Exception { get; }
+    }
 
     public class AutomatonymousConsumeExceptionEventContext<TInstance, TData, TException> :
         AutomatonymousConsumeEventContext<TInstance, TData>,

--- a/src/MassTransit.AutomatonymousIntegration/PublishExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/PublishExtensions.cs
@@ -77,6 +77,48 @@ namespace Automatonymous
             return source.Add(new PublishActivity<TInstance, TData, TMessage>(messageFactory, contextCallback));
         }
 
+        public static ExceptionActivityBinder<TInstance, TException> Publish<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, TMessage message,
+            Action<PublishContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new PublishActivity<TInstance, TMessage>(x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> PublishAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Task<TMessage> message,
+            Action<PublishContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new PublishActivity<TInstance, TMessage>(x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Publish<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<PublishContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedPublishActivity<TInstance, TException, TMessage>(messageFactory, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> PublishAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<PublishContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedPublishActivity<TInstance, TException, TMessage>(messageFactory, contextCallback));
+        }
+
         public static ExceptionActivityBinder<TInstance, TData, TException> Publish<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, TMessage message,
             Action<PublishContext<TMessage>> contextCallback = null)

--- a/src/MassTransit.AutomatonymousIntegration/RequestExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/RequestExtensions.cs
@@ -113,6 +113,110 @@
         /// Send a request to the configured service endpoint, and setup the state machine to accept the response.
         /// </summary>
         /// <typeparam name="TInstance">The state instance type</typeparam>
+        /// <typeparam name="TRequest">The request message type</typeparam>
+        /// <typeparam name="TResponse">The response message type</typeparam>
+        /// <typeparam name="TException"></typeparam>
+        /// <param name="binder">The event binder</param>
+        /// <param name="request">The configured request to use</param>
+        /// <param name="messageFactory">The request message factory</param>
+        /// <returns></returns>
+        public static ExceptionActivityBinder<TInstance, TException> Request<TInstance, TException, TRequest, TResponse>(
+            this ExceptionActivityBinder<TInstance, TException> binder, Request<TInstance, TRequest, TResponse> request,
+            EventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            where TInstance : class, SagaStateMachineInstance
+            where TRequest : class
+            where TResponse : class
+            where TException : Exception
+        {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
+            var activity = new FaultedRequestActivity<TInstance, TException, TRequest, TResponse>(request, messageFactory);
+
+            return binder.Add(activity);
+        }
+
+        /// <summary>
+        /// Send a request to the configured service endpoint, and setup the state machine to accept the response.
+        /// </summary>
+        /// <typeparam name="TInstance">The state instance type</typeparam>
+        /// <typeparam name="TRequest">The request message type</typeparam>
+        /// <typeparam name="TResponse">The response message type</typeparam>
+        /// <typeparam name="TException"></typeparam>
+        /// <param name="binder">The event binder</param>
+        /// <param name="request">The configured request to use</param>
+        /// <param name="messageFactory">The request message factory</param>
+        /// <returns></returns>
+        public static ExceptionActivityBinder<TInstance, TException> Request<TInstance, TException, TRequest, TResponse>(
+            this ExceptionActivityBinder<TInstance, TException> binder, Request<TInstance, TRequest, TResponse> request,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            where TInstance : class, SagaStateMachineInstance
+            where TRequest : class
+            where TResponse : class
+            where TException : Exception
+        {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
+            var activity = new FaultedRequestActivity<TInstance, TException, TRequest, TResponse>(request, messageFactory);
+
+            return binder.Add(activity);
+        }
+
+        /// <summary>
+        /// Send a request to the configured service endpoint, and setup the state machine to accept the response.
+        /// </summary>
+        /// <typeparam name="TInstance">The state instance type</typeparam>
+        /// <typeparam name="TRequest">The request message type</typeparam>
+        /// <typeparam name="TResponse">The response message type</typeparam>
+        /// <typeparam name="TException"></typeparam>
+        /// <param name="binder">The event binder</param>
+        /// <param name="request">The configured request to use</param>
+        /// <param name="serviceAddressProvider"></param>
+        /// <param name="messageFactory">The request message factory</param>
+        /// <returns></returns>
+        public static ExceptionActivityBinder<TInstance, TException> Request<TInstance, TException, TRequest, TResponse>(
+            this ExceptionActivityBinder<TInstance, TException> binder, Request<TInstance, TRequest, TResponse> request,
+            ServiceAddressExceptionProvider<TInstance, TException> serviceAddressProvider,
+            EventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            where TInstance : class, SagaStateMachineInstance
+            where TRequest : class
+            where TResponse : class
+            where TException : Exception
+        {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
+            var activity = new FaultedRequestActivity<TInstance, TException, TRequest, TResponse>(request, serviceAddressProvider, messageFactory);
+
+            return binder.Add(activity);
+        }
+
+        /// <summary>
+        /// Send a request to the configured service endpoint, and setup the state machine to accept the response.
+        /// </summary>
+        /// <typeparam name="TInstance">The state instance type</typeparam>
+        /// <typeparam name="TRequest">The request message type</typeparam>
+        /// <typeparam name="TResponse">The response message type</typeparam>
+        /// <typeparam name="TException"></typeparam>
+        /// <param name="binder">The event binder</param>
+        /// <param name="request">The configured request to use</param>
+        /// <param name="serviceAddressProvider"></param>
+        /// <param name="messageFactory">The request message factory</param>
+        /// <returns></returns>
+        public static ExceptionActivityBinder<TInstance, TException> Request<TInstance, TException, TRequest, TResponse>(
+            this ExceptionActivityBinder<TInstance, TException> binder, Request<TInstance, TRequest, TResponse> request,
+            ServiceAddressExceptionProvider<TInstance, TException> serviceAddressProvider,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TRequest> messageFactory)
+            where TInstance : class, SagaStateMachineInstance
+            where TRequest : class
+            where TResponse : class
+            where TException : Exception
+        {
+            ScheduleTokenId.UseTokenId<RequestTimeoutExpired<TRequest>>(x => x.RequestId);
+            var activity = new FaultedRequestActivity<TInstance, TException, TRequest, TResponse>(request, serviceAddressProvider, messageFactory);
+
+            return binder.Add(activity);
+        }
+
+        /// <summary>
+        /// Send a request to the configured service endpoint, and setup the state machine to accept the response.
+        /// </summary>
+        /// <typeparam name="TInstance">The state instance type</typeparam>
         /// <typeparam name="TData">The event data type</typeparam>
         /// <typeparam name="TRequest">The request message type</typeparam>
         /// <typeparam name="TResponse">The response message type</typeparam>
@@ -178,7 +282,7 @@
         /// <returns></returns>
         public static ExceptionActivityBinder<TInstance, TData, TException> Request<TInstance, TData, TException, TRequest, TResponse>(
             this ExceptionActivityBinder<TInstance, TData, TException> binder, Request<TInstance, TRequest, TResponse> request,
-            ServiceAddressProvider<TInstance, TData, TException> serviceAddressProvider,
+            ServiceAddressExceptionProvider<TInstance, TData, TException> serviceAddressProvider,
             EventExceptionMessageFactory<TInstance, TData, TException, TRequest> messageFactory)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
@@ -207,7 +311,7 @@
         /// <returns></returns>
         public static ExceptionActivityBinder<TInstance, TData, TException> Request<TInstance, TData, TException, TRequest, TResponse>(
             this ExceptionActivityBinder<TInstance, TData, TException> binder, Request<TInstance, TRequest, TResponse> request,
-            ServiceAddressProvider<TInstance, TData, TException> serviceAddressProvider,
+            ServiceAddressExceptionProvider<TInstance, TData, TException> serviceAddressProvider,
             AsyncEventExceptionMessageFactory<TInstance, TData, TException, TRequest> messageFactory)
             where TInstance : class, SagaStateMachineInstance
             where TData : class

--- a/src/MassTransit.AutomatonymousIntegration/RespondExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/RespondExtensions.cs
@@ -47,6 +47,48 @@ namespace Automatonymous
             return source.Add(new RespondActivity<TInstance, TData, TMessage>(messageFactory, contextCallback));
         }
 
+        public static ExceptionActivityBinder<TInstance, TException> Respond<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, TMessage message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedRespondActivity<TInstance, TException, TMessage>(x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> RespondAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Task<TMessage> message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedRespondActivity<TInstance, TException, TMessage>(x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Respond<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedRespondActivity<TInstance, TException, TMessage>(messageFactory, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> RespondAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedRespondActivity<TInstance, TException, TMessage>(messageFactory, contextCallback));
+        }
+
         public static ExceptionActivityBinder<TInstance, TData, TException> Respond<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, TMessage message,
             Action<SendContext<TMessage>> contextCallback = null)

--- a/src/MassTransit.AutomatonymousIntegration/ScheduleDateTimeExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ScheduleDateTimeExtensions.cs
@@ -87,9 +87,51 @@ namespace Automatonymous
             return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(messageFactory, schedule, timeProvider, contextCallback));
         }
 
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
+            ScheduleTimeExceptionProvider<TInstance, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(x => message, schedule, timeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule, Task<TMessage> message,
+            ScheduleTimeExceptionProvider<TInstance, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(x => message, schedule, timeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TData, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            ScheduleTimeExceptionProvider<TInstance, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(messageFactory, schedule, timeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            ScheduleTimeExceptionProvider<TInstance, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(messageFactory, schedule, timeProvider, contextCallback));
+        }
+
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
-            ScheduleTimeProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleTimeExceptionProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -100,7 +142,7 @@ namespace Automatonymous
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, Task<TMessage> message,
-            ScheduleTimeProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleTimeExceptionProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -112,7 +154,7 @@ namespace Automatonymous
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule,
             EventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
-            ScheduleTimeProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleTimeExceptionProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -124,7 +166,7 @@ namespace Automatonymous
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule,
             AsyncEventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
-            ScheduleTimeProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleTimeExceptionProvider<TInstance, TData, TException> timeProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception

--- a/src/MassTransit.AutomatonymousIntegration/ScheduleDelayExceptionProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ScheduleDelayExceptionProvider.cs
@@ -1,0 +1,11 @@
+﻿namespace Automatonymous
+{
+    using System;
+
+
+    public delegate TimeSpan ScheduleDelayExceptionProvider<in TInstance, in TException>(ConsumeExceptionEventContext<TInstance, TException> context);
+
+
+    public delegate TimeSpan ScheduleDelayExceptionProvider<in TInstance, in TData, in TException>(ConsumeExceptionEventContext<TInstance, TData, TException> context)
+        where TData : class;
+}

--- a/src/MassTransit.AutomatonymousIntegration/ScheduleDelayProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ScheduleDelayProvider.cs
@@ -8,8 +8,4 @@
 
     public delegate TimeSpan ScheduleDelayProvider<in TInstance, in TData>(ConsumeEventContext<TInstance, TData> context)
         where TData : class;
-
-
-    public delegate TimeSpan ScheduleDelayProvider<in TInstance, in TData, in TException>(ConsumeExceptionEventContext<TInstance, TData, TException> context)
-        where TData : class;
 }

--- a/src/MassTransit.AutomatonymousIntegration/ScheduleTimeExceptionProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ScheduleTimeExceptionProvider.cs
@@ -1,0 +1,11 @@
+namespace Automatonymous
+{
+    using System;
+
+
+    public delegate DateTime ScheduleTimeExceptionProvider<in TInstance, in TException>(ConsumeExceptionEventContext<TInstance, TException> context);
+
+
+    public delegate DateTime ScheduleTimeExceptionProvider<in TInstance, in TData, in TException>(ConsumeExceptionEventContext<TInstance, TData, TException> context)
+        where TData : class;
+}

--- a/src/MassTransit.AutomatonymousIntegration/ScheduleTimeProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ScheduleTimeProvider.cs
@@ -8,8 +8,4 @@ namespace Automatonymous
 
     public delegate DateTime ScheduleTimeProvider<in TInstance, in TData>(ConsumeEventContext<TInstance, TData> context)
         where TData : class;
-
-
-    public delegate DateTime ScheduleTimeProvider<in TInstance, in TData, in TException>(ConsumeExceptionEventContext<TInstance, TData, TException> context)
-        where TData : class;
 }

--- a/src/MassTransit.AutomatonymousIntegration/ScheduleTimeSpanExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ScheduleTimeSpanExtensions.cs
@@ -236,6 +236,128 @@ namespace Automatonymous
             return source.Add(new ScheduleActivity<TInstance, TData, TMessage>(messageFactory, schedule, TimeProvider, contextCallback));
         }
 
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + schedule.Delay;
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(x => message, schedule, TimeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule, Task<TMessage> message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + schedule.Delay;
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(x => message, schedule, TimeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
+            ScheduleDelayExceptionProvider<TInstance, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + delayProvider(context);
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(x => message, schedule, TimeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule, Task<TMessage> message,
+            ScheduleDelayExceptionProvider<TInstance, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + delayProvider(context);
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(x => message, schedule, TimeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + schedule.Delay;
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(messageFactory, schedule, TimeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + schedule.Delay;
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(messageFactory, schedule, TimeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            ScheduleDelayExceptionProvider<TInstance, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + delayProvider(context);
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(messageFactory, schedule, TimeProvider, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Schedule<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance, TMessage> schedule,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory,
+            ScheduleDelayExceptionProvider<TInstance, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+            where TMessage : class
+        {
+            DateTime TimeProvider(ConsumeExceptionEventContext<TInstance, TException> context)
+            {
+                return DateTime.UtcNow + delayProvider(context);
+            }
+
+            return source.Add(new FaultedScheduleActivity<TInstance, TException, TMessage>(messageFactory, schedule, TimeProvider, contextCallback));
+        }
+
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
             Action<SendContext<TMessage>> contextCallback = null)
@@ -270,7 +392,7 @@ namespace Automatonymous
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, TMessage message,
-            ScheduleDelayProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleDelayExceptionProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -286,7 +408,7 @@ namespace Automatonymous
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule, Task<TMessage> message,
-            ScheduleDelayProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleDelayExceptionProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -335,7 +457,7 @@ namespace Automatonymous
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule,
             EventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
-            ScheduleDelayProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleDelayExceptionProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -352,7 +474,7 @@ namespace Automatonymous
         public static ExceptionActivityBinder<TInstance, TData, TException> Schedule<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Schedule<TInstance, TMessage> schedule,
             AsyncEventExceptionMessageFactory<TInstance, TData, TException, TMessage> messageFactory,
-            ScheduleDelayProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
+            ScheduleDelayExceptionProvider<TInstance, TData, TException> delayProvider, Action<SendContext<TMessage>> contextCallback = null)
             where TInstance : class, SagaStateMachineInstance
             where TData : class
             where TException : Exception
@@ -408,6 +530,20 @@ namespace Automatonymous
             where TInstance : class, SagaStateMachineInstance
         {
             return source.Add(new UnscheduleActivity<TInstance>(schedule));
+        }
+
+        /// <summary>
+        /// Unschedule a message, if the message was scheduled.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="schedule"></param>
+        /// <returns></returns>
+        public static ExceptionActivityBinder<TInstance, TException> Unschedule<TInstance, TException>(
+            this ExceptionActivityBinder<TInstance, TException> source, Schedule<TInstance> schedule)
+            where TInstance : class, SagaStateMachineInstance
+            where TException : Exception
+        {
+            return source.Add(new FaultedUnscheduleActivity<TInstance>(schedule));
         }
     }
 }

--- a/src/MassTransit.AutomatonymousIntegration/SendByConventionExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/SendByConventionExtensions.cs
@@ -77,6 +77,46 @@ namespace Automatonymous
             return source.Add(new SendActivity<TInstance, TData, TMessage>(messageFactory, contextCallback));
         }
 
+        public static ExceptionActivityBinder<TInstance, TException> Send<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, TMessage message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new SendActivity<TInstance, TMessage>(x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> SendAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Task<TMessage> message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new SendActivity<TInstance, TMessage>(x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Send<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(messageFactory, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> SendAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(messageFactory, contextCallback));
+        }
+
         public static ExceptionActivityBinder<TInstance, TData, TException> Send<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, TMessage message,
             Action<SendContext<TMessage>> contextCallback = null)

--- a/src/MassTransit.AutomatonymousIntegration/SendExtensions.cs
+++ b/src/MassTransit.AutomatonymousIntegration/SendExtensions.cs
@@ -150,6 +150,66 @@
             return source.Add(new SendActivity<TInstance, TData, TMessage>(destinationAddressProvider, messageFactory, contextCallback));
         }
 
+        public static ExceptionActivityBinder<TInstance, TException> Send<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Uri destinationAddress, TMessage message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(_ => destinationAddress, x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> SendAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Uri destinationAddress, Task<TMessage> message,
+            Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(_ => destinationAddress, x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Send<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, DestinationAddressProvider<TInstance> destinationAddressProvider,
+            TMessage message, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new SendActivity<TInstance, TMessage>(destinationAddressProvider, x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> SendAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, DestinationAddressProvider<TInstance> destinationAddressProvider,
+            Task<TMessage> message, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new SendActivity<TInstance, TMessage>(destinationAddressProvider, x => message, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> Send<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Uri destinationAddress,
+            EventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(_ => destinationAddress, messageFactory, contextCallback));
+        }
+
+        public static ExceptionActivityBinder<TInstance, TException> SendAsync<TInstance, TException, TMessage>(
+            this ExceptionActivityBinder<TInstance, TException> source, Uri destinationAddress,
+            AsyncEventExceptionMessageFactory<TInstance, TException, TMessage> messageFactory, Action<SendContext<TMessage>> contextCallback = null)
+            where TInstance : class, SagaStateMachineInstance
+            where TMessage : class
+            where TException : Exception
+        {
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(_ => destinationAddress, messageFactory, contextCallback));
+        }
+
         public static ExceptionActivityBinder<TInstance, TData, TException> Send<TInstance, TData, TException, TMessage>(
             this ExceptionActivityBinder<TInstance, TData, TException> source, Uri destinationAddress, TMessage message,
             Action<SendContext<TMessage>> contextCallback = null)

--- a/src/MassTransit.AutomatonymousIntegration/ServiceAddressExceptionProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ServiceAddressExceptionProvider.cs
@@ -2,29 +2,28 @@ namespace Automatonymous
 {
     using System;
 
-    /// <summary>
-    /// Returns a message from an event exception
-    /// </summary>
-    /// <typeparam name="TInstance"></typeparam>
-    /// <typeparam name="TException"></typeparam>
-    /// <typeparam name="TMessage"></typeparam>
-    /// <param name="context"></param>
-    /// <returns></returns>
-    public delegate TMessage EventExceptionMessageFactory<in TInstance, in TException, out TMessage>(
-        ConsumeExceptionEventContext<TInstance, TException> context)
-        where TException : Exception;
 
     /// <summary>
-    /// Returns a message from an event exception
+    /// Provides an address for the request service
     /// </summary>
     /// <typeparam name="TInstance"></typeparam>
     /// <typeparam name="TData"></typeparam>
     /// <typeparam name="TException"></typeparam>
-    /// <typeparam name="TMessage"></typeparam>
     /// <param name="context"></param>
     /// <returns></returns>
-    public delegate TMessage EventExceptionMessageFactory<in TInstance, in TData, in TException, out TMessage>(
-        ConsumeExceptionEventContext<TInstance, TData, TException> context)
+    public delegate Uri ServiceAddressExceptionProvider<in TInstance, in TException>(ConsumeExceptionEventContext<TInstance, TException> context)
+        where TException : Exception;
+
+
+    /// <summary>
+    /// Provides an address for the request service
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <typeparam name="TData"></typeparam>
+    /// <typeparam name="TException"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate Uri ServiceAddressExceptionProvider<in TInstance, in TData, in TException>(ConsumeExceptionEventContext<TInstance, TData, TException> context)
         where TData : class
         where TException : Exception;
 }

--- a/src/MassTransit.AutomatonymousIntegration/ServiceAddressProvider.cs
+++ b/src/MassTransit.AutomatonymousIntegration/ServiceAddressProvider.cs
@@ -32,17 +32,4 @@ namespace Automatonymous
     /// <returns></returns>
     public delegate Uri ServiceAddressProvider<in TInstance, in TData>(ConsumeEventContext<TInstance, TData> context)
         where TData : class;
-
-
-    /// <summary>
-    /// Provides an address for the request service
-    /// </summary>
-    /// <typeparam name="TInstance"></typeparam>
-    /// <typeparam name="TData"></typeparam>
-    /// <typeparam name="TException"></typeparam>
-    /// <param name="context"></param>
-    /// <returns></returns>
-    public delegate Uri ServiceAddressProvider<in TInstance, in TData, in TException>(ConsumeExceptionEventContext<TInstance, TData, TException> context)
-        where TData : class
-        where TException : Exception;
 }


### PR DESCRIPTION
The API is currently allowing 
- `Send`/`SendAsync`
- `Schedule`/`Unschedule`
- `Respond`/`RespondAsync`
- `Request`
- `Publish`/`PublishAsync`

 from
- `When(Event)`
- `When(Event).Catch<Exception>()`
- `WhenEnter(State)`

but not from
- `WhenEnter(State).Catch<Exception>().`

This PR aims to close this gap in the API.

-----

Some renaming had to occur to remove a collision between `<TInstance, TData>` and `<TInstance, TException>`

This is sort of a breaking change as projects referencing these types might need to adapt their code a little bit.
