### PR TITLE
Scoped filters for MSDI and Autofac

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -148,7 +148,8 @@ module.exports = {
                   '/advanced/middleware/circuit-breaker',
                   '/advanced/middleware/rate-limiter',
                   '/advanced/middleware/transactions',
-                  '/advanced/middleware/custom'
+                  '/advanced/middleware/custom',
+                  '/advanced/middleware/scoped'
                 ]
               },
               {

--- a/docs/advanced/middleware/scoped.md
+++ b/docs/advanced/middleware/scoped.md
@@ -1,0 +1,57 @@
+# Scoped Filters
+
+By default filters are singleton, but using container integration (MSDI and Autofac) you are able to use scoped filters. Those filters will be resolved with current container scope, if the scope is not available - new scope will be created using root container
+
+## Available Context Types
+
+| Type                         | Usage                                                     |
+| ---------------------------- | --------------------------------------------------------- |
+| `ConsumeContext<T>`          | `UseConsumeFilter(typeof(TFilter<>), context)`            |
+| `SendContext<T>`             | `UseSendFilter(typeof(TFilter<>), context)`               |
+| `PublishContext<T>`          | `UsePublishFilter(typeof(TFilter<>), context)`            |
+| `ExecuteContext<TArguments>` | `UseExecuteActivityFilter(typeof(TFilter<>), context)`    |
+| `CompensateContext<TLog>`    | `UseCompensateActivityFilter(typeof(TFilter<>), context)` |
+
+More information could be found inside [middleware](README.md) section
+
+## Usage
+
+::: warning
+Methods with filter type should only be used for resolving filters with generic argument
+:::
+
+```csharp
+public class MySendFilter<T> :
+    IFilter<SendContext<T>>
+    where T : class
+{
+    public MySendFilter(IMyDependency dependency) { }
+      
+    public async Task Send(SendContext<T> context, IPipe<SendContext<T>> next) { }
+      
+    public void Probe(ProbeContext context) { }
+}
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+      	//other configuration
+      	services.AddScoped<IMyDependency, MyDependency>(); //register dependency
+        services.AddScoped(typeof(MySendFilter<>)); //register generic filter
+          
+        services.AddMassTransit(x =>
+        {
+          	// configuration
+            x.AddBus(context => Bus.Factory.CreateUsingRabbitMq(cfg =>
+            {
+               // bus configuration
+              cfg.UseSendFilter(typeof(MySendFilter<>), context); //generic filter
+            }));
+        });
+    }
+}
+```
+
+
+

--- a/src/Containers/MassTransit.AutofacIntegration/AutofacFilterExtensions.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/AutofacFilterExtensions.cs
@@ -1,0 +1,189 @@
+namespace MassTransit
+{
+    using System;
+    using Autofac;
+    using AutofacIntegration;
+    using AutofacIntegration.Filters;
+    using Courier;
+
+
+    public static class AutofacFilterExtensions
+    {
+        /// <summary>
+        /// Use scoped filter for <see cref="ConsumeContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="lifetimeScopeProvider">Lifetime Scope Provider</param>
+        public static void UseConsumeFilter(this IConsumePipeConfigurator configurator, Type filterType,
+            ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (lifetimeScopeProvider == null)
+                throw new ArgumentNullException(nameof(lifetimeScopeProvider));
+
+            var observer = new ScopedConsumePipeSpecificationObserver(configurator, filterType, lifetimeScopeProvider);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="ConsumeContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseConsumeFilter(this IConsumePipeConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var lifetimeScope = registration.GetRequiredService<ILifetimeScope>();
+            ILifetimeScopeProvider lifetimeScopeProvider = new SingleLifetimeScopeProvider(lifetimeScope);
+            configurator.UseConsumeFilter(filterType, lifetimeScopeProvider);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="SendContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="lifetimeScopeProvider">Lifetime Scope Provider</param>
+        public static void UseSendFilter(this ISendPipelineConfigurator configurator, Type filterType, ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (lifetimeScopeProvider == null)
+                throw new ArgumentNullException(nameof(lifetimeScopeProvider));
+
+            var observer = new ScopedSendPipeSpecificationObserver(filterType, lifetimeScopeProvider);
+            configurator.ConfigureSend(cfg => cfg.ConnectSendPipeSpecificationObserver(observer));
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="SendContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseSendFilter(this ISendPipelineConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var lifetimeScope = registration.GetRequiredService<ILifetimeScope>();
+            ILifetimeScopeProvider lifetimeScopeProvider = new SingleLifetimeScopeProvider(lifetimeScope);
+            configurator.UseSendFilter(filterType, lifetimeScopeProvider);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="PublishContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="lifetimeScopeProvider">Lifetime Scope Provider</param>
+        public static void UsePublishFilter(this IPublishPipelineConfigurator configurator, Type filterType, ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (lifetimeScopeProvider == null)
+                throw new ArgumentNullException(nameof(lifetimeScopeProvider));
+
+            var observer = new ScopedPublishPipeSpecificationObserver(filterType, lifetimeScopeProvider);
+            configurator.ConfigurePublish(cfg => cfg.ConnectPublishPipeSpecificationObserver(observer));
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="PublishContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UsePublishFilter(this IPublishPipelineConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var lifetimeScope = registration.GetRequiredService<ILifetimeScope>();
+            ILifetimeScopeProvider lifetimeScopeProvider = new SingleLifetimeScopeProvider(lifetimeScope);
+            configurator.UsePublishFilter(filterType, lifetimeScopeProvider);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="ExecuteContext{TArguments}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="lifetimeScopeProvider">Lifetime Scope Provider</param>
+        public static void UseExecuteActivityFilter(this IConsumePipeConfigurator configurator, Type filterType,
+            ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (lifetimeScopeProvider == null)
+                throw new ArgumentNullException(nameof(lifetimeScopeProvider));
+
+            var observer = new ScopedExecuteActivityPipeSpecificationObserver(filterType, lifetimeScopeProvider);
+            configurator.ConnectActivityConfigurationObserver(observer);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="ExecuteContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseExecuteActivityFilter(this IConsumePipeConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var lifetimeScope = registration.GetRequiredService<ILifetimeScope>();
+            ILifetimeScopeProvider lifetimeScopeProvider = new SingleLifetimeScopeProvider(lifetimeScope);
+            configurator.UseExecuteActivityFilter(filterType, lifetimeScopeProvider);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="CompensateContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="lifetimeScopeProvider">Lifetime Scope Provider</param>
+        public static void UseCompensateActivityFilter(this IConsumePipeConfigurator configurator, Type filterType,
+            ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (lifetimeScopeProvider == null)
+                throw new ArgumentNullException(nameof(lifetimeScopeProvider));
+
+            var observer = new ScopedCompensateActivityPipeSpecificationObserver(filterType, lifetimeScopeProvider);
+            configurator.ConnectActivityConfigurationObserver(observer);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="CompensateContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseCompensateActivityFilter(this IConsumePipeConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var lifetimeScope = registration.GetRequiredService<ILifetimeScope>();
+            ILifetimeScopeProvider lifetimeScopeProvider = new SingleLifetimeScopeProvider(lifetimeScope);
+            configurator.UseCompensateActivityFilter(filterType, lifetimeScopeProvider);
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedCompensateActivityPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedCompensateActivityPipeSpecificationObserver.cs
@@ -1,0 +1,48 @@
+namespace MassTransit.AutofacIntegration.Filters
+{
+    using System;
+    using ConsumeConfigurators;
+    using Courier;
+    using GreenPipes;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedCompensateActivityPipeSpecificationObserver :
+        IActivityConfigurationObserver
+    {
+        readonly Type _filterType;
+        readonly ILifetimeScopeProvider _lifetimeScopeProvider;
+
+        public ScopedCompensateActivityPipeSpecificationObserver(Type filterType, ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            _filterType = filterType;
+            _lifetimeScopeProvider = lifetimeScopeProvider;
+        }
+
+        public void ActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator, Uri compensateAddress)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+        }
+
+        public void ExecuteActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+        }
+
+        public void CompensateActivityConfigured<TActivity, TLog>(ICompensateActivityConfigurator<TActivity, TLog> configurator)
+            where TActivity : class, ICompensateActivity<TLog>
+            where TLog : class
+        {
+            var scopeProviderType =
+                typeof(AutofacFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(TLog)),
+                    typeof(CompensateContext<TLog>));
+            var scopeProvider = (IFilterContextScopeProvider<CompensateContext<TLog>>)Activator.CreateInstance(scopeProviderType, _lifetimeScopeProvider);
+            var filter = new ScopedFilter<CompensateContext<TLog>>(scopeProvider);
+
+            configurator.Log(a => a.UseFilter(filter));
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedConsumePipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedConsumePipeSpecificationObserver.cs
@@ -1,0 +1,39 @@
+namespace MassTransit.AutofacIntegration.Filters
+{
+    using System;
+    using ConsumeConfigurators;
+    using GreenPipes.Specifications;
+    using PipeConfigurators;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedConsumePipeSpecificationObserver :
+        ConfigurationObserver,
+        IMessageConfigurationObserver
+    {
+        readonly Type _filterType;
+        readonly ILifetimeScopeProvider _lifetimeScopeProvider;
+
+        public ScopedConsumePipeSpecificationObserver(IConsumePipeConfigurator configurator, Type filterType, ILifetimeScopeProvider lifetimeScopeProvider)
+            : base(configurator)
+        {
+            _filterType = filterType;
+            _lifetimeScopeProvider = lifetimeScopeProvider;
+            Connect(this);
+        }
+
+        public void MessageConfigured<TMessage>(IConsumePipeConfigurator configurator)
+            where TMessage : class
+        {
+            var scopeProviderType =
+                typeof(AutofacFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(TMessage)),
+                    typeof(ConsumeContext<TMessage>));
+            var scopeProvider = (IFilterContextScopeProvider<ConsumeContext<TMessage>>)Activator.CreateInstance(scopeProviderType, _lifetimeScopeProvider);
+            var filter = new ScopedFilter<ConsumeContext<TMessage>>(scopeProvider);
+            var specification = new FilterPipeSpecification<ConsumeContext<TMessage>>(filter);
+
+            configurator.AddPipeSpecification(specification);
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedExecuteActivityPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedExecuteActivityPipeSpecificationObserver.cs
@@ -1,0 +1,49 @@
+namespace MassTransit.AutofacIntegration.Filters
+{
+    using System;
+    using ConsumeConfigurators;
+    using Courier;
+    using GreenPipes;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedExecuteActivityPipeSpecificationObserver :
+        IActivityConfigurationObserver
+    {
+        readonly Type _filterType;
+        readonly ILifetimeScopeProvider _lifetimeScopeProvider;
+
+        public ScopedExecuteActivityPipeSpecificationObserver(Type filterType, ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            _filterType = filterType;
+            _lifetimeScopeProvider = lifetimeScopeProvider;
+        }
+
+        public void ActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator, Uri compensateAddress)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+           ExecuteActivityConfigured(configurator);
+        }
+
+        public void ExecuteActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+            var scopeProviderType =
+                typeof(AutofacFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(TArguments)),
+                    typeof(ExecuteContext<TArguments>));
+            var scopeProvider = (IFilterContextScopeProvider<ExecuteContext<TArguments>>)Activator.CreateInstance(scopeProviderType, _lifetimeScopeProvider);
+            var filter = new ScopedFilter<ExecuteContext<TArguments>>(scopeProvider);
+
+            configurator.Arguments(a => a.UseFilter(filter));
+        }
+
+        public void CompensateActivityConfigured<TActivity, TLog>(ICompensateActivityConfigurator<TActivity, TLog> configurator)
+            where TActivity : class, ICompensateActivity<TLog>
+            where TLog : class
+        {
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedPublishPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedPublishPipeSpecificationObserver.cs
@@ -1,0 +1,33 @@
+namespace MassTransit.AutofacIntegration.Filters
+{
+    using System;
+    using GreenPipes;
+    using PublishPipeSpecifications;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedPublishPipeSpecificationObserver :
+        IPublishPipeSpecificationObserver
+    {
+        readonly Type _filterType;
+        readonly ILifetimeScopeProvider _lifetimeScopeProvider;
+
+        public ScopedPublishPipeSpecificationObserver(Type filterType, ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            _filterType = filterType;
+            _lifetimeScopeProvider = lifetimeScopeProvider;
+        }
+
+        public void MessageSpecificationCreated<T>(IMessagePublishPipeSpecification<T> specification)
+            where T : class
+        {
+            var scopeProviderType =
+                typeof(AutofacFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(T)), typeof(PublishContext<T>));
+            var scopeProvider = (IFilterContextScopeProvider<PublishContext<T>>)Activator.CreateInstance(scopeProviderType, _lifetimeScopeProvider);
+            var filter = new ScopedFilter<PublishContext<T>>(scopeProvider);
+
+            specification.UseFilter(filter);
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedSendPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Filters/ScopedSendPipeSpecificationObserver.cs
@@ -1,0 +1,33 @@
+namespace MassTransit.AutofacIntegration.Filters
+{
+    using System;
+    using GreenPipes;
+    using ScopeProviders;
+    using Scoping.Filters;
+    using SendPipeSpecifications;
+
+
+    public class ScopedSendPipeSpecificationObserver :
+        ISendPipeSpecificationObserver
+    {
+        readonly Type _filterType;
+        readonly ILifetimeScopeProvider _lifetimeScopeProvider;
+
+        public ScopedSendPipeSpecificationObserver(Type filterType, ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            _filterType = filterType;
+            _lifetimeScopeProvider = lifetimeScopeProvider;
+        }
+
+        public void MessageSpecificationCreated<T>(IMessageSendPipeSpecification<T> specification)
+            where T : class
+        {
+            var scopeProviderType =
+                typeof(AutofacFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(T)), typeof(SendContext<T>));
+            var scopeProvider = (IFilterContextScopeProvider<SendContext<T>>)Activator.CreateInstance(scopeProviderType, _lifetimeScopeProvider);
+            var filter = new ScopedFilter<SendContext<T>>(scopeProvider);
+
+            specification.UseFilter(filter);
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/ScopeProviders/AutofacFilterContextScopeProvider.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/ScopeProviders/AutofacFilterContextScopeProvider.cs
@@ -1,0 +1,107 @@
+namespace MassTransit.AutofacIntegration.ScopeProviders
+{
+    using System;
+    using System.Threading.Tasks;
+    using Autofac;
+    using Autofac.Core;
+    using Autofac.Core.Lifetime;
+    using Autofac.Core.Resolving;
+    using GreenPipes;
+    using Scoping.Filters;
+
+
+    public class AutofacFilterContextScopeProvider<TFilter, TContext> :
+        IFilterContextScopeProvider<TContext>
+        where TFilter : IFilter<TContext>
+        where TContext : class, PipeContext
+    {
+        readonly ILifetimeScopeProvider _lifetimeScopeProvider;
+
+        public AutofacFilterContextScopeProvider(ILifetimeScopeProvider lifetimeScopeProvider)
+        {
+            _lifetimeScopeProvider = lifetimeScopeProvider;
+        }
+
+        public IFilterContextScope<TContext> Create(TContext context)
+        {
+            var scope = new AutofacFilterContextScope(context, _lifetimeScopeProvider.LifetimeScope);
+            return scope;
+        }
+
+
+        class AutofacFilterContextScope :
+            IFilterContextScope<TContext>
+        {
+            readonly ILifetimeScope _lifetimeScope;
+
+            public AutofacFilterContextScope(TContext context, ILifetimeScope lifetimeScope)
+            {
+                Context = context;
+                _lifetimeScope = context.TryGetPayload(out ILifetimeScope scope) ? new NoopLifetimeScope(scope) : lifetimeScope.BeginLifetimeScope();
+            }
+
+            public void Dispose()
+            {
+                _lifetimeScope.Dispose();
+            }
+
+            public IFilter<TContext> Filter => _lifetimeScope.Resolve<TFilter>();
+
+            public TContext Context { get; }
+
+
+            class NoopLifetimeScope :
+                ILifetimeScope
+            {
+                readonly ILifetimeScope _lifetimeScope;
+
+                public NoopLifetimeScope(ILifetimeScope lifetimeScope)
+                {
+                    _lifetimeScope = lifetimeScope;
+                }
+
+                public object ResolveComponent(ResolveRequest request) => _lifetimeScope.ResolveComponent(request);
+
+                public IComponentRegistry ComponentRegistry => _lifetimeScope.ComponentRegistry;
+
+                public void Dispose()
+                {
+                }
+
+                public ValueTask DisposeAsync() => default;
+
+                public ILifetimeScope BeginLifetimeScope() => _lifetimeScope.BeginLifetimeScope();
+
+                public ILifetimeScope BeginLifetimeScope(object tag) => _lifetimeScope.BeginLifetimeScope(tag);
+
+                public ILifetimeScope BeginLifetimeScope(Action<ContainerBuilder> configurationAction) =>
+                    _lifetimeScope.BeginLifetimeScope(configurationAction);
+
+                public ILifetimeScope BeginLifetimeScope(object tag, Action<ContainerBuilder> configurationAction) =>
+                    _lifetimeScope.BeginLifetimeScope(tag, configurationAction);
+
+                public IDisposer Disposer => _lifetimeScope.Disposer;
+
+                public object Tag => _lifetimeScope.Tag;
+
+                public event EventHandler<LifetimeScopeBeginningEventArgs> ChildLifetimeScopeBeginning
+                {
+                    add => _lifetimeScope.ChildLifetimeScopeBeginning += value;
+                    remove => _lifetimeScope.ChildLifetimeScopeBeginning -= value;
+                }
+
+                public event EventHandler<LifetimeScopeEndingEventArgs> CurrentScopeEnding
+                {
+                    add => _lifetimeScope.CurrentScopeEnding += value;
+                    remove => _lifetimeScope.CurrentScopeEnding -= value;
+                }
+
+                public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning
+                {
+                    add => _lifetimeScope.ResolveOperationBeginning += value;
+                    remove => _lifetimeScope.ResolveOperationBeginning -= value;
+                }
+            }
+        }
+    }
+}

--- a/src/Containers/MassTransit.Containers.Tests/Autofac_Tests/Autofac_SagaStateMachine.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Autofac_Tests/Autofac_SagaStateMachine.cs
@@ -1,5 +1,7 @@
 namespace MassTransit.Containers.Tests.Autofac_Tests
 {
+    using System;
+    using System.Threading.Tasks;
     using Autofac;
     using Common_Tests;
     using NUnit.Framework;
@@ -26,6 +28,38 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         public void Close_container()
         {
             _container.Dispose();
+        }
+
+        protected override IRegistration Registration => _container.Resolve<IRegistration>();
+    }
+
+
+    [TestFixture]
+    public class Autofac_StateMachine_Filter :
+        Common_StateMachine_Filter
+    {
+        readonly IContainer _container;
+
+        public Autofac_StateMachine_Filter()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register(_ => new MyId(Guid.NewGuid())).InstancePerLifetimeScope();
+            builder.RegisterGeneric(typeof(ScopedFilter<>)).InstancePerLifetimeScope();
+            builder.RegisterInstance(TaskCompletionSource);
+            builder.AddMassTransit(ConfigureRegistration);
+
+            _container = builder.Build();
+        }
+
+        [OneTimeTearDown]
+        public async Task Close_container()
+        {
+            await _container.DisposeAsync();
+        }
+
+        protected override void ConfigureFilter(IConsumePipeConfigurator configurator)
+        {
+            AutofacFilterExtensions.UseConsumeFilter(configurator, typeof(ScopedFilter<>), Registration);
         }
 
         protected override IRegistration Registration => _container.Resolve<IRegistration>();

--- a/src/Containers/MassTransit.Containers.Tests/Common_Tests/Common_Consumer.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Common_Tests/Common_Consumer.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using Definition;
+    using GreenPipes;
     using GreenPipes.Internals.Extensions;
     using NUnit.Framework;
     using Scenarios;
@@ -42,6 +43,71 @@
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
             configurator.ConfigureConsumer<SimpleConsumer>(Registration);
+        }
+    }
+
+
+    public abstract class Common_Consume_Filter :
+        InMemoryTestFixture
+    {
+        protected readonly TaskCompletionSource<MyId> TaskCompletionSource;
+
+        protected Common_Consume_Filter()
+        {
+            TaskCompletionSource = GetTask<MyId>();
+        }
+
+        [Test]
+        public async Task Should_use_scope()
+        {
+            await InputQueueSendEndpoint.Send<SimpleMessageInterface>(new {Name = "test"});
+
+            var result = await TaskCompletionSource.Task;
+            Assert.IsNotNull(result);
+        }
+        protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)
+        {
+            ConfigureFilter(configurator);
+        }
+
+        protected abstract void ConfigureFilter(IConsumePipeConfigurator configurator);
+        protected abstract IRegistration Registration { get; }
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            configurator.ConfigureConsumer<SimplerConsumer>(Registration);
+        }
+
+        protected void ConfigureRegistration<T>(IRegistrationConfigurator<T> configurator)
+            where T : class
+        {
+            configurator.AddConsumer<SimplerConsumer>();
+            configurator.AddBus(provider => BusControl);
+        }
+
+
+        protected class ScopedFilter<T> :
+            IFilter<ConsumeContext<T>>
+            where T : class
+        {
+            readonly TaskCompletionSource<MyId> _taskCompletionSource;
+            readonly MyId _myId;
+
+            public ScopedFilter(TaskCompletionSource<MyId> taskCompletionSource, MyId myId)
+            {
+                _taskCompletionSource = taskCompletionSource;
+                _myId = myId;
+            }
+
+            public Task Send(ConsumeContext<T> context, IPipe<ConsumeContext<T>> next)
+            {
+                _taskCompletionSource.TrySetResult(_myId);
+                return next.Send(context);
+            }
+
+            public void Probe(ProbeContext context)
+            {
+            }
         }
     }
 

--- a/src/Containers/MassTransit.Containers.Tests/Common_Tests/Common_SagaStateMachine.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Common_Tests/Common_SagaStateMachine.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Containers.Tests.Common_Tests
 {
     using System.Threading.Tasks;
+    using GreenPipes;
     using NUnit.Framework;
     using TestFramework;
     using TestFramework.Sagas;
@@ -42,6 +43,74 @@ namespace MassTransit.Containers.Tests.Common_Tests
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
             configurator.ConfigureSaga<TestInstance>(Registration);
+        }
+    }
+
+     public abstract class Common_StateMachine_Filter :
+        InMemoryTestFixture
+    {
+        protected readonly TaskCompletionSource<MyId> TaskCompletionSource;
+
+        protected Common_StateMachine_Filter()
+        {
+            TaskCompletionSource = GetTask<MyId>();
+        }
+
+        [Test]
+        public async Task Should_use_scope()
+        {
+            await InputQueueSendEndpoint.Send(new StartTest
+            {
+                CorrelationId = NewId.NextGuid(),
+                TestKey = "Unique"
+            });
+
+            var result = await TaskCompletionSource.Task;
+            Assert.NotNull(result);
+        }
+
+        protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)
+        {
+            ConfigureFilter(configurator);
+        }
+
+        protected abstract void ConfigureFilter(IConsumePipeConfigurator configurator);
+        protected abstract IRegistration Registration { get; }
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            configurator.ConfigureSaga<TestInstance>(Registration);
+        }
+        protected void ConfigureRegistration<T>(IRegistrationConfigurator<T> configurator)
+            where T : class
+        {
+            configurator.AddSagaStateMachine<TestStateMachineSaga, TestInstance>()
+                .InMemoryRepository();
+            configurator.AddBus(provider => BusControl);
+        }
+
+        protected class ScopedFilter<T> :
+            IFilter<ConsumeContext<T>>
+            where T : class
+        {
+            readonly TaskCompletionSource<MyId> _taskCompletionSource;
+            readonly MyId _myId;
+
+            public ScopedFilter(TaskCompletionSource<MyId> taskCompletionSource, MyId myId)
+            {
+                _taskCompletionSource = taskCompletionSource;
+                _myId = myId;
+            }
+
+            public Task Send(ConsumeContext<T> context, IPipe<ConsumeContext<T>> next)
+            {
+                _taskCompletionSource.TrySetResult(_myId);
+                return next.Send(context);
+            }
+
+            public void Probe(ProbeContext context)
+            {
+            }
         }
     }
 }

--- a/src/Containers/MassTransit.Containers.Tests/Common_Tests/Common_ScopeSend.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Common_Tests/Common_ScopeSend.cs
@@ -66,4 +66,75 @@ namespace MassTransit.Containers.Tests.Common_Tests
             }
         }
     }
+
+
+    public abstract class Common_Send_Filter :
+        InMemoryTestFixture
+    {
+        protected readonly TaskCompletionSource<MyId> TaskCompletionSource;
+
+        protected Common_Send_Filter()
+        {
+            TaskCompletionSource = GetTask<MyId>();
+        }
+
+        [Test]
+        public async Task Should_use_scope()
+        {
+            var endpoint = await SendEndpointProvider.GetSendEndpoint(InputQueueAddress);
+            await endpoint.Send<SimpleMessageInterface>(new {Name = "test"});
+
+            var result = await TaskCompletionSource.Task;
+            Assert.AreEqual(MyId, result);
+        }
+
+        protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)
+        {
+            ConfigureFilter(configurator);
+        }
+
+        protected abstract void ConfigureFilter(ISendPipelineConfigurator sendPipelineConfigurator);
+        protected abstract IRegistration Registration { get; }
+
+        protected abstract MyId MyId { get; }
+
+        protected abstract ISendEndpointProvider SendEndpointProvider { get; }
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            configurator.ConfigureConsumer<SimplerConsumer>(Registration);
+        }
+
+        protected void ConfigureRegistration<T>(IRegistrationConfigurator<T> configurator)
+            where T : class
+        {
+            configurator.AddConsumer<SimplerConsumer>();
+            configurator.AddBus(provider => BusControl);
+        }
+
+
+        protected class ScopedFilter<T> :
+            IFilter<SendContext<T>>
+            where T : class
+        {
+            readonly TaskCompletionSource<MyId> _taskCompletionSource;
+            readonly MyId _myId;
+
+            public ScopedFilter(TaskCompletionSource<MyId> taskCompletionSource, MyId myId)
+            {
+                _taskCompletionSource = taskCompletionSource;
+                _myId = myId;
+            }
+
+            public Task Send(SendContext<T> context, IPipe<SendContext<T>> next)
+            {
+                _taskCompletionSource.TrySetResult(_myId);
+                return next.Send(context);
+            }
+
+            public void Probe(ProbeContext context)
+            {
+            }
+        }
+    }
 }

