### PR TITLE
Updated the correct links to DiagnosticSource reference on documentation

### DIFF
--- a/docs/getting-started/upgrade-v6.md
+++ b/docs/getting-started/upgrade-v6.md
@@ -51,7 +51,7 @@ This should be done prior to configuring the bus.
 As of version 6, MassTransit now uses DiagnosticSource for tracking messaging operations, such as Send, Receive, Publish, Consume, etc. An `Activity` is
 created for each operation, and context-relevant tags and baggage are added.
 
-MassTransit follows the [guidance](https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md) from Microsoft. To connect listeners, look at the [section](https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#subscribe-to-diagnosticsource) that explains how to connect.
+MassTransit follows the [guidance](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md) from Microsoft. To connect listeners, look at the [section](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#subscribe-to-diagnosticsource) that explains how to connect.
 
 ## Receive Endpoint Configuration
 

--- a/docs/getting-started/upgrade-v6.md
+++ b/docs/getting-started/upgrade-v6.md
@@ -51,7 +51,7 @@ This should be done prior to configuring the bus.
 As of version 6, MassTransit now uses DiagnosticSource for tracking messaging operations, such as Send, Receive, Publish, Consume, etc. An `Activity` is
 created for each operation, and context-relevant tags and baggage are added.
 
-MassTransit follows the [guidance](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md) from Microsoft. To connect listeners, look at the [section](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#subscribe-to-diagnosticsource) that explains how to connect.
+MassTransit follows the [guidance](https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md) from Microsoft. To connect listeners, look at the [section](https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#subscribe-to-diagnosticsource) that explains how to connect.
 
 ## Receive Endpoint Configuration
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-MassTransit can be used in any .NET application, however, the application type can influence the bus configuration. Several different application type examples are shwon below, each of which lists any additional dependencies are required. Each example focuses on simplicity, and therefore may omit certain extra features to avoid confusion. 
+MassTransit can be used in any .NET application, however, the application type can influence the bus configuration. Several different application type examples are shown below, each of which lists any additional dependencies are required. Each example focuses on simplicity, and therefore may omit certain extra features to avoid confusion. 
 
 ::: tip NOTE
 Except where required by the application type, no dependency injection container is used. For container configuration examples, refer to the [containers](/usage/containers) section.


### PR DESCRIPTION
Upgrading guide to logging contains references to DiagnosticSource from Corefx repo. 
Corefx repo is moved into dotnet runtime repo.([Reference](https://github.com/dotnet/corefx/))

This Pr should point them to new repository.