### PR TITLE
Remove CancellationToken from MassTransitHostedService.StopAsync

### DIFF
--- a/src/Containers/MassTransit.AspNetCoreIntegration/MassTransitHostedService.cs
+++ b/src/Containers/MassTransit.AspNetCoreIntegration/MassTransitHostedService.cs
@@ -39,7 +39,7 @@ namespace MassTransit.AspNetCoreIntegration
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
-            await _bus.StopAsync(cancellationToken).ConfigureAwait(false);
+            await _bus.StopAsync().ConfigureAwait(false);
 
             _simplifiedBusCheck?.ReportBusStopped();
         }


### PR DESCRIPTION
The `CancellationToken` passed to `IHostedService.StopAsync` is a timeout token, it is cancelled when the application has waited long enough for the service to gracefully exit and wants to tell it to hurry up, whereas `IBusControl.StopAsync` is expecting a "stop stopping" token.