### PR TITLE
Change SignalR Configuration Approach

### DIFF
--- a/src/MassTransit.SignalR.Tests/Utils/MassTransitHubLifetimeTestFixture.cs
+++ b/src/MassTransit.SignalR.Tests/Utils/MassTransitHubLifetimeTestFixture.cs
@@ -1,20 +1,26 @@
 ﻿namespace MassTransit.SignalR.Tests
 {
-    using MassTransit.SignalR.Consumers;
-    using MassTransit.SignalR.Contracts;
-    using MassTransit.Testing;
+    using System;
+    using Consumers;
+    using Contracts;
     using Microsoft.AspNetCore.SignalR;
     using Microsoft.AspNetCore.SignalR.Internal;
     using Microsoft.AspNetCore.SignalR.Protocol;
     using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.Extensions.Options;
-    using System;
+    using Testing;
     using Utils;
 
 
     public abstract class MassTransitHubLifetimeTestFixture<THub>
         where THub : Hub
     {
+        readonly string _prefix;
+
+        protected MassTransitHubLifetimeTestFixture()
+        {
+            _prefix = Environment.MachineName;
+        }
         protected abstract BusTestHarness Harness { get; set; }
 
         protected SignalRBackplaneConsumersTestHarness<THub> RegisterBusEndpoint(string queueName = "receiveEndpoint")
@@ -22,27 +28,30 @@
             var consumersTestHarness = new SignalRBackplaneConsumersTestHarness<THub>(Harness, queueName);
 
             consumersTestHarness.AddAllConsumer(new HubLifetimeManagerConsumerFactory<AllConsumer<THub>, THub>(hubMgr => new AllConsumer<THub>(hubMgr)));
-            consumersTestHarness.AddConnectionConsumer(new HubLifetimeManagerConsumerFactory<ConnectionConsumer<THub>, THub>(hubMgr => new ConnectionConsumer<THub>(hubMgr)));
+            consumersTestHarness.AddConnectionConsumer(
+                new HubLifetimeManagerConsumerFactory<ConnectionConsumer<THub>, THub>(hubMgr => new ConnectionConsumer<THub>(hubMgr)));
             consumersTestHarness.AddGroupConsumer(new HubLifetimeManagerConsumerFactory<GroupConsumer<THub>, THub>(hubMgr => new GroupConsumer<THub>(hubMgr)));
-            consumersTestHarness.AddGroupManagementConsumer(new HubLifetimeManagerConsumerFactory<GroupManagementConsumer<THub>, THub>(hubMgr => new GroupManagementConsumer<THub>(hubMgr)));
+            consumersTestHarness.AddGroupManagementConsumer(
+                new HubLifetimeManagerConsumerFactory<GroupManagementConsumer<THub>, THub>(hubMgr => new GroupManagementConsumer<THub>(hubMgr)));
             consumersTestHarness.AddUserConsumer(new HubLifetimeManagerConsumerFactory<UserConsumer<THub>, THub>(hubMgr => new UserConsumer<THub>(hubMgr)));
 
             return consumersTestHarness;
         }
 
-        public HubLifetimeManager<THub> CreateLifetimeManager(MessagePackHubProtocolOptions messagePackOptions = null, JsonHubProtocolOptions jsonOptions = null)
+        protected HubLifetimeManager<THub> CreateLifetimeManager(MessagePackHubProtocolOptions messagePackOptions = null,
+            JsonHubProtocolOptions jsonOptions = null)
         {
-            messagePackOptions = messagePackOptions ?? new MessagePackHubProtocolOptions();
-            jsonOptions = jsonOptions ?? new JsonHubProtocolOptions();
+            messagePackOptions ??= new MessagePackHubProtocolOptions();
+            jsonOptions ??= new JsonHubProtocolOptions();
 
             var manager = new MassTransitHubLifetimeManager<THub>(
-            Harness.Bus,
-            Harness.Bus.CreateClientFactory(TimeSpan.FromSeconds(5)),
-            new DefaultHubProtocolResolver(new IHubProtocol[]
-            {
-                new JsonHubProtocol(Options.Create(jsonOptions)),
-                new MessagePackHubProtocol(Options.Create(messagePackOptions)),
-            }, NullLogger<DefaultHubProtocolResolver>.Instance));
+                new HubLifetimeManagerOptions<THub> {ServerName = $"{_prefix}_{Guid.NewGuid():N}"},
+                Harness.Bus,
+                Harness.Bus.CreateClientFactory().CreateRequestClient<GroupManagement<THub>>(TimeSpan.FromSeconds(5)),
+                new DefaultHubProtocolResolver(
+                    new IHubProtocol[] {new JsonHubProtocol(Options.Create(jsonOptions)), new MessagePackHubProtocol(Options.Create(messagePackOptions)),},
+                    NullLogger<DefaultHubProtocolResolver>.Instance)
+            );
 
             return manager;
         }

