### PR TITLE
TaskCreationOptions.RunContinuationsAsynchronously

### DIFF
--- a/src/Containers/MassTransit.Containers.Tests/CastleWindsor_Specs.cs
+++ b/src/Containers/MassTransit.Containers.Tests/CastleWindsor_Specs.cs
@@ -94,13 +94,13 @@
 
             static Dependency()
             {
-                _completed = new TaskCompletionSource<string>();
+                _completed = TaskCompletionSourceFactory.New<string>();
             }
 
             public Dependency()
             {
-                _first = new TaskCompletionSource<string>();
-                _second = new TaskCompletionSource<string>();
+                _first = TaskCompletionSourceFactory.New<string>();
+                _second = TaskCompletionSourceFactory.New<string>();
             }
 
             public static Task<string> Completed => _completed.Task;

--- a/src/Containers/MassTransit.Containers.Tests/Scenarios/SimpleConsumer.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Scenarios/SimpleConsumer.cs
@@ -1,25 +1,26 @@
 // Copyright 2007-2014 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Containers.Tests.Scenarios
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
 
 
     public class SimpleConsumer :
         IConsumer<SimpleMessageInterface>
     {
-        static readonly TaskCompletionSource<SimpleConsumer> _consumerCreated = new TaskCompletionSource<SimpleConsumer>();
+        static readonly TaskCompletionSource<SimpleConsumer> _consumerCreated = TaskCompletionSourceFactory.New<SimpleConsumer>();
 
         readonly ISimpleConsumerDependency _dependency;
         readonly TaskCompletionSource<SimpleMessageInterface> _received;
@@ -29,7 +30,7 @@ namespace MassTransit.Containers.Tests.Scenarios
             _dependency = dependency;
             Console.WriteLine("SimpleConsumer()");
 
-            _received = new TaskCompletionSource<SimpleMessageInterface>();
+            _received = TaskCompletionSourceFactory.New<SimpleMessageInterface>();
 
             _consumerCreated.TrySetResult(this);
         }