--- a/src/Containers/MassTransit.Containers.Tests/Common_Tests/MyId.cs
+++ b/src/Containers/MassTransit.Containers.Tests/Common_Tests/MyId.cs
@@ -1,0 +1,41 @@
+namespace MassTransit.Containers.Tests.Common_Tests
+{
+    using System;
+
+
+    public class MyId :
+        IEquatable<MyId>
+    {
+        readonly Guid _id;
+
+        public MyId(Guid id)
+        {
+            _id = id;
+        }
+
+        public bool Equals(MyId other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return _id.Equals(other._id);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((MyId)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return _id.GetHashCode();
+        }
+    }
+}

--- a/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Consumer.cs
+++ b/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Consumer.cs
@@ -74,4 +74,29 @@ namespace MassTransit.Containers.Tests.DependencyInjection_Tests
 
         protected override IRegistration Registration => _provider.GetRequiredService<IRegistration>();
     }
+
+
+    [TestFixture]
+    public class DependencyInjection_Consume_Filter :
+        Common_Consume_Filter
+    {
+        readonly IServiceProvider _provider;
+
+        public DependencyInjection_Consume_Filter()
+        {
+            var services = new ServiceCollection();
+            services.AddScoped(_ => new MyId(Guid.NewGuid()));
+            services.AddScoped(typeof(ScopedFilter<>));
+            services.AddSingleton(TaskCompletionSource);
+            services.AddMassTransit(ConfigureRegistration);
+            _provider = services.BuildServiceProvider(true);
+        }
+
+        protected override void ConfigureFilter(IConsumePipeConfigurator configurator)
+        {
+            DependencyInjectionFilterExtensions.UseConsumeFilter(configurator, typeof(ScopedFilter<>), Registration);
+        }
+
+        protected override IRegistration Registration => _provider.GetRequiredService<IRegistration>();
+    }
 }

