### PR TITLE
Update connectionString example for Marten 3.11.0

### DIFF
--- a/docs/usage/sagas/marten.md
+++ b/docs/usage/sagas/marten.md
@@ -24,7 +24,7 @@ To configure Marten as the saga repository for a saga, use the code shown below 
 ```cs {6}
 container.AddMassTransit(cfg =>
 {
-    var connectionString = "server=localhost;port=5432;database=orders;user id=web;password=webpw;";
+    var connectionString = "host=localhost;port=5432;database=orders;username=web;password=webpw;";
 
     cfg.AddSagaStateMachine<OrderStateMachine, OrderState>()
         .MartenRepository(connectionString);
@@ -38,7 +38,7 @@ To use Marten's built-in Optimistic concurrency, use the configuration options t
 ```cs {8}
 container.AddMassTransit(cfg =>
 {
-    var connectionString = "server=localhost;port=5432;database=orders;user id=web;password=webpw;";
+    var connectionString = "host=localhost;port=5432;database=orders;username=web;password=webpw;";
 
     cfg.AddSagaStateMachine<OrderStateMachine, OrderState>()
         .MartenRepository(connectionString, r =>
@@ -80,7 +80,7 @@ public class OrderState :
 ```cs {8}
 container.AddMassTransit(cfg =>
 {
-    var connectionString = "server=localhost;port=5432;database=orders;user id=web;password=webpw;";
+    var connectionString = "host=localhost;port=5432;database=orders;username=web;password=webpw;";
 
     cfg.AddSagaStateMachine<OrderStateMachine, OrderState>()
         .MartenRepository(connectionString, r =>


### PR DESCRIPTION
The connectionString example on the doc for Marten doesn't work for latest Marten 3.11.0, changed `server` to `host` and `user id` to `username` and got it working properly.
