### PR TITLE
Mediator registration refactoring [#1891]

### DIFF
--- a/src/Containers/MassTransit.AutofacIntegration/AutofacRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/AutofacRegistrationExtensions.cs
@@ -6,6 +6,7 @@ namespace MassTransit
     using Autofac.Core;
     using AutofacIntegration;
     using AutofacIntegration.Registration;
+    using Mediator;
     using Metadata;
 
 
@@ -22,7 +23,32 @@ namespace MassTransit
         /// <param name="configure"></param>
         public static ContainerBuilder AddMassTransit(this ContainerBuilder builder, Action<IContainerBuilderConfigurator> configure = null)
         {
+            if (builder.ComponentRegistryBuilder.IsRegistered(new TypedService(typeof(IRegistration))))
+            {
+                throw new ConfigurationException(
+                    "AddBus() was already called. To configure multiple bus instances, refer to the documentation: https://masstransit-project.com/usage/containers/multibus.html");
+            }
+
             var configurator = new ContainerBuilderRegistrationConfigurator(builder);
+
+            configure?.Invoke(configurator);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the required services to the service collection, and allows consumers to be added and/or discovered
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configure"></param>
+        public static ContainerBuilder AddMediator(this ContainerBuilder builder, Action<IContainerBuilderMediatorConfigurator> configure = null)
+        {
+            if (builder.ComponentRegistryBuilder.IsRegistered(new TypedService(typeof(IMediator))))
+            {
+                throw new ConfigurationException("AddMediator() was already called and may only be called once per container.");
+            }
+
+            var configurator = new ContainerBuilderRegistrationMediatorConfigurator(builder);
 
             configure?.Invoke(configurator);
 

--- a/src/Containers/MassTransit.AutofacIntegration/IContainerBuilderMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/IContainerBuilderMediatorConfigurator.cs
@@ -1,0 +1,16 @@
+namespace MassTransit.AutofacIntegration
+{
+    using System;
+    using Autofac;
+
+
+    public interface IContainerBuilderMediatorConfigurator :
+        IMediatorRegistrationConfigurator<IComponentContext>
+    {
+        ContainerBuilder Builder { get; }
+
+        string ScopeName { set; }
+
+        Action<ContainerBuilder, ConsumeContext> ConfigureScope { set; }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Registration/AutofacContainerRegistrar.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Registration/AutofacContainerRegistrar.cs
@@ -7,6 +7,7 @@ namespace MassTransit.AutofacIntegration.Registration
     using Courier;
     using Definition;
     using MassTransit.Registration;
+    using Mediator;
     using Saga;
     using ScopeProviders;
     using Scoping;
@@ -131,7 +132,7 @@ namespace MassTransit.AutofacIntegration.Registration
         {
             _builder.Register(context =>
             {
-                var clientFactory = context.Resolve<IClientFactory>();
+                var clientFactory = GetClientFactory(context);
 
                 if (context.TryResolve(out ConsumeContext consumeContext))
                     return clientFactory.CreateRequestClient<T>(consumeContext, timeout);
@@ -146,7 +147,7 @@ namespace MassTransit.AutofacIntegration.Registration
         {
             _builder.Register(context =>
             {
-                var clientFactory = context.Resolve<IClientFactory>();
+                var clientFactory = GetClientFactory(context);
 
                 if (context.TryResolve(out ConsumeContext consumeContext))
                     return clientFactory.CreateRequestClient<T>(consumeContext, destinationAddress, timeout);
@@ -207,6 +208,26 @@ namespace MassTransit.AutofacIntegration.Registration
             var lifetimeScopeProvider = new SingleLifetimeScopeProvider(context.Resolve<ILifetimeScope>());
 
             return new AutofacCompensateActivityScopeProvider<TActivity, TLog>(lifetimeScopeProvider, "message");
+        }
+
+        protected virtual IClientFactory GetClientFactory(IComponentContext componentContext)
+        {
+            return componentContext.Resolve<IClientFactory>();
+        }
+    }
+
+
+    public class AutofacContainerMediatorRegistrar :
+        AutofacContainerRegistrar
+    {
+        public AutofacContainerMediatorRegistrar(ContainerBuilder builder)
+            : base(builder)
+        {
+        }
+
+        protected override IClientFactory GetClientFactory(IComponentContext componentContext)
+        {
+            return componentContext.Resolve<IMediator>();
         }
     }
 }

--- a/src/Containers/MassTransit.AutofacIntegration/Registration/ContainerBuilderRegistrationMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Registration/ContainerBuilderRegistrationMediatorConfigurator.cs
@@ -1,0 +1,90 @@
+namespace MassTransit.AutofacIntegration.Registration
+{
+    using System;
+    using Autofac;
+    using MassTransit.Registration;
+    using Mediator;
+    using ScopeProviders;
+    using Scoping;
+
+
+    public class ContainerBuilderRegistrationMediatorConfigurator :
+        RegistrationConfigurator,
+        IContainerBuilderMediatorConfigurator
+    {
+        readonly ContainerBuilder _builder;
+        readonly AutofacContainerRegistrar _registrar;
+        Action<IComponentContext, IReceiveEndpointConfigurator> _configure;
+
+        public ContainerBuilderRegistrationMediatorConfigurator(ContainerBuilder builder)
+            : this(builder, new AutofacContainerMediatorRegistrar(builder))
+        {
+        }
+
+        ContainerBuilderRegistrationMediatorConfigurator(ContainerBuilder builder, AutofacContainerRegistrar registrar)
+            : base(registrar)
+        {
+            _builder = builder;
+            _registrar = registrar;
+
+            ScopeName = "message";
+
+            builder.Register(CreateConsumerScopeProvider)
+                .As<IConsumerScopeProvider>()
+                .SingleInstance()
+                .IfNotRegistered(typeof(IConsumerScopeProvider));
+
+            builder.Register(context => new AutofacConfigurationServiceProvider(context.Resolve<ILifetimeScope>()))
+                .As<IConfigurationServiceProvider>()
+                .SingleInstance()
+                .IfNotRegistered(typeof(IConfigurationServiceProvider));
+
+            builder.Register(MediatorFactory)
+                .As<IMediator>()
+                .SingleInstance();
+        }
+
+        public string ScopeName
+        {
+            private get => _registrar.ScopeName;
+            set => _registrar.ScopeName = value;
+        }
+
+        ContainerBuilder IContainerBuilderMediatorConfigurator.Builder => _builder;
+
+        public Action<ContainerBuilder, ConsumeContext> ConfigureScope
+        {
+            get => _registrar.ConfigureScope;
+            set => _registrar.ConfigureScope = value;
+        }
+
+        IMediator MediatorFactory(IComponentContext context)
+        {
+            var provider = context.Resolve<IConfigurationServiceProvider>();
+
+            ConfigureLogContext(provider);
+
+            return Bus.Factory.CreateMediator(cfg =>
+            {
+                _configure?.Invoke(context, cfg);
+
+                ConfigureMediator(cfg, provider);
+            });
+        }
+
+        IConsumerScopeProvider CreateConsumerScopeProvider(IComponentContext context)
+        {
+            var lifetimeScopeProvider = new SingleLifetimeScopeProvider(context.Resolve<ILifetimeScope>());
+            return new AutofacConsumerScopeProvider(lifetimeScopeProvider, ScopeName, ConfigureScope);
+        }
+
+        public void ConfigureMediator(Action<IComponentContext, IReceiveEndpointConfigurator> configure)
+        {
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            ThrowIfAlreadyConfigured();
+            _configure = configure;
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/DependencyInjectionRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/DependencyInjectionRegistrationExtensions.cs
@@ -4,6 +4,7 @@ namespace MassTransit
     using System.Linq;
     using ExtensionsDependencyInjectionIntegration;
     using ExtensionsDependencyInjectionIntegration.Registration;
+    using Mediator;
     using Microsoft.Extensions.DependencyInjection;
 
 
@@ -27,6 +28,25 @@ namespace MassTransit
             }
 
             var configurator = new ServiceCollectionConfigurator(collection);
+
+            configure?.Invoke(configurator);
+
+            return collection;
+        }
+
+        /// <summary>
+        /// Adds the required services to the service collection, and allows consumers to be added and/or discovered
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="configure"></param>
+        public static IServiceCollection AddMediator(this IServiceCollection collection, Action<IServiceCollectionMediatorConfigurator> configure = null)
+        {
+            if (collection.Any(d => d.ServiceType == typeof(IMediator)))
+            {
+                throw new ConfigurationException("AddMediator() was already called and may only be called once per container.");
+            }
+
+            var configurator = new ServiceCollectionMediatorConfigurator(collection);
 
             configure?.Invoke(configurator);
 

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/IServiceCollectionMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/IServiceCollectionMediatorConfigurator.cs
@@ -1,0 +1,12 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration
+{
+    using System;
+    using Microsoft.Extensions.DependencyInjection;
+
+
+    public interface IServiceCollectionMediatorConfigurator :
+        IMediatorRegistrationConfigurator<IServiceProvider>
+    {
+        IServiceCollection Collection { get; }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/MultiBus/DependencyInjectionMultiBusRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/MultiBus/DependencyInjectionMultiBusRegistrationExtensions.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.MultiBus
 {
     using System;
+    using System.Linq;
     using ExtensionsDependencyInjectionIntegration.MultiBus;
     using Internals.Reflection;
     using Microsoft.Extensions.DependencyInjection;
@@ -25,6 +26,12 @@ namespace MassTransit.MultiBus
         {
             if (configure == null)
                 throw new ArgumentNullException(nameof(configure));
+
+            if (collection.Any(d => d.ServiceType == typeof(Bind<TBus, IRegistration>)))
+            {
+                throw new ConfigurationException(
+                    $"AddMassTransit<{typeof(TBus).Name},{typeof(TBusInstance).Name}>() was already called and may only be called once per container. To configure additional bus instances, refer to the documentation: https://masstransit-project.com/usage/containers/multibus.html");
+            }
 
             var configurator = new ServiceCollectionConfigurator<TBus, TBusInstance>(collection);
 

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Registration/DependencyInjectionContainerRegistrar.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Registration/DependencyInjectionContainerRegistrar.cs
@@ -5,6 +5,7 @@ namespace MassTransit.ExtensionsDependencyInjectionIntegration.Registration
     using Clients;
     using Definition;
     using MassTransit.Registration;
+    using Mediator;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Saga;
@@ -171,6 +172,20 @@ namespace MassTransit.ExtensionsDependencyInjectionIntegration.Registration
         protected override IClientFactory GetClientFactory(IServiceProvider provider)
         {
             return provider.GetRequiredService<Bind<TBus, IClientFactory>>().Value;
+        }
+    }
+
+    public class DependencyInjectionMediatorContainerRegistrar :
+        DependencyInjectionContainerRegistrar
+    {
+        public DependencyInjectionMediatorContainerRegistrar(IServiceCollection collection)
+            : base(collection)
+        {
+        }
+
+        protected override IClientFactory GetClientFactory(IServiceProvider provider)
+        {
+            return provider.GetRequiredService<IMediator>();
         }
     }
 }

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Registration/ServiceCollectionMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/Registration/ServiceCollectionMediatorConfigurator.cs
@@ -1,0 +1,61 @@
+namespace MassTransit.ExtensionsDependencyInjectionIntegration.Registration
+{
+    using System;
+    using Context;
+    using MassTransit.Registration;
+    using Mediator;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using ScopeProviders;
+    using Scoping;
+
+
+    public class ServiceCollectionMediatorConfigurator :
+        RegistrationConfigurator,
+        IServiceCollectionMediatorConfigurator
+    {
+        Action<IServiceProvider, IReceiveEndpointConfigurator> _configure;
+
+        public ServiceCollectionMediatorConfigurator(IServiceCollection collection)
+            : base(new DependencyInjectionMediatorContainerRegistrar(collection))
+        {
+            Collection = collection;
+
+            Collection.AddSingleton(MediatorFactory);
+            AddMassTransitComponents(collection);
+        }
+
+        public IServiceCollection Collection { get; }
+
+        static void AddMassTransitComponents(IServiceCollection collection)
+        {
+            collection.TryAddScoped<ScopedConsumeContextProvider>();
+            collection.TryAddScoped(provider => provider.GetRequiredService<ScopedConsumeContextProvider>().GetContext() ?? new MissingConsumeContext());
+            collection.TryAddSingleton<IConsumerScopeProvider>(provider => new DependencyInjectionConsumerScopeProvider(provider));
+            collection.TryAddSingleton<IConfigurationServiceProvider>(provider => new DependencyInjectionConfigurationServiceProvider(provider));
+        }
+
+        public void ConfigureMediator(Action<IServiceProvider, IReceiveEndpointConfigurator> configure)
+        {
+            if(configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            ThrowIfAlreadyConfigured();
+            _configure = configure;
+        }
+
+        IMediator MediatorFactory(IServiceProvider serviceProvider)
+        {
+            var provider = serviceProvider.GetRequiredService<IConfigurationServiceProvider>();
+
+            ConfigureLogContext(provider);
+
+            return Bus.Factory.CreateMediator(cfg =>
+            {
+                _configure?.Invoke(serviceProvider, cfg);
+
+                ConfigureMediator(cfg, provider);
+            });
+        }
+    }
+}

--- a/src/Containers/MassTransit.LamarIntegration/IServiceRegistryMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.LamarIntegration/IServiceRegistryMediatorConfigurator.cs
@@ -1,0 +1,11 @@
+namespace MassTransit.LamarIntegration
+{
+    using Lamar;
+
+
+    public interface IServiceRegistryMediatorConfigurator :
+        IMediatorRegistrationConfigurator<IServiceContext>
+    {
+        ServiceRegistry Builder { get; }
+    }
+}

--- a/src/Containers/MassTransit.LamarIntegration/Registration/ServiceRegistryMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.LamarIntegration/Registration/ServiceRegistryMediatorConfigurator.cs
@@ -1,0 +1,64 @@
+namespace MassTransit.LamarIntegration.Registration
+{
+    using System;
+    using Lamar;
+    using MassTransit.Registration;
+    using Mediator;
+    using ScopeProviders;
+    using Scoping;
+
+
+    public class ServiceRegistryMediatorConfigurator :
+        RegistrationConfigurator,
+        IServiceRegistryMediatorConfigurator
+    {
+        readonly ServiceRegistry _registry;
+        Action<IServiceContext, IReceiveEndpointConfigurator> _configure;
+
+        public ServiceRegistryMediatorConfigurator(ServiceRegistry registry)
+            : base(new LamarContainerMediatorRegistrar(registry))
+        {
+            _registry = registry;
+
+            registry.For<IConsumerScopeProvider>()
+                .Use(CreateConsumerScopeProvider)
+                .Singleton();
+
+            registry.For<IConfigurationServiceProvider>()
+                .Use(context => new LamarConfigurationServiceProvider(context.GetInstance<IContainer>()))
+                .Singleton();
+
+            registry.Injectable<ConsumeContext>();
+
+            _registry.For<IMediator>()
+                .Use(MediatorFactory)
+                .Singleton();
+        }
+
+        ServiceRegistry IServiceRegistryMediatorConfigurator.Builder => _registry;
+
+        IMediator MediatorFactory(IServiceContext context)
+        {
+            var provider = context.GetInstance<IConfigurationServiceProvider>();
+
+            ConfigureLogContext(provider);
+
+            return Bus.Factory.CreateMediator(cfg =>
+            {
+                _configure?.Invoke(context, cfg);
+
+                ConfigureMediator(cfg, provider);
+            });
+        }
+
+        static IConsumerScopeProvider CreateConsumerScopeProvider(IServiceContext context)
+        {
+            return new LamarConsumerScopeProvider(context.GetInstance<IContainer>());
+        }
+
+        public void ConfigureMediator(Action<IServiceContext, IReceiveEndpointConfigurator> configure)
+        {
+            _configure = configure;
+        }
+    }
+}

--- a/src/Containers/MassTransit.SimpleInjectorIntegration/ISimpleInjectorMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/ISimpleInjectorMediatorConfigurator.cs
@@ -1,0 +1,17 @@
+namespace MassTransit.SimpleInjectorIntegration
+{
+    using System;
+    using SimpleInjector;
+
+
+    public interface ISimpleInjectorMediatorConfigurator :
+        IMediatorRegistrationConfigurator<Container>
+    {
+        Container Container { get; }
+        /// <summary>
+        /// Optionally configure the pipeline used by the mediator
+        /// </summary>
+        /// <param name="configure"></param>
+        void ConfigureMediator(Action<IReceiveEndpointConfigurator> configure);
+    }
+}

--- a/src/Containers/MassTransit.SimpleInjectorIntegration/Registration/SimpleInjectorContainerRegistrar.cs
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/Registration/SimpleInjectorContainerRegistrar.cs
@@ -7,6 +7,7 @@ namespace MassTransit.SimpleInjectorIntegration.Registration
     using Courier;
     using Definition;
     using MassTransit.Registration;
+    using Mediator;
     using Saga;
     using ScopeProviders;
     using Scoping;
@@ -132,7 +133,7 @@ namespace MassTransit.SimpleInjectorIntegration.Registration
         {
             _container.Register(() =>
             {
-                var clientFactory = _container.GetInstance<IClientFactory>();
+                var clientFactory = GetClientFactory(_container);
                 var consumeContext = _container.GetConsumeContext();
 
                 if (consumeContext != null)
@@ -148,7 +149,7 @@ namespace MassTransit.SimpleInjectorIntegration.Registration
         {
             _container.Register(() =>
             {
-                var clientFactory = _container.GetInstance<IClientFactory>();
+                var clientFactory = GetClientFactory(_container);
                 var consumeContext = _container.GetConsumeContext();
 
                 if (consumeContext != null)
@@ -191,6 +192,26 @@ namespace MassTransit.SimpleInjectorIntegration.Registration
 
             if (notExists)
                 _container.Register<TActivity>(Lifestyle.Scoped);
+        }
+
+        protected virtual IClientFactory GetClientFactory(Container container)
+        {
+            return container.GetInstance<IClientFactory>();
+        }
+    }
+
+
+    public class SimpleInjectorContainerMediatorRegistrar :
+        SimpleInjectorContainerRegistrar
+    {
+        public SimpleInjectorContainerMediatorRegistrar(Container container)
+            : base(container)
+        {
+        }
+
+        protected override IClientFactory GetClientFactory(Container container)
+        {
+            return container.GetInstance<IMediator>();
         }
     }
 }

--- a/src/Containers/MassTransit.SimpleInjectorIntegration/Registration/SimpleInjectorMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/Registration/SimpleInjectorMediatorConfigurator.cs
@@ -1,0 +1,65 @@
+namespace MassTransit.SimpleInjectorIntegration.Registration
+{
+    using System;
+    using Context;
+    using MassTransit.Registration;
+    using Mediator;
+    using ScopeProviders;
+    using Scoping;
+    using SimpleInjector;
+
+
+    public class SimpleInjectorMediatorConfigurator :
+        RegistrationConfigurator,
+        ISimpleInjectorMediatorConfigurator
+    {
+        Action<Container, IReceiveEndpointConfigurator> _configure;
+
+        public SimpleInjectorMediatorConfigurator(Container container)
+            : base(new SimpleInjectorContainerMediatorRegistrar(container))
+        {
+            Container = container;
+
+            Container.RegisterSingleton(MediatorFactory);
+            AddMassTransitComponents(Container);
+        }
+
+        public Container Container { get; }
+
+        public void ConfigureMediator(Action<IReceiveEndpointConfigurator> configure)
+        {
+            ConfigureMediator((_, cfg) => configure(cfg));
+        }
+
+        IMediator MediatorFactory()
+        {
+            var provider = Container.GetInstance<IConfigurationServiceProvider>();
+
+            ConfigureLogContext(provider);
+
+            return Bus.Factory.CreateMediator(cfg =>
+            {
+                _configure?.Invoke(Container, cfg);
+
+                ConfigureMediator(cfg, provider);
+            });
+        }
+
+        public void ConfigureMediator(Action<Container, IReceiveEndpointConfigurator> configure)
+        {
+            ThrowIfAlreadyConfigured();
+            _configure = configure;
+        }
+
+        static void AddMassTransitComponents(Container container)
+        {
+            container.Register<ScopedConsumeContextProvider>(Lifestyle.Scoped);
+
+            container.Register(() => container.GetInstance<ScopedConsumeContextProvider>().GetContext() ?? new MissingConsumeContext(),
+                Lifestyle.Scoped);
+
+            container.RegisterSingleton<IConsumerScopeProvider>(() => new SimpleInjectorConsumerScopeProvider(container));
+            container.RegisterSingleton<IConfigurationServiceProvider>(() => new SimpleInjectorConfigurationServiceProvider(container));
+        }
+    }
+}

--- a/src/Containers/MassTransit.SimpleInjectorIntegration/SimpleInjectorRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/SimpleInjectorRegistrationExtensions.cs
@@ -2,6 +2,7 @@ namespace MassTransit
 {
     using System;
     using System.Linq;
+    using Mediator;
     using Metadata;
     using SimpleInjector;
     using SimpleInjectorIntegration;
@@ -21,7 +22,32 @@ namespace MassTransit
         /// <param name="configure"></param>
         public static Container AddMassTransit(this Container container, Action<ISimpleInjectorConfigurator> configure = null)
         {
-            var configurator = new SimpleInjectorRegistrationConfigurator(container);
+            if (container.GetCurrentRegistrations().Any(d => d.ServiceType == typeof(IRegistration)))
+            {
+                throw new ConfigurationException(
+                    "AddBus() was already called. To configure multiple bus instances, refer to the documentation: https://masstransit-project.com/usage/containers/multibus.html");
+            }
+
+            var configurator = new SimpleInjectorConfigurator(container);
+
+            configure?.Invoke(configurator);
+
+            return container;
+        }
+
+        /// <summary>
+        /// Adds the required services to the service collection, and allows consumers to be added and/or discovered
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="configure"></param>
+        public static Container AddMediator(this Container container, Action<ISimpleInjectorMediatorConfigurator> configure = null)
+        {
+            if (container.GetCurrentRegistrations().Any(d => d.ServiceType == typeof(IMediator)))
+            {
+                throw new ConfigurationException("AddMediator() was already called and may only be called once per container.");
+            }
+
+            var configurator = new SimpleInjectorMediatorConfigurator(container);
 
             configure?.Invoke(configurator);
 

--- a/src/Containers/MassTransit.StructureMapIntegration/IConfigurationExpressionMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.StructureMapIntegration/IConfigurationExpressionMediatorConfigurator.cs
@@ -1,0 +1,11 @@
+namespace MassTransit.StructureMapIntegration
+{
+    using StructureMap;
+
+
+    public interface IConfigurationExpressionMediatorConfigurator :
+        IMediatorRegistrationConfigurator<IContext>
+    {
+        ConfigurationExpression Builder { get; }
+    }
+}

--- a/src/Containers/MassTransit.StructureMapIntegration/Registration/ConfigurationExpressionMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.StructureMapIntegration/Registration/ConfigurationExpressionMediatorConfigurator.cs
@@ -1,0 +1,63 @@
+namespace MassTransit.StructureMapIntegration.Registration
+{
+    using System;
+    using MassTransit.Registration;
+    using Mediator;
+    using ScopeProviders;
+    using Scoping;
+    using StructureMap;
+
+
+    public class ConfigurationExpressionMediatorConfigurator :
+        RegistrationConfigurator,
+        IConfigurationExpressionMediatorConfigurator
+    {
+        readonly ConfigurationExpression _expression;
+        Action<IContext, IReceiveEndpointConfigurator> _configure;
+
+        public ConfigurationExpressionMediatorConfigurator(ConfigurationExpression expression)
+            : base(new StructureMapContainerMediatorRegistrar(expression))
+        {
+            _expression = expression;
+
+            _expression.For<IMediator>()
+                .Use(context => MediatorFactory(context))
+                .Singleton();
+
+            expression.For<IConsumerScopeProvider>()
+                .Use(context => CreateConsumerScopeProvider(context))
+                .Singleton();
+
+            expression.For<IConfigurationServiceProvider>()
+                .Use(context => new StructureMapConfigurationServiceProvider(context.GetInstance<IContainer>()))
+                .Singleton();
+        }
+
+        ConfigurationExpression IConfigurationExpressionMediatorConfigurator.Builder => _expression;
+
+        public void ConfigureMediator(Action<IContext, IReceiveEndpointConfigurator> configure)
+        {
+            ThrowIfAlreadyConfigured();
+            _configure = configure;
+        }
+
+        IMediator MediatorFactory(IContext context)
+        {
+            var provider = context.GetInstance<IConfigurationServiceProvider>();
+
+            ConfigureLogContext(provider);
+
+            return Bus.Factory.CreateMediator(cfg =>
+            {
+                _configure?.Invoke(context, cfg);
+
+                ConfigureMediator(cfg, provider);
+            });
+        }
+
+        static IConsumerScopeProvider CreateConsumerScopeProvider(IContext context)
+        {
+            return new StructureMapConsumerScopeProvider(context.GetInstance<IContainer>());
+        }
+    }
+}

--- a/src/Containers/MassTransit.StructureMapIntegration/Registration/StructureMapContainerRegistrar.cs
+++ b/src/Containers/MassTransit.StructureMapIntegration/Registration/StructureMapContainerRegistrar.cs
@@ -6,6 +6,7 @@ namespace MassTransit.StructureMapIntegration.Registration
     using Courier;
     using Definition;
     using MassTransit.Registration;
+    using Mediator;
     using Saga;
     using ScopeProviders;
     using Scoping;
@@ -159,10 +160,10 @@ namespace MassTransit.StructureMapIntegration.Registration
             _expression.For<T>().Use(instance).Singleton();
         }
 
-        static IRequestClient<T> CreateRequestClient<T>(RequestTimeout timeout, IContext context)
+        IRequestClient<T> CreateRequestClient<T>(RequestTimeout timeout, IContext context)
             where T : class
         {
-            var clientFactory = context.GetInstance<IClientFactory>();
+            var clientFactory = GetClientFactory(context);
             var consumeContext = context.TryGetInstance<ConsumeContext>();
 
             if (consumeContext != null)
@@ -172,10 +173,10 @@ namespace MassTransit.StructureMapIntegration.Registration
                 .CreateRequestClient<T>(timeout);
         }
 
-        static IRequestClient<T> CreateRequestClient<T>(Uri destinationAddress, RequestTimeout timeout, IContext context)
+        IRequestClient<T> CreateRequestClient<T>(Uri destinationAddress, RequestTimeout timeout, IContext context)
             where T : class
         {
-            var clientFactory = context.GetInstance<IClientFactory>();
+            var clientFactory = GetClientFactory(context);
             var consumeContext = context.TryGetInstance<ConsumeContext>();
 
             if (consumeContext != null)
@@ -197,6 +198,26 @@ namespace MassTransit.StructureMapIntegration.Registration
             where TLog : class
         {
             return new StructureMapCompensateActivityScopeProvider<TActivity, TLog>(context.GetInstance<IContainer>());
+        }
+
+        protected virtual IClientFactory GetClientFactory(IContext context)
+        {
+            return context.GetInstance<IClientFactory>();
+        }
+    }
+
+
+    public class StructureMapContainerMediatorRegistrar :
+        StructureMapContainerRegistrar
+    {
+        public StructureMapContainerMediatorRegistrar(ConfigurationExpression expression)
+            : base(expression)
+        {
+        }
+
+        protected override IClientFactory GetClientFactory(IContext context)
+        {
+            return context.GetInstance<IMediator>();
         }
     }
 }

--- a/src/Containers/MassTransit.StructureMapIntegration/StructureMapRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.StructureMapIntegration/StructureMapRegistrationExtensions.cs
@@ -21,7 +21,19 @@ namespace MassTransit
         /// <param name="configure"></param>
         public static void AddMassTransit(this ConfigurationExpression expression, Action<IConfigurationExpressionConfigurator> configure = null)
         {
-            var configurator = new ConfigurationExpressionRegistrationConfigurator(expression);
+            var configurator = new ConfigurationExpressionConfigurator(expression);
+
+            configure?.Invoke(configurator);
+        }
+
+        /// <summary>
+        /// Adds the required services to the service collection, and allows consumers to be added and/or discovered
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <param name="configure"></param>
+        public static void AddMediator(this ConfigurationExpression expression, Action<IConfigurationExpressionMediatorConfigurator> configure = null)
+        {
+            var configurator = new ConfigurationExpressionMediatorConfigurator(expression);
 
             configure?.Invoke(configurator);
         }

--- a/src/Containers/MassTransit.WindsorIntegration/IWindsorContainerMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.WindsorIntegration/IWindsorContainerMediatorConfigurator.cs
@@ -1,0 +1,12 @@
+namespace MassTransit.WindsorIntegration
+{
+    using Castle.MicroKernel;
+    using Castle.Windsor;
+
+
+    public interface IWindsorContainerMediatorConfigurator :
+        IMediatorRegistrationConfigurator<IKernel>
+    {
+        IWindsorContainer Container { get; }
+    }
+}

--- a/src/Containers/MassTransit.WindsorIntegration/Registration/WindsorContainerMediatorConfigurator.cs
+++ b/src/Containers/MassTransit.WindsorIntegration/Registration/WindsorContainerMediatorConfigurator.cs
@@ -1,0 +1,65 @@
+namespace MassTransit.WindsorIntegration.Registration
+{
+    using System;
+    using Castle.MicroKernel;
+    using Castle.MicroKernel.Registration;
+    using Castle.Windsor;
+    using MassTransit.Registration;
+    using Mediator;
+    using ScopeProviders;
+    using Scoping;
+
+
+    public class WindsorContainerMediatorConfigurator :
+        RegistrationConfigurator,
+        IWindsorContainerMediatorConfigurator
+    {
+        Action<IKernel, IReceiveEndpointConfigurator> _configure;
+
+        public WindsorContainerMediatorConfigurator(IWindsorContainer container)
+            : base(new WindsorContainerMediatorRegistrar(container))
+        {
+            Container = container;
+
+            container.RegisterScopedContextProviderIfNotPresent();
+
+            if (!container.Kernel.HasComponent(typeof(IConsumerScopeProvider)))
+                container.Register(Component.For<IConsumerScopeProvider>()
+                    .ImplementedBy<WindsorConsumerScopeProvider>()
+                    .LifestyleTransient());
+
+            if (!container.Kernel.HasComponent(typeof(IConfigurationServiceProvider)))
+                container.Register(Component.For<IConfigurationServiceProvider>()
+                    .ImplementedBy<WindsorConfigurationServiceProvider>()
+                    .LifestyleSingleton());
+
+            container.Register(
+                Component.For<IMediator>()
+                    .UsingFactoryMethod(MediatorFactory)
+                    .LifestyleSingleton()
+            );
+        }
+
+        public IWindsorContainer Container { get; }
+
+        public void ConfigureMediator(Action<IKernel, IReceiveEndpointConfigurator> configure)
+        {
+            ThrowIfAlreadyConfigured();
+            _configure = configure;
+        }
+
+        IMediator MediatorFactory(IKernel kernel)
+        {
+            var provider = kernel.Resolve<IConfigurationServiceProvider>();
+
+            ConfigureLogContext(provider);
+
+            return Bus.Factory.CreateMediator(cfg =>
+            {
+                _configure?.Invoke(kernel, cfg);
+
+                ConfigureMediator(cfg, provider);
+            });
+        }
+    }
+}

--- a/src/Containers/MassTransit.WindsorIntegration/Registration/WindsorContainerRegistrar.cs
+++ b/src/Containers/MassTransit.WindsorIntegration/Registration/WindsorContainerRegistrar.cs
@@ -9,6 +9,7 @@ namespace MassTransit.WindsorIntegration.Registration
     using Courier;
     using Definition;
     using MassTransit.Registration;
+    using Mediator;
     using Saga;
     using ScopeProviders;
     using Scoping;
@@ -141,7 +142,7 @@ namespace MassTransit.WindsorIntegration.Registration
         {
             _container.Register(Component.For<IRequestClient<T>>().UsingFactoryMethod(kernel =>
             {
-                var clientFactory = kernel.Resolve<IClientFactory>();
+                var clientFactory = GetClientFactory(kernel);
                 var consumeContext = kernel.GetConsumeContext();
 
                 if (consumeContext != null)
@@ -157,7 +158,7 @@ namespace MassTransit.WindsorIntegration.Registration
         {
             _container.Register(Component.For<IRequestClient<T>>().UsingFactoryMethod(kernel =>
             {
-                var clientFactory = kernel.Resolve<IClientFactory>();
+                var clientFactory = GetClientFactory(kernel);
                 var consumeContext = kernel.GetConsumeContext();
 
                 if (consumeContext != null)
@@ -203,6 +204,24 @@ namespace MassTransit.WindsorIntegration.Registration
         {
             if (!_container.Kernel.HasComponent(typeof(TActivity)))
                 _container.Register(Component.For<TActivity>().LifestyleScoped());
+        }
+
+        protected virtual IClientFactory GetClientFactory(IKernel kernel)
+        {
+            return kernel.Resolve<IClientFactory>();
+        }
+    }
+    public class WindsorContainerMediatorRegistrar :
+        WindsorContainerRegistrar
+    {
+        public WindsorContainerMediatorRegistrar(IWindsorContainer container)
+            : base(container)
+        {
+        }
+
+        protected override IClientFactory GetClientFactory(IKernel kernel)
+        {
+            return kernel.Resolve<IMediator>();
         }
     }
 }

--- a/src/Containers/MassTransit.WindsorIntegration/WindsorRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.WindsorIntegration/WindsorRegistrationExtensions.cs
@@ -3,6 +3,7 @@ namespace MassTransit
     using System;
     using System.Linq;
     using Castle.Windsor;
+    using Mediator;
     using Metadata;
     using WindsorIntegration;
     using WindsorIntegration.Registration;
@@ -21,7 +22,32 @@ namespace MassTransit
         /// <param name="configure"></param>
         public static IWindsorContainer AddMassTransit(this IWindsorContainer container, Action<IWindsorContainerConfigurator> configure = null)
         {
-            var configurator = new WindsorContainerRegistrationConfigurator(container);
+            if (container.Kernel.HasComponent(typeof(IRegistration)))
+            {
+                throw new ConfigurationException(
+                    "AddBus() was already called. To configure multiple bus instances, refer to the documentation: https://masstransit-project.com/usage/containers/multibus.html");
+            }
+
+            var configurator = new WindsorContainerConfigurator(container);
+
+            configure?.Invoke(configurator);
+
+            return container;
+        }
+
+        /// <summary>
+        /// Adds the required services to the service collection, and allows consumers to be added and/or discovered
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="configure"></param>
+        public static IWindsorContainer AddMediator(this IWindsorContainer container, Action<IWindsorContainerMediatorConfigurator> configure = null)
+        {
+            if (container.Kernel.HasComponent(typeof(IMediator)))
+            {
+                throw new ConfigurationException("AddMediator() was already called and may only be called once per container.");
+            }
+
+            var configurator = new WindsorContainerMediatorConfigurator(container);
 
             configure?.Invoke(configurator);
 

--- a/src/MassTransit/Configuration/IMediatorRegistrationConfigurator.cs
+++ b/src/MassTransit/Configuration/IMediatorRegistrationConfigurator.cs
@@ -1,0 +1,17 @@
+namespace MassTransit
+{
+    using System;
+
+
+    public interface IMediatorRegistrationConfigurator<out TContainerContext> :
+        IRegistrationConfigurator
+        where TContainerContext : class
+
+    {
+        /// <summary>
+        /// Optionally configure the pipeline used by the mediator
+        /// </summary>
+        /// <param name="configure"></param>
+        void ConfigureMediator(Action<TContainerContext, IReceiveEndpointConfigurator> configure);
+    }
+}

--- a/src/MassTransit/Configuration/IRegistrationConfigurator.cs
+++ b/src/MassTransit/Configuration/IRegistrationConfigurator.cs
@@ -217,12 +217,6 @@ namespace MassTransit
         /// </summary>
         /// <param name="busFactory"></param>
         void AddBus(Func<IRegistrationContext<TContainerContext>, IBusControl> busFactory);
-
-        /// <summary>
-        /// Add a mediator to the container
-        /// </summary>
-        /// <param name="configure">Optionally configure the pipeline used by the mediator</param>
-        void AddMediator(Action<TContainerContext, IReceiveEndpointConfigurator> configure = null);
     }
 
 

--- a/src/MassTransit/Mediator/Contexts/MediatorReceiveContext.cs
+++ b/src/MassTransit/Mediator/Contexts/MediatorReceiveContext.cs
@@ -57,7 +57,7 @@ namespace MassTransit.Mediator.Contexts
             AddOrUpdatePayload<ConsumeContext>(() => _consumeContext, existing => _consumeContext);
         }
 
-        public bool IsDelivered { get; private set; }
+        public bool IsDelivered { get; internal set; }
         public bool IsFaulted { get; private set; }
 
         public Stream GetBodyStream()

--- a/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_Mediator.cs
@@ -17,7 +17,7 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         public Autofac_Mediator()
         {
             _container = new ContainerBuilder()
-                .AddMassTransit(ConfigureRegistration)
+                .AddMediator(ConfigureRegistration)
                 .Build();
         }
 
@@ -40,7 +40,7 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         public Autofac_Mediator_Request()
         {
             _container = new ContainerBuilder()
-                .AddMassTransit(ConfigureRegistration)
+                .AddMediator(ConfigureRegistration)
                 .Build();
         }
 
@@ -67,7 +67,7 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         public Autofac_Mediator_Saga()
         {
             _container = new ContainerBuilder()
-                .AddMassTransit(ConfigureRegistration)
+                .AddMediator(ConfigureRegistration)
                 .Build();
         }
 

--- a/tests/MassTransit.Containers.Tests/Common_Tests/Common_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/Common_Tests/Common_Mediator.cs
@@ -31,12 +31,10 @@ namespace MassTransit.Containers.Tests.Common_Tests
             await lastConsumer.Last.OrCanceled(TestCancellationToken);
         }
 
-        protected void ConfigureRegistration<T>(IRegistrationConfigurator<T> configurator)
+        protected void ConfigureRegistration<T>(IMediatorRegistrationConfigurator<T> configurator)
             where T : class
         {
             configurator.AddConsumer<SimplerConsumer>();
-
-            configurator.AddMediator();
         }
     }
 
@@ -66,7 +64,7 @@ namespace MassTransit.Containers.Tests.Common_Tests
         protected abstract IRequestClient<T> GetRequestClient<T>()
             where T : class;
 
-        protected void ConfigureRegistration<T>(IRegistrationConfigurator<T> configurator)
+        protected void ConfigureRegistration<T>(IMediatorRegistrationConfigurator<T> configurator)
             where T : class
         {
             configurator.AddConsumer<InitialConsumer>();
@@ -74,7 +72,6 @@ namespace MassTransit.Containers.Tests.Common_Tests
 
             configurator.AddRequestClient<InitialRequest>();
             configurator.AddRequestClient<SubsequentRequest>();
-            configurator.AddMediator();
         }
 
 
@@ -169,14 +166,12 @@ namespace MassTransit.Containers.Tests.Common_Tests
         protected abstract ISagaRepository<T> GetSagaRepository<T>()
             where T : class, ISaga;
 
-        protected void ConfigureRegistration<T>(IRegistrationConfigurator<T> configurator)
+        protected void ConfigureRegistration<T>(IMediatorRegistrationConfigurator<T> configurator)
             where T : class
         {
             configurator.AddConsumer<OrderConsumer>();
             configurator.AddSaga<OrderSaga>()
                 .InMemoryRepository();
-
-            configurator.AddMediator();
         }
 
 

--- a/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Mediator.cs
@@ -16,7 +16,7 @@ namespace MassTransit.Containers.Tests.DependencyInjection_Tests
         public DependencyInjection_Mediator()
         {
             _provider = new ServiceCollection()
-                .AddMassTransit(ConfigureRegistration)
+                .AddMediator(ConfigureRegistration)
                 .BuildServiceProvider(true);
         }
 

--- a/tests/MassTransit.Containers.Tests/Lamar_Tests/Lamar_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/Lamar_Tests/Lamar_Mediator.cs
@@ -16,7 +16,7 @@ namespace MassTransit.Containers.Tests.Lamar_Tests
         {
             _container = new Container(registry =>
             {
-                registry.AddMassTransit(ConfigureRegistration);
+                registry.AddMediator(ConfigureRegistration);
             });
         }
 

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Mediator.cs
@@ -17,7 +17,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         {
             _container = new Container();
             _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
-            _container.AddMassTransit(ConfigureRegistration);
+            _container.AddMediator(ConfigureRegistration);
         }
 
         [OneTimeTearDown]

--- a/tests/MassTransit.Containers.Tests/StructureMap_Tests/StructureMap_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/StructureMap_Tests/StructureMap_Mediator.cs
@@ -14,7 +14,7 @@ namespace MassTransit.Containers.Tests.StructureMap_Tests
 
         public StructureMap_Mediator()
         {
-            _container = new Container(expression => expression.AddMassTransit(ConfigureRegistration));
+            _container = new Container(expression => expression.AddMediator(ConfigureRegistration));
         }
 
         [OneTimeTearDown]

--- a/tests/MassTransit.Containers.Tests/Windsor_Tests/Windsor_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/Windsor_Tests/Windsor_Mediator.cs
@@ -15,7 +15,7 @@ namespace MassTransit.Containers.Tests.Windsor_Tests
         public Windsor_Mediator()
         {
             _container = new WindsorContainer();
-            _container.AddMassTransit(ConfigureRegistration);
+            _container.AddMediator(ConfigureRegistration);
         }
 
         [OneTimeTearDown]


### PR DESCRIPTION
- [x] Use method `AddMediator` on container registration level
- [x] Change mediator configuration method to `ConfigureMediator` instead of confusing with second level `AddMediator`
- [x] Use bus factory for bus registration (simplified registration a bit)
- [x] Currently, Publish throws an exception if there are no consumers. Should not throw an exception for publish, but continue to throw one for Send.
- [ ] How to add/remove consumers after creation to allow components to connect into the mediator, and then disconnect.
- [ ] New mediator docs
- [ ] ~~Rename `AddBus` to `BusFactory` or something ?~~