### PR TITLE
Fix a typo in IBusControl.StartAsync XML doc

### DIFF
--- a/src/MassTransit/IBusControl.cs
+++ b/src/MassTransit/IBusControl.cs
@@ -20,7 +20,7 @@ namespace MassTransit
         IBus
     {
         /// <summary>
-        /// Starts the bus (assuming the battery isn't dead). Once the bus has been started, it cannot be started again, even after is has been stopped.
+        /// Starts the bus (assuming the battery isn't dead). Once the bus has been started it cannot be started again, even after it has been stopped.
         /// </summary>
         /// <returns>The BusHandle for the started bus. This is no longer needed, as calling Stop on the IBusControl will stop the bus equally well.</returns>
         Task<BusHandle> StartAsync(CancellationToken cancellationToken = default);


### PR DESCRIPTION
Also removed a comma. Seems to me that "Once the bus has been started it cannot be started again..." is a single statement and shouldn't be broken up by a comma. However the main purpose of this change is to fix the typo and I'm not hung up on the comma either way.

I didn't want to add the newline on the end of the file but the Github web editor seems to be inserting it automatically, if this is a deal breaker I'll fork and edit the file properly.