### PR TITLE
The function FlushFinalBlock cryptostream should be called for the se…

### DIFF
--- a/src/MassTransit/Serialization/EncryptedMessageSerializer.cs
+++ b/src/MassTransit/Serialization/EncryptedMessageSerializer.cs
@@ -49,6 +49,8 @@ namespace MassTransit.Serialization
                 _serializer.Serialize(jsonWriter, envelope, typeof(MessageEnvelope));
 
                 jsonWriter.Flush();
+
+                ((System.Security.Cryptography.CryptoStream)cryptoStream).FlushFinalBlock();
             }
         }
     }

--- a/src/MassTransit/Serialization/EncryptedMessageSerializerV2.cs
+++ b/src/MassTransit/Serialization/EncryptedMessageSerializerV2.cs
@@ -49,6 +49,8 @@ namespace MassTransit.Serialization
                     _serializer.Serialize(jsonWriter, envelope, typeof(MessageEnvelope));
 
                     jsonWriter.Flush();
+
+                    ((System.Security.Cryptography.CryptoStream)cryptoStream).FlushFinalBlock();
                 }
             }
         }


### PR DESCRIPTION
The serialization process during the encryption process works fine for AES but not for RijndaelManaged

In order to correct the issue, all that is needed is to call the function FlushFinalBlock on the CryptoStream used after serializing with the BsonWriter


