### PR TITLE
WIP: Added configuration action for QueueErrorSettings and QueueDeadLetter…

### DIFF
--- a/src/MassTransit.ActiveMqTransport/Topology/Configuration/IActiveMqSendTopologyConfigurator.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/Configuration/IActiveMqSendTopologyConfigurator.cs
@@ -1,23 +1,27 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.ActiveMqTransport.Topology
 {
+    using System;
     using MassTransit.Topology;
+    using Settings;
 
 
     public interface IActiveMqSendTopologyConfigurator :
         ISendTopologyConfigurator,
         IActiveMqSendTopology
     {
+        Action<ActiveMqErrorSettings> ConfigureErrorSettings { set; }
+        Action<ActiveMqDeadLetterSettings> ConfigureDeadLetterSettings { set; }
     }
 }

--- a/src/MassTransit.ActiveMqTransport/Topology/IActiveMqSendTopology.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/IActiveMqSendTopology.cs
@@ -1,19 +1,20 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.ActiveMqTransport.Topology
 {
     using System;
     using MassTransit.Topology;
+    using Settings;
 
 
     public interface IActiveMqSendTopology :
@@ -23,6 +24,9 @@ namespace MassTransit.ActiveMqTransport.Topology
             where T : class;
 
         SendSettings GetSendSettings(ActiveMqEndpointAddress address);
+
+        Action<ActiveMqErrorSettings> ConfigureErrorSettings { get; }
+        Action<ActiveMqDeadLetterSettings> ConfigureDeadLetterSettings { get; }
 
         /// <summary>
         /// Return the error settings for the queue

--- a/src/MassTransit.ActiveMqTransport/Topology/Topologies/ActiveMqSendTopology.cs
+++ b/src/MassTransit.ActiveMqTransport/Topology/Topologies/ActiveMqSendTopology.cs
@@ -16,6 +16,8 @@
         }
 
         public IEntityNameValidator EntityNameValidator { get; }
