### PR TITLE
Extending extension methods for sagas

### DIFF
--- a/src/MassTransit/Testing/ExtensionMethodsForSagas.cs
+++ b/src/MassTransit/Testing/ExtensionMethodsForSagas.cs
@@ -25,11 +25,17 @@ namespace MassTransit.Testing
         public static async Task<Guid?> ShouldContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
             where TSaga : class, ISaga
         {
+            return await (repository as IQuerySagaRepository<TSaga>).ShouldContainSaga(sagaId, timeout).ConfigureAwait(false);
+        }
+
+        public static async Task<Guid?> ShouldContainSaga<TSaga>(this IQuerySagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
             DateTime giveUpAt = DateTime.Now + timeout;
 
             while (DateTime.Now < giveUpAt)
             {
-                Guid saga = (await (repository as IQuerySagaRepository<TSaga>).Where(x => x.CorrelationId == sagaId).ConfigureAwait(false)).FirstOrDefault();
+                Guid saga = (await repository.Where(x => x.CorrelationId == sagaId).ConfigureAwait(false)).FirstOrDefault();
                 if (saga != Guid.Empty)
                     return saga;
 
@@ -42,12 +48,18 @@ namespace MassTransit.Testing
         public static async Task<Guid?> ShouldNotContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
             where TSaga : class, ISaga
         {
+            return await (repository as IQuerySagaRepository<TSaga>).ShouldNotContainSaga(sagaId, timeout).ConfigureAwait(false);
+        }
+
+        public static async Task<Guid?> ShouldNotContainSaga<TSaga>(this IQuerySagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
             DateTime giveUpAt = DateTime.Now + timeout;
 
             Guid? saga = default;
             while (DateTime.Now < giveUpAt)
             {
-                saga = (await (repository as IQuerySagaRepository<TSaga>).Where(x => x.CorrelationId == sagaId).ConfigureAwait(false)).FirstOrDefault();
+                saga = (await repository.Where(x => x.CorrelationId == sagaId).ConfigureAwait(false)).FirstOrDefault();
                 if (saga == Guid.Empty)
                     return default;
 
@@ -61,13 +73,20 @@ namespace MassTransit.Testing
             TimeSpan timeout)
             where TSaga : class, ISaga
         {
+            return await (repository as IQuerySagaRepository<TSaga>).ShouldContainSaga(filter, timeout).ConfigureAwait(false);
+        }
+
+        public static async Task<Guid?> ShouldContainSaga<TSaga>(this IQuerySagaRepository<TSaga> repository, Expression<Func<TSaga, bool>> filter,
+            TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
             DateTime giveUpAt = DateTime.Now + timeout;
 
             var query = new SagaQuery<TSaga>(filter);
 
             while (DateTime.Now < giveUpAt)
             {
-                List<Guid> sagas = (await (repository as IQuerySagaRepository<TSaga>).Where(query.FilterExpression).ConfigureAwait(false)).ToList();
+                List<Guid> sagas = (await repository.Where(query.FilterExpression).ConfigureAwait(false)).ToList();
                 if (sagas.Count > 0)
                     return sagas.Single();
 

--- a/src/MassTransit/Testing/ExtensionMethodsForSagas.cs
+++ b/src/MassTransit/Testing/ExtensionMethodsForSagas.cs
@@ -28,6 +28,12 @@ namespace MassTransit.Testing
             return await (repository as IQuerySagaRepository<TSaga>).ShouldContainSaga(sagaId, timeout).ConfigureAwait(false);
         }
 
+        public static async Task<Guid?> ShouldContainSaga<TSaga>(this InMemorySagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
+            return await (repository as IQuerySagaRepository<TSaga>).ShouldContainSaga(sagaId, timeout).ConfigureAwait(false);
+        }
+
         public static async Task<Guid?> ShouldContainSaga<TSaga>(this IQuerySagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
             where TSaga : class, ISaga
         {
@@ -43,6 +49,11 @@ namespace MassTransit.Testing
             }
 
             return default;
+        }
+        public static async Task<Guid?> ShouldNotContainSaga<TSaga>(this InMemorySagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
+            return await (repository as IQuerySagaRepository<TSaga>).ShouldNotContainSaga(sagaId, timeout).ConfigureAwait(false);
         }
 
         public static async Task<Guid?> ShouldNotContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Guid sagaId, TimeSpan timeout)
@@ -67,6 +78,12 @@ namespace MassTransit.Testing
             }
 
             return saga;
+        }
+        public static async Task<Guid?> ShouldContainSaga<TSaga>(this InMemorySagaRepository<TSaga> repository, Expression<Func<TSaga, bool>> filter,
+            TimeSpan timeout)
+            where TSaga : class, ISaga
+        {
+            return await (repository as IQuerySagaRepository<TSaga>).ShouldContainSaga(filter, timeout).ConfigureAwait(false);
         }
 
         public static async Task<Guid?> ShouldContainSaga<TSaga>(this ISagaRepository<TSaga> repository, Expression<Func<TSaga, bool>> filter,


### PR DESCRIPTION
I've extended the extension methods for sagas for testing so they can just work on `IQuerySagaRepository<TSaga>` type.

This was because not all types implementing `ISagaRepository<TSaga>` also implement `IQuerySagaRepository<TSaga>` so the casting fails. I actually think it's only the `InMemorySagaRepository<TSaga>` that implements both and we're using the MongoDB implementation in our tests.