### PR TITLE
Fixed EF Saga Persistence example

### DIFF
--- a/docs/usage/sagas/ef.md
+++ b/docs/usage/sagas/ef.md
@@ -90,7 +90,7 @@ services.AddMassTransit(x =>
         {
             r.ConcurrencyMode = ConcurrencyMode.Optimistic;
 
-            r.AddDbContext<DbContext, OrderStateDbContext>(connectionString)
+            r.DatabaseFactory(() => new OrderStateDbContext(connectionString));
         });
 
     x.AddBus(provider => Bus.Factory.CreateUsingInMemory(cfg =>


### PR DESCRIPTION
`AddDbContext` is not available for EF. It is available only for EF Core.

You can see that only the second link has `AddDbContext`:

[MassTransit.EntityFrameworkIntegration's IEntityFrameworkSagaRepositoryConfigurator](https://github.com/MassTransit/MassTransit/blob/master/src/Persistence/MassTransit.EntityFrameworkIntegration/Configuration/IEntityFrameworkSagaRepositoryConfigurator.cs)

[MassTransit.EntityFrameworkCoreIntegration's IEntityFrameworkSagaRepositoryConfigurator](https://github.com/MassTransit/MassTransit/blob/master/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/IEntityFrameworkSagaRepositoryConfigurator.cs)
