### PR TITLE
Use FailureStatus from health check registration rather than hardcoded

### DIFF
--- a/src/Containers/MassTransit.AspNetCoreIntegration/HealthChecks/SimplifiedBusHealthCheck.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/HealthChecks/SimplifiedBusHealthCheck.cs
@@ -14,7 +14,7 @@ namespace MassTransit.AspNetCoreIntegration.HealthChecks
         {
             return Task.FromResult(_busStarted
                 ? HealthCheckResult.Healthy("Bus started")
-                : HealthCheckResult.Unhealthy("Bus not yet started"));
+                : new HealthCheckResult(context.Registration.FailureStatus, "Bus not yet started"));
         }
 
         public void ReportBusStarted()


### PR DESCRIPTION
Last time I made a mistake - I created a PR and I didn't check that the code works because the change was so trivial that I didn't think anything could be wrong. Unfortunately I missed that there were two places where failure status for health checks was hardcoded so that my customization didn't work as intended.
I learned my lesson and now I really tested it in my real project
This PR removes hardcoded health check failure status and uses the status from health check registration that is initially comes from HealthCheckOptions.FailureStatus