### PR TITLE
Configure method is called in the ExecuteActivityRegistration

### DIFF
--- a/src/MassTransit/Configuration/Registration/ExecuteActivityRegistration.cs
+++ b/src/MassTransit/Configuration/Registration/ExecuteActivityRegistration.cs
@@ -35,6 +35,9 @@ namespace MassTransit.Registration
 
             var specification = new ExecuteActivityHostSpecification<TActivity, TArguments>(executeActivityFactory, configurator);
 
+            GetActivityDefinition(configurationServiceProvider)
+                .Configure(configurator, specification);
+
             foreach (var action in _configureActions)
                 action(specification);
 


### PR DESCRIPTION
Fix issue where `Configure` method is not being called in the `ExecuteActivityDefinition`. This is kind of related to the following issue: #1670 

I have built the project locally, but haven't actually used the built assemblies to test that everything is working as expected. However, this seems like the missing piece from the puzzle.

In the meantime, I can use `Activity` with "empty" log and `Compensate` method.