### PR TITLE
Fixed regression in deserializing ISet/HashSet

### DIFF
--- a/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/MoreSerialization_Specs.cs
@@ -158,6 +158,120 @@ namespace MassTransit.Tests.Serialization
         }
 
 
+        public class PrimitiveHashSetClass
+        {
+            public PrimitiveHashSetClass()
+            {
+                Values = new HashSet<int>();
+            }
+
+            public HashSet<int> Values { get; set; }
+
+            public bool Equals(PrimitiveHashSetClass other)
+            {
+                if (ReferenceEquals(null, other))
+                    return false;
+
+                if (ReferenceEquals(this, other))
+                    return true;
+
+                if (ReferenceEquals(other.Values, Values))
+                    return true;
+
+                if (other.Values == null && Values != null)
+                    return false;
+
+                if (other.Values != null && Values == null)
+                    return false;
+
+                if (other.Values != null && Values != null)
+                {
+                    if (other.Values.Count != Values.Count)
+                        return false;
+
+                    return other.Values.SetEquals(Values);
+                }
+
+                return true;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj))
+                    return false;
+
+                if (ReferenceEquals(this, obj))
+                    return true;
+
+                if (obj.GetType() != typeof(PrimitiveHashSetClass))
+                    return false;
+
+                return Equals((PrimitiveHashSetClass)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return (Values != null ? Values.GetHashCode() : 0);
+            }
+        }
+
+        public class PrimitiveSetClass
+        {
+            public PrimitiveSetClass()
+            {
+                Values = new HashSet<int>();
+            }
+
+            public ISet<int> Values { get; set; }
+
+            public bool Equals(PrimitiveSetClass other)
+            {
+                if (ReferenceEquals(null, other))
+                    return false;
+
+                if (ReferenceEquals(this, other))
+                    return true;
+
+                if (ReferenceEquals(other.Values, Values))
+                    return true;
+
+                if (other.Values == null && Values != null)
+                    return false;
+
+                if (other.Values != null && Values == null)
+                    return false;
+
+                if (other.Values != null && Values != null)
+                {
+                    if (other.Values.Count != Values.Count)
+                        return false;
+
+                    return other.Values.SetEquals(Values);
+                }
+
+                return true;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj))
+                    return false;
+
+                if (ReferenceEquals(this, obj))
+                    return true;
+
+                if (obj.GetType() != typeof(PrimitiveSetClass))
+                    return false;
+
+                return Equals((PrimitiveSetClass)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return (Values != null ? Values.GetHashCode() : 0);
+            }
+        }
+
         [Serializable]
         public class PrimitiveArrayClass
         {
@@ -586,6 +700,38 @@ namespace MassTransit.Tests.Serialization
         public void A_readonly_dictionary_list_message()
         {
             var message = new SucceededCommandResult(NewId.NextGuid());
+
+            TestSerialization(message);
+        }
+
+        [Test]
+        public void A_hashset_of_integers_should_be_properly_serialized()
+        {
+            var message = new PrimitiveHashSetClass()
+            {
+                Values =
+                {
+                    1,
+                    2,
+                    3
+                }
+            };
+
+            TestSerialization(message);
+        }
+
+        [Test]
+        public void A_set_of_integers_should_be_properly_serialized()
+        {
+            var message = new PrimitiveSetClass()
+            {
+                Values =
+                {
+                    1,
+                    2,
+                    3
+                }
+            };
 
             TestSerialization(message);
         }

--- a/src/MassTransit/Serialization/JsonConverters/ListJsonConverter.cs
+++ b/src/MassTransit/Serialization/JsonConverters/ListJsonConverter.cs
@@ -87,8 +87,8 @@ namespace MassTransit.Serialization.JsonConverters
                 if (reader.TokenType == JsonToken.Null)
                     return null;
 
-                IList<T> list = contract.DefaultCreator != null
-                    ? contract.DefaultCreator() as IList<T>
+                ICollection<T> list = contract.DefaultCreator != null
+                    ? contract.DefaultCreator() as ICollection<T>
                     : new List<T>();
 
                 if (reader.TokenType == JsonToken.StartArray)


### PR DESCRIPTION
The `ListJsonConverter` was recently changed to check for the existence of `IReadOnlyCollection`, but this breaks deserialization for `ISet<T>` and derivatives because the collection is then safe-casted to `IList<T>` which is not an interface implemented by sets, resulting in null and the below exception. I've changed the cast to `ICollection<T>`, which sets do implement. I've added two tests that make sure the change functions properly.

The error:

```
Parameter name: target
System.ArgumentNullException: Value cannot be null.
Parameter name: target
   at Newtonsoft.Json.Utilities.ValidationUtils.ArgumentNotNull(Object value, String parameterName)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Populate(JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerProxy.PopulateInternal(JsonReader reader, Object target)
   at Newtonsoft.Json.JsonSerializer.Populate(JsonReader reader, Object target)
   at MassTransit.Serialization.JsonConverters.ListJsonConverter.CachedConverter`1.MassTransit.Serialization.JsonConverters.BaseJsonConverter.IConverter.D
eserialize(JsonReader reader, Type objectType, JsonSerializer serializer)
   at MassTransit.Serialization.JsonConverters.BaseJsonConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer seriali
zer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Objec
t existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerCon
tract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProp
erty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty memb
er, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProper
ty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerCon
tract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProp
erty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty memb
er, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProper
ty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at MassTransit.Serialization.JsonConsumeContext.TryGetMessage[T](ConsumeContext`1& message)
   at MassTransit.Context.Converters.ConsumeContextConverterFactory.Converter`1.GreenPipes.Filters.IPipeContextConverter<MassTransit.ConsumeContext,MassTr
ansit.ConsumeContext<T>>.TryConvert(ConsumeContext input, ConsumeContext`1& output)
   at GreenPipes.Filters.OutputPipeFilter`2.GreenPipes.IFilter<TInput>.Send(TInput context, IPipe`1 next)
   at GreenPipes.Filters.DynamicFilter`1.OutputPipe`1.Send(TInput context)
   at GreenPipes.Filters.DynamicFilter`1.Send(TInput context, IPipe`1 next)
   at MassTransit.Pipeline.Filters.DeserializeFilter.Send(ReceiveContext context, IPipe`1 next)
   at GreenPipes.Filters.RescueFilter`2.GreenPipes.IFilter<TContext>.Send(TContext context, IPipe`1 next)
```