### PR TITLE
Strip address part when comparing forwardTo in CreateSubscription

### DIFF
--- a/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusNamespaceContext.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Contexts/ServiceBusNamespaceContext.cs
@@ -180,12 +180,16 @@ namespace MassTransit.AzureServiceBusTransport.Contexts
                 }
                 else
                 {
-                    var forwardTo = subscriptionDescription.ForwardTo;
-                    var address = _namespaceManager.Address.ToString();
-                    if (forwardTo.StartsWith(address))
-                        forwardTo = forwardTo.Substring(address.Length).Trim('/');
+                    string NormalizeForwardTo(string forwardTo)
+                    {
+                        var address = _namespaceManager.Address.ToString();
+                        return forwardTo.Replace(address, string.Empty).Trim('/');
+                    }
+                    
+                    var targetForwardTo = NormalizeForwardTo(description.ForwardTo);
+                    var currentForwardTo = NormalizeForwardTo(subscriptionDescription.ForwardTo);
 
-                    if (description.ForwardTo.Equals(forwardTo))
+                    if (targetForwardTo.Equals(currentForwardTo))
                     {
                         if (_log.IsDebugEnabled)
                             _log.DebugFormat("Updating subscription: {0} ({1} -> {2})", subscriptionDescription.Name, subscriptionDescription.TopicPath,


### PR DESCRIPTION
We are having an issue with lost topic-subscription for ASB. In cases when ASB throws an exception while configuring the topology, the target forwardTo value contains the ASB uri. This fails the comparison and the subscription is deleted for that topic.

I think other people is also having kind of this issue. Eg. here:
https://github.com/MassTransit/MassTransit/issues/1137
https://github.com/MassTransit/MassTransit/issues/1227