### PR TITLE
Azure Service Bus brokered message receiver exception handling

### DIFF
--- a/docs/usage/transports/azure-sb.md
+++ b/docs/usage/transports/azure-sb.md
@@ -25,6 +25,24 @@ MassTransit supports Azure Service Bus and Azure Event Hub when running from an 
 > The [Sample Code](https://github.com/MassTransit/MassTransit/tree/develop/src/Samples/Sample.AzureFunctions.ServiceBus) is available
 for reference as well.
 
+The functions [host.json](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus#host-json) file needs to have messageHandlerOptions > autoComplete set to true. This is so that the message is removed from the queue once processing has completed successfully.
+
+```
+{
+  "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "prefetchCount": 20,
+      "messageHandlerOptions": {
+        "autoComplete": true,
+        "maxConcurrentCalls": 20,
+        "maxAutoRenewDuration": "00:55:00"
+      }
+    }
+  },
+}
+```
+
 ### Azure Service Bus
 
 The bindings for using MassTransit with Azure Service Bus are shown below.

--- a/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/BrokeredMessageReceiverServiceBusEndpointConfiguration.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/BrokeredMessageReceiverServiceBusEndpointConfiguration.cs
@@ -25,8 +25,6 @@
         {
             return Receive.CreatePipe(ConsumePipe, Serialization.Deserializer, configurator =>
             {
-                Receive.ErrorConfigurator.UseFilter(new GenerateFaultFilter());
-
                 configurator.UseRescue(Receive.ErrorConfigurator.Build(), x =>
                 {
                     x.Ignore<OperationCanceledException>();

--- a/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/BrokeredMessageReceiverServiceBusEndpointConfiguration.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/BrokeredMessageReceiverServiceBusEndpointConfiguration.cs
@@ -23,13 +23,7 @@
 
         public override IReceivePipe CreateReceivePipe()
         {
-            return Receive.CreatePipe(ConsumePipe, Serialization.Deserializer, configurator =>
-            {
-                configurator.UseRescue(Receive.ErrorConfigurator.Build(), x =>
-                {
-                    x.Ignore<OperationCanceledException>();
-                });
-            });
+            return Receive.CreatePipe(ConsumePipe, Serialization.Deserializer);
         }
     }
 }


### PR DESCRIPTION
This allows exceptions within a consumer used in an Azure Service Bus brokered message receiver to bubble outside of the receiver. This is necessary for Azure Functions to properly handle exceptions. More details are logged in this issue: https://github.com/MassTransit/MassTransit/issues/1661

To test, I threw an exception within the consumer. Before code changes, the exception was logged yet the message was removed from the queue (completed). After these changes, the exception is caught by the Azure Function and moved to the dead letter queue after a configured number of retry attempts.
