### PR TITLE
Fix for ?? operator priority

### DIFF
--- a/src/MassTransit.AmazonSqsTransport/Topology/AmazonSqsHostEqualityComparer.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/AmazonSqsHostEqualityComparer.cs
@@ -40,7 +40,7 @@ namespace MassTransit.AmazonSqsTransport.Topology
             unchecked
             {
                 var hashCode = obj.AccessKey?.GetHashCode() ?? 0;
-                hashCode = (hashCode * 397) ^ obj.Region?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (obj.Region?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }


### PR DESCRIPTION
Priority of '??' operator is lower than '^'. And without parentheses we always get hashCode=0 if obj.Region is null. With parentheses we get correct value.