### PR TITLE
Added missing GroupId and DeduplicationId in AmazonSqsSendContext

### DIFF
--- a/src/MassTransit.AmazonSqsTransport/AmazonSqsSendContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/AmazonSqsSendContext.cs
@@ -23,5 +23,7 @@ namespace MassTransit.AmazonSqsTransport
     public interface AmazonSqsSendContext :
         SendContext
     {
+        string GroupId { get; set; }
+        string DeduplicationId { get; set; }
     }
 }


### PR DESCRIPTION
Those properties have been added to `TransportAmazonSqsSendContext` but should also be defined in `AmazonSqsSendContext` interface.