### PR TITLE
Fix default ClientProvidedName for RabbitMQ

### DIFF
--- a/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs
@@ -34,8 +34,10 @@ namespace MassTransit.RabbitMqTransport.Configurators
                 });
             }
 
-            _settings.ClientProvidedName = connectionName;
             _settings.VirtualHost = GetVirtualHost(hostAddress);
+
+            if (!string.IsNullOrEmpty(connectionName))
+                _settings.ClientProvidedName = connectionName;
         }
 
         public RabbitMqHostConfigurator(string host, string virtualHost, ushort port = 5672, string connectionName = null)
@@ -45,8 +47,10 @@ namespace MassTransit.RabbitMqTransport.Configurators
                 Host = host,
                 Port = port,
                 VirtualHost = virtualHost,
-                ClientProvidedName = connectionName
             };
+
+            if (!string.IsNullOrEmpty(connectionName))
+                _settings.ClientProvidedName = connectionName;
         }
 
         public RabbitMqHostSettings Settings => _settings;

--- a/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -175,15 +175,6 @@ namespace MassTransit.RabbitMqTransport
             if (hostInfo.AssemblyVersion != null)
                 factory.ClientProperties["assembly_version"] = hostInfo.AssemblyVersion;
 
-            if (string.IsNullOrEmpty(settings.ClientProvidedName))
-            {
-                factory.ClientProperties["connection_name"] = $"{hostInfo.MachineName}.{hostInfo.Assembly}_{hostInfo.ProcessName}";
-            }
-            else
-            {
-                factory.ClientProperties["connection_name"] = settings.ClientProvidedName;
-            }
-
             return factory;
         }
 


### PR DESCRIPTION
I had the problem that the RabbitMQ connections all had an `undefined` connection name, both in the “Client-provided name” and the `connection_name` client property:

![RabbitMQ shows “undefined” connection names](https://user-images.githubusercontent.com/132240/68301761-eed62380-00a0-11ea-941c-5e1d88a89614.png)

So I looked into this and found out that there is a [default value being set](https://github.com/MassTransit/MassTransit/blob/v5.5.6/src/MassTransit.RabbitMqTransport/Configuration/Configurators/ConfigurationHostSettings.cs#L36) but which is then overridden [in the constructors](https://github.com/MassTransit/MassTransit/blob/v5.5.6/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs#L48) of `RabbitMqHostConfigurator` even if there was no passed connection name:

https://github.com/MassTransit/MassTransit/blob/1f6a8f0509698705a8d892dd10e3cc2a96e14ed3/src/MassTransit.RabbitMqTransport/Configuration/Configurators/RabbitMqHostConfigurator.cs#L37

So the first part of this change is to fix that, to only overwrite the `ClientProvidedName` if there was an actual name passed to the constructor.

---

Then I looked further and saw that `RabbitMqAddressExtensions.GetConnectionFactory` would set the `connection_name` client property and intialize it with a sensible default if it is empty. So this path would have applied if the original code from above reset the `ClientProvidedName` to `null`:

https://github.com/MassTransit/MassTransit/blob/1f6a8f0509698705a8d892dd10e3cc2a96e14ed3/src/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs#L178-L185

However, that also had no effect, so I digged deeper into RabbitMQ.Client and saw that the underlying `Connection` actually [overwrites the `connection_name`](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/v5.1.2/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs#L1356) with the `ClientProvidedName` that was passed to [the connection factory](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/v5.1.2/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs#L408). Apparently this was pretty much always [how it worked](https://github.com/rabbitmq/rabbitmq-dotnet-client/commit/7d6e31e97d0a1b2c7d92b7f3f6e532f9b3b50dd7).

So the value that actually gets used is the one passed to the factory in the `ConnectionContextFactory`:

https://github.com/MassTransit/MassTransit/blob/1f6a8f0509698705a8d892dd10e3cc2a96e14ed3/src/MassTransit.RabbitMqTransport/Integration/ConnectionContextFactory.cs#L95-L104

And that value is the original `ClientProviderName` (which was overwritten with `null` before and as such resulted in an `undefined` value).

So tl;dr: The default `ClientProviderName` is now only overwritten if it is actually specified. And the `connection_name` client property does not need to be set ever since the RabbitMQ.Client library will overwrite it anyway.

I’ve verified this with an example project running against RabbitMQ 3.7.17, and RabbitMQ.Client 5.1.1.