### PR TITLE
Adding missing `cfg.UseHealthCheck(serviceProvider);` in to example.

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -97,6 +97,8 @@ public class Startup
         {
             return Bus.Factory.CreateUsingRabbitMq(cfg =>
             {
+                cfg.UseHealthCheck(serviceProvider);
+
                 cfg.Host("rabbitmq://localhost");
 
                 cfg.ReceiveEndpoint("submit-order", ep =>


### PR DESCRIPTION
Just updating the docs to include `UseHealthCheck()` inside the bus configuration otherwise the health checks aways say the bus is unhealthy. 👍
