### PR TITLE
When converting from object to Enum, first converts input to the Enum…

### DIFF
--- a/src/MassTransit.Tests/Initializers/Expando_Specs.cs
+++ b/src/MassTransit.Tests/Initializers/Expando_Specs.cs
@@ -62,12 +62,16 @@ namespace MassTransit.Tests.Initializers
             dto.Add(nameof(MessageContract.Id), 27);
             dto.Add(nameof(MessageContract.CustomerId), "SuperMart");
             dto.Add(nameof(MessageContract.UniqueId), uniqueId);
+            dto.Add(nameof(MessageContract.CustomerType),(long)1);
+            dto.Add(nameof(MessageContract.TypeByName),"Internal");
 
             var message = await MessageInitializerCache<MessageContract>.Initialize(dto);
 
             Assert.That(message.Message.Id, Is.EqualTo(27));
             Assert.That(message.Message.CustomerId, Is.EqualTo("SuperMart"));
             Assert.That(message.Message.UniqueId, Is.EqualTo(uniqueId));
+            Assert.That(message.Message.CustomerType, Is.EqualTo(CustomerType.Public));
+            Assert.That(message.Message.TypeByName, Is.EqualTo(CustomerType.Internal));
         }
 
 
@@ -76,8 +80,15 @@ namespace MassTransit.Tests.Initializers
             int Id { get; }
             string CustomerId { get; }
             Guid UniqueId { get; }
+            CustomerType CustomerType { get; }
+            CustomerType TypeByName { get; }
         }
 
+        public enum CustomerType
+        {
+            Public = 1,
+            Internal = 2
+        }
 
         public interface MessageEnvelope
         {

--- a/src/MassTransit/Initializers/TypeConverters/EnumTypeConverter.cs
+++ b/src/MassTransit/Initializers/TypeConverters/EnumTypeConverter.cs
@@ -119,11 +119,16 @@
 
         public bool TryConvert(object input, out T result)
         {
+            if (input is string)
+                return TryConvert(input as string, out result);
+
             if (input != null)
             {
-                if (Enum.IsDefined(typeof(T), input))
+                var value = Convert.ChangeType(input, Enum.GetUnderlyingType(typeof(T)));
+
+                if (Enum.IsDefined(typeof(T), value))
                 {
-                    result = (T)Enum.Parse(typeof(T), Enum.GetName(typeof(T), input));
+                    result = (T)Enum.Parse(typeof(T), Enum.GetName(typeof(T), value));
                     return true;
                 }
             }


### PR DESCRIPTION
When converting from object to Enum, if the object wasn't of the same type as the underlying Enum type, an exception was thrown.

With this PR, the Enum Initializer will first convert the input to the enum underlying type, or it will call the initializer for string input.

Adresses issue #1511

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
