### PR TITLE
Add ClientContextProvider

### DIFF
--- a/src/MassTransit.AmazonSqsTransport/ClientContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/ClientContext.cs
@@ -24,7 +24,7 @@ namespace MassTransit.AmazonSqsTransport
 
 
     public interface ClientContext :
-        PipeContext
+        PipeContext, IAsyncDisposable
     {
         /// <summary>
         /// The connection context for the model

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsBusConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsBusConfiguration.cs
@@ -17,6 +17,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
     using Topology;
     using Topology.Settings;
     using Topology.Topologies;
+    using Transport;
 
 
     public class AmazonSqsBusConfiguration :
@@ -29,6 +30,8 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
             : base(topology)
         {
             _hosts = new HostCollection<IAmazonSqsHostConfiguration>();
+
+            ClientContextProvider = new ClientContextProvider();
         }
 
         public bool DeployTopologyOnly { get; set; }
@@ -77,6 +80,8 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
         }
 
         public IReadOnlyHostCollection Hosts => _hosts;
+
+        public IClientContextProvider ClientContextProvider { get; set; }
 
         IAmazonSqsHostTopology CreateHostTopology(Uri hostAddress)
         {

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsBusConfiguration.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configuration/IAmazonSqsBusConfiguration.cs
@@ -15,8 +15,8 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
     using System;
     using MassTransit.Configuration;
     using Topology.Settings;
-
-
+    using Transport;
+    
     public interface IAmazonSqsBusConfiguration :
         IBusConfiguration
     {
@@ -72,5 +72,10 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configuration
         /// <returns></returns>
         IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(QueueReceiveSettings settings,
             IAmazonSqsEndpointConfiguration endpointConfiguration);
+
+        /// <summary>
+        /// Sets or gets the client context provider
+        /// </summary>
+        IClientContextProvider ClientContextProvider { get; set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
@@ -21,6 +21,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
     using MassTransit.Builders;
     using Topology.Configuration;
     using Topology.Settings;
+    using Transport;
 
 
     public class AmazonSqsBusFactoryConfigurator :
@@ -122,6 +123,11 @@ namespace MassTransit.AmazonSqsTransport.Configuration.Configurators
         public bool DeployTopologyOnly
         {
             set => _configuration.DeployTopologyOnly = value;
+        }
+
+        public IClientContextProvider ClientContextProvider
+        {
+            set => _configuration.ClientContextProvider = value;
         }
 
         public override void ReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter,

--- a/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsBusFactoryConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsBusFactoryConfigurator.cs
@@ -14,6 +14,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration
 {
     using System;
     using Topology.Configuration;
+    using Transport;
 
 
     public interface IAmazonSqsBusFactoryConfigurator :
@@ -77,5 +78,10 @@ namespace MassTransit.AmazonSqsTransport.Configuration
         /// <param name="queueName">The input queue name</param>
         /// <param name="configure">The configuration method</param>
         void ReceiveEndpoint(IAmazonSqsHost host, string queueName, Action<IAmazonSqsReceiveEndpointConfigurator> configure);
+
+        /// <summary>
+        /// Sets or gets the client context provider
+        /// </summary>
+        IClientContextProvider ClientContextProvider { set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/ConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/ConnectionContext.cs
@@ -47,5 +47,11 @@ namespace MassTransit.AmazonSqsTransport
         /// </summary>
         /// <returns></returns>
         Task<IAmazonSimpleNotificationService> CreateAmazonSns();
+
+        /// <summary>
+        /// Creates a client context
+        /// </summary>
+        /// <returns></returns>
+        Task<ClientContext> CreateClientContext();
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsClientContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsClientContext.cs
@@ -37,8 +37,7 @@ namespace MassTransit.AmazonSqsTransport.Contexts
 
     public class AmazonSqsClientContext :
         BasePipeContext,
-        ClientContext,
-        IAsyncDisposable
+        ClientContext
     {
         static readonly ILog _log = Logger.Get<AmazonSqsClientContext>();
 
@@ -50,13 +49,12 @@ namespace MassTransit.AmazonSqsTransport.Contexts
         readonly IDictionary<string, string> _queueUrls;
         readonly IDictionary<string, string> _topicArns;
 
-        public AmazonSqsClientContext(ConnectionContext connectionContext, IAmazonSQS amazonSqs, IAmazonSimpleNotificationService amazonSns,
-            CancellationToken cancellationToken)
-            : base(new PayloadCacheScope(connectionContext), cancellationToken)
+        public AmazonSqsClientContext(ConnectionContext connectionContext)
+            : base(new PayloadCacheScope(connectionContext), connectionContext.CancellationToken)
         {
             _connectionContext = connectionContext;
-            _amazonSqs = amazonSqs;
-            _amazonSns = amazonSns;
+            _amazonSqs = connectionContext.Connection.CreateAmazonSqsClient();
+            _amazonSns = connectionContext.Connection.CreateAmazonSnsClient();
 
             _taskScheduler = new LimitedConcurrencyLevelTaskScheduler(1);
 

--- a/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsConnectionContext.cs
@@ -54,5 +54,10 @@ namespace MassTransit.AmazonSqsTransport.Contexts
         {
             return Task.Factory.StartNew(() => Connection.CreateAmazonSnsClient(), CancellationToken, TaskCreationOptions.None, _taskScheduler);
         }
+
+        public Task<ClientContext> CreateClientContext()
+        {
+            return Task.Factory.StartNew(() => _configuration.BusConfiguration.ClientContextProvider.Create(this), CancellationToken, TaskCreationOptions.None, _taskScheduler);
+        }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Contexts/SharedClientContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/SharedClientContext.cs
@@ -137,5 +137,10 @@ namespace MassTransit.AmazonSqsTransport.Contexts
         }
 
         CancellationToken PipeContext.CancellationToken => _cancellationToken;
+
+        public Task DisposeAsync(CancellationToken cancellationToken)
+        {
+            return _context.DisposeAsync(cancellationToken);
+        }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Contexts/SharedConnectionContext.cs
+++ b/src/MassTransit.AmazonSqsTransport/Contexts/SharedConnectionContext.cs
@@ -69,5 +69,10 @@ namespace MassTransit.AmazonSqsTransport.Contexts
         {
             return _context.CreateAmazonSns();
         }
+
+        Task<ClientContext> ConnectionContext.CreateClientContext()
+        {
+            return _context.CreateClientContext();
+        }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/ReceiveClientFilter.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/ReceiveClientFilter.cs
@@ -40,10 +40,7 @@ namespace MassTransit.AmazonSqsTransport.Pipeline
 
         async Task IFilter<ConnectionContext>.Send(ConnectionContext context, IPipe<ConnectionContext> next)
         {
-            var amazonSqs = await context.CreateAmazonSqs().ConfigureAwait(false);
-            var amazonSns = await context.CreateAmazonSns().ConfigureAwait(false);
-
-            var modelContext = new AmazonSqsClientContext(context, amazonSqs, amazonSns, context.CancellationToken);
+            var modelContext = await context.CreateClientContext().ConfigureAwait(false);
 
             try
             {

--- a/src/MassTransit.AmazonSqsTransport/Transport/ClientContextFactory.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/ClientContextFactory.cs
@@ -63,10 +63,7 @@ namespace MassTransit.AmazonSqsTransport.Transport
 
                 try
                 {
-                    var amazonSqs = await connectionContext.CreateAmazonSqs().ConfigureAwait(false);
-                    var amazonSns = await connectionContext.CreateAmazonSns().ConfigureAwait(false);
-
-                    var modelContext = new AmazonSqsClientContext(connectionContext, amazonSqs, amazonSns, cancellationToken);
+                    var modelContext = await connectionContext.CreateClientContext();
 
                     await asyncContext.Created(modelContext).ConfigureAwait(false);
 

--- a/src/MassTransit.AmazonSqsTransport/Transport/ClientContextProvider.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/ClientContextProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    using Contexts;
+
+
+    public class ClientContextProvider : IClientContextProvider
+    {
+        public ClientContext Create(ConnectionContext connectionContext)
+        {
+            return new AmazonSqsClientContext(connectionContext);
+        }
+    }
+}

--- a/src/MassTransit.AmazonSqsTransport/Transport/IClientContextProvider.cs
+++ b/src/MassTransit.AmazonSqsTransport/Transport/IClientContextProvider.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.AmazonSqsTransport.Transport
+{
+    public interface IClientContextProvider
+    {
+        ClientContext Create(ConnectionContext connetionContext);
+    }
+}


### PR DESCRIPTION
Add ClientContextProvider to SQS Transport to allow the use of custom ClientContexts.

Implementation and unit test added.