### PR TITLE
Process manager issues after updating to 6.2

### DIFF
--- a/src/MassTransit.Tests/AutomatonymousIntegration/CompositeEventsInInitialState_Specs.cs
+++ b/src/MassTransit.Tests/AutomatonymousIntegration/CompositeEventsInInitialState_Specs.cs
@@ -1,0 +1,146 @@
+﻿namespace MassTransit.Tests.AutomatonymousIntegration
+{
+    using System;
+    using System.Threading.Tasks;
+    using Automatonymous;
+    using Automatonymous.Contexts;
+    using MassTransit.Saga;
+    using MassTransit.Testing;
+    using NUnit.Framework;
+    using TestFramework;
+
+    [TestFixture]
+    public class When_combining_events_into_a_single_event_in_the_initial_state :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_have_combined_event()
+        {
+            var correlationId = Guid.NewGuid();
+            var firstMessage = new FirstMessage(correlationId);
+            var secondMessage = new SecondMessage(correlationId);
+
+            await InputQueueSendEndpoint.Send(firstMessage);
+            await InputQueueSendEndpoint.Send(secondMessage);
+
+            Guid? saga = await _repository.ShouldContainSaga(x => x.CorrelationId == correlationId, TestTimeout);
+            Assert.IsTrue(saga.HasValue);
+
+            Task<ConsumeContext<CompleteMessage>> received =
+                ConnectPublishHandler<CompleteMessage>(x => x.Message.CorrelationId == correlationId);
+
+            await received;
+        }
+
+        InMemorySagaRepository<Instance> _repository;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _machine = new TestStateMachine();
+            _repository = new InMemorySagaRepository<Instance>();
+
+            configurator.StateMachineSaga(_machine, _repository);
+        }
+
+        TestStateMachine _machine;
+
+        async Task<State> GetCurrentState(Instance state)
+        {
+            var context = new StateMachineInstanceContext<Instance>(state);
+            return await _machine.GetState(context.Instance);
+        }
+
+
+        class Instance :
+            SagaStateMachineInstance
+        {
+            public Instance(Guid correlationId)
+            {
+                CorrelationId = correlationId;
+            }
+
+            protected Instance()
+            {
+            }
+
+            public int CompositeStatus { get; set; }
+            public int CurrentState { get; set; }
+
+            public bool ReceivedFirst { get; set; }
+            public bool ReceivedSecond { get; set; }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+        sealed class TestStateMachine :
+            MassTransitStateMachine<Instance>
+        {
+            public TestStateMachine()
+            {
+                InstanceState(x => x.CurrentState);
+
+                Event(() => First, x => x.CorrelateById(m => m.Message.CorrelationId));
+                Event(() => Second, x => x.CorrelateById(m => m.Message.CorrelationId));
+
+                Initially(
+                    When(First)
+                        .Then(ctx =>
+                        {
+                            ctx.Instance.ReceivedFirst = true;
+                        }),
+                    When(Second)
+                        .Then(ctx =>
+                        {
+                            ctx.Instance.ReceivedSecond = true;
+                        }),
+
+                    When(Third)
+                        .Publish(ctx => new CompleteMessage(ctx.Instance.CorrelationId))
+                );
+
+                CompositeEvent(
+                    () => Third,
+                    x => x.CompositeStatus,
+                    CompositeEventOptions.IncludeInitial,
+                    First, Second);
+            }
+
+            public Event<FirstMessage> First { get; private set; }
+            public Event<SecondMessage> Second { get; private set; }
+            public Event Third { get; private set; }
+        }
+
+        class FirstMessage :
+            CorrelatedBy<Guid>
+        {
+            public FirstMessage(Guid correlationId)
+            {
+                CorrelationId = correlationId;
+            }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+
+        class SecondMessage
+        {
+            public SecondMessage(Guid correlationId)
+            {
+                CorrelationId = correlationId;
+            }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+        class CompleteMessage :
+            CorrelatedBy<Guid>
+        {
+            public CompleteMessage(Guid correlationId)
+            {
+                CorrelationId = correlationId;
+            }
+
+            public Guid CorrelationId { get; set; }
+        }
+    }
+}

--- a/src/MassTransit.Tests/AutomatonymousIntegration/Finalize_Specs.cs
+++ b/src/MassTransit.Tests/AutomatonymousIntegration/Finalize_Specs.cs
@@ -1,0 +1,120 @@
+﻿namespace MassTransit.Tests.AutomatonymousIntegration
+{
+    using System;
+    using System.Threading.Tasks;
+    using Automatonymous;
+    using Automatonymous.Contexts;
+    using MassTransit.Saga;
+    using MassTransit.Testing;
+    using NUnit.Framework;
+    using TestFramework;
+
+
+    public class Finalize_Specs
+        : InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_remove_saga_when_completed_in_whenenter()
+        {
+            var correlationId = Guid.NewGuid();
+            var firstMessage = new FirstMessage(correlationId);
+
+            await InputQueueSendEndpoint.Send(firstMessage);
+
+            Guid? saga = await _repository.ShouldContainSaga(x => x.CorrelationId == correlationId
+                && GetCurrentState(x).Result == _machine.OtherState, TestTimeout);
+            Assert.IsTrue(saga.HasValue);
+
+            _taskCompletionSource.SetResult(true);
+
+            saga = await _repository.ShouldNotContainSaga(correlationId, TestTimeout);
+            Assert.IsFalse(saga.HasValue);
+        }
+
+        InMemorySagaRepository<Instance> _repository;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            _machine = new TestStateMachine(_taskCompletionSource.Task);
+            _repository = new InMemorySagaRepository<Instance>();
+
+            configurator.StateMachineSaga(_machine, _repository);
+        }
+
+        readonly TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>();
+        TestStateMachine _machine;
+
+        async Task<State> GetCurrentState(Instance state)
+        {
+            var context = new StateMachineInstanceContext<Instance>(state);
+            return await _machine.GetState(context.Instance);
+        }
+
+
+        class Instance :
+            SagaStateMachineInstance
+        {
+            public Instance(Guid correlationId)
+            {
+                CorrelationId = correlationId;
+            }
+
+            protected Instance()
+            {
+            }
+
+            public int CurrentState { get; set; }
+
+            public bool ReceivedFirst { get; set; }
+            public bool TruthProvided { get; set; }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+        sealed class TestStateMachine :
+            MassTransitStateMachine<Instance>
+        {
+            public TestStateMachine(Task<bool> truthProvider)
+            {
+                InstanceState(x => x.CurrentState);
+
+                Event(() => First, x => x.CorrelateById(m => m.Message.CorrelationId));
+
+                SetCompletedWhenFinalized();
+
+                Initially(
+                    When(First)
+                        .Then(ctx =>
+                        {
+                            ctx.Instance.ReceivedFirst = true;
+                        }).TransitionTo(OtherState)
+                );
+
+                WhenEnter(OtherState, x => x
+                    .Then(async ctx =>
+                    {
+                        ctx.Instance.TruthProvided = await truthProvider;
+                    })
+                    .If(ctx => ctx.Instance.ReceivedFirst && ctx.Instance.TruthProvided,
+                        ctx => ctx.Finalize())
+                );
+            }
+
+            public State OtherState { get; private set; }
+
+            public Event<FirstMessage> First { get; private set; }
+        }
+
+        class FirstMessage :
+            CorrelatedBy<Guid>
+        {
+            public FirstMessage(Guid correlationId)
+            {
+                CorrelationId = correlationId;
+            }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+    }
+}


### PR DESCRIPTION
Reproductions of issues in our process manager tests that we saw after updating to 6.2.

Composite events in initial state of a process manager and finalizing in a WhenEnter.