### PR TITLE
Allow using a specific instance of the bus with the hosted service

### DIFF
--- a/src/Containers/MassTransit.AspNetCoreIntegration/HealthChecks/SimplifiedBusHealthCheck.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/HealthChecks/SimplifiedBusHealthCheck.cs
@@ -1,10 +1,12 @@
 namespace MassTransit.AspNetCoreIntegration.HealthChecks
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 
+    [Obsolete("Use AddMassTransitHostedService, which requires registered the proper bus health check")]
     public class SimplifiedBusHealthCheck :
         IHealthCheck
     {
@@ -17,9 +19,14 @@ namespace MassTransit.AspNetCoreIntegration.HealthChecks
                 : new HealthCheckResult(context.Registration.FailureStatus, "Bus not yet started"));
         }
 
-        public void ReportBusStarted()
+        internal void ReportBusStarted()
         {
             _busStarted = true;
+        }
+
+        internal void ReportBusStopped()
+        {
+            _busStarted = false;
         }
     }
 }

--- a/src/Containers/MassTransit.AspNetCoreIntegration/ServiceCollectionExtensions.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@
         /// <param name="createBus">Bus factory that loads consumers and sagas from IServiceProvider</param>
         /// <param name="configureHealthChecks">Optional, allows you to specify custom health check names</param>
         /// <returns></returns>
+        [Obsolete("Use AddMassTransitHostedService")]
         public static IServiceCollection AddMassTransit(this IServiceCollection services, Func<IServiceProvider, IBusControl> createBus,
             Action<HealthCheckOptions> configureHealthChecks = null)
         {
@@ -40,6 +41,7 @@
         /// <param name="configureHealthChecks">Optional, allows you to specify custom health check names</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
+        [Obsolete("Use AddMassTransitHostedService")]
         public static IServiceCollection AddMassTransit(this IServiceCollection services, Func<IServiceProvider, IBusControl> createBus,
             Action<IServiceCollectionConfigurator> configure, Action<HealthCheckOptions> configureHealthChecks = null)
         {
@@ -66,6 +68,7 @@
         /// <param name="loggerFactory">Optional: ASP.NET Core logger factory instance</param>
         /// <param name="configureHealthChecks">Optional, allows you to specify custom health check names</param>
         /// <returns></returns>
+        [Obsolete("Use AddMassTransitHostedService")]
         public static IServiceCollection AddMassTransit(this IServiceCollection services, IBusControl bus, ILoggerFactory loggerFactory = null,
             Action<HealthCheckOptions> configureHealthChecks = null)
         {

--- a/src/Samples/MassTransit.SignalR.Sample/Startup.cs
+++ b/src/Samples/MassTransit.SignalR.Sample/Startup.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.SignalR.Sample
 {
@@ -40,7 +40,7 @@ namespace MassTransit.SignalR.Sample
 
                 x.AddBus(provider => Bus.Factory.CreateUsingRabbitMq(cfg =>
                 {
-                    var host = cfg.Host("localhost", "/");
+                    cfg.Host("localhost", "/");
 
                     cfg.UseHealthCheck(provider);
 


### PR DESCRIPTION
**Motivation**

The new `AddMassTransitHostedService` assumes that everyone uses containers and there's no more than one bus instance exists in the application. That's not always the case. We don't use containers for everything and we sometimes host two bus instances in one service.

There's also a bit of confusion about older extensions that have conflicting method names with the Microsoft DI integration library.

**Implementation**

Marked old extensions obsolete, along with the `SimplifiedBusHealthCheck` to encourage people to use new extensions and also add `UseBusHealthCheck` to the bus configuration code.

Added an overload for `AddMassTransitHostedService` that accepts an instance of `IBusControl`.