### PR TITLE
Allow turning prefetching off (prefetchCount=0) on Azure Service Bus

### DIFF
--- a/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
@@ -46,7 +46,7 @@
             set
             {
                 _settings.MaxConcurrentCalls = value;
-                if (_settings.MaxConcurrentCalls > _settings.PrefetchCount)
+                if (_settings.PrefetchCount > 0 && _settings.MaxConcurrentCalls > _settings.PrefetchCount)
                     _settings.PrefetchCount = _settings.MaxConcurrentCalls;
             }
         }

--- a/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configurators/ServiceBusBusFactoryConfigurator.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Configuration/Configurators/ServiceBusBusFactoryConfigurator.cs
@@ -82,7 +82,7 @@
             set
             {
                 _settings.MaxConcurrentCalls = value;
-                if (_settings.MaxConcurrentCalls > _settings.PrefetchCount)
+                if (_settings.PrefetchCount > 0 && _settings.MaxConcurrentCalls > _settings.PrefetchCount)
                     _settings.PrefetchCount = _settings.MaxConcurrentCalls;
             }
         }


### PR DESCRIPTION
0 is a valid value for Prefetch count, but not for MaxConcurrentCalls.
Setting PrefetchCount to be atleast equal to MaxConcurrentCalls
will make it impossible to set PrefetchCount=0

---

Verified by directly referencing relevant projects locally:

```xml
  <ItemGroup>
    <ProjectReference Include="..\MassTransit\src\Containers\MassTransit.ExtensionsDependencyInjectionIntegration\MassTransit.ExtensionsDependencyInjectionIntegration.csproj" />
    <ProjectReference Include="..\MassTransit\src\MassTransit.Azure.ServiceBus.Core\MassTransit.Azure.ServiceBus.Core.csproj" />
  </ItemGroup>
```


Related: https://github.com/MassTransit/MassTransit/issues/1757
I was able to reproduce the same behavior without MassTransit only after I turned prefetching on. The change in this PR causes competing consumers to work like I expected it to in #1757 