### PR TITLE
Fix ubuntu build test reporting and update cake

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ skip_commits:
 
 image:
   - Visual Studio 2017
-  - Ubuntu1804
+  - Previous Ubuntu1804
 
 services:
   - mongodb

--- a/build.cake
+++ b/build.cake
@@ -53,28 +53,13 @@ Task("Build")
     .IsDependentOn("Restore-NuGet")
     .Does<BuildParameters>(data =>
 {
-    if(data.IsRunningOnUnix)
-    {
-        var settings = new DotNetCoreBuildSettings{
-            NoRestore = true,
-            Configuration = data.Configuration,
-            MSBuildSettings = new DotNetCoreMSBuildSettings().WithProperty("Version", data.Version.Version)
-        };
+    var settings = new DotNetCoreBuildSettings{
+        NoRestore = true,
+        Configuration = data.Configuration,
+        MSBuildSettings = new DotNetCoreMSBuildSettings().WithProperty("Version", data.Version.Version)
+    };
 
-        DotNetCoreBuild(data.Paths.Directories.Solution.FullPath, settings);
-    }
-    else
-    {
-        var settings = new MSBuildSettings
-        {
-            Restore = false,
-            Configuration = data.Configuration,
-            ToolVersion = MSBuildToolVersion.VS2017
-        };
-
-        MSBuild(data.Paths.Directories.Solution.FullPath, settings.WithProperty("Version",data.Version.Version));
-    }
-
+    DotNetCoreBuild(data.Paths.Directories.Solution.FullPath, settings);
 });
 
 Task("Test")

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.32.1" />
+    <package id="Cake" version="0.34.1" />
 </packages>


### PR DESCRIPTION
Ubuntu test results stopped showing up. Started [thread here](https://help.appveyor.com/discussions/problems/24784-dotnet-test-from-ubuntu1804-started-failing-to-post-results-to-appveyor-api) to ask, they recommended using previous.

Also they fixed the dotnet build, so don't need to perform the check in cake anymore to run MSBuild versus DotNetCoreBuild