### PR TITLE
Do not default SessionId to ConversationId.

### DIFF
--- a/src/MassTransit.Azure.ServiceBus.Core/Transport/ServiceBusSendTransport.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Transport/ServiceBusSendTransport.cs
@@ -216,13 +216,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Transport
                 if (context.PartitionKey != null)
                     brokeredMessage.PartitionKey = context.PartitionKey;
 
-                var sessionId = string.IsNullOrWhiteSpace(context.SessionId) ? context.ConversationId?.ToString("N") : context.SessionId;
-                if (!string.IsNullOrWhiteSpace(sessionId))
+                if (!string.IsNullOrWhiteSpace(context.SessionId))
                 {
-                    brokeredMessage.SessionId = sessionId;
+                    brokeredMessage.SessionId = context.SessionId;
 
                     if (context.ReplyToSessionId == null)
-                        brokeredMessage.ReplyToSessionId = sessionId;
+                        brokeredMessage.ReplyToSessionId = context.SessionId;
                 }
 
                 if (context.ReplyToSessionId != null)

--- a/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransport.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/ServiceBusSendTransport.cs
@@ -217,13 +217,12 @@ namespace MassTransit.AzureServiceBusTransport.Transport
                 if (context.PartitionKey != null)
                     brokeredMessage.PartitionKey = context.PartitionKey;
 
-                var sessionId = string.IsNullOrWhiteSpace(context.SessionId) ? context.ConversationId?.ToString("N") : context.SessionId;
-                if (!string.IsNullOrWhiteSpace(sessionId))
+                if (!string.IsNullOrWhiteSpace(context.SessionId))
                 {
-                    brokeredMessage.SessionId = sessionId;
+                    brokeredMessage.SessionId = context.SessionId;
 
                     if (context.ReplyToSessionId == null)
-                        brokeredMessage.ReplyToSessionId = sessionId;
+                        brokeredMessage.ReplyToSessionId = context.SessionId;
                 }
 
                 if (context.ReplyToSessionId != null)


### PR DESCRIPTION
SessionId was being set to ConversationId when otherwise unspecified by the user. This has the potential (to be determined) to break the Azure Service Bus auto-forwarder feature when sending messages to non-partitioned topics that are forwarding to partitioned queues. At least according to Azure support.

@phatboyg Seems to think there isn't a good reason for this to be done.