### PR TITLE
Fix for #1437, an Unobserved Task Exception

### DIFF
--- a/src/MassTransit.Azure.ServiceBus.Core/Pipeline/JoinContextFactory.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Pipeline/JoinContextFactory.cs
@@ -18,6 +18,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Pipeline
     using GreenPipes;
     using GreenPipes.Agents;
     using Logging;
+    using Util;
 
 
     public abstract class JoinContextFactory<TLeft, TRight, TContext> :
@@ -45,7 +46,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Pipeline
         {
             IAsyncPipeContextAgent<TContext> asyncContext = supervisor.AddAsyncContext<TContext>();
 
-            Task<TContext> context = CreateJoinContext(asyncContext, supervisor.Stopped);
+            TaskUtil.Await(() => CreateJoinContext(asyncContext, supervisor.Stopped));
 
             return asyncContext;
         }


### PR DESCRIPTION
Fixes #1437 .  Prevents an unobserved-task exception by waiting on the task.

Tests pass locally, except for a couple unrelated ones due to missing LocalDB:
* In `MassTransit.AutomatonymousIntegration.Tests`
  * In `MassTransit.UnitTests.StateMachineTest`
     * `Test_Discarded_Missing_Saga_Instance_Is_Not_Persisted`
  * In `PreInsert.When_pre_inserting_the_state_machine_instance_using_ef`
    * `Should_receive_the_published_message`