### PR TITLE
Make health check less opinionated and more configurable

### DIFF
--- a/src/Containers/MassTransit.AspNetCoreIntegration/HealthChecks/HealthCheckOptions.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/HealthChecks/HealthCheckOptions.cs
@@ -1,15 +1,22 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Collections.Generic;
+
 namespace MassTransit.AspNetCoreIntegration.HealthChecks
 {
     public class HealthCheckOptions
     {
         public string BusHealthCheckName { get; set; }
         public string ReceiveEndpointHealthCheckName { get; set; }
+        public HealthStatus FailureStatus { get; set; }
+        public IEnumerable<string> Tags { get; set; }
 
         public static HealthCheckOptions Default
             => new HealthCheckOptions
             {
                 BusHealthCheckName = "masstransit-bus",
-                ReceiveEndpointHealthCheckName = "masstransit-endpoint"
+                ReceiveEndpointHealthCheckName = "masstransit-endpoint",
+                FailureStatus = HealthStatus.Unhealthy,
+                Tags = new[] { "ready" }
             };
     }
 }

--- a/src/Containers/MassTransit.AspNetCoreIntegration/ServiceCollectionExtensions.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/ServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@
     using Logging;
     using Logging.Tracing;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Diagnostics.HealthChecks;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
 
@@ -115,8 +114,8 @@
             configureHealthChecks?.Invoke(healthCheckOptions);
 
             services.AddHealthChecks()
-                .AddBusHealthCheck(healthCheckOptions.BusHealthCheckName, busCheck)
-                .AddBusHealthCheck(healthCheckOptions.ReceiveEndpointHealthCheckName, receiveEndpointCheck);
+                .AddCheck(healthCheckOptions.BusHealthCheckName, busCheck, healthCheckOptions.FailureStatus, healthCheckOptions.Tags)
+                .AddCheck(healthCheckOptions.ReceiveEndpointHealthCheckName, receiveEndpointCheck, healthCheckOptions.FailureStatus, healthCheckOptions.Tags);
 
             services.AddSingleton<IHostedService>(p =>
             {
@@ -125,11 +124,6 @@
 
                 return new MassTransitHostedService(bus, loggerFactory, busCheck, receiveEndpointCheck);
             });
-        }
-
-        static IHealthChecksBuilder AddBusHealthCheck(this IHealthChecksBuilder builder, string healthCheckName, IHealthCheck healthCheck)
-        {
-            return builder.AddCheck(healthCheckName, healthCheck, HealthStatus.Unhealthy, new[] {"ready"});
         }
     }
 }


### PR DESCRIPTION
It's a small PR that lets you provide desired FailureStatus and Tags for MT health check.
Why is it needed? Let's take as an example an app that receives messages from rabbitMQ using MT, stores them to database and serves them via HTTP. If rabbitMQ is down - the app can still answer HTTP calls and return whatever it has in database. So the app is still working but not fully - hence it's degraded.
Without this PR the app would have Unhealthy status which if used together with k8s would stop k8s from connecting the app to load balancer rendering the app offline and inaccessible.
The PR is backwards compatible because it uses old values as default values in HealthCheckOptions