### PR TITLE
Add MassTransit Logo to Nuget Packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,6 +26,7 @@
 
   <PropertyGroup Condition="'$(MSBuildProjectName.Contains(Tests))' == false">
     <!-- Nuget Package Details -->
+    <PackageIconUrl>http://masstransit-project.com/public/open-graph-logo.png</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>MassTransit is a message-based distributed application framework for .NET http://masstransit-project.com</Description>
     <IsPackable>True</IsPackable>


### PR DESCRIPTION
- Will help users identify official MassTransit Packages in Nuget package search