### PR TITLE
Fix exception when using MessageRequestClient from asp.net/signalr - Fixes #1395

### DIFF
--- a/src/MassTransit/Clients/ClientRequestHandle.cs
+++ b/src/MassTransit/Clients/ClientRequestHandle.cs
@@ -198,7 +198,7 @@ namespace MassTransit.Clients
             }
         }
 
-        async void HandleFault()
+        async Task HandleFault()
         {
             try
             {


### PR DESCRIPTION
When running under ASP.Net/SignalR (not dotnet core) the `AspNetSynchronisationContext` won't allow `async void` methods to be called.
Changing this to an `async Task` fixes the problem.