--- a/src/MassTransit.SignalR/BaseMassTransitHubLifetimeManager.cs
+++ b/src/MassTransit.SignalR/BaseMassTransitHubLifetimeManager.cs
@@ -1,54 +1,47 @@
 ﻿// Copyright 2007-2019 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.SignalR
 {
-    using MassTransit.SignalR.Contracts;
-    using MassTransit.SignalR.Utils;
+    using System.Collections.Generic;
+    using Contracts;
     using Microsoft.AspNetCore.SignalR;
     using Microsoft.AspNetCore.SignalR.Protocol;
-    using System;
-    using System.Collections.Generic;
+    using Utils;
 
-    public abstract class BaseMassTransitHubLifetimeManager<THub> : HubLifetimeManager<THub>
+
+    public abstract class BaseMassTransitHubLifetimeManager<THub> :
+        HubLifetimeManager<THub>
         where THub : Hub
     {
-        protected readonly IRequestClient<GroupManagement<THub>> _groupManagementRequestClient;
-        protected readonly IReadOnlyList<IHubProtocol> _protocols;
+        protected readonly IRequestClient<GroupManagement<THub>> GroupManagementRequestClient;
+        protected readonly IReadOnlyList<IHubProtocol> Protocols;
+        readonly HubLifetimeManagerOptions<THub> _hubLifetimeManagerOptions;
+        protected readonly IPublishEndpoint PublishEndpoint;
 
-        protected readonly IPublishEndpoint _publishEndpoint;
-
-        public BaseMassTransitHubLifetimeManager(
+        protected BaseMassTransitHubLifetimeManager(HubLifetimeManagerOptions<THub> hubLifetimeManagerOptions,
             IPublishEndpoint publishEndpoint,
-            IClientFactory clientFactory,
+            IRequestClient<GroupManagement<THub>> groupManagementRequestClient,
             IHubProtocolResolver hubProtocolResolver)
         {
-            _publishEndpoint = publishEndpoint;
-            _groupManagementRequestClient = clientFactory.CreateRequestClient<GroupManagement<THub>>(TimeSpan.FromSeconds(20));
-            _protocols = hubProtocolResolver.AllProtocols;
+            _hubLifetimeManagerOptions = hubLifetimeManagerOptions;
+            PublishEndpoint = publishEndpoint;
+            GroupManagementRequestClient = groupManagementRequestClient;
+            Protocols = hubProtocolResolver.AllProtocols;
         }
 
-        public string ServerName { get; } = GenerateServerName();
-
-        public HubConnectionStore Connections { get; } = new HubConnectionStore();
-
-        public MassTransitSubscriptionManager Groups { get; } = new MassTransitSubscriptionManager();
-        public MassTransitSubscriptionManager Users { get; } = new MassTransitSubscriptionManager();
-
-        static string GenerateServerName()
-        {
-            // Use the machine name for convenient diagnostics, but add a guid to make it unique.
-            // Example: MyServerName_02db60e5fab243b890a847fa5c4dcb29
-            return $"{Environment.MachineName}_{Guid.NewGuid():N}";
-        }
+        public string ServerName => _hubLifetimeManagerOptions.ServerName;
+        public HubConnectionStore Connections => _hubLifetimeManagerOptions.ConnectionStore;
+        public MassTransitSubscriptionManager Groups => _hubLifetimeManagerOptions.GroupsSubscriptionManager;
+        public MassTransitSubscriptionManager Users => _hubLifetimeManagerOptions.UsersSubscriptionManager;
     }
 }

--- a/src/MassTransit.SignalR/Configuration/HubLifetimeManagerOptions.cs
+++ b/src/MassTransit.SignalR/Configuration/HubLifetimeManagerOptions.cs
@@ -1,0 +1,29 @@
+namespace MassTransit.SignalR
+{
+    using System;
+    using Microsoft.AspNetCore.SignalR;
+    using Utils;
+
+
+    public class HubLifetimeManagerOptions<THub> :
+        IHubLifetimeManagerOptions<THub>
+        where THub : Hub
+    {
+        public HubLifetimeManagerOptions()
+        {
+            ServerName = $"{Environment.MachineName}_{NewId.NextGuid():N}";
+            UseMessageData = false;
+            RequestTimeout = TimeSpan.FromSeconds(20);
+            ConnectionStore = new HubConnectionStore();
+            GroupsSubscriptionManager = new MassTransitSubscriptionManager();
+            UsersSubscriptionManager = new MassTransitSubscriptionManager();
+        }
+
+        public bool UseMessageData { get; set; }
+        public string ServerName { get; set; }
+        public RequestTimeout RequestTimeout { get; set; }
+        public HubConnectionStore ConnectionStore { get; set; }
+        public MassTransitSubscriptionManager GroupsSubscriptionManager { get; set; }
+        public MassTransitSubscriptionManager UsersSubscriptionManager { get; set; }
+    }
+}

--- a/src/MassTransit.SignalR/Configuration/IHubLifetimeManagerOptions.cs
+++ b/src/MassTransit.SignalR/Configuration/IHubLifetimeManagerOptions.cs
@@ -1,0 +1,19 @@
+namespace MassTransit.SignalR
+{
+    using Microsoft.AspNetCore.SignalR;
+
+
+    public interface IHubLifetimeManagerOptions
+    {
+        bool UseMessageData { set; }
+        string ServerName { set; }
+        RequestTimeout RequestTimeout { set; }
+    }
+
+
+    public interface IHubLifetimeManagerOptions<THub> :
+        IHubLifetimeManagerOptions
+        where THub : Hub
+    {
+    }
+}

--- a/src/MassTransit.SignalR/Consumers/AllMessageDataConsumer.cs
+++ b/src/MassTransit.SignalR/Consumers/AllMessageDataConsumer.cs
@@ -1,9 +1,10 @@
 ﻿namespace MassTransit.SignalR.Consumers
 {
-    using MassTransit.SignalR.Contracts;
-    using MassTransit.SignalR.Utils;
-    using Microsoft.AspNetCore.SignalR;
     using System.Threading.Tasks;
+    using Contracts;
+    using Microsoft.AspNetCore.SignalR;
+    using Utils;
+
 
     public class AllMessageDataConsumer<THub> : AllBaseConsumer<THub>, IConsumer<AllMessageData<THub>>
         where THub : Hub

--- a/src/MassTransit.SignalR/Consumers/ConnectionMessageDataConsumer.cs
+++ b/src/MassTransit.SignalR/Consumers/ConnectionMessageDataConsumer.cs
@@ -1,9 +1,10 @@
 ﻿namespace MassTransit.SignalR.Consumers
 {
-    using MassTransit.SignalR.Contracts;
-    using MassTransit.SignalR.Utils;
-    using Microsoft.AspNetCore.SignalR;
     using System.Threading.Tasks;
+    using Contracts;
+    using Microsoft.AspNetCore.SignalR;
+    using Utils;
+
 
     public class ConnectionMessageDataConsumer<THub> : ConnectionBaseConsumer<THub>, IConsumer<ConnectionMessageData<THub>>
         where THub : Hub

--- a/src/MassTransit.SignalR/Consumers/GroupManagementConsumer.cs
+++ b/src/MassTransit.SignalR/Consumers/GroupManagementConsumer.cs
@@ -1,10 +1,10 @@
 ﻿namespace MassTransit.SignalR.Consumers
 {
-    using MassTransit.Logging;
-    using MassTransit.SignalR.Contracts;
-    using Microsoft.AspNetCore.SignalR;
     using System;
     using System.Threading.Tasks;
+    using Contracts;
+    using Microsoft.AspNetCore.SignalR;
+
 
     public class GroupManagementConsumer<THub> : IConsumer<GroupManagement<THub>> where THub : Hub
     {

--- a/src/MassTransit.SignalR/Consumers/GroupMessageDataConsumer.cs
+++ b/src/MassTransit.SignalR/Consumers/GroupMessageDataConsumer.cs
@@ -1,9 +1,10 @@
 ﻿namespace MassTransit.SignalR.Consumers
 {
-    using MassTransit.SignalR.Contracts;
-    using MassTransit.SignalR.Utils;
-    using Microsoft.AspNetCore.SignalR;
     using System.Threading.Tasks;
+    using Contracts;
+    using Microsoft.AspNetCore.SignalR;
+    using Utils;
+
 
     public class GroupMessageDataConsumer<THub> : GroupBaseConsumer<THub>, IConsumer<GroupMessageData<THub>>
         where THub : Hub

--- a/src/MassTransit.SignalR/Consumers/UserMessageDataConsumer.cs
+++ b/src/MassTransit.SignalR/Consumers/UserMessageDataConsumer.cs
@@ -1,9 +1,10 @@
 ﻿namespace MassTransit.SignalR.Consumers
 {
-    using MassTransit.SignalR.Contracts;
-    using MassTransit.SignalR.Utils;
-    using Microsoft.AspNetCore.SignalR;
     using System.Threading.Tasks;
+    using Contracts;
+    using Microsoft.AspNetCore.SignalR;
+    using Utils;
+
 
     public class UserMessageDataConsumer<THub> : UserBaseConsumer<THub>, IConsumer<UserMessageData<THub>>
         where THub : Hub

--- a/src/MassTransit.SignalR/Contracts/Connection.cs
+++ b/src/MassTransit.SignalR/Contracts/Connection.cs
@@ -1,9 +1,8 @@
 ﻿namespace MassTransit.SignalR.Contracts
 {
-    using Microsoft.AspNetCore.SignalR;
-    using System;
     using System.Collections.Generic;
-    using System.Text;
+    using Microsoft.AspNetCore.SignalR;
+
 
     public interface Connection<THub> where THub : Hub
     {

--- a/src/MassTransit.SignalR/Contracts/Group.cs
+++ b/src/MassTransit.SignalR/Contracts/Group.cs
@@ -1,9 +1,8 @@
 ﻿namespace MassTransit.SignalR.Contracts
 {
-    using Microsoft.AspNetCore.SignalR;
-    using System;
     using System.Collections.Generic;
-    using System.Text;
+    using Microsoft.AspNetCore.SignalR;
+
 
     public interface Group<THub> where THub : Hub
     {

--- a/src/MassTransit.SignalR/MassTransitDependencyInjectionExtensions.cs
+++ b/src/MassTransit.SignalR/MassTransitDependencyInjectionExtensions.cs
@@ -12,10 +12,12 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.SignalR
 {
+    using System;
     using Microsoft.AspNetCore.SignalR;
     using Microsoft.Extensions.DependencyInjection;
-    using System;
 
+
+    [Obsolete("Replaced with HubLifetimeManagerOptions<THub>")]
     public static class MassTransitDependencyInjectionExtensions
     {
         /// <summary>
@@ -27,15 +29,9 @@ namespace MassTransit.SignalR
             Action<MassTransitSignalROptions> configureOptions = null)
         {
             var options = new MassTransitSignalROptions();
-
             configureOptions?.Invoke(options);
 
             signalRServerBuilder.Services.AddSingleton(options);
-
-            if (options.UseMessageData)
-                signalRServerBuilder.Services.AddSingleton(typeof(HubLifetimeManager<>), typeof(MassTransitMessageDataHubLifetimeManager<>));
-            else
-                signalRServerBuilder.Services.AddSingleton(typeof(HubLifetimeManager<>), typeof(MassTransitHubLifetimeManager<>));
 
             return signalRServerBuilder;
         }

--- a/src/MassTransit.SignalR/MassTransitSignalROptions.cs
+++ b/src/MassTransit.SignalR/MassTransitSignalROptions.cs
@@ -1,7 +1,12 @@
 ﻿namespace MassTransit.SignalR
 {
+    using System;
+
+
+    [Obsolete]
     public class MassTransitSignalROptions
     {
+        [Obsolete("Use HubLifetimeManagerOptions.UseMessageData")]
         /// <summary>
         /// Gets or Sets whether or not to use MessageData for the Built In SignalR Consumers. Defaults to false.
         /// </summary>

--- a/src/MassTransit.SignalR/Utils/MassTransitSubscriptionManager.cs
+++ b/src/MassTransit.SignalR/Utils/MassTransitSubscriptionManager.cs
@@ -1,34 +1,35 @@
 ﻿namespace MassTransit.SignalR.Utils
 {
-    using Microsoft.AspNetCore.SignalR;
     using System;
     using System.Collections.Concurrent;
+    using Microsoft.AspNetCore.SignalR;
+
 
     public class MassTransitSubscriptionManager
     {
-        public readonly ConcurrentDictionary<string, HubConnectionStore> Subscriptions = new ConcurrentDictionary<string, HubConnectionStore>(StringComparer.Ordinal);
+        readonly ConcurrentDictionary<string, HubConnectionStore> _subscriptions = new ConcurrentDictionary<string, HubConnectionStore>(StringComparer.Ordinal);
 
         public HubConnectionStore this[string identifier]
         {
             get
             {
-                Subscriptions.TryGetValue(identifier, out var connectionStore);
+                _subscriptions.TryGetValue(identifier, out var connectionStore);
                 return connectionStore;
             }
         }
 
-        public int Count => Subscriptions.Count;
+        public int Count => _subscriptions.Count;
 
         public void AddSubscription(string id, HubConnectionContext connection)
         {
-            var subscription = Subscriptions.GetOrAdd(id, _ => new HubConnectionStore());
+            var subscription = _subscriptions.GetOrAdd(id, _ => new HubConnectionStore());
 
             subscription.Add(connection);
         }
 
         public void RemoveSubscription(string id, HubConnectionContext connection)
         {
-            if (!Subscriptions.TryGetValue(id, out var subscription))
+            if (!_subscriptions.TryGetValue(id, out var subscription))
             {
                 return;
             }

--- a/src/MassTransit.SignalR/Utils/SerializedHubMessageExtensions.cs
+++ b/src/MassTransit.SignalR/Utils/SerializedHubMessageExtensions.cs
@@ -1,13 +1,14 @@
 ﻿namespace MassTransit.SignalR.Utils
 {
-    using MassTransit.MessageData;
-    using Microsoft.AspNetCore.SignalR;
-    using Microsoft.AspNetCore.SignalR.Protocol;
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Runtime.Serialization.Formatters.Binary;
     using System.Threading.Tasks;
+    using MessageData;
+    using Microsoft.AspNetCore.SignalR;
+    using Microsoft.AspNetCore.SignalR.Protocol;
+
 
     public static class SerializedHubMessageExtensions
     {


### PR DESCRIPTION
This pull request provide few changes for SignalR:
- configure LifetimeManager as scoped per hub (which allows to use all advantages of MassTransit MSDI setup)
- applied code style a bit
- configure `UseMessageData` per hub
- request timeout per hub