### PR TITLE
Scheduler Outbox

### DIFF
--- a/src/MassTransit.QuartzIntegration.Tests/OutboxScheduler_Specs.cs
+++ b/src/MassTransit.QuartzIntegration.Tests/OutboxScheduler_Specs.cs
@@ -1,0 +1,112 @@
+﻿namespace MassTransit.QuartzIntegration.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using GreenPipes.Internals.Extensions;
+    using NUnit.Framework;
+    using TestFramework;
+    using TestFramework.Messages;
+
+
+    public class Cancel_scheduled_message_through_the_outbox :
+        QuartzInMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_cancel_the_message()
+        {
+            await InputQueueSendEndpoint.Send(new PingMessage());
+
+            await _pingReceived.Task;
+
+            Console.WriteLine("Ping was received");
+
+            var scheduledMessage = await _scheduledMessage.Task;
+
+            Console.WriteLine("Pong was scheduled");
+
+            Assert.That(async () => await _pongReceived.Task.UntilCompletedOrTimeout(5000), Throws.TypeOf<TimeoutException>());
+        }
+
+        TaskCompletionSource<ConsumeContext<PingMessage>> _pingReceived;
+        TaskCompletionSource<ConsumeContext<PongMessage>> _pongReceived;
+        TaskCompletionSource<Scheduling.ScheduledMessage> _scheduledMessage;
+
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            configurator.UseInMemoryOutbox();
+
+            _pingReceived = GetTask<ConsumeContext<PingMessage>>();
+            _scheduledMessage = GetTask<Scheduling.ScheduledMessage>();
+
+            configurator.Handler<PingMessage>(async context =>
+            {
+                _pingReceived.TrySetResult(context);
+
+                var scheduledMessage = await context.ScheduleSend(TimeSpan.FromSeconds(3), new PongMessage());
+
+                _scheduledMessage.TrySetResult(scheduledMessage);
+
+                throw new IntentionalTestException("This time bad things happen");
+            });
+
+            _pongReceived = GetTask<ConsumeContext<PongMessage>>();
+
+            configurator.Handler<PongMessage>(async context =>
+            {
+                _pongReceived.TrySetResult(context);
+            });
+        }
+    }
+
+    public class Not_cancel_scheduled_message_with_no_outbox :
+        QuartzInMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_not_cancel_the_message()
+        {
+            await InputQueueSendEndpoint.Send(new PingMessage());
+
+            await _pingReceived.Task;
+
+            Console.WriteLine("Ping was received");
+
+            await _scheduledMessage.Task;
+
+            Console.WriteLine("Pong was scheduled");
+
+            await _pongReceived.Task;
+
+            Console.WriteLine("Pong was received");
+        }
+
+        TaskCompletionSource<ConsumeContext<PingMessage>> _pingReceived;
+        TaskCompletionSource<ConsumeContext<PongMessage>> _pongReceived;
+        TaskCompletionSource<Scheduling.ScheduledMessage> _scheduledMessage;
+
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _pingReceived = GetTask<ConsumeContext<PingMessage>>();
+            _scheduledMessage = GetTask<Scheduling.ScheduledMessage>();
+
+            configurator.Handler<PingMessage>(async context =>
+            {
+                _pingReceived.TrySetResult(context);
+
+                var scheduledMessage = await context.ScheduleSend(TimeSpan.FromSeconds(3), new PongMessage());
+
+                _scheduledMessage.TrySetResult(scheduledMessage);
+
+                throw new IntentionalTestException("This time bad things happen");
+            });
+
+            _pongReceived = GetTask<ConsumeContext<PongMessage>>();
+
+            configurator.Handler<PongMessage>(async context =>
+            {
+                _pongReceived.TrySetResult(context);
+            });
+        }
+    }
+}

--- a/src/MassTransit/Context/InMemoryOutboxMessageSchedulerContext.cs
+++ b/src/MassTransit/Context/InMemoryOutboxMessageSchedulerContext.cs
@@ -47,7 +47,7 @@ namespace MassTransit.Context
             lock (_listLock)
                 scheduledMessages = _scheduledMessages.ToArray();
 
