### PR TITLE
Add Transaction Outbox

### DIFF
--- a/docs/advanced/middleware/transactions.md
+++ b/docs/advanced/middleware/transactions.md
@@ -83,3 +83,52 @@ public class TransactionalConsumer :
 The connection (and by use of the connection, the command) are enlisted in the transaction. Once the method completes, and control is returned to the transaction middleware, if no exceptions are thrown the transaction is committed (which should complete the database operation). If an exception is thrown, the transaction is rolled back.
 
 While not shown here, a class that provides the connection, and enlists the connection upon creation, should be added to the container to ensure that the transaction is not enlisted twice (not sure that's a bad thing though, it should be ignored). Also, as long as only a single connection string is enlisted, the DTC should not get involved. Using the same transaction across multiple connection strings is a bad thing, as it will make the DTC come into play which slows the world down significantly.
+
+## Transaction Outbox
+
+While the [In Memory Outbox](/usage/exceptions#outbox) is the best choice for an outbox when within a consumer, sometimes you need to Publish/Send a message onto the bus from outside a consumer. Such scenarios might be from a console app, or maybe an HTTP Endpoint. Below is an example of registration and usage for the Transaction Outbox.
+
+```cs
+services.AddMassTransit(x =>
+{
+    x.AddBus(provider => Bus.Factory.CreateUsingRabbitMq(cfg =>
+    {
+        var host = cfg.Host("localhost", "/");
+    }));
+
+    // This needs to be after AddBus, because it registers a decorator over IPublishEndpoint and ISendEndpointProvider, and DI Registration order matters (last registration wins)
+    x.AddTransactionOutbox();
+});
+```
+
+That is all that's needed. Now here's an example usage within an MVC Action.  It's also important to use `TransactionScopeAsyncFlowOption.Enabled` as shown below.
+
+```cs
+public class MyController : ControllerBase
+{
+    private readonly IPublishEndpoint _publishEndpoint;
+    private readonly MyDbContext _dbContext;
+
+    public ValuesController(IPublishEndpoint publishEndpoint, MyDbContext dbContext)
+    {
+        _publishEndpoint = publishEndpoint;
+        _dbContext = dbContext;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Post([FromBody] string value)
+    {
+        using(var transaction = TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+        {
+            _dbContext.Posts.Add(new Post{...});
+            await _dbContext.SaveChangesAsync();
+
+            await _publishEndpoint.Publish(new PostCreated{...});
+
+            transaction.Complete();
+        }
+
+        return Ok();
+    }
+}
+```

--- a/src/Containers/MassTransit.AutoFacIntegration/AutofacTransactionOutboxExtensions.cs
+++ b/src/Containers/MassTransit.AutoFacIntegration/AutofacTransactionOutboxExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Autofac;
+using MassTransit.AutofacIntegration;
+using MassTransit.Transactions;
+using Microsoft.Extensions.Logging;
+
+namespace MassTransit
+{
+    public static class AutofacTransactionOutboxExtensions
+    {
+        /// <summary>
+        /// Decorates the IPublishEndpoint and ISendEndpointProvider with a Transaction Outbox. Messages will not be
+        /// released/sent until the ambient transaction is committed. This is only meant to be used outside of a consumer.
+        /// If you want an outbox for Consumers, it is recommended to use the InMemoryOutbox.
+        /// </summary>
+        public static void AddTransactionOutbox(this IContainerBuilderConfigurator builder)
+        {
+            builder.Builder
+                .Register(c =>
+                {
+                    var busControl = c.Resolve<IBusControl>();
+                    return new TransactionOutbox(busControl, busControl, c.ResolveOptional<ILoggerFactory>());
+                })
+                .SingleInstance()
+                .AsImplementedInterfaces();
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/DependencyInjectionTransactionOutboxExtensions.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/DependencyInjectionTransactionOutboxExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace MassTransit
+{
+    using MassTransit.ExtensionsDependencyInjectionIntegration;
+    using MassTransit.Transactions;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Logging;
+
+    public static class DependencyInjectionTransactionOutboxExtensions
+    {
+        /// <summary>
+        /// Decorates the IPublishEndpoint and ISendEndpointProvider with a Transaction Outbox. Messages will not be
+        /// released/sent until the ambient transaction is committed. This is only meant to be used outside of a consumer.
+        /// If you want an outbox for Consumers, it is recommended to use the InMemoryOutbox.
+        /// </summary>
+        public static void AddTransactionOutbox(this IServiceCollectionConfigurator configurator)
+        {
+            configurator.Collection.TryAddSingleton(provider =>
+            {
+                var busControl = provider.GetRequiredService<IBusControl>();
+                return new TransactionOutbox(busControl, busControl, provider.GetService<ILoggerFactory>());
+            });
+
+            // This should override the registrations from AddBus, in favor of the TransactionOutbox implementations
+            configurator.Collection.AddSingleton<IPublishEndpoint>(x => x.GetRequiredService<TransactionOutbox>());
+            configurator.Collection.AddSingleton<ISendEndpointProvider>(x => x.GetRequiredService<TransactionOutbox>());
+        }
+    }
+}

--- a/src/Containers/MassTransit.LamarIntegration/LamarTransactionOutboxExtensions.cs
+++ b/src/Containers/MassTransit.LamarIntegration/LamarTransactionOutboxExtensions.cs
@@ -1,0 +1,35 @@
+namespace MassTransit
+{
+    using Lamar;
+    using LamarIntegration;
+    using MassTransit.Transactions;
+    using Microsoft.Extensions.Logging;
+
+
+    public static class LamarTransactionOutboxExtensions
+    {
+        /// <summary>
+        /// Decorates the IPublishEndpoint and ISendEndpointProvider with a Transaction Outbox. Messages will not be
+        /// released/sent until the ambient transaction is committed. This is only meant to be used outside of a consumer.
+        /// If you want an outbox for Consumers, it is recommended to use the InMemoryOutbox.
+        /// </summary>
+        public static void AddTransactionOutbox(this IServiceRegistryConfigurator builder)
+        {
+            builder.Builder
+                .For<TransactionOutbox>()
+                .Use(x =>
+                {
+                    var busControl = x.GetInstance<IBusControl>();
+
+                    return new TransactionOutbox(busControl, busControl, x.TryGetInstance<ILoggerFactory>());
+                })
+                .Singleton();
+
+            builder.Builder
+                .Use<TransactionOutbox>()
+                .Singleton()
+                .For<IPublishEndpoint>()
+                .For<ISendEndpointProvider>();
+        }
+    }
+}

--- a/src/Containers/MassTransit.SimpleInjectorIntegration/SimpleInjectorTransactionOutboxExtensions.cs
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/SimpleInjectorTransactionOutboxExtensions.cs
@@ -1,0 +1,33 @@
+﻿namespace MassTransit
+{
+    using MassTransit.Transactions;
+    using Microsoft.Extensions.Logging;
+    using SimpleInjector;
+    using SimpleInjectorIntegration;
+
+
+    public static class SimpleInjectorTransactionOutboxExtensions
+    {
+        /// <summary>
+        /// Decorates the IPublishEndpoint and ISendEndpointProvider with a Transaction Outbox. Messages will not be
+        /// released/sent until the ambient transaction is committed. This is only meant to be used outside of a consumer.
+        /// If you want an outbox for Consumers, it is recommended to use the InMemoryOutbox.
+        /// </summary>
+        public static void AddTransactionOutbox(this ISimpleInjectorConfigurator builder)
+        {
+            builder.Container
+                .RegisterSingleton(()=>
+                {
+                    var busControl = builder.Container.GetInstance<IBusControl>();
+
+                    return new TransactionOutbox(busControl, busControl, builder.Container.TryGetInstance<ILoggerFactory>());
+                });
+
+            builder.Container
+                .Register(() => (IPublishEndpoint)builder.Container.GetInstance<TransactionOutbox>(), Lifestyle.Singleton);
+
+            builder.Container
+                .Register(() => (ISendEndpointProvider)builder.Container.GetInstance<TransactionOutbox>(), Lifestyle.Singleton);
+        }
+    }
+}

--- a/src/Containers/MassTransit.StructureMapIntegration/StructureMapTransactionOutboxExtensions.cs
+++ b/src/Containers/MassTransit.StructureMapIntegration/StructureMapTransactionOutboxExtensions.cs
@@ -1,0 +1,37 @@
+﻿namespace MassTransit
+{
+    using MassTransit.Transactions;
+    using Microsoft.Extensions.Logging;
+    using StructureMapIntegration;
+
+    public static class StructureMapTransactionOutboxExtensions
+    {
+        /// <summary>
+        /// Decorates the IPublishEndpoint and ISendEndpointProvider with a Transaction Outbox. Messages will not be
+        /// released/sent until the ambient transaction is committed. This is only meant to be used outside of a consumer.
+        /// If you want an outbox for Consumers, it is recommended to use the InMemoryOutbox.
+        /// </summary>
+        public static void AddTransactionOutbox(this IConfigurationExpressionConfigurator builder)
+        {
+            builder.Builder
+                .For<TransactionOutbox>()
+                .Use("Fetch Bus Control and Create TransactionOutbox", x =>
+                {
+                    var busControl = x.GetInstance<IBusControl>();
+
+                    return new TransactionOutbox(busControl, busControl, x.TryGetInstance<ILoggerFactory>());
+                })
+                .Singleton();
+
+            builder.Builder
+                .For<IPublishEndpoint>()
+                .Use(x => x.GetInstance<TransactionOutbox>())
+                .Singleton();
+
+            builder.Builder
+                .For<ISendEndpointProvider>()
+                .Use(x => x.GetInstance<TransactionOutbox>())
+                .Singleton();
+        }
+    }
+}

--- a/src/Containers/MassTransit.WindsorIntegration/WindsorTransactionOutboxExtensions.cs
+++ b/src/Containers/MassTransit.WindsorIntegration/WindsorTransactionOutboxExtensions.cs
@@ -1,0 +1,35 @@
+﻿namespace MassTransit
+{
+    using Castle.MicroKernel.Registration;
+    using MassTransit.Transactions;
+    using Microsoft.Extensions.Logging;
+    using WindsorIntegration;
+
+
+    public static class WindsorTransactionOutboxExtensions
+    {
+        /// <summary>
+        /// Decorates the IPublishEndpoint and ISendEndpointProvider with a Transaction Outbox. Messages will not be
+        /// released/sent until the ambient transaction is committed. This is only meant to be used outside of a consumer.
+        /// If you want an outbox for Consumers, it is recommended to use the InMemoryOutbox.
+        /// </summary>
+        public static void AddTransactionOutbox(this IWindsorContainerConfigurator builder)
+        {
+            builder.Container
+                .Register(
+                    Component.For<TransactionOutbox>()
+                        .UsingFactoryMethod(x =>
+                        {
+                            var busControl = x.Resolve<IBusControl>();
+
+                            return new TransactionOutbox(busControl, busControl, x.Resolve<ILoggerFactory>());
+                        })
+                        .LifestyleSingleton(),
+                    Component.For<IPublishEndpoint>()
+                        .Forward<ISendEndpointProvider>()
+                        .UsingFactoryMethod(x => x.Resolve<TransactionOutbox>())
+                        .LifestyleSingleton()
+                );
+        }
+    }
+}

--- a/src/MassTransit.Tests/Transactions/TransactionOutbox_Specs.cs
+++ b/src/MassTransit.Tests/Transactions/TransactionOutbox_Specs.cs
@@ -1,0 +1,127 @@
+﻿using GreenPipes.Internals.Extensions;
+using MassTransit.TestFramework;
+using MassTransit.TestFramework.Messages;
+using MassTransit.Transactions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace MassTransit.Tests.Transactions
+{
+    [TestFixture]
+    public class When_using_transaction_scope_with_publish_and_complete :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_publish_properly()
+        {
+            var message = new PingMessage();
+            var transactionOutbox = new TransactionOutbox(Bus, Bus, new NullLoggerFactory());
+
+            using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                await transactionOutbox.Publish(message);
+
+                // Hasn't published yet
+                Assert.That(async () => await _received.OrTimeout(s: 3), Throws.TypeOf<TimeoutException>());
+
+                transaction.Complete();
+            }
+            // Now has published
+            await _received;
+        }
+
+        Task<ConsumeContext<PingMessage>> _received;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _received = Handled<PingMessage>(configurator);
+        }
+    }
+
+    [TestFixture]
+    public class When_using_transaction_scope_with_send_and_complete :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_send_properly()
+        {
+            var message = new PingMessage();
+            var transactionOutbox = new TransactionOutbox(Bus, Bus, new NullLoggerFactory());
+
+            using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var sendEndpoint = await transactionOutbox.GetSendEndpoint(InputQueueAddress);
+                await sendEndpoint.Send(message);
+
+                Assert.That(async () => await _received.OrTimeout(s: 3), Throws.TypeOf<TimeoutException>());
+
+                transaction.Complete();
+            }
+
+            await _received;
+        }
+
+        Task<ConsumeContext<PingMessage>> _received;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _received = Handled<PingMessage>(configurator);
+        }
+    }
+
+    [TestFixture]
+    public class When_using_transaction_scope_with_publish_and_no_complete :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_not_publish_properly()
+        {
+            var message = new PingMessage();
+            var transactionOutbox = new TransactionOutbox(Bus, Bus, new NullLoggerFactory());
+
+            using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                await transactionOutbox.Publish(message);
+            }
+
+            Assert.That(async () => await _received.OrTimeout(s: 3), Throws.TypeOf<TimeoutException>());
+        }
+
+        Task<ConsumeContext<PingMessage>> _received;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _received = Handled<PingMessage>(configurator);
+        }
+    }
+
+    [TestFixture]
+    public class When_using_transaction_scope_with_send_and_no_complete :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_not_send_properly()
+        {
+            var message = new PingMessage();
+            var transactionOutbox = new TransactionOutbox(Bus, Bus, new NullLoggerFactory());
+
+            using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var sendEndpoint = await transactionOutbox.GetSendEndpoint(InputQueueAddress);
+                await sendEndpoint.Send(message);
+            }
+
+            Assert.That(async () => await _received.OrTimeout(s: 3), Throws.TypeOf<TimeoutException>());
+        }
+
+        Task<ConsumeContext<PingMessage>> _received;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _received = Handled<PingMessage>(configurator);
+        }
+    }
+}

