### PR TITLE
Doc: Pass the host to TurnoutEndpoint()

### DIFF
--- a/docs/advanced/turnout/README.md
+++ b/docs/advanced/turnout/README.md
@@ -16,11 +16,11 @@ To configure a turnout, a turnout endpoint is created for the command message ty
 ```csharp
 var busControl = Bus.Factory.CreateUsingRabbitMq(cfg =>
 {
-    cfg.Host("localhost");
+    var host = cfg.Host("localhost");
 
     cfg.UseInMemoryScheduler();
 
-    cfg.TurnoutEndpoint<AuditCustomerHistory>("audit_consumer_history", e =>
+    cfg.TurnoutEndpoint<AuditCustomerHistory>(host, "audit_consumer_history", e =>
     {
         e.SuperviseInterval = TimeSpan.FromSeconds(30);
         e.SetJobFactory(async context =>


### PR DESCRIPTION
Would be nice if this wasn't required, but seems like it is as of v6.1

Ref: https://github.com/MassTransit/MassTransit/blob/v6.1/src/MassTransit.RabbitMqTransport/Configuration/RabbitMqTurnoutConfigurationExtensions.cs

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
