### PR TITLE
Made DefaultEndpointNameFormatter compatible with generic consumers

### DIFF
--- a/src/MassTransit.Tests/Configuration/DefaultEndpointNameFormatter_Specs.cs
+++ b/src/MassTransit.Tests/Configuration/DefaultEndpointNameFormatter_Specs.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MassTransit.Tests.Configuration
+{
+    using MassTransit;
+    using MassTransit.Definition;
+    using NUnit.Framework;
+    using Shouldly;
+
+    public class When_consumers_are_generic_classes
+    {
+        List<string> _endpointNames;
+
+        [SetUp]
+        public void A_formatter_derives_endpoint_names()
+        {
+            var formatter = DefaultEndpointNameFormatter.Instance;
+
+            _endpointNames = new List<string>()
+            {
+                formatter.Consumer<GenericConsumer<Msg1>>(),
+                formatter.Consumer<GenericConsumer<Msg2>>(),
+                formatter.Consumer<GenericConsumer<Msg3>>(),
+            };
+        }
+
+        [Test]
+        public void Should_all_be_unique()
+        {
+            _endpointNames.Distinct().Count().ShouldBe(_endpointNames.Count());
+        }
+
+        [Test]
+        public void Should_be_named_after_first_generic_parameter()
+        {
+            _endpointNames.ShouldBe(new[] { nameof(Msg1), nameof(Msg2), nameof(Msg3) });
+        }
+
+        class GenericConsumer<TMessage> : IConsumer<TMessage>
+            where TMessage : class
+        {
+            public Task Consume(ConsumeContext<TMessage> context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        class Msg1 { }
+        class Msg2 { }
+        class Msg3 { }
+    }
+}

--- a/src/MassTransit/Configuration/Definition/DefaultEndpointNameFormatter.cs
+++ b/src/MassTransit/Configuration/Definition/DefaultEndpointNameFormatter.cs
@@ -55,7 +55,7 @@ namespace MassTransit.Definition
         public string Consumer<T>()
             where T : class, IConsumer
         {
-            return GetConsumerName(typeof(T).Name);
+            return GetConsumerName(typeof(T));
         }
 
         public string Saga<T>()
@@ -82,11 +82,16 @@ namespace MassTransit.Definition
             return $"{activityName}_compensate";
         }
 
-        string GetConsumerName(string typeName)
-        {
-            const string consumer = "Consumer";
+        string GetConsumerName(Type type)
+        {            
+            if (type.IsGenericType)
+            {
+                return SanitizeName(type.GetGenericArguments()[0].Name);
+            }
 
-            var consumerName = typeName;
+            const string consumer = "Consumer";
+            var consumerName = type.Name;
+
             if (consumerName.EndsWith(consumer, StringComparison.InvariantCultureIgnoreCase))
                 consumerName = consumerName.Substring(0, consumerName.Length - consumer.Length);
 


### PR DESCRIPTION
After some recent refactor (of a project that I currently work on) we experienced "sequence contains more than one element" error when executing "ConfigureEndpoints". It turns out that DefaultEndpointNameFormatter is not compatible with generic consumers. Here is something similar to what I did in my custom formatter in order to fix it. Tests included. Probably should be applied also to other methods (GetSagaName, GetActivityName).
