### PR TITLE
fixed Add-Migration item with same key exception

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextFactoryWithResilienceStrategy.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/ContextFactoryWithResilienceStrategy.cs
@@ -5,11 +5,11 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
     using Microsoft.EntityFrameworkCore.Design;
 
 
-    public class ContextFactoryWithResilienceStrategy : IDesignTimeDbContextFactory<SimpleSagaDbContext>
+    public class ContextFactoryWithResilienceStrategy : IDesignTimeDbContextFactory<SimpleSagaDbContextWithResilienceStrategy>
     {
-        public SimpleSagaDbContext CreateDbContext(string[] args)
+        public SimpleSagaDbContextWithResilienceStrategy CreateDbContext(string[] args)
         {
-            var dbContextOptionsBuilder = new DbContextOptionsBuilder<SimpleSagaDbContext>();
+            var dbContextOptionsBuilder = new DbContextOptionsBuilder<SimpleSagaDbContextWithResilienceStrategy>();
 
             dbContextOptionsBuilder.UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString(),
                 m =>
@@ -19,7 +19,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
                         m.EnableRetryOnFailure();
                     });
 
-            return new SimpleSagaDbContext(dbContextOptionsBuilder.Options);
+            return new SimpleSagaDbContextWithResilienceStrategy(dbContextOptionsBuilder.Options);
         }
     }
 }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SimpleSagaDbContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SimpleSagaDbContext.cs
@@ -8,7 +8,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
 
     public class SimpleSagaDbContext : SagaDbContext
     {
-        public SimpleSagaDbContext(DbContextOptions<SimpleSagaDbContext> options)
+        public SimpleSagaDbContext(DbContextOptions options)
             : base(options)
         {
         }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SimpleSagaDbContextWithResilienceStrategy.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/SimpleSagaDbContextWithResilienceStrategy.cs
@@ -1,0 +1,13 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using Microsoft.EntityFrameworkCore;
+
+    public class SimpleSagaDbContextWithResilienceStrategy : SimpleSagaDbContext
+    {
+        public SimpleSagaDbContextWithResilienceStrategy(DbContextOptions options)
+            : base(options)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
While working on some changes on the EFAudit feature to add a new column to the audit records I found a issue with adding migrations. When detecting implementations of IDesignTimeDbContextFactory the tool finds multiple implementations returning the same DBContext type. Please find below the command output:

```
PM> EntityFrameworkCore\Add-Migration -Name dummy -Context auditdbcontext -Verbose
Both Entity Framework Core and Entity Framework 6 are installed. The Entity Framework Core tools are running. Use 'EntityFramework\Add-Migration' for Entity Framework 6.
Using project 'Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests'.
Using startup project 'Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests'.
Build started...
Build succeeded.
C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.entityframeworkcore.tools\2.2.0\tools\net461\any\ef.exe migrations add dummy --json --context auditdbcontext --verbose --no-color --prefix-output --assembly C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests\bin\Debug\net461\MassTransit.EntityFrameworkCoreIntegration.Tests.dll --startup-assembly C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests\bin\Debug\net461\MassTransit.EntityFrameworkCoreIntegration.Tests.dll --project-dir C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests\ --language C# --working-dir C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests --root-namespace MassTransit.EntityFrameworkCoreIntegration.Tests
Using assembly 'MassTransit.EntityFrameworkCoreIntegration.Tests'.
Using startup assembly 'MassTransit.EntityFrameworkCoreIntegration.Tests'.
Using application base 'C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests\bin\Debug\net461'.
Using working directory 'C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests'.
Using root namespace 'MassTransit.EntityFrameworkCoreIntegration.Tests'.
Using project directory 'C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests\'.
Using configuration file 'C:\Temp\MassTransit-SentTimeFork\src\Persistence\MassTransit.EntityFrameworkCoreIntegration.Tests\bin\Debug\net461\MassTransit.EntityFrameworkCoreIntegration.Tests.dll.config'.
Finding DbContext classes...
Finding IDesignTimeDbContextFactory implementations...
Found IDesignTimeDbContextFactory implementation 'AuditContextFactory'.
Found DbContext 'AuditDbContext'.
Found IDesignTimeDbContextFactory implementation 'ContextFactory'.
Found DbContext 'SimpleSagaDbContext'.
Found IDesignTimeDbContextFactory implementation 'ContextFactoryWithResilienceStrategy'.
Found DbContext 'SimpleSagaDbContext'.
System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at Microsoft.EntityFrameworkCore.Design.Internal.DbContextOperations.FindContextTypes()
   at Microsoft.EntityFrameworkCore.Design.Internal.DbContextOperations.FindContextType(String name)
   at Microsoft.EntityFrameworkCore.Design.Internal.DbContextOperations.CreateContext(String contextType)
   at Microsoft.EntityFrameworkCore.Design.Internal.MigrationsOperations.AddMigration(String name, String outputDir, String contextType)
   at Microsoft.EntityFrameworkCore.Design.OperationExecutor.AddMigrationImpl(String name, String outputDir, String contextType)
   at Microsoft.EntityFrameworkCore.Design.OperationExecutor.OperationBase.<>c__DisplayClass3_0`1.<Execute>b__0()
   at Microsoft.EntityFrameworkCore.Design.OperationExecutor.OperationBase.Execute(Action action)
An item with the same key has already been added.
```

To reproduce the error, please follow the steps described below:

```
1. Open the solution MassTransit.sln
2. Find the project MassTransit.EntityFrameworkCoreIntegration
3. Open the file AuditRecord from the Audit folder
4. Add a new property to the AuditRecord class (e.g.: public string Dummy { get; set; } )
5. Set the project MassTransit.EntityFrameworkCoreIntegration.Tests as the startup project
6. Open the Package Manager Console
7. Execute the following command:

   EntityFrameworkCore\Add-Migration -Name dummy -Context auditdbcontext -Verbose
```

After applying the changes in this PR, I ran the tests from the groups below and all tests passed

![image](https://user-images.githubusercontent.com/11743735/68973444-4b7dc080-07bc-11ea-865a-c1ff7214e73a.png)

PS: This is a first PR regarding adding a SentTime column to audit records.