### PR TITLE
Add FaultedWithVariables in ConsumeContext

### DIFF
--- a/src/MassTransit.TestFramework/Courier/SetVariablesFaultyActivity.cs
+++ b/src/MassTransit.TestFramework/Courier/SetVariablesFaultyActivity.cs
@@ -1,0 +1,18 @@
+namespace MassTransit.TestFramework.Courier
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using MassTransit.Courier;
+    using MassTransit.Courier.Exceptions;
+
+
+    public class SetVariablesFaultyActivity :
+        IExecuteActivity<SetVariablesFaultyArguments>
+    {
+        public async Task<ExecutionResult> Execute(ExecuteContext<SetVariablesFaultyArguments> context)
+        {
+            return context.FaultedWithVariables(new IntentionalTestException("Things that make you go boom!"),
+                new Dictionary<string, object> {{ "Test", "Data" }});
+        }
+    }
+}

--- a/src/MassTransit.TestFramework/Courier/SetVariablesFaultyArguments.cs
+++ b/src/MassTransit.TestFramework/Courier/SetVariablesFaultyArguments.cs
@@ -1,0 +1,6 @@
+﻿namespace MassTransit.TestFramework.Courier
+{
+    public interface SetVariablesFaultyArguments
+    {
+    }
+}

--- a/src/MassTransit.Tests/Courier/Fault_Specs.cs
+++ b/src/MassTransit.Tests/Courier/Fault_Specs.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2014 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Tests.Courier
 {
@@ -161,6 +161,24 @@ namespace MassTransit.Tests.Courier
             await compensated;
         }
 
+        [Test]
+        public async Task Should_publish_the_faulted_routing_slip_event_and_set_variables()
+        {
+            var builder = new RoutingSlipBuilder(Guid.NewGuid());
+
+            ActivityTestContext testActivity = GetActivityContext<SetVariablesFaultyActivity>();
+
+            Task<ConsumeContext<RoutingSlipFaulted>> handled = ConnectPublishHandler<RoutingSlipFaulted>(x => x.Message.TrackingNumber == builder.TrackingNumber);
+
+            builder.AddActivity(testActivity.Name, testActivity.ExecuteUri);
+
+            await Bus.Execute(builder.Build());
+
+            var context = await handled;
+
+            Assert.AreEqual("Data", context.Message.GetVariable<string>("Test"));
+        }
+
         protected override void SetupActivities(BusTestHarness testHarness)
         {
             AddActivityContext<TestActivity, TestArguments, TestLog>(() => new TestActivity());
@@ -168,6 +186,7 @@ namespace MassTransit.Tests.Courier
             AddActivityContext<FaultyCompensateActivity, TestArguments, TestLog>(() => new FaultyCompensateActivity());
             AddActivityContext<FaultyActivity, FaultyArguments, FaultyLog>(() => new FaultyActivity());
             AddActivityContext<NastyFaultyActivity, FaultyArguments, FaultyLog>(() => new NastyFaultyActivity());
+            AddActivityContext<SetVariablesFaultyActivity, SetVariablesFaultyArguments>(() => new SetVariablesFaultyActivity());
         }
     }
 }

--- a/src/MassTransit/Courier/Contexts/ExecuteContextProxy.cs
+++ b/src/MassTransit/Courier/Contexts/ExecuteContextProxy.cs
@@ -124,5 +124,15 @@ namespace MassTransit.Courier.Contexts
         {
             return _context.Faulted(exception);
         }
+
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, object variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
+
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
     }
 }

--- a/src/MassTransit/Courier/Contexts/ExecuteContextScope.cs
+++ b/src/MassTransit/Courier/Contexts/ExecuteContextScope.cs
@@ -117,5 +117,15 @@ namespace MassTransit.Courier.Contexts
         {
             return _context.Faulted(exception);
         }
+
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, object variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
+
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
     }
 }

--- a/src/MassTransit/Courier/Contexts/HostExecuteContext.cs
+++ b/src/MassTransit/Courier/Contexts/HostExecuteContext.cs
@@ -230,5 +230,29 @@ namespace MassTransit.Courier.Contexts
 
             return new FaultedExecutionResult<TArguments>(this, Publisher, _activity, RoutingSlip, exception);
         }
+
+        public ExecutionResult FaultedWithVariables(Exception exception, object variables)
+        {
+            if (exception == null)
+                throw new ArgumentNullException(nameof(exception));
+
+            if (variables == null)
+                throw new ArgumentNullException(nameof(variables));
+
+            return new FaultedWithVariablesExecutionResult<TArguments>(this, Publisher, _activity, RoutingSlip, exception,
+                RoutingSlipBuilder.GetObjectAsDictionary(variables));
+        }
+
+        public ExecutionResult FaultedWithVariables(Exception exception, IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            if (exception == null)
+                throw new ArgumentNullException(nameof(exception));
+
+            if (variables == null)
+                throw new ArgumentNullException(nameof(variables));
+
+            return new FaultedWithVariablesExecutionResult<TArguments>(this, Publisher, _activity, RoutingSlip, exception,
+                variables.ToDictionary(x => x.Key, x => x.Value));
+        }
     }
 }