--- a/src/MassTransit.sln
+++ b/src/MassTransit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Persistence", "Persistence", "{56F516D7-BC3C-49E1-A639-83C5F14953F8}"
 EndProject
@@ -137,7 +137,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.SignalR.Sample"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.WebJobs.EventHubsIntegration", "MassTransit.WebJobs.EventHubsIntegration\MassTransit.WebJobs.EventHubsIntegration.csproj", "{56E9DB90-C063-49CA-BAF7-FFCFE963E44C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.WebJobs.Tests", "MassTransit.WebJobs.Tests\MassTransit.WebJobs.Tests.csproj", "{0C214618-DBFA-45B6-B1B3-99E90F17FE23}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.WebJobs.Tests", "MassTransit.WebJobs.Tests\MassTransit.WebJobs.Tests.csproj", "{0C214618-DBFA-45B6-B1B3-99E90F17FE23}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/MassTransit/Transactions/TransactionOutbox.cs
+++ b/src/MassTransit/Transactions/TransactionOutbox.cs
@@ -1,0 +1,103 @@
+﻿using GreenPipes;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace MassTransit.Transactions
+{
+    public class TransactionOutbox : IPublishEndpoint, ISendEndpointProvider
+    {
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IPublishEndpoint _publishEndpoint;
+        private readonly ISendEndpointProvider _sendEndpointProvider;
+        readonly ConcurrentDictionary<Transaction, TransactionOutboxEnlistment> _pendingActions;
+
+        public TransactionOutbox(IPublishEndpoint publishEndpoint, ISendEndpointProvider sendEndpointProvider, ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+            _publishEndpoint = publishEndpoint;
+            _sendEndpointProvider = sendEndpointProvider;
+            _pendingActions = new ConcurrentDictionary<Transaction, TransactionOutboxEnlistment>();
+        }
+
+        public void ClearTransaction(Transaction transaction)
+        {
+            if (_pendingActions.TryRemove(transaction, out var transactionOutboxEnlistment))
+            {
+                transaction.TransactionCompleted -= TransactionCompleted;
+            }
+        }
+
+        public ConnectHandle ConnectPublishObserver(IPublishObserver observer)
+            => _publishEndpoint.ConnectPublishObserver(observer);
+
+        public ConnectHandle ConnectSendObserver(ISendObserver observer)
+            => _sendEndpointProvider.ConnectSendObserver(observer);
+
+        public Task Outbox(Func<Task> action)
+        {
+            if (Transaction.Current == null)
+                return action();
+
+            var pendingActions = GetOrCreateEnlistment();
+
+            pendingActions.Add(action);
+
+            return Task.CompletedTask;
+        }
+
+        public async Task<ISendEndpoint> GetSendEndpoint(Uri address)
+            => new TransactionOutboxSendEndpoint(this, await _sendEndpointProvider.GetSendEndpoint(address));
+
+        public Task Publish<T>(T message, CancellationToken cancellationToken = default) where T : class
+            => Outbox(() => _publishEndpoint.Publish<T>(message, cancellationToken));
+
+        public Task Publish<T>(T message, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken = default) where T : class
+            => Outbox(() => _publishEndpoint.Publish<T>(message, publishPipe, cancellationToken));
+
+        public Task Publish<T>(T message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default) where T : class
+            => Outbox(() => _publishEndpoint.Publish<T>(message, publishPipe, cancellationToken));
+
+        public Task Publish(object message, CancellationToken cancellationToken = default)
+            => Outbox(() => _publishEndpoint.Publish(message, cancellationToken));
+
+        public Task Publish(object message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default)
+            => Outbox(() => _publishEndpoint.Publish(message, publishPipe, cancellationToken));
+
+        public Task Publish(object message, Type messageType, CancellationToken cancellationToken = default)
+            => Outbox(() => _publishEndpoint.Publish(message, messageType, cancellationToken));
+
+        public Task Publish(object message, Type messageType, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default)
+            => Outbox(() => _publishEndpoint.Publish(message, messageType, publishPipe, cancellationToken));
+
+        public Task Publish<T>(object values, CancellationToken cancellationToken = default) where T : class
+            => Outbox(() => _publishEndpoint.Publish<T>(values, cancellationToken));
+
+        public Task Publish<T>(object values, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken = default) where T : class
+            => Outbox(() => _publishEndpoint.Publish<T>(values, publishPipe, cancellationToken));
+
+        public Task Publish<T>(object values, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default) where T : class
+            => Outbox(() => _publishEndpoint.Publish<T>(values, publishPipe, cancellationToken));
+
+        private TransactionOutboxEnlistment GetOrCreateEnlistment()
+        {
+            return _pendingActions.GetOrAdd(Transaction.Current, transaction =>
+            {
+                var transactionEnlistment = new TransactionOutboxEnlistment(_loggerFactory);
+
+                transaction.TransactionCompleted += TransactionCompleted;
+                transaction.EnlistVolatile(transactionEnlistment, EnlistmentOptions.None);
+
+                return transactionEnlistment;
+            });
+        }
+
+        private void TransactionCompleted(object sender, TransactionEventArgs e)
+        {
+            ClearTransaction(e.Transaction);
+        }
+    }
+}

