### PR TITLE
Add the ability to create only exchange for RabbitMq ReceiveEndpoint

### DIFF
--- a/src/MassTransit.RabbitMqTransport/Configuration/Builders/RabbitMqReceiveEndpointBuilder.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Builders/RabbitMqReceiveEndpointBuilder.cs
@@ -92,12 +92,15 @@ namespace MassTransit.RabbitMqTransport.Builders
                 queueAutoDelete = false;
             }
 
-            topologyBuilder.Queue = topologyBuilder.QueueDeclare(settings.QueueName, settings.Durable, queueAutoDelete, settings.Exclusive, queueArguments);
-
             topologyBuilder.Exchange = topologyBuilder.ExchangeDeclare(settings.ExchangeName ?? settings.QueueName, settings.ExchangeType, settings.Durable,
                 settings.AutoDelete, settings.ExchangeArguments);
 
-            topologyBuilder.QueueBind(topologyBuilder.Exchange, topologyBuilder.Queue, settings.RoutingKey, settings.BindingArguments);
+            if (settings.BindQueue)
+            {
+                topologyBuilder.Queue = topologyBuilder.QueueDeclare(settings.QueueName, settings.Durable, queueAutoDelete, settings.Exclusive, queueArguments);
+
+                topologyBuilder.QueueBind(topologyBuilder.Exchange, topologyBuilder.Queue, settings.RoutingKey, settings.BindingArguments);
+            }
 
             _configuration.Topology.Consume.Apply(topologyBuilder);
 

--- a/src/MassTransit.RabbitMqTransport/Configuration/Configuration/RabbitMqReceiveEndpointConfiguration.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configuration/RabbitMqReceiveEndpointConfiguration.cs
@@ -179,6 +179,11 @@ namespace MassTransit.RabbitMqTransport.Configuration
             set => _settings.Lazy = value;
         }
 
+        public bool BindQueue
+        {
+            set => _settings.BindQueue = value;
+        }
+
         public TimeSpan? QueueExpiration
         {
             set => _settings.QueueExpiration = value;

--- a/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqReceiveEndpointConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/IRabbitMqReceiveEndpointConfigurator.cs
@@ -29,6 +29,11 @@ namespace MassTransit.RabbitMqTransport
         bool BindMessageExchanges { set; }
 
         /// <summary>
+        /// If false, deploys only exchange, without queue
+        /// </summary>
+        bool BindQueue { set; }
+
+        /// <summary>
         /// Specifies the dead letter exchange name, which is used to send expired messages
         /// </summary>
         string DeadLetterExchange { set; }

--- a/src/MassTransit.RabbitMqTransport/Topology/ReceiveSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/ReceiveSettings.cs
@@ -68,6 +68,11 @@ namespace MassTransit.RabbitMqTransport.Topology
         TimeSpan? QueueExpiration { get; }
 
         /// <summary>
+        /// If false, deploys only exchange, without queue
+        /// </summary>
+        bool BindQueue { get; }
+
+        /// <summary>
         /// Get the input address for the transport on the specified host
         /// </summary>
         Uri GetInputAddress(Uri hostAddress);

--- a/src/MassTransit.RabbitMqTransport/Topology/Settings/RabbitMqReceiveSettings.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/Settings/RabbitMqReceiveSettings.cs
@@ -33,6 +33,8 @@ namespace MassTransit.RabbitMqTransport.Topology.Settings
         public bool PurgeOnStartup { get; set; }
         public bool ExclusiveConsumer { get; set; }
 
+        public bool BindQueue { get; set; } = true;
+
         public int ConsumerPriority
         {
             set => ConsumeArguments["x-priority"] = value;


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
When is used `DeployTopologyOnly=true` for creating RabbitMQ Bus very useful to have the ability to deploy the only exchange, without a queue.  It's helpful for cases when we have a topology with direct exchanges.  
 For this purpose added property `CreateExchangeOnly` in IRabbitMqReceiveEndpointConfigurator.