--- a/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Courier.cs
+++ b/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Courier.cs
@@ -97,4 +97,31 @@ namespace MassTransit.Containers.Tests.DependencyInjection_Tests
 
         protected override IRegistration Registration => _container.GetRequiredService<IRegistration>();
     }
+
+
+    [TestFixture]
+    public class DependencyInjection_Courier_Activity_Filter :
+        Common_Activity_Filter
+    {
+        readonly IServiceProvider _provider;
+
+        public DependencyInjection_Courier_Activity_Filter()
+        {
+            var services = new ServiceCollection();
+            services.AddScoped(_ => new MyId(Guid.NewGuid()));
+            services.AddScoped(typeof(ScopedFilter<>));
+            services.AddSingleton(ExecuteTaskCompletionSource);
+
+            services.AddMassTransit(ConfigureRegistration);
+
+            _provider = services.BuildServiceProvider();
+        }
+
+        protected override void ConfigureFilter(IConsumePipeConfigurator configurator)
+        {
+            DependencyInjectionFilterExtensions.UseExecuteActivityFilter(configurator, typeof(ScopedFilter<>), Registration);
+        }
+
+        protected override IRegistration Registration => _provider.GetRequiredService<IRegistration>();
+    }
 }

--- a/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_SagaStateMachine.cs
+++ b/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_SagaStateMachine.cs
@@ -23,4 +23,29 @@
 
         protected override IRegistration Registration => _provider.GetRequiredService<IRegistration>();
     }