--- a/src/MassTransit/Transactions/TransactionOutboxEnlistment.cs
+++ b/src/MassTransit/Transactions/TransactionOutboxEnlistment.cs
@@ -1,0 +1,94 @@
+﻿using MassTransit.Util;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace MassTransit.Transactions
+{
+    public class TransactionOutboxEnlistment : IEnlistmentNotification
+    {
+        private readonly ILogger<TransactionOutboxEnlistment> _logger;
+        readonly List<Func<Task>> _pendingActions;
+
+        public TransactionOutboxEnlistment(
+            ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory?.CreateLogger<TransactionOutboxEnlistment>();
+            _pendingActions = new List<Func<Task>>();
+        }
+
+        public void Add(Func<Task> method)
+        {
+            lock (_pendingActions)
+                _pendingActions.Add(method);
+        }
+
+        private void ExecutePendingActions()
+        {
+            Func<Task>[] pendingActions;
+            lock (_pendingActions)
+                pendingActions = _pendingActions.ToArray();
+
+            foreach (var action in pendingActions)
+            {
+                TaskUtil.Await(action);
+            }
+        }
+
+        private void DiscardPendingActions()
+        {
+            lock (_pendingActions)
+                _pendingActions.Clear();
+        }
+
+        public void Prepare(PreparingEnlistment preparingEnlistment)
+        {
+            _logger?.LogDebug("Prepare notification received");
+
+            try
+            {
+                ExecutePendingActions();
+
+                //If work finished correctly, reply prepared
+                preparingEnlistment.Prepared();
+            }
+            catch (Exception e)
+            {
+                _logger?.LogError(e, "MASSTRANSIT: Error executing pending actions");
+                // We can't stop any messages that might have been already published, but we can stop the rest from publishing
+                // But with a message broker, you should support idempotence, and so retry is a valid mechanism to handle this
+                // scenario
+                preparingEnlistment.ForceRollback();
+            }
+        }
+
+        public void Commit(Enlistment enlistment)
+        {
+            _logger?.LogDebug("Commit notification received");
+
+            DiscardPendingActions();
+
+            enlistment.Done();
+        }
+
+        public void Rollback(Enlistment enlistment)
+        {
+            _logger?.LogDebug("Rollback notification received");
+
+            DiscardPendingActions();
+
+            enlistment.Done();
+        }
+
+        public void InDoubt(Enlistment enlistment)
+        {
+            _logger?.LogDebug("In doubt notification received");
+
+            DiscardPendingActions();
+
+            enlistment.Done();
+        }
+    }
+}