--- a/src/MassTransit/Courier/Contexts/InMemoryOutboxExecuteContext.cs
+++ b/src/MassTransit/Courier/Contexts/InMemoryOutboxExecuteContext.cs
@@ -103,6 +103,16 @@ namespace MassTransit.Courier.Contexts
             return _context.Faulted(exception);
         }
 
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, object variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
+
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
+
         ExecutionResult ExecuteContext.Result
         {
             get => _context.Result;

--- a/src/MassTransit/Courier/ExecuteContext.cs
+++ b/src/MassTransit/Courier/ExecuteContext.cs
@@ -125,6 +125,24 @@
         ExecutionResult Faulted(Exception exception);
 
         /// <summary>
+        /// The activity Faulted with no exception, but compensation should be triggered and passing additional variables to set on
+        /// the routing slip
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <param name="variables">An anonymous object of values to add/set as variables on the routing slip</param>
+        /// <returns></returns>
+        ExecutionResult FaultedWithVariables(Exception exception, object variables);
+
+        /// <summary>
+        /// The activity Faulted with no exception, but compensation should be triggered and passing additional variables to set on
+        /// the routing slip
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <param name="variables">An dictionary of values to add/set as variables on the routing slip</param>
+        /// <returns></returns>
+        ExecutionResult FaultedWithVariables(Exception exception, IEnumerable<KeyValuePair<string, object>> variables);
+
+        /// <summary>
         /// Set the execution result, which completes the activity
         /// </summary>
         ExecutionResult Result { get; set; }

--- a/src/MassTransit/Courier/Hosts/ExecuteActivityHost.cs
+++ b/src/MassTransit/Courier/Hosts/ExecuteActivityHost.cs
@@ -48,6 +48,10 @@ namespace MassTransit.Courier.Hosts
 
                     await result.Evaluate().ConfigureAwait(false);
                 }
+                catch (AggregateExceptionWithVariables ex)
+                {
+                    await executeContext.FaultedWithVariables(ex, ex.Variables).Evaluate().ConfigureAwait(false);
+                }
                 catch (Exception ex)
                 {
                     await executeContext.Faulted(ex).Evaluate().ConfigureAwait(false);

--- a/src/MassTransit/Courier/Pipeline/ExecuteActivityFilter.cs
+++ b/src/MassTransit/Courier/Pipeline/ExecuteActivityFilter.cs
@@ -27,7 +27,12 @@
 
             var result = context.Result ?? context.Faulted(new ActivityExecutionException("The activity execute did not return a result"));
             if (result.IsFaulted(out var exception))
-                throw new AggregateException(exception);
+            {
+                var ex = exception is ExceptionWithVariables exceptionWithVariables ?
+                    new AggregateExceptionWithVariables(exceptionWithVariables, exceptionWithVariables.Variables) :
+                    new AggregateException(exception);
+                throw ex;
+            }
 
             await next.Send(context).ConfigureAwait(false);
         }

--- a/src/MassTransit/Courier/Results/FaultedWithVariablesExecutionResult.cs
+++ b/src/MassTransit/Courier/Results/FaultedWithVariablesExecutionResult.cs
@@ -1,0 +1,47 @@
+// Copyright 2007-2015 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace MassTransit.Courier.Results
+{
+    using System;
+    using System.Collections.Generic;
+    using Contracts;
+
+
+    class FaultedWithVariablesExecutionResult<TArguments> :
+        FaultedExecutionResult<TArguments>
+        where TArguments : class
+    {
+        readonly Exception _exception;
+        readonly IDictionary<string, object> _variables;
+
+        public FaultedWithVariablesExecutionResult(ExecuteContext<TArguments> executeContext, IRoutingSlipEventPublisher publisher, Activity activity,
+            RoutingSlip routingSlip, Exception exception, IDictionary<string, object> variables)
+            : base(executeContext, publisher, activity, routingSlip, exception)
+        {
+            _exception = exception;
+            _variables = variables;
+        }
+
+        public override bool IsFaulted(out Exception exception)
+        {
+            exception = new ExceptionWithVariables(_variables, _exception.Message, _exception);
+            return true;
+        }
+
+        protected override void Build(RoutingSlipBuilder builder)
+        {
+            base.Build(builder);
+            builder.SetVariables(_variables);
+        }
+    }
+}

--- a/src/MassTransit/Exceptions/AggregateExceptionWithVariables.cs
+++ b/src/MassTransit/Exceptions/AggregateExceptionWithVariables.cs
@@ -1,0 +1,17 @@
+namespace MassTransit
+{
+    using System;
+    using System.Collections.Generic;
+
+    [Serializable]
+    public class AggregateExceptionWithVariables : AggregateException
+    {
+        public AggregateExceptionWithVariables(Exception exception, IDictionary<string, object> variables)
+            : base(exception)
+        {
+            Variables = variables ?? throw new ArgumentNullException(nameof(variables));
+        }
+
+        public IDictionary<string, object> Variables { get; protected set; }
+    }
+}

--- a/src/MassTransit/Exceptions/ExceptionWithVariables.cs
+++ b/src/MassTransit/Exceptions/ExceptionWithVariables.cs
@@ -1,0 +1,43 @@
+namespace MassTransit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    public class ExceptionWithVariables : Exception
+    {
+        public ExceptionWithVariables()
+        {
+        }
+
+        public ExceptionWithVariables(IDictionary<string, object> variables, string message)
+            : base(message)
+        {
+            Variables = variables ?? throw new ArgumentNullException(nameof(variables));
+        }
+
+        public ExceptionWithVariables(IDictionary<string, object> variables, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Variables = variables ?? throw new ArgumentNullException(nameof(variables));
+        }
+
+        public ExceptionWithVariables(string message)
+            : base(message)
+        {
+        }
+
+        public ExceptionWithVariables(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected ExceptionWithVariables(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        public IDictionary<string, object> Variables { get; protected set; }
+    }
+}


### PR DESCRIPTION
Implement faulting with variables in a routing slip. There is a `TerminateWithVariables` but it doesn't execute compensation. This PR addresses that missing behavior.

This is needed if data (read variables) needs to be passed back to the routing slip executor. At this time, only exception infos can be passed back, but any custom fields will be lost during the serialization/deserialization.

Question @ [StackOverflow](https://stackoverflow.com/questions/45699396/masstransit-activity-fault-with-parameters). 

