### PR TITLE
Fix regression for FSharpList #1566

### DIFF
--- a/src/MassTransit/Serialization/JsonConverters/ListJsonConverter.cs
+++ b/src/MassTransit/Serialization/JsonConverters/ListJsonConverter.cs
@@ -34,6 +34,8 @@ namespace MassTransit.Serialization.JsonConverters
                 if (typeInfo.ClosesType(typeof(IDictionary<,>))
                     || typeInfo.ClosesType(typeof(IReadOnlyDictionary<,>))
                     || typeInfo.ClosesType(typeof(Dictionary<,>))
+                    || typeInfo.ClosesType(typeof(IReadOnlyList<>))
+                    || typeInfo.ClosesType(typeof(IReadOnlyCollection<>))
                     || typeInfo.ClosesType(typeof(IEnumerable<>), out Type[] enumerableType) && enumerableType[0].ClosesType(typeof(KeyValuePair<,>)))
                 {
                     elementType = default;
@@ -41,9 +43,7 @@ namespace MassTransit.Serialization.JsonConverters
                 }
 
                 if (typeInfo.ClosesType(typeof(IList<>), out Type[] elementTypes)
-                    || typeInfo.ClosesType(typeof(IReadOnlyList<>), out elementTypes)
                     || typeInfo.ClosesType(typeof(List<>), out elementTypes)
-                    || typeInfo.ClosesType(typeof(IReadOnlyCollection<>), out elementTypes)
                     || typeInfo.ClosesType(typeof(IEnumerable<>), out elementTypes))
                 {
                     elementType = elementTypes[0];


### PR DESCRIPTION
This is a PR for issue #1566.
I guess it's better to let newtonsoft deserialize readonly collections - as it also correctly supports F# types (hence FSharpList).

