### PR TITLE
Fixed Retry Interval code for EF Saga docs

### DIFF
--- a/docs/usage/sagas/ef.md
+++ b/docs/usage/sagas/ef.md
@@ -105,7 +105,7 @@ services.AddMassTransit(x =>
                 // the code might be different
                 r.Handle<DbUpdateException>(y => y.InnerException is SqlException e && e.Number == 2627);
 
-                x.Interval(5, TimeSpan.FromMilliseconds(100)));
+                r.Interval(5, TimeSpan.FromMilliseconds(100));
             });
 
             e.ConfigureSaga<OrderState>(provider);


### PR DESCRIPTION
I saw a little mistake in the docs related to the way we should set the retry interval.

`Interval` method is an extension on `IRetryConfigurator` and not on `IServiceCollectionConfigurator`.