### PR TITLE
Use MSBuild V15.X on Windows

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -53,13 +53,28 @@ Task("Build")
     .IsDependentOn("Restore-NuGet")
     .Does<BuildParameters>(data =>
 {
-    var settings = new DotNetCoreBuildSettings{
-        NoRestore = true,
-        Configuration = data.Configuration,
-        MSBuildSettings = new DotNetCoreMSBuildSettings().WithProperty("Version", data.Version.Version)
-    };
+    if(data.IsRunningOnUnix)
+    {
+        var settings = new DotNetCoreBuildSettings{
+            NoRestore = true,
+            Configuration = data.Configuration,
+            MSBuildSettings = new DotNetCoreMSBuildSettings().WithProperty("Version", data.Version.Version)
+        };
 
-    DotNetCoreBuild(data.Paths.Directories.Solution.FullPath, settings);
+        DotNetCoreBuild(data.Paths.Directories.Solution.FullPath, settings);
+    }
+    else
+    {
+        var settings = new MSBuildSettings
+        {
+            Restore = false,
+            Configuration = data.Configuration,
+            ToolVersion = MSBuildToolVersion.VS2017
+        };
+
+        MSBuild(data.Paths.Directories.Solution.FullPath, settings.WithProperty("Version",data.Version.Version));
+    }
+
 });
 
 Task("Test")

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Product>MassTransit</Product>
     <Copyright>Copyright 2007-2019 Chris Patterson</Copyright>
     <Authors>Chris Patterson</Authors>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
When installing VS2017 and VS2019 side by side, it will use MSBuild V16, and enforce C#8 rules, even though it's still in preview.

So we explicitly use MSBuild V15, and set the lang version to 7.3

Once .NET Core 3.0 is released, this will likely need to be modified again, once we want to support C#8