### PR TITLE
- fix reschedule message when quartz uses old jobDetails

### DIFF
--- a/src/MassTransit.QuartzIntegration.Tests/PastEvent_Specs.cs
+++ b/src/MassTransit.QuartzIntegration.Tests/PastEvent_Specs.cs
@@ -1,19 +1,20 @@
 ﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.QuartzIntegration.Tests
 {
     using System;
     using System.Threading.Tasks;
+    using Context;
     using GreenPipes;
     using NUnit.Framework;
 
@@ -109,6 +110,49 @@ namespace MassTransit.QuartzIntegration.Tests
             await QuartzEndpoint.ScheduleSend(Bus.Address, DateTime.UtcNow + TimeSpan.FromHours(-1), new A {Name = "Joe"});
 
             await handler;
+        }
+    }
+
+
+    [TestFixture]
+    public class Specifying_an_event_reschedule_if_exists :
+        QuartzInMemoryTestFixture
+    {
+        public Specifying_an_event_reschedule_if_exists()
+        {
+            ScheduleTokenId.UseTokenId<A>(x => x.Id);
+        }
+
+
+        class A
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+
+
+        [Test]
+        public async Task Should_reschedule()
+        {
+            var handler = SubscribeHandler<A>();
+            var id = NewId.NextGuid();
+            var expected = "Joe 2";
+            await QuartzEndpoint.ScheduleSend(Bus.Address, TimeSpan.FromSeconds(120), new A
+            {
+                Id = id,
+                Name = "Joe"
+            });
+
+            await Task.Delay(2000);
+
+            await QuartzEndpoint.ScheduleSend(Bus.Address, TimeSpan.FromSeconds(5), new A
+            {
+                Id = id,
+                Name = expected
+            });
+
+            ConsumeContext<A> result = await handler;
+            Assert.AreEqual(expected, result.Message.Name);
         }
     }
 }

--- a/src/MassTransit.QuartzIntegration/CancelScheduledMessageConsumer.cs
+++ b/src/MassTransit.QuartzIntegration/CancelScheduledMessageConsumer.cs
@@ -35,7 +35,7 @@ namespace MassTransit.QuartzIntegration
             var correlationId = context.Message.TokenId.ToString("N");
 
             var jobKey = new JobKey(correlationId);
-            var deletedJob = await _scheduler.DeleteJob(jobKey).ConfigureAwait(false);
+            var deletedJob = await _scheduler.DeleteJob(jobKey, context.CancellationToken).ConfigureAwait(false);
 
             if (_log.IsDebugEnabled)
             {
@@ -53,11 +53,10 @@ namespace MassTransit.QuartzIntegration
             string scheduleId = context.Message.ScheduleId;
 
             if (!scheduleId.StartsWith(prependedValue))
-            {
                 scheduleId = string.Concat(prependedValue, scheduleId);
-            }
 
-            bool unscheduledJob = await _scheduler.UnscheduleJob(new TriggerKey(scheduleId, context.Message.ScheduleGroup)).ConfigureAwait(false);
+            bool unscheduledJob = await _scheduler.UnscheduleJob(new TriggerKey(scheduleId, context.Message.ScheduleGroup), context.CancellationToken)
+                .ConfigureAwait(false);
 
             if (_log.IsDebugEnabled)
             {

--- a/src/MassTransit.QuartzIntegration/MassTransitJobFactory.cs
+++ b/src/MassTransit.QuartzIntegration/MassTransitJobFactory.cs
@@ -155,8 +155,7 @@ namespace MassTransit.QuartzIntegration
         /// <param name="bundle"></param>
         string CreatePayloadHeaderString(TriggerFiredBundle bundle)
         {
-            var timeHeaders = new Dictionary<string, DateTimeOffset?>();
-            timeHeaders.Add(MessageHeaders.Quartz.Sent, bundle.FireTimeUtc);
+            var timeHeaders = new Dictionary<string, DateTimeOffset?> {{MessageHeaders.Quartz.Sent, bundle.FireTimeUtc}};
             if (bundle.ScheduledFireTimeUtc.HasValue)
                 timeHeaders.Add(MessageHeaders.Quartz.Scheduled, bundle.ScheduledFireTimeUtc);
 

--- a/src/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
+++ b/src/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
@@ -13,6 +13,8 @@
 namespace MassTransit
 {
     using System;
+    using System.Diagnostics;
+    using System.Threading;
     using GreenPipes;
     using Quartz;
     using Quartz.Impl;
@@ -47,7 +49,7 @@ namespace MassTransit
 
             configurator.ReceiveEndpoint(queueName, e =>
             {
-                var partitioner = configurator.CreatePartitioner(16);
+                var partitioner = configurator.CreatePartitioner(Environment.ProcessorCount);
 
                 e.Consumer(() => new ScheduleMessageConsumer(scheduler), x =>
                     x.Message<ScheduleMessage>(m => m.UsePartitioner(partitioner, p => p.Message.CorrelationId)));

--- a/src/MassTransit.QuartzIntegration/ScheduledMessageJob.cs
+++ b/src/MassTransit.QuartzIntegration/ScheduledMessageJob.cs
@@ -48,7 +48,7 @@ namespace MassTransit.QuartzIntegration
 
                 var scheduled = new Scheduled();
 
-                await endpoint.Send(scheduled, sendPipe).ConfigureAwait(false);
+                await endpoint.Send(scheduled, sendPipe, context.CancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -99,10 +99,9 @@ namespace MassTransit.QuartzIntegration
         static Guid? ConvertIdToGuid(string id)
         {
             if (string.IsNullOrWhiteSpace(id))
-                return default(Guid?);
+                return default;
 
-            Guid messageId;
-            if (Guid.TryParse(id, out messageId))
+            if (Guid.TryParse(id, out var messageId))
                 return messageId;
 
             throw new FormatException("The Id was not a Guid: " + id);


### PR DESCRIPTION
When `TokenId` for schedule message is the same, Quartz should reschedule a message with new data, but now it uses old data and only change a trigger date.
Also other improvements:
- use `CancellationToken` from `ConsumeContext`
- use `CancellationToken` from `IJobExecutionContext`
- use `Environment.ProcessorCount` for partitioner