### PR TITLE
Fix variable reference in docs

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -104,7 +104,7 @@ public class Startup
                     ep.PrefetchCount = 16;
                     ep.UseMessageRetry(r => r.Interval(2, 100));
 
-                    ep.ConfigureConsumer<OrderConsumer>(provider);
+                    ep.ConfigureConsumer<OrderConsumer>(serviceProvider);
                 });
             });
         }


### PR DESCRIPTION
Minor change to the documentation to fix the variable name being used 😃 