--- a/src/MassTransit/Transactions/TransactionOutboxSendEndpoint.cs
+++ b/src/MassTransit/Transactions/TransactionOutboxSendEndpoint.cs
@@ -1,0 +1,52 @@
+﻿using GreenPipes;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MassTransit.Transactions
+{
+    public class TransactionOutboxSendEndpoint : ISendEndpoint
+    {
+        private readonly TransactionOutbox _transactionOutbox;
+        private readonly ISendEndpoint _sendEndpoint;
+
+        public TransactionOutboxSendEndpoint(TransactionOutbox transactionOutbox, ISendEndpoint sendEndpoint)
+        {
+            _transactionOutbox = transactionOutbox;
+            _sendEndpoint = sendEndpoint;
+        }
+
+        public ConnectHandle ConnectSendObserver(ISendObserver observer)
+            => _sendEndpoint.ConnectSendObserver(observer);
+
+        public Task Send<T>(T message, CancellationToken cancellationToken = default) where T : class
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send<T>(message, cancellationToken));
+
+        public Task Send<T>(T message, IPipe<SendContext<T>> pipe, CancellationToken cancellationToken = default) where T : class
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send<T>(message, pipe, cancellationToken));
+
+        public Task Send<T>(T message, IPipe<SendContext> pipe, CancellationToken cancellationToken = default) where T : class
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send<T>(message, pipe, cancellationToken));
+
+        public Task Send(object message, CancellationToken cancellationToken = default)
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send(message, cancellationToken));
+
+        public Task Send(object message, Type messageType, CancellationToken cancellationToken = default)
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send(message, messageType, cancellationToken));
+
+        public Task Send(object message, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send(message, pipe, cancellationToken));
+
+        public Task Send(object message, Type messageType, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send(message, messageType, pipe, cancellationToken));
+
+        public Task Send<T>(object values, CancellationToken cancellationToken = default) where T : class
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send<T>(values, cancellationToken));
+
+        public Task Send<T>(object values, IPipe<SendContext<T>> pipe, CancellationToken cancellationToken = default) where T : class
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send<T>(values, pipe, cancellationToken));
+
+        public Task Send<T>(object values, IPipe<SendContext> pipe, CancellationToken cancellationToken = default) where T : class
+            => _transactionOutbox.Outbox(() => _sendEndpoint.Send<T>(values, pipe, cancellationToken));
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/LocalDbConnectionStringProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/LocalDbConnectionStringProvider.cs
@@ -24,15 +24,15 @@
         /// <summary>
         /// Loops through the array of potential localdb connection strings to find one that we can use for the unit tests
         /// </summary>
