### PR TITLE
Fixed bit typo in NewId docs

### DIFF
--- a/docs/architecture/newid.md
+++ b/docs/architecture/newid.md
@@ -1,6 +1,6 @@
 # NewId
 
-NewId generates sequential unique identifiers that are 128-bit (16-bits) and fit nicely into a `Guid`. It was inspired from [Snowflake][1] and [flake][2].
+NewId generates sequential unique identifiers that are 128-bit (16-bytes) and fit nicely into a `Guid`. It was inspired from [Snowflake][1] and [flake][2].
 
 ## The Problem
 


### PR DESCRIPTION
In text it says 128-bits (16-bits), but instead of "16-bytes", it was "16-bits"