+        public Action<ActiveMqErrorSettings> ConfigureErrorSettings { get; set; }
+        public Action<ActiveMqDeadLetterSettings> ConfigureDeadLetterSettings { get; set; }
 
         IActiveMqMessageSendTopologyConfigurator<T> IActiveMqSendTopology.GetMessageTopology<T>()
         {
@@ -34,12 +36,20 @@
 
         public ErrorSettings GetErrorSettings(EntitySettings settings)
         {
-            return new ActiveMqErrorSettings(settings, settings.EntityName + "_error");
+            var errorSettings = new ActiveMqErrorSettings(settings, settings.EntityName + "_error");
+
+            ConfigureErrorSettings?.Invoke(errorSettings);
+
+            return errorSettings;
         }
 
         public DeadLetterSettings GetDeadLetterSettings(EntitySettings settings)
         {
-            return new ActiveMqDeadLetterSettings(settings, settings.EntityName + "_skipped");
+            var deadLetterSetting = new ActiveMqDeadLetterSettings(settings, settings.EntityName + "_skipped");
+
+            ConfigureDeadLetterSettings?.Invoke(deadLetterSetting);
+
+            return deadLetterSetting;
         }
 
         protected override IMessageSendTopologyConfigurator CreateMessageTopology<T>(Type type)

--- a/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsSendTopologyConfigurator.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Configuration/IAmazonSqsSendTopologyConfigurator.cs
@@ -1,23 +1,27 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.AmazonSqsTransport.Topology.Configuration
 {
+    using System;
     using MassTransit.Topology;
+    using Settings;
 
 
     public interface IAmazonSqsSendTopologyConfigurator :
         ISendTopologyConfigurator,
         IAmazonSqsSendTopology
     {
+        Action<QueueErrorSettings> ConfigureErrorSettings { set; }
+        Action<QueueDeadLetterSettings> ConfigureDeadLetterSettings { set; }
     }
 }

--- a/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsSendTopology.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/IAmazonSqsSendTopology.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2007-2018 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 // this file except in compliance with the License. You may obtain a copy of the
 // License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -15,11 +15,15 @@ namespace MassTransit.AmazonSqsTransport.Topology
     using System;
     using Configuration;
     using MassTransit.Topology;
+    using Settings;
 
 
     public interface IAmazonSqsSendTopology :
         ISendTopology
     {
+        Action<QueueErrorSettings> ConfigureErrorSettings { get; }
+        Action<QueueDeadLetterSettings> ConfigureDeadLetterSettings { get; }
+
         new IAmazonSqsMessageSendTopologyConfigurator<T> GetMessageTopology<T>()
             where T : class;
 

--- a/src/MassTransit.Azure.ServiceBus.Core/Topology/Configuration/IServiceBusSendTopologyConfigurator.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Topology/Configuration/IServiceBusSendTopologyConfigurator.cs
@@ -1,18 +1,20 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Azure.ServiceBus.Core.Topology.Configuration
 {
+    using System;
     using MassTransit.Topology;
+    using Settings;
 
 
     public interface IServiceBusSendTopologyConfigurator :
@@ -21,5 +23,8 @@ namespace MassTransit.Azure.ServiceBus.Core.Topology.Configuration
     {
         new IServiceBusMessageSendTopologyConfigurator<T> GetMessageTopology<T>()
             where T : class;
+
+        Action<QueueSendSettings> ConfigureErrorSettings { set; }
+        Action<QueueSendSettings> ConfigureDeadLetterSettings { set; }
     }
 }

--- a/src/MassTransit.Azure.ServiceBus.Core/Topology/IServiceBusSendTopology.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Topology/IServiceBusSendTopology.cs
@@ -3,6 +3,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Topology
     using System;
     using Configuration;
     using MassTransit.Topology;
+    using Settings;
     using Transport;
 
 
@@ -11,6 +12,9 @@ namespace MassTransit.Azure.ServiceBus.Core.Topology
     {
         new IServiceBusMessageSendTopology<T> GetMessageTopology<T>()
             where T : class;
+
+        Action<QueueSendSettings> ConfigureErrorSettings { get; }
+        Action<QueueSendSettings> ConfigureDeadLetterSettings { get; }
 
         SendSettings GetSendSettings(ServiceBusEndpointAddress address);
 

--- a/src/MassTransit.Azure.ServiceBus.Core/Topology/Topologies/ServiceBusSendTopology.cs
+++ b/src/MassTransit.Azure.ServiceBus.Core/Topology/Topologies/ServiceBusSendTopology.cs
@@ -17,6 +17,9 @@
         const string ErrorQueueSuffix = "_error";
         const string DeadLetterQueueSuffix = "_skipped";
 
+        public Action<QueueSendSettings> ConfigureErrorSettings { get; set; }
+        public Action<QueueSendSettings> ConfigureDeadLetterSettings { get; set; }
+
         IServiceBusMessageSendTopology<T> IServiceBusSendTopology.GetMessageTopology<T>()
         {
             return GetMessageTopology<T>() as IServiceBusMessageSendTopologyConfigurator<T>;
@@ -49,7 +52,11 @@
             var description = configurator.GetQueueDescription();
             description.Path = description.Path + ErrorQueueSuffix;
 
-            return new QueueSendSettings(description);
+            var errorSettings = new QueueSendSettings(description);
+
+            ConfigureErrorSettings?.Invoke(errorSettings);
+
+            return errorSettings;
         }
 
         public SendSettings GetErrorSettings(ISubscriptionConfigurator configurator, Uri hostAddress)
@@ -62,7 +69,11 @@
             queueDescription.DefaultMessageTimeToLive = description.DefaultMessageTimeToLive;
             queueDescription.AutoDeleteOnIdle = description.AutoDeleteOnIdle;
 
-            return new QueueSendSettings(queueDescription);
+            var errorSettings = new QueueSendSettings(queueDescription);
+
+            ConfigureErrorSettings?.Invoke(errorSettings);
+
+            return errorSettings;
         }
 
         public SendSettings GetDeadLetterSettings(IQueueConfigurator configurator)
@@ -70,7 +81,11 @@
             var description = configurator.GetQueueDescription();
             description.Path = description.Path + DeadLetterQueueSuffix;
 
-            return new QueueSendSettings(description);
+            var deadLetterSetting = new QueueSendSettings(description);
+
+            ConfigureDeadLetterSettings?.Invoke(deadLetterSetting);
+
+            return deadLetterSetting;
         }
 
         public SendSettings GetDeadLetterSettings(ISubscriptionConfigurator configurator, Uri hostAddress)
@@ -83,7 +98,11 @@
             queueDescription.DefaultMessageTimeToLive = description.DefaultMessageTimeToLive;
             queueDescription.AutoDeleteOnIdle = description.AutoDeleteOnIdle;
 
-            return new QueueSendSettings(queueDescription);
+            var deadLetterSetting = new QueueSendSettings(queueDescription);
+
+            ConfigureDeadLetterSettings?.Invoke(deadLetterSetting);
+
+            return deadLetterSetting;
         }
 
         protected override IMessageSendTopologyConfigurator CreateMessageTopology<T>(Type type)