-        public static string GetLocalDbConnectionString()
+        public static string GetLocalDbConnectionString(string initialCatalog = "MassTransitUnitTests_v12_2015;")
         {
             if (!string.IsNullOrWhiteSpace(_connectionString))
-                return _connectionString;
+                return _connectionString + "Initial Catalog=" + initialCatalog;
 
             lock (_lockConnectionString)
             {
                 if (!string.IsNullOrWhiteSpace(_connectionString))
-                    return _connectionString;
+                    return _connectionString + "Initial Catalog=" + initialCatalog;
 
                 // Lets find a localdb that we can use for our unit test
                 foreach (var connectionString in _possibleLocalDbConnectionStrings)
@@ -44,7 +44,7 @@
                             connection.Open();
 
                             // It worked, we can save this as our connection string
-                            _connectionString = connectionString + "Initial Catalog=MassTransitUnitTests_v12_2015;";
+                            _connectionString = connectionString;
                             break;
                         }
                     }
@@ -60,7 +60,7 @@
                         "Couldn't connect to any of the LocalDB Databases. You might have a version installed that is not in the list. Please check the list and modify as necessary");
             }
 
-            return _connectionString;
+            return _connectionString + "Initial Catalog=" + initialCatalog;
         }
     }
 }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
@@ -24,6 +24,11 @@
     <ProjectReference Include="..\MassTransit.EntityFrameworkCoreIntegration\MassTransit.EntityFrameworkCoreIntegration.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Migrations\" />
     <Folder Include="Migrations\SagaWithDependency" />

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/TransactionOutbox_Specs.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration.Tests/TransactionOutbox_Specs.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.EntityFrameworkCoreIntegration.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using GreenPipes.Internals.Extensions;
+    using MassTransit.Tests.Saga.Messages;
+    using MassTransit.Transactions;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using NUnit.Framework;
+    using TestFramework;
+
+
+    /// <summary>
+    /// This test fixture has nothing to do with the Saga, but I wanted to test EFCore with the TransactionOutbox,
+    /// so this was the easiest project to add a test spec to which has EF Core already referenced.
+    /// </summary>
+    [TestFixture]
+    [Category("Integration")]
+    public class TransactionOutbox_Specs :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_publish_after_db_create()
+        {
+            var message = new InitiateSimpleSaga();
+            var product = new Product { Name = "Should_publish_after_db_create" };
+            var transactionOutbox = new TransactionOutbox(Bus, Bus, new NullLoggerFactory());
+
+            using(var dbContext = GetDbContext())
+            using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                dbContext.Products.Add(product);
+                await dbContext.SaveChangesAsync();
+
+                await transactionOutbox.Publish(message);
+
+                // Hasn't published yet
+                Assert.That(async () => await _received.OrTimeout(s: 3), Throws.TypeOf<TimeoutException>());
+
+                transaction.Complete();
+            }
+
+            // Now has published
+            await _received;
+
+            using (var dbContext = GetDbContext())
+            {
+                Assert.IsTrue(await dbContext.Products.AnyAsync(x => x.Id == product.Id));
+            }
+        }
+
+        [Test]
+        public async Task Should_not_publish_properly()
+        {
+            var message = new InitiateSimpleSaga();
+            var product = new Product { Name = "Should_not_publish_properly" };
+            var transactionOutbox = new TransactionOutbox(Bus, Bus, new NullLoggerFactory());
+
+            using (var dbContext = GetDbContext())
+            using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var entity = dbContext.Products.Add(product);
+                await dbContext.SaveChangesAsync();
+
+                await transactionOutbox.Publish(message);
+            }
+
+            Assert.That(async () => await _received.OrTimeout(s: 3), Throws.TypeOf<TimeoutException>());
+
+            using (var dbContext = GetDbContext())
+            {
+                Assert.IsFalse(await dbContext.Products.AnyAsync(x => x.Id == product.Id));
+            }
+        }
+
+        Task<ConsumeContext<InitiateSimpleSaga>> _received;
+
+        private TransactionOutboxTestsDbContext GetDbContext()
+        {
+            var dbContext = new TransactionOutboxTestsDbContext(new DbContextOptionsBuilder().UseSqlServer(LocalDbConnectionStringProvider.GetLocalDbConnectionString("MassTransitUnitTests_TransactionOutbox")).Options);
+            return dbContext;
+        }
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _received = Handled<InitiateSimpleSaga>(configurator);
+        }
+
+        public TransactionOutbox_Specs()
+        {
+            using (var dbContext = GetDbContext())
+            {
+                dbContext.Database.EnsureCreated();
+                //RelationalDatabaseCreator databaseCreator = (RelationalDatabaseCreator)dbContext.Database.GetService<IDatabaseCreator>();
+                //databaseCreator.CreateTables();
+            }
+        }
+    }
+
+    public class TransactionOutboxTestsDbContext : DbContext
+    {
+        public TransactionOutboxTestsDbContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Product> Products { get; set; }
+    }
+
+    public class Product
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public int Quantity { get; set; }
+    }
+}