@@ -61,13 +62,13 @@ namespace MassTransit.Containers.Tests.Scenarios
     public class SimplerConsumer :
         IConsumer<SimpleMessageInterface>
     {
-        static readonly TaskCompletionSource<SimplerConsumer> _consumerCreated = new TaskCompletionSource<SimplerConsumer>();
+        static readonly TaskCompletionSource<SimplerConsumer> _consumerCreated = TaskCompletionSourceFactory.New<SimplerConsumer>();
 
         readonly TaskCompletionSource<SimpleMessageInterface> _received;
 
         public SimplerConsumer()
         {
-            _received = new TaskCompletionSource<SimpleMessageInterface>();
+            _received = TaskCompletionSourceFactory.New<SimpleMessageInterface>();
 
             _consumerCreated.TrySetResult(this);
         }

--- a/src/Containers/MassTransit.Containers.Tests/Scenarios/SimpleConsumerDependency.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Scenarios/SimpleConsumerDependency.cs
@@ -1,19 +1,20 @@
 ﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Containers.Tests.Scenarios
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
 
 
     public class SimpleConsumerDependency :
@@ -24,7 +25,7 @@ namespace MassTransit.Containers.Tests.Scenarios
 
         public SimpleConsumerDependency()
         {
-            _disposed = new TaskCompletionSource<bool>();
+            _disposed = TaskCompletionSourceFactory.New<bool>();
         }
 
         public void Dispose()

--- a/src/Containers/MassTransit.Containers.Tests/Scenarios/SimpleSaga.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Scenarios/SimpleSaga.cs
@@ -1,20 +1,21 @@
 // Copyright 2007-2014 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Containers.Tests.Scenarios
 {
     using System;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
+    using Internals.Extensions;
     using Saga;
 
 
@@ -24,9 +25,9 @@ namespace MassTransit.Containers.Tests.Scenarios
         Orchestrates<SecondSagaMessage>,
         Observes<ThirdSagaMessage, SimpleSaga>
     {
-        readonly TaskCompletionSource<FirstSagaMessage> _first = new TaskCompletionSource<FirstSagaMessage>();
-        readonly TaskCompletionSource<SecondSagaMessage> _second = new TaskCompletionSource<SecondSagaMessage>();
-        readonly TaskCompletionSource<ThirdSagaMessage> _third = new TaskCompletionSource<ThirdSagaMessage>();
+        readonly TaskCompletionSource<FirstSagaMessage> _first = TaskCompletionSourceFactory.New<FirstSagaMessage>();
+        readonly TaskCompletionSource<SecondSagaMessage> _second = TaskCompletionSourceFactory.New<SecondSagaMessage>();
+        readonly TaskCompletionSource<ThirdSagaMessage> _third = TaskCompletionSourceFactory.New<ThirdSagaMessage>();
 
         public SimpleSaga(Guid correlationId)
         {

--- a/src/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
+++ b/src/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
@@ -7,6 +7,7 @@ namespace MassTransit.ActiveMqTransport.Tests
     using System.Threading.Tasks;
     using Configurators;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using MassTransit.Testing;
     using NUnit.Framework;
     using TestFramework.Messages;
@@ -119,7 +120,7 @@ namespace MassTransit.ActiveMqTransport.Tests
         [Test]
         public async Task Should_succeed_and_connect_when_properly_configured()
         {
-            TaskCompletionSource<bool> received = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> received = TaskCompletionSourceFactory.New<bool>();
 
             Uri sendAddress = null;
 

--- a/src/MassTransit.ActiveMqTransport/Pipeline/ActiveMqBasicConsumer.cs
+++ b/src/MassTransit.ActiveMqTransport/Pipeline/ActiveMqBasicConsumer.cs
@@ -10,6 +10,7 @@ namespace MassTransit.ActiveMqTransport.Pipeline
     using GreenPipes;
     using GreenPipes.Agents;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Logging;
     using Topology;
     using Transports.Metrics;
@@ -51,7 +52,7 @@ namespace MassTransit.ActiveMqTransport.Pipeline
 
             _pending = new ConcurrentDictionary<string, ActiveMqReceiveContext>();
 
-            _deliveryComplete = new TaskCompletionSource<bool>();
+            _deliveryComplete = TaskCompletionSourceFactory.New<bool>();
 
             messageConsumer.Listener += HandleMessage;
 

--- a/src/MassTransit.AmazonSqsTransport.Tests/Configure_Specs.cs
+++ b/src/MassTransit.AmazonSqsTransport.Tests/Configure_Specs.cs
@@ -23,6 +23,7 @@ namespace MassTransit.AmazonSqsTransport.Tests
     using Configuration;
     using Context;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using MassTransit.Testing;
     using NUnit.Framework;
     using TestFramework.Logging;
@@ -149,7 +150,7 @@ namespace MassTransit.AmazonSqsTransport.Tests
         [Test]
         public async Task Should_succeed_and_connect_when_properly_configured()
         {
-            TaskCompletionSource<bool> received = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> received = TaskCompletionSourceFactory.New<bool>();
 
             IAmazonSqsHost host = null;
 
@@ -362,7 +363,7 @@ namespace MassTransit.AmazonSqsTransport.Tests
                 typeof(Message21), typeof(Message22)
             };
 
-            var tasksCompleted = messageTypes.ToDictionary(k => k, v => new TaskCompletionSource<bool>());
+            var tasksCompleted = messageTypes.ToDictionary(k => k, v => TaskCompletionSourceFactory.New<bool>());
 
             IAmazonSqsHost host = null;
 

--- a/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsBasicConsumer.cs
+++ b/src/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsBasicConsumer.cs
@@ -10,6 +10,7 @@ namespace MassTransit.AmazonSqsTransport.Pipeline
     using GreenPipes;
     using GreenPipes.Agents;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Logging;
     using Topology;
     using Transports.Metrics;
@@ -49,7 +50,7 @@ namespace MassTransit.AmazonSqsTransport.Pipeline
 
             _pending = new ConcurrentDictionary<string, AmazonSqsReceiveContext>();
 
-            _deliveryComplete = new TaskCompletionSource<bool>();
+            _deliveryComplete = TaskCompletionSourceFactory.New<bool>();
 
             SetReady();
         }

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/ConfiguringAzure_Specs.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/ConfiguringAzure_Specs.cs
@@ -6,6 +6,7 @@
         using System.Threading.Tasks;
         using GreenPipes;
         using Hosting;
+        using Internals.Extensions;
         using MassTransit.Testing;
         using NUnit.Framework;
         using TestFramework;
@@ -26,7 +27,7 @@
                     "MassTransit.Azure.ServiceBus.Core.Tests"
                 );
 
-                var completed = new TaskCompletionSource<A>();
+                var completed = TaskCompletionSourceFactory.New<A>();
 
                 IBusControl bus = Bus.Factory.CreateUsingAzureServiceBus(x =>
                 {

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/LockTimeout_Specs.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/LockTimeout_Specs.cs
@@ -1,19 +1,20 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Azure.ServiceBus.Core.Tests
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
     using TestFramework.Messages;
 
 
@@ -47,7 +48,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         class PingConsumer :
             IConsumer<PingMessage>
         {
-            public static TaskCompletionSource<PingMessage> Completed = new TaskCompletionSource<PingMessage>();
+            public static TaskCompletionSource<PingMessage> Completed = TaskCompletionSourceFactory.New<PingMessage>();
 
             public async Task Consume(ConsumeContext<PingMessage> context)
             {

--- a/src/MassTransit.Azure.ServiceBus.Core.Tests/Verify_account_settings.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core.Tests/Verify_account_settings.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Azure.ServiceBus.Core.Tests
 {
@@ -21,6 +21,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         using System.Threading.Tasks;
         using Contexts;
         using Hosting;
+        using Internals.Extensions;
         using Microsoft.Azure.ServiceBus;
         using Microsoft.Azure.ServiceBus.Core;
         using Microsoft.Azure.ServiceBus.Management;
@@ -67,7 +68,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
                 var receiver = factory.CreateQueueClient("Control");
                 receiver.PrefetchCount = 100;
 
-                var done = new TaskCompletionSource<bool>();
+                var done = TaskCompletionSourceFactory.New<bool>();
                 var count = 0;
                 const int limit = 1000;
                 receiver.RegisterMessageHandler(async (message, cancellationToken) =>

--- a/src/MassTransit.Azure.ServiceBus.Core/Transport/Receiver.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Transport/Receiver.cs
@@ -9,6 +9,7 @@
     using GreenPipes;
     using GreenPipes.Agents;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Microsoft.Azure.ServiceBus;
     using Microsoft.Azure.ServiceBus.Core;
     using Transports.Metrics;
@@ -30,7 +31,7 @@
             _messageReceiver = messageReceiver;
 
             Tracker = new DeliveryTracker(HandleDeliveryComplete);
-            _deliveryComplete = new TaskCompletionSource<bool>();
+            _deliveryComplete = TaskCompletionSourceFactory.New<bool>();
         }
 
         public DeliveryMetrics GetDeliveryMetrics()

--- a/src/MassTransit.AzureServiceBusTransport.Tests/ConfiguringAzure_Specs.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/ConfiguringAzure_Specs.cs
@@ -5,6 +5,7 @@
         using System;
         using System.Threading.Tasks;
         using GreenPipes;
+        using Internals.Extensions;
         using MassTransit.Testing;
         using Microsoft.ServiceBus;
         using Microsoft.ServiceBus.Messaging;
@@ -24,7 +25,7 @@
                 Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace,
                     "MassTransit.AzureServiceBusTransport.Tests");
 
-                var completed = new TaskCompletionSource<A>();
+                var completed = TaskCompletionSourceFactory.New<A>();
 
                 IBusControl bus = Bus.Factory.CreateUsingAzureServiceBus(x =>
                 {
@@ -75,7 +76,7 @@
                 Uri serviceUri = ServiceBusEnvironment.CreateServiceUri("sb", Configuration.ServiceNamespace,
                     "MassTransit.AzureServiceBusTransport.Tests");
 
-                var completed = new TaskCompletionSource<A>();
+                var completed = TaskCompletionSourceFactory.New<A>();
 
                 IBusControl bus = Bus.Factory.CreateUsingAzureServiceBus(x =>
                 {

--- a/src/MassTransit.AzureServiceBusTransport.Tests/LockTimeout_Specs.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/LockTimeout_Specs.cs
@@ -1,19 +1,20 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Tests
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
     using NUnit.Framework;
     using TestFramework.Messages;
 
@@ -51,7 +52,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
         class PingConsumer :
             IConsumer<PingMessage>
         {
-            public static TaskCompletionSource<PingMessage> Completed = new TaskCompletionSource<PingMessage>();
+            public static TaskCompletionSource<PingMessage> Completed = TaskCompletionSourceFactory.New<PingMessage>();
 
             public async Task Consume(ConsumeContext<PingMessage> context)
             {

--- a/src/MassTransit.AzureServiceBusTransport.Tests/Verify_account_settings.cs
+++ b/src/MassTransit.AzureServiceBusTransport.Tests/Verify_account_settings.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2014 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AzureServiceBusTransport.Tests
 {
@@ -20,6 +20,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
         using System.Threading;
         using System.Threading.Tasks;
         using Contexts;
+        using Internals.Extensions;
         using MassTransit.Pipeline;
         using Microsoft.ServiceBus;
         using Microsoft.ServiceBus.Messaging;
@@ -64,7 +65,7 @@ namespace MassTransit.AzureServiceBusTransport.Tests
                 MessageReceiver receiver = await factory.CreateMessageReceiverAsync("Control");
                 receiver.PrefetchCount = 100;
 
-                var done = new TaskCompletionSource<bool>();
+                var done = TaskCompletionSourceFactory.New<bool>();
                 int count = 0;
                 const int limit = 1000;
                 receiver.OnMessageAsync(async message =>

--- a/src/MassTransit.AzureServiceBusTransport/Pipeline/RenewLockFilter.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Pipeline/RenewLockFilter.cs
@@ -17,6 +17,7 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
     using System.Threading.Tasks;
     using Context;
     using GreenPipes;
+    using Internals.Extensions;
     using Microsoft.ServiceBus.Messaging;
 
 
@@ -63,7 +64,7 @@ namespace MassTransit.AzureServiceBusTransport.Pipeline
                 _context = context;
                 _delay = delay;
                 _source = new CancellationTokenSource();
-                _completed = new TaskCompletionSource<bool>();
+                _completed = TaskCompletionSourceFactory.New<bool>();
 
                 if (context != null)
                 {

--- a/src/MassTransit.AzureServiceBusTransport/Transport/Receiver.cs
+++ b/src/MassTransit.AzureServiceBusTransport/Transport/Receiver.cs
@@ -19,6 +19,7 @@ namespace MassTransit.AzureServiceBusTransport.Transport
     using GreenPipes;
     using GreenPipes.Agents;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Microsoft.ServiceBus.Messaging;
     using Transports.Metrics;
     using Util;
@@ -39,7 +40,7 @@ namespace MassTransit.AzureServiceBusTransport.Transport
             _messageReceiver = messageReceiver;
 
             _tracker = new DeliveryTracker(HandleDeliveryComplete);
-            _deliveryComplete = new TaskCompletionSource<bool>();
+            _deliveryComplete = TaskCompletionSourceFactory.New<bool>();
         }
 
         public Task DeliveryCompleted => _deliveryComplete.Task;

--- a/src/MassTransit.HttpTransport/Transport/HttpConsumer.cs
+++ b/src/MassTransit.HttpTransport/Transport/HttpConsumer.cs
@@ -19,6 +19,7 @@ namespace MassTransit.HttpTransport.Transport
     using Contexts;
     using GreenPipes.Agents;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Microsoft.AspNetCore.Http;
     using Pipeline;
     using Transports.Metrics;
@@ -38,7 +39,7 @@ namespace MassTransit.HttpTransport.Transport
             _context = context;
 
             _tracker = new DeliveryTracker(OnDeliveryComplete);
-            _deliveryComplete = new TaskCompletionSource<bool>();
+            _deliveryComplete = TaskCompletionSourceFactory.New<bool>();
 
             SetReady();
         }

--- a/src/MassTransit.HttpTransport/Transport/HttpHost.cs
+++ b/src/MassTransit.HttpTransport/Transport/HttpHost.cs
@@ -9,6 +9,7 @@
     using GreenPipes;
     using GreenPipes.Agents;
     using Hosting;
+    using Internals.Extensions;
     using Logging;
     using MassTransit.Topology;
     using Transports;
@@ -61,8 +62,8 @@
             SendLogContext = LogContext.Current.CreateLogContext(LogCategoryName.Transport.Send);
             ReceiveLogContext = LogContext.Current.CreateLogContext(LogCategoryName.Transport.Receive);
 
-            var handlesReady = new TaskCompletionSource<HostReceiveEndpointHandle[]>();
-            var hostStarted = new TaskCompletionSource<bool>();
+            var handlesReady = TaskCompletionSourceFactory.New<HostReceiveEndpointHandle[]>();
+            var hostStarted = TaskCompletionSourceFactory.New<bool>();
 
             IPipe<HttpHostContext> connectionPipe = Pipe.ExecuteAsync<HttpHostContext>(async context =>
             {

--- a/src/MassTransit.QuartzIntegration.Tests/XmlHeaderBug_Specs.cs
+++ b/src/MassTransit.QuartzIntegration.Tests/XmlHeaderBug_Specs.cs
@@ -14,6 +14,7 @@ namespace MassTransit.QuartzIntegration.Tests
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
     using NUnit.Framework;
     using TestFramework;
 
@@ -57,7 +58,7 @@ namespace MassTransit.QuartzIntegration.Tests
         {
             public Task Completed => _source.Task;
 
-            readonly TaskCompletionSource<ConsumeContext<IMyMessage>> _source = new TaskCompletionSource<ConsumeContext<IMyMessage>>();
+            readonly TaskCompletionSource<ConsumeContext<IMyMessage>> _source = TaskCompletionSourceFactory.New<ConsumeContext<IMyMessage>>();
 
             public async Task Consume(ConsumeContext<IMyMessage> context)
             {

--- a/src/MassTransit.RabbitMqTransport.Tests/ConsumerBind_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/ConsumerBind_Specs.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.RabbitMqTransport.Tests
 {
@@ -16,6 +16,7 @@ namespace MassTransit.RabbitMqTransport.Tests
     {
         using System;
         using System.Threading.Tasks;
+        using Internals.Extensions;
         using MassTransit.Testing;
         using NUnit.Framework;
         using RabbitMQ.Client;
@@ -261,8 +262,8 @@ namespace MassTransit.RabbitMqTransport.Tests
             InitiatedBy<A>,
             Orchestrates<B>
         {
-            readonly TaskCompletionSource<A> _a = new TaskCompletionSource<A>();
-            readonly TaskCompletionSource<B> _b = new TaskCompletionSource<B>();
+            readonly TaskCompletionSource<A> _a = TaskCompletionSourceFactory.New<A>();
+            readonly TaskCompletionSource<B> _b = TaskCompletionSourceFactory.New<B>();
 
             public TestSaga()
             {

--- a/src/MassTransit.RabbitMqTransport.Tests/RoutingKeyDirect_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/RoutingKeyDirect_Specs.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.RabbitMqTransport.Tests
 {
     using System;
     using System.Threading.Tasks;
     using GreenPipes.Util;
+    using Internals.Extensions;
     using NUnit.Framework;
     using RabbitMQ.Client;
     using RoutingKeyDirect;
@@ -108,8 +109,8 @@ namespace MassTransit.RabbitMqTransport.Tests
         class Consumer :
             IConsumer<Message>
         {
-            static readonly TaskCompletionSource<Message> _foo = new TaskCompletionSource<Message>();
-            static readonly TaskCompletionSource<Message> _bar = new TaskCompletionSource<Message>();
+            static readonly TaskCompletionSource<Message> _foo = TaskCompletionSourceFactory.New<Message>();
+            static readonly TaskCompletionSource<Message> _bar = TaskCompletionSourceFactory.New<Message>();
             public static Task<Message> Foo => _foo.Task;
             public static Task<Message> Bar => _bar.Task;
 

--- a/src/MassTransit.RabbitMqTransport.Tests/RoutingKeyTopic_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/RoutingKeyTopic_Specs.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using GreenPipes.Util;
+    using Internals.Extensions;
     using NUnit.Framework;
     using RabbitMQ.Client;
     using RoutingKeyTopic;
@@ -96,8 +97,8 @@
         class Consumer :
             IConsumer<Message>
         {
-            static readonly TaskCompletionSource<Message> _microsoft = new TaskCompletionSource<Message>();
-            static readonly TaskCompletionSource<Message> _uber = new TaskCompletionSource<Message>();
+            static readonly TaskCompletionSource<Message> _microsoft = TaskCompletionSourceFactory.New<Message>();
+            static readonly TaskCompletionSource<Message> _uber = TaskCompletionSourceFactory.New<Message>();
             public static Task<Message> Microsoft => _microsoft.Task;
             public static Task<Message> Uber => _uber.Task;
 

--- a/src/MassTransit.RabbitMqTransport.Tests/SendObserver_Specs.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/SendObserver_Specs.cs
@@ -12,6 +12,7 @@
     namespace ObserverTests
     {
         using GreenPipes.Internals.Extensions;
+        using Internals.Extensions;
 
 
         [TestFixture]
@@ -101,9 +102,9 @@
 
             public PublishObserver()
             {
-                _sendFaulted = new TaskCompletionSource<PublishContext>();
-                _preSend = new TaskCompletionSource<PublishContext>();
-                _postSend = new TaskCompletionSource<PublishContext>();
+                _sendFaulted = TaskCompletionSourceFactory.New<PublishContext>();
+                _preSend = TaskCompletionSourceFactory.New<PublishContext>();
+                _postSend = TaskCompletionSourceFactory.New<PublishContext>();
             }
 
             public Task<PublishContext> PreSent
@@ -144,9 +145,9 @@
         class SendObserver :
             ISendObserver
         {
-            readonly TaskCompletionSource<SendContext> _postSend = new TaskCompletionSource<SendContext>();
-            readonly TaskCompletionSource<SendContext> _preSend = new TaskCompletionSource<SendContext>();
-            readonly TaskCompletionSource<SendContext> _sendFaulted = new TaskCompletionSource<SendContext>();
+            readonly TaskCompletionSource<SendContext> _postSend = TaskCompletionSourceFactory.New<SendContext>();
+            readonly TaskCompletionSource<SendContext> _preSend = TaskCompletionSourceFactory.New<SendContext>();
+            readonly TaskCompletionSource<SendContext> _sendFaulted = TaskCompletionSourceFactory.New<SendContext>();
 
             public Task<SendContext> PreSent
             {

--- a/src/MassTransit.RabbitMqTransport.Tests/TestConnectionPipe.cs
+++ b/src/MassTransit.RabbitMqTransport.Tests/TestConnectionPipe.cs
@@ -3,6 +3,7 @@ namespace MassTransit.RabbitMqTransport.Tests
     using System.Threading;
     using System.Threading.Tasks;
     using GreenPipes;
+    using Internals.Extensions;
     using MassTransit.Pipeline;
     using RabbitMqTransport;
 
@@ -14,7 +15,7 @@ namespace MassTransit.RabbitMqTransport.Tests
 
         public TestConnectionPipe(CancellationToken testCancellationToken)
         {
-            _called = new TaskCompletionSource<ConnectionContext>();
+            _called = TaskCompletionSourceFactory.New<ConnectionContext>();
             testCancellationToken.Register(() => _called.TrySetCanceled());
         }
 

--- a/src/MassTransit.RabbitMqTransport/Integration/PendingPublish.cs
+++ b/src/MassTransit.RabbitMqTransport/Integration/PendingPublish.cs
@@ -2,6 +2,7 @@ namespace MassTransit.RabbitMqTransport.Integration
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
 
 
     /// <summary>
@@ -19,7 +20,7 @@ namespace MassTransit.RabbitMqTransport.Integration
             _connectionContext = connectionContext;
             _exchange = exchange;
             _publishTag = publishTag;
-            _source = new TaskCompletionSource<ulong>();
+            _source = TaskCompletionSourceFactory.New<ulong>();
         }
 
         public Task Task => _source.Task;

--- a/src/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs
+++ b/src/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs
@@ -9,6 +9,7 @@ namespace MassTransit.RabbitMqTransport.Pipeline
     using GreenPipes;
     using GreenPipes.Agents;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Logging;
     using RabbitMQ.Client;
     using RabbitMQ.Client.Events;
@@ -53,7 +54,7 @@ namespace MassTransit.RabbitMqTransport.Pipeline
 
             _pending = new ConcurrentDictionary<ulong, RabbitMqReceiveContext>();
 
-            _deliveryComplete = new TaskCompletionSource<bool>();
+            _deliveryComplete = TaskCompletionSourceFactory.New<bool>();
         }
 
         /// <summary>

--- a/src/MassTransit.SignalR.Tests/OfficialFramework/TestClient.cs
+++ b/src/MassTransit.SignalR.Tests/OfficialFramework/TestClient.cs
@@ -10,6 +10,8 @@
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
+    using Internals.Extensions;
+
 
     internal class TestClient : ITransferFormatFeature, IConnectionHeartbeatFeature, IDisposable
     {
@@ -47,7 +49,7 @@
             }
 
             Connection.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
-            Connection.Items["ConnectedTask"] = new TaskCompletionSource<bool>();
+            Connection.Items["ConnectedTask"] = TaskCompletionSourceFactory.New<bool>();
 
             _protocol = protocol ?? new JsonHubProtocol();
             _invocationBinder = invocationBinder ?? new DefaultInvocationBinder();
@@ -233,7 +235,7 @@
                 }
                 else
                 {
-                    // read first message out of the incoming data 
+                    // read first message out of the incoming data
                     if (HandshakeProtocol.TryParseResponseMessage(ref buffer, out var responseMessage))
                     {
                         return responseMessage;

--- a/src/MassTransit.Tests/BinarySerializer_Specs.cs
+++ b/src/MassTransit.Tests/BinarySerializer_Specs.cs
@@ -1,14 +1,14 @@
 // Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests
 {
@@ -19,13 +19,14 @@ namespace MassTransit.Tests
     using MassTransit.Transports.InMemory;
     using System;
     using System.Security.Cryptography.X509Certificates;
+    using Internals.Extensions;
 
 
     [TestFixture]
     public class When_using_the_binary_serializer :
         InMemoryTestFixture
     {
-        readonly TaskCompletionSource<Fault<A>> _faultTaskTcs = new TaskCompletionSource<Fault<A>>();
+        readonly TaskCompletionSource<Fault<A>> _faultTaskTcs = TaskCompletionSourceFactory.New<Fault<A>>();
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)
         {
@@ -100,7 +101,7 @@ namespace MassTransit.Tests
         [Test]
         public async Task Should_be_able_to_consume_messages_polymorphically_if_the_receiving_bus_support_the_binary_serializer()
         {
-            var consumed = new TaskCompletionSource<Base>();
+            var consumed = TaskCompletionSourceFactory.New<Base>();
 
             var bus = Bus.Factory.CreateUsingInMemory(x =>
             {

--- a/src/MassTransit.Tests/Enrichment_Specs.cs
+++ b/src/MassTransit.Tests/Enrichment_Specs.cs
@@ -1,18 +1,19 @@
 ﻿// Copyright 2007-2014 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests
 {
     using System.Threading.Tasks;
+    using Internals.Extensions;
     using NUnit.Framework;
     using TestFramework;
 
@@ -40,7 +41,7 @@ namespace MassTransit.Tests
         }
 
         Task<ConsumeContext<SecureCommand>> _commandHandler;
-        readonly TaskCompletionSource<UserCredentials> _credentials = new TaskCompletionSource<UserCredentials>();
+        readonly TaskCompletionSource<UserCredentials> _credentials = TaskCompletionSourceFactory.New<UserCredentials>();
         Task<ConsumeContext<UserCredentials>> _credentialsHandler;
 
         [OneTimeSetUp]

--- a/src/MassTransit.Tests/Pipeline/OneMessageConsumer.cs
+++ b/src/MassTransit.Tests/Pipeline/OneMessageConsumer.cs
@@ -1,18 +1,19 @@
 // Copyright 2007-2014 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests.Pipeline
 {
     using System.Threading.Tasks;
+    using Internals.Extensions;
     using TestFramework.Messages;
 
 
@@ -23,7 +24,7 @@ namespace MassTransit.Tests.Pipeline
 
         public OneMessageConsumer()
         {
-            _completed = new TaskCompletionSource<MessageA>();
+            _completed = TaskCompletionSourceFactory.New<MessageA>();
         }
 
         public OneMessageConsumer(TaskCompletionSource<MessageA> completed)

--- a/src/MassTransit.Tests/PublishObserver_Specs.cs
+++ b/src/MassTransit.Tests/PublishObserver_Specs.cs
@@ -14,6 +14,7 @@
     namespace ObserverTests
     {
         using GreenPipes.Internals.Extensions;
+        using Internals.Extensions;
 
 
         [TestFixture]
@@ -102,9 +103,9 @@
 
                 public Observer()
                 {
-                    _sendFaulted = new TaskCompletionSource<PublishContext>();
-                    _preSend = new TaskCompletionSource<PublishContext>();
-                    _postSend = new TaskCompletionSource<PublishContext>();
+                    _sendFaulted = TaskCompletionSourceFactory.New<PublishContext>();
+                    _preSend = TaskCompletionSourceFactory.New<PublishContext>();
+                    _postSend = TaskCompletionSourceFactory.New<PublishContext>();
                 }
 
                 public Task<PublishContext> PreSent

--- a/src/MassTransit.Tests/Retry_Specs.cs
+++ b/src/MassTransit.Tests/Retry_Specs.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using GreenPipes;
     using GreenPipes.Introspection;
+    using Internals.Extensions;
     using NUnit.Framework;
     using Shouldly;
     using TestFramework;
@@ -584,7 +585,7 @@
 
             public RetryObserver()
             {
-                _completionSource = new TaskCompletionSource<RetryContext>();
+                _completionSource = TaskCompletionSourceFactory.New<RetryContext>();
             }
 
             public Task<RetryContext> Completed => _completionSource.Task;

--- a/src/MassTransit.Tests/SendObserver_Specs.cs
+++ b/src/MassTransit.Tests/SendObserver_Specs.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests
 {
@@ -23,6 +23,7 @@ namespace MassTransit.Tests
     namespace ObserverTests
     {
         using GreenPipes;
+        using Internals.Extensions;
 
 
         [TestFixture]
@@ -146,7 +147,7 @@ namespace MassTransit.Tests
 
                 bus.ConnectSendObserver(_observer);
             }
-            
+
 
             [Test]
             public async Task Should_invoke_the_observer_after_send()
@@ -155,7 +156,7 @@ namespace MassTransit.Tests
 
                     await _observer.PostSent;
             }
-            
+
         }
 
         [TestFixture]
@@ -189,9 +190,9 @@ namespace MassTransit.Tests
         class SendObserver :
             ISendObserver
         {
-            readonly TaskCompletionSource<SendContext> _postSend = new TaskCompletionSource<SendContext>();
-            readonly TaskCompletionSource<SendContext> _preSend = new TaskCompletionSource<SendContext>();
-            readonly TaskCompletionSource<SendContext> _sendFaulted = new TaskCompletionSource<SendContext>();
+            readonly TaskCompletionSource<SendContext> _postSend = TaskCompletionSourceFactory.New<SendContext>();
+            readonly TaskCompletionSource<SendContext> _preSend = TaskCompletionSourceFactory.New<SendContext>();
+            readonly TaskCompletionSource<SendContext> _sendFaulted = TaskCompletionSourceFactory.New<SendContext>();
 
             public Task<SendContext> PreSent
             {

--- a/src/MassTransit.Transports.Tests/Observers/PublishObserver.cs
+++ b/src/MassTransit.Transports.Tests/Observers/PublishObserver.cs
@@ -14,6 +14,7 @@ namespace MassTransit.Transports.Tests.Observers
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
 
 
     public class PublishObserver :
@@ -25,9 +26,9 @@ namespace MassTransit.Transports.Tests.Observers
 
         public PublishObserver()
         {
-            _sendFaulted = new TaskCompletionSource<PublishContext>();
-            _preSend = new TaskCompletionSource<PublishContext>();
-            _postSend = new TaskCompletionSource<PublishContext>();
+            _sendFaulted = TaskCompletionSourceFactory.New<PublishContext>();
+            _preSend = TaskCompletionSourceFactory.New<PublishContext>();
+            _postSend = TaskCompletionSourceFactory.New<PublishContext>();
         }
 
         public Task<PublishContext> PrePublished

--- a/src/MassTransit.Transports.Tests/Observers/SendObserver.cs
+++ b/src/MassTransit.Transports.Tests/Observers/SendObserver.cs
@@ -14,14 +14,15 @@ namespace MassTransit.Transports.Tests.Observers
 {
     using System;
     using System.Threading.Tasks;
+    using Internals.Extensions;
 
 
     public class SendObserver :
         ISendObserver
     {
-        readonly TaskCompletionSource<SendContext> _postSend = new TaskCompletionSource<SendContext>();
-        readonly TaskCompletionSource<SendContext> _preSend = new TaskCompletionSource<SendContext>();
-        readonly TaskCompletionSource<SendContext> _sendFaulted = new TaskCompletionSource<SendContext>();
+        readonly TaskCompletionSource<SendContext> _postSend = TaskCompletionSourceFactory.New<SendContext>();
+        readonly TaskCompletionSource<SendContext> _preSend = TaskCompletionSourceFactory.New<SendContext>();
+        readonly TaskCompletionSource<SendContext> _sendFaulted = TaskCompletionSourceFactory.New<SendContext>();
 
         public Task<SendContext> PreSent => _preSend.Task;
 

--- a/src/MassTransit/Clients/ClientRequestHandle.cs
+++ b/src/MassTransit/Clients/ClientRequestHandle.cs
@@ -20,6 +20,7 @@ namespace MassTransit.Clients
     using GreenPipes;
     using GreenPipes.Builders;
     using GreenPipes.Configurators;
+    using Internals.Extensions;
     using Metadata;
     using Util;
 
@@ -65,8 +66,8 @@ namespace MassTransit.Clients
                     : TaskScheduler.FromCurrentSynchronizationContext());
 
             _pipeConfigurator = new PipeConfigurator<SendContext<TRequest>>();
-            _sendContext = new TaskCompletionSource<SendContext<TRequest>>();
-            _readyToSend = new TaskCompletionSource<bool>();
+            _sendContext = TaskCompletionSourceFactory.New<SendContext<TRequest>>();
+            _readyToSend = TaskCompletionSourceFactory.New<bool>();
             _cancellationTokenSource = new CancellationTokenSource();
             _responseHandlers = new Dictionary<Type, HandlerConnectHandle>();
 

--- a/src/MassTransit/Clients/ResponseHandlerConfigurator.cs
+++ b/src/MassTransit/Clients/ResponseHandlerConfigurator.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Clients
 {
@@ -19,6 +19,7 @@ namespace MassTransit.Clients
     using ConsumeConfigurators;
     using GreenPipes;
     using GreenPipes.Util;
+    using Internals.Extensions;
     using Pipeline;
 
 
@@ -43,7 +44,7 @@ namespace MassTransit.Clients
             _requestTask = requestTask;
 
             _specifications = new List<IPipeSpecification<ConsumeContext<TResponse>>>();
-            _completed = new TaskCompletionSource<ConsumeContext<TResponse>>();
+            _completed = TaskCompletionSourceFactory.New<ConsumeContext<TResponse>>();
         }
 
         public void AddPipeSpecification(IPipeSpecification<ConsumeContext<TResponse>> specification)

--- a/src/MassTransit/Conductor/Client/MessageClient.cs
+++ b/src/MassTransit/Conductor/Client/MessageClient.cs
@@ -10,6 +10,7 @@ namespace MassTransit.Conductor.Client
     using Distribution;
     using GreenPipes;
     using GreenPipes.Caching;
+    using Internals.Extensions;
     using Metadata;
     using Util;
 
@@ -32,7 +33,7 @@ namespace MassTransit.Conductor.Client
 
             ClientId = clientId;
 
-            _serviceAddress = new TaskCompletionSource<Uri>();
+            _serviceAddress = TaskCompletionSourceFactory.New<Uri>();
 
             var cacheSettings = new CacheSettings(1000, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(30));
             _cache = new GreenCache<EndpointInfo>(cacheSettings);

--- a/src/MassTransit/Conductor/Server/ServiceInstance.cs
+++ b/src/MassTransit/Conductor/Server/ServiceInstance.cs
@@ -6,6 +6,7 @@ namespace MassTransit.Conductor.Server
     using Consumers;
     using Contracts;
     using Initializers;
+    using Internals.Extensions;
     using Metadata;
     using Util;
 
@@ -27,7 +28,7 @@ namespace MassTransit.Conductor.Server
             _instanceAddress = new Lazy<Uri>(() => configurator.InputAddress);
 
             _messageTypes = new Dictionary<Type, IMessageEndpoint>();
-            _receiveEndpoint = new TaskCompletionSource<IReceiveEndpoint>();
+            _receiveEndpoint = TaskCompletionSourceFactory.New<IReceiveEndpoint>();
 
             configurator.ConnectReceiveEndpointObserver(new InstanceReadyObserver(_receiveEndpoint));
         }

--- a/src/MassTransit/Context/InMemoryOutboxConsumeContext.cs
+++ b/src/MassTransit/Context/InMemoryOutboxConsumeContext.cs
@@ -3,6 +3,7 @@ namespace MassTransit.Context
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Internals.Extensions;
 
 
     public class InMemoryOutboxConsumeContext :
@@ -19,7 +20,7 @@ namespace MassTransit.Context
             ReceiveContext = new InMemoryOutboxReceiveContext(this, context.ReceiveContext);
 
             _pendingActions = new List<Func<Task>>();
-            _clearToSend = new TaskCompletionSource<InMemoryOutboxConsumeContext>();
+            _clearToSend = TaskCompletionSourceFactory.New<InMemoryOutboxConsumeContext>();
 
             if (context.TryGetPayload(out MessageSchedulerContext schedulerContext))
             {

--- a/src/MassTransit/Internals/Extensions/TaskCompletionSourceFactory.cs
+++ b/src/MassTransit/Internals/Extensions/TaskCompletionSourceFactory.cs
@@ -1,0 +1,17 @@
+namespace MassTransit.Internals.Extensions
+{
+    using System.Threading.Tasks;
+
+
+    public class TaskCompletionSourceFactory
+    {
+        public static TaskCompletionSource<T> New<T>()
+        {
+        #if NETFRAMEWORK
+            return new TaskCompletionSource<T>();
+        #elif NETSTANDARD
+            return new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        #endif
+        }
+    }
+}

--- a/src/MassTransit/Internals/Extensions/TaskExtensions.cs
+++ b/src/MassTransit/Internals/Extensions/TaskExtensions.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Internals.Extensions
 {
@@ -21,7 +21,7 @@ namespace MassTransit.Internals.Extensions
     {
         public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = TaskCompletionSourceFactory.New<bool>();
             using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
                 if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                     throw new OperationCanceledException(cancellationToken);
@@ -31,7 +31,7 @@ namespace MassTransit.Internals.Extensions
 
         public static async Task WithCancellation(this Task task, CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = TaskCompletionSourceFactory.New<bool>();
             using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
                 if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                     throw new OperationCanceledException(cancellationToken);
@@ -43,7 +43,7 @@ namespace MassTransit.Internals.Extensions
         {
             using (var tokenSource = new CancellationTokenSource(milliseconds))
             {
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = TaskCompletionSourceFactory.New<bool>();
                 using (tokenSource.Token.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
                     if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                         throw new OperationCanceledException(tokenSource.Token);
@@ -56,7 +56,7 @@ namespace MassTransit.Internals.Extensions
         {
             using (var tokenSource = new CancellationTokenSource(timeout))
             {
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = TaskCompletionSourceFactory.New<bool>();
                 using (tokenSource.Token.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
                     if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                         throw new OperationCanceledException(tokenSource.Token);

--- a/src/MassTransit/Pipeline/ConsumerFactories/BatchConsumer.cs
+++ b/src/MassTransit/Pipeline/ConsumerFactories/BatchConsumer.cs
@@ -20,6 +20,7 @@ namespace MassTransit.Pipeline.ConsumerFactories
     using System.Threading.Tasks;
     using Context;
     using GreenPipes;
+    using Internals.Extensions;
 
 
     public class BatchConsumer<TConsumer, TMessage> :
@@ -46,7 +47,7 @@ namespace MassTransit.Pipeline.ConsumerFactories
             _consumerFactory = consumerFactory;
             _consumerPipe = consumerPipe;
             _messages = new SortedDictionary<Guid, ConsumeContext<TMessage>>();
-            _completed = new TaskCompletionSource<DateTime>();
+            _completed = TaskCompletionSourceFactory.New<DateTime>();
             _firstMessage = DateTime.UtcNow;
 
             _timer = new Timer(TimeLimitExpired, null, timeLimit, TimeSpan.Zero);

--- a/src/MassTransit/Pipeline/Pipes/ConsumePipe.cs
+++ b/src/MassTransit/Pipeline/Pipes/ConsumePipe.cs
@@ -5,6 +5,7 @@ namespace MassTransit.Pipeline.Pipes
     using GreenPipes;
     using GreenPipes.Internals.Extensions;
     using GreenPipes.Filters;
+    using Internals.Extensions;
 
 
     public class ConsumePipe :
@@ -19,7 +20,7 @@ namespace MassTransit.Pipeline.Pipes
             _dynamicFilter = dynamicFilter ?? throw new ArgumentNullException(nameof(dynamicFilter));
             _pipe = pipe ?? throw new ArgumentNullException(nameof(pipe));
 
-            _connected = new TaskCompletionSource<bool>();
+            _connected = TaskCompletionSourceFactory.New<bool>();
 
             if (autoStart)
                 _connected.TrySetResult(true);

--- a/src/MassTransit/Testing/AsyncTestHarness.cs
+++ b/src/MassTransit/Testing/AsyncTestHarness.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Testing
 {
@@ -16,6 +16,7 @@ namespace MassTransit.Testing
     using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
+    using Internals.Extensions;
     using Observers;
     using Util;
 
@@ -56,7 +57,7 @@ namespace MassTransit.Testing
                     _cancellationTokenSource = new CancellationTokenSource((int)TestTimeout.TotalMilliseconds);
                     _cancellationToken = _cancellationTokenSource.Token;
 
-                    var source = new TaskCompletionSource<bool>();
+                    var source = TaskCompletionSourceFactory.New<bool>();
                     _cancelledTask = source.Task;
 
                     _cancellationToken.Register(() => source.TrySetCanceled());
@@ -91,7 +92,7 @@ namespace MassTransit.Testing
         /// <returns></returns>
         public TaskCompletionSource<T> GetTask<T>()
         {
-            var source = new TaskCompletionSource<T>();
+            var source = TaskCompletionSourceFactory.New<T>();
 
             TestCancelledTask.ContinueWith(x => source.TrySetCanceled(), TaskContinuationOptions.OnlyOnCanceled);
 

--- a/src/MassTransit/Testing/BusTestHarness.cs
+++ b/src/MassTransit/Testing/BusTestHarness.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using Context;
     using GreenPipes;
+    using Internals.Extensions;
     using Observers;
     using Util;
 
@@ -185,7 +186,7 @@
         public Task<ConsumeContext<T>> SubscribeHandler<T>()
             where T : class
         {
-            var source = new TaskCompletionSource<ConsumeContext<T>>();
+            var source = TaskCompletionSourceFactory.New<ConsumeContext<T>>();
 
             ConnectHandle handler = null;
             handler = Bus.ConnectHandler<T>(async context =>
@@ -215,7 +216,7 @@
         public Task<ConsumeContext<T>> SubscribeHandler<T>(Func<ConsumeContext<T>, bool> filter)
             where T : class
         {
-            var source = new TaskCompletionSource<ConsumeContext<T>>();
+            var source = TaskCompletionSourceFactory.New<ConsumeContext<T>>();
 
             ConnectHandle handler = null;
             handler = Bus.ConnectHandler<T>(async context =>

--- a/src/MassTransit/Transports/InMemory/Fabric/InMemoryQueue.cs
+++ b/src/MassTransit/Transports/InMemory/Fabric/InMemoryQueue.cs
@@ -17,6 +17,7 @@ namespace MassTransit.Transports.InMemory.Fabric
     using System.Threading.Tasks;
     using GreenPipes;
     using GreenPipes.Util;
+    using Internals.Extensions;
     using Util;
 
 
@@ -37,7 +38,7 @@ namespace MassTransit.Transports.InMemory.Fabric
             _cancellationToken = new CancellationTokenSource();
 
             _consumers = new Connectable<IInMemoryQueueConsumer>();
-            _consumer = new TaskCompletionSource<IInMemoryQueueConsumer>();
+            _consumer = TaskCompletionSourceFactory.New<IInMemoryQueueConsumer>();
             _cancellationToken.Token.Register(() => _consumer.TrySetCanceled());
         }
 

--- a/src/MassTransit/Transports/ReceiveEndpoint.cs
+++ b/src/MassTransit/Transports/ReceiveEndpoint.cs
@@ -7,6 +7,7 @@ namespace MassTransit.Transports
     using Events;
     using GreenPipes;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Pipeline;
 
 
@@ -28,7 +29,7 @@ namespace MassTransit.Transports
             _context = context;
             _receiveTransport = receiveTransport;
 
-            _started = new TaskCompletionSource<ReceiveEndpointReady>();
+            _started = TaskCompletionSourceFactory.New<ReceiveEndpointReady>();
             _handle = receiveTransport.ConnectReceiveTransportObserver(new Observer(this, context.EndpointObservers));
         }
 

--- a/src/MassTransit/Transports/ReceiveEndpointCollection.cs
+++ b/src/MassTransit/Transports/ReceiveEndpointCollection.cs
@@ -7,6 +7,7 @@
     using System.Threading.Tasks;
     using GreenPipes;
     using GreenPipes.Agents;
+    using Internals.Extensions;
     using Pipeline.Observables;
     using Util;
 
@@ -238,7 +239,7 @@
                 public Observer(IReceiveEndpoint endpoint, CancellationToken cancellationToken)
                 {
                     _cancellationToken = cancellationToken;
-                    _ready = new TaskCompletionSource<ReceiveEndpointReady>();
+                    _ready = TaskCompletionSourceFactory.New<ReceiveEndpointReady>();
 
                     _handle = endpoint.ConnectReceiveEndpointObserver(this);
                 }

--- a/src/MassTransit/Transports/ReceiveEndpointDependency.cs
+++ b/src/MassTransit/Transports/ReceiveEndpointDependency.cs
@@ -3,6 +3,7 @@ namespace MassTransit.Transports
     using System.Threading.Tasks;
     using GreenPipes;
     using GreenPipes.Internals.Extensions;
+    using Internals.Extensions;
     using Util;
 
 
@@ -15,7 +16,7 @@ namespace MassTransit.Transports
 
         public ReceiveEndpointDependency(IReceiveEndpointObserverConnector connector)
         {
-            _ready = new TaskCompletionSource<ReceiveEndpointReady>();
+            _ready = TaskCompletionSourceFactory.New<ReceiveEndpointReady>();
 
             _handle = connector.ConnectReceiveEndpointObserver(this);
         }

--- a/src/MassTransit/Util/TaskUtil.cs
+++ b/src/MassTransit/Util/TaskUtil.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2016 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Util
 {
@@ -17,6 +17,7 @@ namespace MassTransit.Util
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
+    using Internals.Extensions;
 
 
     public static class TaskUtil
@@ -30,7 +31,7 @@ namespace MassTransit.Util
 
         public static Task<T> Faulted<T>(Exception exception)
         {
-            var source = new TaskCompletionSource<T>();
+            var source = TaskCompletionSourceFactory.New<T>();
             source.TrySetException(exception);
 
             return source.Task;
@@ -180,7 +181,7 @@ namespace MassTransit.Util
 
             static Task<T> GetCanceledTask()
             {
-                var source = new TaskCompletionSource<T>();
+                var source = TaskCompletionSourceFactory.New<T>();
                 source.SetCanceled();
                 return source.Task;
             }


### PR DESCRIPTION
use `TaskCompletionSourceFactory` to create `TaskCompletionSource` with `TaskCreationOptions.RunContinuationsAsynchronously` option for .NET Standard

https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-create-taskcompletionsourcet-with-taskcreationoptionsruncontinuationsasynchronously