-            var tasks = new List<Task>();
+            var tasks = new List<Task>(scheduledMessages.Length);
             foreach (var scheduledMessage in scheduledMessages)
             {
                 tasks.Add(_context.CancelScheduledSend(scheduledMessage.Destination, scheduledMessage.TokenId));

--- a/src/MassTransit/Context/InMemoryOutboxMessageSchedulerContext.cs
+++ b/src/MassTransit/Context/InMemoryOutboxMessageSchedulerContext.cs
@@ -1,0 +1,266 @@
+﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Context
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using GreenPipes;
+    using Scheduling;
+
+
+    public class InMemoryOutboxMessageSchedulerContext :
+        MessageSchedulerContext
+    {
+        readonly MessageSchedulerContext _context;
+        readonly object _listLock = new object();
+        readonly List<ScheduledMessage> _scheduledMessages;
+
+        public InMemoryOutboxMessageSchedulerContext(MessageSchedulerContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+
+            _scheduledMessages = new List<ScheduledMessage>();
+        }
+
+        void AddScheduledMessage(ScheduledMessage scheduledMessage)
+        {
+            lock (_listLock)
+                _scheduledMessages.Add(scheduledMessage);
+        }
+
+        public Task CancelAllScheduledMessages()
+        {
+            ScheduledMessage[] scheduledMessages;
+
+            lock (_listLock)
+                scheduledMessages = _scheduledMessages.ToArray();
+
+            var tasks = new List<Task>();
+            foreach (var scheduledMessage in scheduledMessages)
+            {
+                tasks.Add(_context.CancelScheduledSend(scheduledMessage.Destination, scheduledMessage.TokenId));
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
+        Task IMessageScheduler.CancelScheduledSend(Guid tokenId)
+        {
+            return _context.CancelScheduledSend(tokenId);
+        }
+
+        public Task CancelScheduledSend(Uri destinationAddress, Guid tokenId)
+        {
+            return _context.CancelScheduledSend(destinationAddress, tokenId);
+        }
+
+        async Task<ScheduledMessage<T>> IMessageScheduler.ScheduleSend<T>(Uri destinationAddress, DateTime scheduledTime, T message,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, message, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> IMessageScheduler.ScheduleSend<T>(Uri destinationAddress, DateTime scheduledTime, T message, IPipe<SendContext<T>> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, message, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> IMessageScheduler.ScheduleSend<T>(Uri destinationAddress, DateTime scheduledTime, T message, IPipe<SendContext> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, message, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> IMessageScheduler.ScheduleSend(Uri destinationAddress, DateTime scheduledTime, object message,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, message, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> IMessageScheduler.ScheduleSend(Uri destinationAddress, DateTime scheduledTime, object message, Type messageType,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, message, messageType, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> IMessageScheduler.ScheduleSend(Uri destinationAddress, DateTime scheduledTime, object message, IPipe<SendContext> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, message, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> IMessageScheduler.ScheduleSend(Uri destinationAddress, DateTime scheduledTime, object message, Type messageType,
+            IPipe<SendContext> pipe, CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, message, messageType, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> IMessageScheduler.ScheduleSend<T>(Uri destinationAddress, DateTime scheduledTime, object values,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend<T>(destinationAddress, scheduledTime, values, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> IMessageScheduler.ScheduleSend<T>(Uri destinationAddress, DateTime scheduledTime, object values, IPipe<SendContext<T>> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(destinationAddress, scheduledTime, values, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> IMessageScheduler.ScheduleSend<T>(Uri destinationAddress, DateTime scheduledTime, object values, IPipe<SendContext> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend<T>(destinationAddress, scheduledTime, values, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> MessageSchedulerContext.ScheduleSend<T>(DateTime scheduledTime, T message, CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, message, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> MessageSchedulerContext.ScheduleSend<T>(DateTime scheduledTime, T message, IPipe<SendContext<T>> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, message, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> MessageSchedulerContext.ScheduleSend<T>(DateTime scheduledTime, T message, IPipe<SendContext> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, message, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> MessageSchedulerContext.ScheduleSend(DateTime scheduledTime, object message, CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, message, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> MessageSchedulerContext.ScheduleSend(DateTime scheduledTime, object message, Type messageType,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, message, messageType, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> MessageSchedulerContext.ScheduleSend(DateTime scheduledTime, object message, IPipe<SendContext> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, message, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage> MessageSchedulerContext.ScheduleSend(DateTime scheduledTime, object message, Type messageType, IPipe<SendContext> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, message, messageType, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> MessageSchedulerContext.ScheduleSend<T>(DateTime scheduledTime, object values, CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend<T>(scheduledTime, values, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> MessageSchedulerContext.ScheduleSend<T>(DateTime scheduledTime, object values, IPipe<SendContext<T>> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend(scheduledTime, values, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+
+        async Task<ScheduledMessage<T>> MessageSchedulerContext.ScheduleSend<T>(DateTime scheduledTime, object values, IPipe<SendContext> pipe,
+            CancellationToken cancellationToken)
+        {
+            var scheduledMessage = await _context.ScheduleSend<T>(scheduledTime, values, pipe, cancellationToken).ConfigureAwait(false);
+
+            AddScheduledMessage(scheduledMessage);
+
+            return scheduledMessage;
+        }
+    }
+}

--- a/src/MassTransit/Pipeline/Filters/InMemoryOutboxFilter.cs
+++ b/src/MassTransit/Pipeline/Filters/InMemoryOutboxFilter.cs
@@ -16,14 +16,24 @@ namespace MassTransit.Pipeline.Filters
     using System.Threading.Tasks;
     using Context;
     using GreenPipes;
-
+    using MassTransit.Logging;
 
     public class InMemoryOutboxFilter :
         IFilter<ConsumeContext>
     {
+        static readonly ILog _log = Logger.Get<InMemoryOutboxFilter>();
+
         public async Task Send(ConsumeContext context, IPipe<ConsumeContext> next)
         {
+            InMemoryOutboxMessageSchedulerContext outboxSchedulerContext = null;
+            if (context.TryGetPayload(out MessageSchedulerContext schedulerContext))
+            {
+                outboxSchedulerContext = new InMemoryOutboxMessageSchedulerContext(schedulerContext);
+                context.AddOrUpdatePayload(() => outboxSchedulerContext, _ => outboxSchedulerContext);
+            }
+
             var outboxContext = new InMemoryOutboxConsumeContext(context);
+
             try
             {
                 await next.Send(outboxContext).ConfigureAwait(false);
@@ -35,6 +45,18 @@ namespace MassTransit.Pipeline.Filters
             catch (Exception)
             {
                 await outboxContext.DiscardPendingActions().ConfigureAwait(false);
+
+                try
+                {
+                    if(outboxSchedulerContext != null)
+                        await outboxSchedulerContext.CancelAllScheduledMessages().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    // Failed to unschedule some messages
+                    if (_log.IsWarnEnabled)
+                        _log.Warn("Some or all of the outbox unschedule failed", e);
+                }
 
                 throw;
             }
@@ -52,8 +74,18 @@ namespace MassTransit.Pipeline.Filters
         IFilter<ConsumeContext<T>>
         where T : class
     {
+        static readonly ILog _log = Logger.Get<InMemoryOutboxFilter<T>>();
+
+
         public async Task Send(ConsumeContext<T> context, IPipe<ConsumeContext<T>> next)
         {
+            InMemoryOutboxMessageSchedulerContext outboxSchedulerContext = null;
+            if (context.TryGetPayload(out MessageSchedulerContext schedulerContext))
+            {
+                outboxSchedulerContext = new InMemoryOutboxMessageSchedulerContext(schedulerContext);
+                context.AddOrUpdatePayload(() => outboxSchedulerContext, _ => outboxSchedulerContext);
+            }
+
             var outboxContext = new InMemoryOutboxConsumeContext<T>(context);
             try
             {
@@ -66,6 +98,18 @@ namespace MassTransit.Pipeline.Filters
             catch (Exception)
             {
                 await outboxContext.DiscardPendingActions().ConfigureAwait(false);
+
+                try
+                {
+                    if (outboxSchedulerContext != null)
+                        await outboxSchedulerContext.CancelAllScheduledMessages().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    // Failed to unschedule some messages
+                    if (_log.IsWarnEnabled)
+                        _log.Warn("Some or all of the outbox unschedule failed", e);
+                }
 
                 throw;
             }


### PR DESCRIPTION
For #1550 

Used Task.WhenAll(...), for unscheduling (if multiple scheduled messages). I also capture the ILog in the filter now, and just log a Warn message if the Task.WhenAll returns an exception (one or more of the unschedules failed).