--- a/src/Samples/MassTransit.SignalR.SampleConsole/Program.cs
+++ b/src/Samples/MassTransit.SignalR.SampleConsole/Program.cs
@@ -1,11 +1,17 @@
 ﻿using MassTransit.SignalR.Contracts;
-using MassTransit.SignalR.Sample.Hubs;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MassTransit.SignalR.Utils;
 using Microsoft.AspNetCore.SignalR;
+using GreenPipes;
+using System.Threading;
+using System.Collections.Concurrent;
+using System.Transactions;
+using MassTransit.Util;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace MassTransit.SignalR.SampleConsole
 {
@@ -13,7 +19,7 @@ namespace MassTransit.SignalR.SampleConsole
     {
         internal static async Task Main(string[] args)
         {
-            IReadOnlyList<IHubProtocol> protocols = new IHubProtocol[] { new JsonHubProtocol() };
+            //IReadOnlyList<IHubProtocol> protocols = new IHubProtocol[] { new JsonHubProtocol() };
             var busControl = Bus.Factory.CreateUsingRabbitMq(cfg =>
             {
                 cfg.Host(new Uri("rabbitmq://localhost"), h =>
@@ -35,9 +41,11 @@ namespace MassTransit.SignalR.SampleConsole
                 if ("quit".Equals(value, StringComparison.OrdinalIgnoreCase))
                     break;
 
-                await busControl.Publish<All<ChatHub>>(new
+                var test = new TransactionOutbox(busControl, new NullLoggerFactory());
+
+                await test.Publish<MyMessage>(new
                 {
-                    Messages = protocols.ToProtocolDictionary("broadcastMessage", new object[] { "backend-process", value })
+                    Name = "John"
                 });
             }
             while (true);
@@ -45,12 +53,170 @@ namespace MassTransit.SignalR.SampleConsole
             await busControl.StopAsync();
         }
     }
-}
 
-namespace MassTransit.SignalR.Sample.Hubs
-{
-    public class ChatHub : Hub
+    public class MyMessage
     {
-        // Actual implementation in the other project, but MT Needs the hub for the generic message type
+        public string Name { get; set; }
+    }
+
+    public class TransactionOutbox : IPublishEndpoint
+    {
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IPublishEndpoint _publishEndpoint;
+        readonly ConcurrentDictionary<Transaction, TransactionOutboxEnlistment> _pendingActions;
+
+        public TransactionOutbox(IPublishEndpoint publishEndpoint, ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+            _publishEndpoint = publishEndpoint;
+            _pendingActions = new ConcurrentDictionary<Transaction, TransactionOutboxEnlistment>();
+        }
+
+        public ConnectHandle ConnectPublishObserver(IPublishObserver observer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish<T>(T message, CancellationToken cancellationToken = default) where T : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish<T>(T message, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken = default) where T : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish<T>(T message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default) where T : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish(object message, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish(object message, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish(object message, Type messageType, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish(object message, Type messageType, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish<T>(object values, CancellationToken cancellationToken = default) where T : class
+        {
+            if (Transaction.Current == null)
+                return _publishEndpoint.Publish(values, cancellationToken);
+
+            var pendingActions = _pendingActions.GetOrAdd(Transaction.Current, new TransactionOutboxEnlistment(_loggerFactory));
+            pendingActions.Add(() => _publishEndpoint.Publish(values, cancellationToken));
+
+            return Task.CompletedTask;
+        }
+
+        public Task Publish<T>(object values, IPipe<PublishContext<T>> publishPipe, CancellationToken cancellationToken = default) where T : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Publish<T>(object values, IPipe<PublishContext> publishPipe, CancellationToken cancellationToken = default) where T : class
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class TransactionOutboxEnlistment : IEnlistmentNotification
+    {
+        private readonly ILogger<TransactionOutboxEnlistment> _logger;
+        readonly List<Func<Task>> _pendingActions;
+
+        public TransactionOutboxEnlistment(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<TransactionOutboxEnlistment>();
+            _pendingActions = new List<Func<Task>>();
+        }
+
+        public void Add(Func<Task> method)
+        {
+            lock (_pendingActions)
+                _pendingActions.Add(method);
+        }
+
+        public void ExecutePendingActions()
+        {
+            Func<Task>[] pendingActions;
+            lock (_pendingActions)
+                pendingActions = _pendingActions.ToArray();
+
+            foreach (var action in pendingActions)
+            {
+                TaskUtil.Await(action);
+            }
+        }
+
+        public void DiscardPendingActions()
+        {
+            lock (_pendingActions)
+                _pendingActions.Clear();
+        }
+
+        public void Prepare(PreparingEnlistment preparingEnlistment)
+        {
+            _logger.LogDebug("Prepare notification received");
+
+            try
+            {
+                ExecutePendingActions();
+
+                //If work finished correctly, reply prepared
+                preparingEnlistment.Prepared();
+            }
+            catch(Exception e)
+            {
+                _logger.LogError(e, "MASSTRANSIT: Error executing pending actions");
+                // We can't stop any messages that might have been already published, but we can stop the rest from publishing
+                // Realizing that with message brokers, idempotence is important, because you can receive duplicate messages
+                preparingEnlistment.ForceRollback();
+            }
+        }
+
+        public void Commit(Enlistment enlistment)
+        {
+            _logger.LogDebug("Commit notification received");
+
+            DiscardPendingActions();
+
+            //Declare done on the enlistment
+            enlistment.Done();
+        }
+
+        public void Rollback(Enlistment enlistment)
+        {
+            _logger.LogDebug("Rollback notification received");
+
+            DiscardPendingActions();
+
+            //Declare done on the enlistment
+            enlistment.Done();
+        }
+
+        public void InDoubt(Enlistment enlistment)
+        {
+            _logger.LogDebug("In doubt notification received");
+
+            DiscardPendingActions();
+
+            //Declare done on the enlistment
+            enlistment.Done();
+        }
     }
 }


### PR DESCRIPTION
- for feature request #1627 
- Documentation added, used decorator on the Singleton (for IBusControl). If using IPublishEndpoint or ISendEndpointProvider from within a ConsumeContext, then use InMemoryOutbox.
- Instead of the cleanup happening in "Commit, InDoubt, or Rollback", I subscribed to the `+= TransactionCompleted` event, and perform clean up there.
- had to use TaskUtil.Await in Prepare method because publish/send are async, but the IEnlistmentNotification interface is not async. So this was the only option. 
- Added tests, also for good measure I added some tests with EFCore, to see how it behaves with DBContext and an ambient transaction.  These are in the EFCore Saga test project, but don't have anything to actually do with EFCore Saga. I just wanted the ease of using existing packages.