+
+
+    [TestFixture]
+    public class DependencyInjection_StateMachine_Filter :
+        Common_StateMachine_Filter
+    {
+        readonly IServiceProvider _provider;
+
+        public DependencyInjection_StateMachine_Filter()
+        {
+            _provider = new ServiceCollection()
+                .AddScoped(_ => new MyId(Guid.NewGuid()))
+                .AddSingleton(TaskCompletionSource)
+                .AddScoped(typeof(ScopedFilter<>))
+                .AddMassTransit(ConfigureRegistration)
+                .BuildServiceProvider();
+        }
+
+        protected override void ConfigureFilter(IConsumePipeConfigurator configurator)
+        {
+            DependencyInjectionFilterExtensions.UseConsumeFilter(configurator, typeof(ScopedFilter<>), Registration);
+        }
+
+        protected override IRegistration Registration => _provider.GetRequiredService<IRegistration>();
+    }
 }

--- a/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_ScopeSend.cs
+++ b/src/Containers/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_ScopeSend.cs
@@ -41,4 +41,41 @@ namespace MassTransit.Containers.Tests.DependencyInjection_Tests
             Assert.AreEqual(_childContainer.ServiceProvider, actual);
         }
     }
+
+
+    [TestFixture]
+    public class DependencyInjection_Send_Filter :
+        Common_Send_Filter
+    {
+        readonly IServiceProvider _provider;
+        readonly IServiceScope _scope;
+
+        public DependencyInjection_Send_Filter()
+        {
+            var services = new ServiceCollection();
+            services.AddScoped(_ => new MyId(Guid.NewGuid()));
+            services.AddSingleton(TaskCompletionSource);
+            services.AddScoped(typeof(ScopedFilter<>));
+
+            services.AddMassTransit(ConfigureRegistration);
+
+            _provider = services.BuildServiceProvider();
+            _scope = _provider.CreateScope();
+        }
+
+        [OneTimeTearDown]
+        public void Close_container()
+        {
+            _scope.Dispose();
+        }
+
+        protected override void ConfigureFilter(ISendPipelineConfigurator configurator)
+        {
+            DependencyInjectionFilterExtensions.UseSendFilter(configurator, typeof(ScopedFilter<>), Registration);
+        }
+
+        protected override IRegistration Registration => _provider.GetRequiredService<IRegistration>();
+        protected override MyId MyId => _scope.ServiceProvider.GetRequiredService<MyId>();
+        protected override ISendEndpointProvider SendEndpointProvider => _scope.ServiceProvider.GetRequiredService<ISendEndpointProvider>();
+    }
 }

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/DependencyInjectionFilterExtensions.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/DependencyInjectionFilterExtensions.cs
@@ -1,0 +1,99 @@
+namespace MassTransit
+{
+    using System;
+    using Courier;
+    using ExtensionsDependencyInjectionIntegration.Filters;
+
+
+    public static class DependencyInjectionFilterExtensions
+    {
+        /// <summary>
+        /// Use scoped filter for <see cref="ConsumeContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseConsumeFilter(this IConsumePipeConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var provider = registration.GetRequiredService<IServiceProvider>();
+            var observer = new ScopedConsumePipeSpecificationObserver(configurator, filterType, provider);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="SendContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseSendFilter(this ISendPipelineConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var provider = registration.GetRequiredService<IServiceProvider>();
+            var observer = new ScopedSendPipeSpecificationObserver(filterType, provider);
+            configurator.ConfigureSend(cfg => cfg.ConnectSendPipeSpecificationObserver(observer));
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="PublishContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UsePublishFilter(this IPublishPipelineConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var provider = registration.GetRequiredService<IServiceProvider>();
+            var observer = new ScopedPublishPipeSpecificationObserver(filterType, provider);
+            configurator.ConfigurePublish(cfg => cfg.ConnectPublishPipeSpecificationObserver(observer));
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="ExecuteContext{TArguments}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseExecuteActivityFilter(this IConsumePipeConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var provider = registration.GetRequiredService<IServiceProvider>();
+            var observer = new ScopedExecuteActivityPipeSpecificationObserver(filterType, provider);
+            configurator.ConnectActivityConfigurationObserver(observer);
+        }
+
+        /// <summary>
+        /// Use scoped filter for <see cref="CompensateContext{T}"/>
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filterType">Filter type</param>
+        /// <param name="registration">Registration Context</param>
+        public static void UseCompensateActivityFilter(this IConsumePipeConfigurator configurator, Type filterType, IRegistration registration)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+            if (registration == null)
+                throw new ArgumentNullException(nameof(registration));
+
+            var provider = registration.GetRequiredService<IServiceProvider>();
+            var observer = new ScopedCompensateActivityPipeSpecificationObserver(filterType, provider);
+            configurator.ConnectActivityConfigurationObserver(observer);
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedCompensateActivityPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedCompensateActivityPipeSpecificationObserver.cs
@@ -1,0 +1,48 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration.Filters
+{
+    using System;
+    using ConsumeConfigurators;
+    using Courier;
+    using GreenPipes;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedCompensateActivityPipeSpecificationObserver :
+        IActivityConfigurationObserver
+    {
+        readonly Type _filterType;
+        readonly IServiceProvider _serviceProvider;
+
+        public ScopedCompensateActivityPipeSpecificationObserver(Type filterType, IServiceProvider serviceProvider)
+        {
+            _filterType = filterType;
+            _serviceProvider = serviceProvider;
+        }
+
+        public void ActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator, Uri compensateAddress)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+        }
+
+        public void ExecuteActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+        }
+
+        public void CompensateActivityConfigured<TActivity, TLog>(ICompensateActivityConfigurator<TActivity, TLog> configurator)
+            where TActivity : class, ICompensateActivity<TLog>
+            where TLog : class
+        {
+            var scopeProviderType =
+                typeof(DependencyInjectionFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(TLog)),
+                    typeof(CompensateContext<TLog>));
+            var scopeProvider = (IFilterContextScopeProvider<CompensateContext<TLog>>)Activator.CreateInstance(scopeProviderType, _serviceProvider);
+            var filter = new ScopedFilter<CompensateContext<TLog>>(scopeProvider);
+
+            configurator.Log(a => a.UseFilter(filter));
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedConsumePipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedConsumePipeSpecificationObserver.cs
@@ -1,0 +1,40 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration.Filters
+{
+    using System;
+    using ConsumeConfigurators;
+    using GreenPipes.Specifications;
+    using PipeConfigurators;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedConsumePipeSpecificationObserver :
+        ConfigurationObserver,
+        IMessageConfigurationObserver
+    {
+        readonly Type _filterType;
+        readonly IServiceProvider _serviceProvider;
+
+        public ScopedConsumePipeSpecificationObserver(IConsumePipeConfigurator configurator, Type filterType, IServiceProvider serviceProvider)
+            : base(configurator)
+        {
+            _filterType = filterType;
+            _serviceProvider = serviceProvider;
+
+            Connect(this);
+        }
+
+        public void MessageConfigured<TMessage>(IConsumePipeConfigurator configurator)
+            where TMessage : class
+        {
+            var scopeProviderType =
+                typeof(DependencyInjectionFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(TMessage)),
+                    typeof(ConsumeContext<TMessage>));
+            var scopeProvider = (IFilterContextScopeProvider<ConsumeContext<TMessage>>)Activator.CreateInstance(scopeProviderType, _serviceProvider);
+            var filter = new ScopedFilter<ConsumeContext<TMessage>>(scopeProvider);
+            var specification = new FilterPipeSpecification<ConsumeContext<TMessage>>(filter);
+
+            configurator.AddPipeSpecification(specification);
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedExecuteActivityPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedExecuteActivityPipeSpecificationObserver.cs
@@ -1,0 +1,49 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration.Filters
+{
+    using System;
+    using ConsumeConfigurators;
+    using Courier;
+    using GreenPipes;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedExecuteActivityPipeSpecificationObserver :
+        IActivityConfigurationObserver
+    {
+        readonly Type _filterType;
+        readonly IServiceProvider _serviceProvider;
+
+        public ScopedExecuteActivityPipeSpecificationObserver(Type filterType, IServiceProvider serviceProvider)
+        {
+            _filterType = filterType;
+            _serviceProvider = serviceProvider;
+        }
+
+        public void ActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator, Uri compensateAddress)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+            ExecuteActivityConfigured(configurator);
+        }
+
+        public void ExecuteActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator)
+            where TActivity : class, IExecuteActivity<TArguments>
+            where TArguments : class
+        {
+            var scopeProviderType =
+                typeof(DependencyInjectionFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(TArguments)),
+                    typeof(ExecuteContext<TArguments>));
+            var scopeProvider = (IFilterContextScopeProvider<ExecuteContext<TArguments>>)Activator.CreateInstance(scopeProviderType, _serviceProvider);
+            var filter = new ScopedFilter<ExecuteContext<TArguments>>(scopeProvider);
+
+            configurator.Arguments(a => a.UseFilter(filter));
+        }
+
+        public void CompensateActivityConfigured<TActivity, TLog>(ICompensateActivityConfigurator<TActivity, TLog> configurator)
+            where TActivity : class, ICompensateActivity<TLog>
+            where TLog : class
+        {
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedPublishPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedPublishPipeSpecificationObserver.cs
@@ -1,0 +1,33 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration.Filters
+{
+    using System;
+    using GreenPipes;
+    using PublishPipeSpecifications;
+    using ScopeProviders;
+    using Scoping.Filters;
+
+
+    public class ScopedPublishPipeSpecificationObserver :
+        IPublishPipeSpecificationObserver
+    {
+        readonly Type _filterType;
+        readonly IServiceProvider _serviceProvider;
+
+        public ScopedPublishPipeSpecificationObserver(Type filterType, IServiceProvider serviceProvider)
+        {
+            _filterType = filterType;
+            _serviceProvider = serviceProvider;
+        }
+
+        public void MessageSpecificationCreated<T>(IMessagePublishPipeSpecification<T> specification)
+            where T : class
+        {
+            var scopeProviderType =
+                typeof(DependencyInjectionFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(T)), typeof(PublishContext<T>));
+            var scopeProvider = (IFilterContextScopeProvider<PublishContext<T>>)Activator.CreateInstance(scopeProviderType, _serviceProvider);
+            var filter = new ScopedFilter<PublishContext<T>>(scopeProvider);
+
+            specification.UseFilter(filter);
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedSendPipeSpecificationObserver.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Filters/ScopedSendPipeSpecificationObserver.cs
@@ -1,0 +1,33 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration.Filters
+{
+    using System;
+    using GreenPipes;
+    using ScopeProviders;
+    using Scoping.Filters;
+    using SendPipeSpecifications;
+
+
+    public class ScopedSendPipeSpecificationObserver :
+        ISendPipeSpecificationObserver
+    {
+        readonly Type _filterType;
+        readonly IServiceProvider _serviceProvider;
+
+        public ScopedSendPipeSpecificationObserver(Type filterType, IServiceProvider serviceProvider)
+        {
+            _filterType = filterType;
+            _serviceProvider = serviceProvider;
+        }
+
+        public void MessageSpecificationCreated<T>(IMessageSendPipeSpecification<T> specification)
+            where T : class
+        {
+            var scopeProviderType =
+                typeof(DependencyInjectionFilterContextScopeProvider<,>).MakeGenericType(_filterType.MakeGenericType(typeof(T)), typeof(SendContext<T>));
+            var scopeProvider = (IFilterContextScopeProvider<SendContext<T>>)Activator.CreateInstance(scopeProviderType, _serviceProvider);
+            var filter = new ScopedFilter<SendContext<T>>(scopeProvider);
+
+            specification.UseFilter(filter);
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ScopeProviders/DependencyInjectionFilterContextScopeProvider.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ScopeProviders/DependencyInjectionFilterContextScopeProvider.cs
@@ -1,0 +1,65 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration.ScopeProviders
+{
+    using System;
+    using GreenPipes;
+    using Microsoft.Extensions.DependencyInjection;
+    using Scoping.Filters;
+
+
+    public class DependencyInjectionFilterContextScopeProvider<TFilter, TContext> :
+        IFilterContextScopeProvider<TContext>
+        where TFilter : IFilter<TContext>
+        where TContext : class, PipeContext
+    {
+        readonly IServiceProvider _serviceProvider;
+
+        public DependencyInjectionFilterContextScopeProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public IFilterContextScope<TContext> Create(TContext context)
+        {
+            var scope = new DependencyInjectionFilterContextScope(context, _serviceProvider);
+            return scope;
+        }
+
+
+        class DependencyInjectionFilterContextScope :
+            IFilterContextScope<TContext>
+        {
+            readonly IServiceScope _scope;
+
+            public DependencyInjectionFilterContextScope(TContext context, IServiceProvider serviceProvider)
+            {
+                Context = context;
+                _scope = context.TryGetPayload(out IServiceProvider provider) ? new NoopScope(provider) : serviceProvider.CreateScope();
+            }
+
+            public void Dispose()
+            {
+                _scope.Dispose();
+            }
+
+            public IFilter<TContext> Filter => _scope.ServiceProvider.GetService<TFilter>();
+
+            public TContext Context { get; }
+
+
+            class NoopScope :
+                IServiceScope
+            {
+                public NoopScope(IServiceProvider serviceProvider)
+                {
+                    ServiceProvider = serviceProvider;
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public IServiceProvider ServiceProvider { get; }
+            }
+        }
+    }
+}

--- a/src/MassTransit/Scoping/Filters/IFilterContextScope.cs
+++ b/src/MassTransit/Scoping/Filters/IFilterContextScope.cs
@@ -1,0 +1,14 @@
+namespace MassTransit.Scoping.Filters
+{
+    using System;
+    using GreenPipes;
+
+
+    public interface IFilterContextScope<TContext> :
+        IDisposable
+        where TContext : class, PipeContext
+    {
+        IFilter<TContext> Filter { get; }
+        TContext Context { get; }
+    }
+}

--- a/src/MassTransit/Scoping/Filters/IFilterContextScopeProvider.cs
+++ b/src/MassTransit/Scoping/Filters/IFilterContextScopeProvider.cs
@@ -1,0 +1,11 @@
+namespace MassTransit.Scoping.Filters
+{
+    using GreenPipes;
+
+
+    public interface IFilterContextScopeProvider<TContext>
+        where TContext : class, PipeContext
+    {
+        IFilterContextScope<TContext> Create(TContext context);
+    }
+}

--- a/src/MassTransit/Scoping/Filters/ScopedFilter.cs
+++ b/src/MassTransit/Scoping/Filters/ScopedFilter.cs
@@ -1,0 +1,28 @@
+namespace MassTransit.Scoping.Filters
+{
+    using System.Threading.Tasks;
+    using GreenPipes;
+
+
+    public class ScopedFilter<TContext> :
+        IFilter<TContext>
+        where TContext : class, PipeContext
+    {
+        readonly IFilterContextScopeProvider<TContext> _filterContextScopeProvider;
+
+        public ScopedFilter(IFilterContextScopeProvider<TContext> filterContextScopeProvider)
+        {
+            _filterContextScopeProvider = filterContextScopeProvider;
+        }
+
+        public async Task Send(TContext context, IPipe<TContext> next)
+        {
+            using IFilterContextScope<TContext> scope = _filterContextScopeProvider.Create(context);
+            await scope.Filter.Send(scope.Context, next).ConfigureAwait(false);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+        }
+    }
+}

--- a/src/MassTransit/Topology/Conventions/CorrelationId/CorrelationIdMessageSendTopologyConvention.cs
+++ b/src/MassTransit/Topology/Conventions/CorrelationId/CorrelationIdMessageSendTopologyConvention.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Topology.Conventions.CorrelationId
 {


### PR DESCRIPTION
Ability to use filters with container scopes. Existing scope inside `Payload` will be used or new one from root container will be created.
Supports only: Autofac and MSDI for now