--- a/src/MassTransit.RabbitMqTransport/Topology/Configuration/IRabbitMqSendTopologyConfigurator.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/Configuration/IRabbitMqSendTopologyConfigurator.cs
@@ -1,23 +1,27 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.RabbitMqTransport.Topology
 {
+    using System;
     using MassTransit.Topology;
+    using Settings;
 
 
     public interface IRabbitMqSendTopologyConfigurator :
         ISendTopologyConfigurator,
         IRabbitMqSendTopology
     {
+        Action<RabbitMqErrorSettings> ConfigureErrorSettings { set; }
+        Action<RabbitMqDeadLetterSettings> ConfigureDeadLetterSettings { set; }
     }
 }

--- a/src/MassTransit.RabbitMqTransport/Topology/IRabbitMqSendTopology.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/IRabbitMqSendTopology.cs
@@ -1,6 +1,8 @@
 ﻿namespace MassTransit.RabbitMqTransport.Topology
 {
+    using System;
     using MassTransit.Topology;
+    using Settings;
 
 
     public interface IRabbitMqSendTopology :
@@ -8,6 +10,9 @@
     {
         new IRabbitMqMessageSendTopologyConfigurator<T> GetMessageTopology<T>()
             where T : class;
+
+        Action<RabbitMqErrorSettings> ConfigureErrorSettings { get; }
+        Action<RabbitMqDeadLetterSettings> ConfigureDeadLetterSettings { get; }
 
         /// <summary>
         /// Return the send settings for the specified <paramref name="address"/>

--- a/src/MassTransit.RabbitMqTransport/Topology/Topologies/RabbitMqSendTopology.cs
+++ b/src/MassTransit.RabbitMqTransport/Topology/Topologies/RabbitMqSendTopology.cs
@@ -18,6 +18,8 @@
 
         public IExchangeTypeSelector ExchangeTypeSelector { get; }
         public IEntityNameValidator EntityNameValidator { get; }
+        public Action<RabbitMqErrorSettings> ConfigureErrorSettings { get; set; }
+        public Action<RabbitMqDeadLetterSettings> ConfigureDeadLetterSettings { get; set; }
 
         IRabbitMqMessageSendTopologyConfigurator<T> IRabbitMqSendTopology.GetMessageTopology<T>()
         {
@@ -33,12 +35,20 @@
 
         public ErrorSettings GetErrorSettings(EntitySettings settings)
         {
-            return new RabbitMqErrorSettings(settings, settings.ExchangeName + "_error");
+            var errorSettings = new RabbitMqErrorSettings(settings, settings.ExchangeName + "_error");
+
+            ConfigureErrorSettings?.Invoke(errorSettings);
+
+            return errorSettings;
         }
 
         public DeadLetterSettings GetDeadLetterSettings(EntitySettings settings)
         {
-            return new RabbitMqDeadLetterSettings(settings, settings.ExchangeName + "_skipped");
+            var deadLetterSetting = new RabbitMqDeadLetterSettings(settings, settings.ExchangeName + "_skipped");
+
+            ConfigureDeadLetterSettings?.Invoke(deadLetterSetting);
+
+            return deadLetterSetting;
         }
 
         protected override IMessageSendTopologyConfigurator CreateMessageTopology<T>(Type type)


### PR DESCRIPTION
Addresses #1638, but is not solved by #1251 / #1252 as the goal is not to change error/deadletter configuration per se, but only tune queue details (tags and attributes to be precise).

1. Currently this is SQS specific but should be generalised if accepted. Probably moved up to `SendTopology`?
2. I don't think current way to set up `Action<QueueErrorSettings>` and `Action<QueueDeadLetterSettings>` is the prettiest. Does not fit into current "configuration model" of MT.