### PR TITLE
Update README.md

### DIFF
--- a/docs/understand/README.md
+++ b/docs/understand/README.md
@@ -12,6 +12,5 @@ Okay, not everything -- at least not yet. But we're working on getting it all do
 * [Under the hood](under-the-hood.md)
 * [What we add to the transport](additions-to-transport.md)
 * [Publishing messages](publishing.md)
-* [Sending messages](sending.md)
 * [Handling faults](faults.md)
 * [Performance counters](perfcounters.md)


### PR DESCRIPTION
Sending messages documentation file (sending.md) is not there anymore. Therefor the link directs to a 404 not found page.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
