### PR TITLE
Use copy of tags in error/dead-letter settings.

### DIFF
--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/QueueDeadLetterSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/QueueDeadLetterSettings.cs
@@ -1,5 +1,6 @@
 ﻿namespace MassTransit.AmazonSqsTransport.Topology.Settings
 {
+    using System.Linq;
     using Builders;
     using Configurators;
 
@@ -11,7 +12,7 @@
         public QueueDeadLetterSettings(EntitySettings source, string queueName)
             : base(queueName, source.Durable, source.AutoDelete)
         {
-            QueueTags = source.Tags;
+            QueueTags = source.Tags?.ToDictionary(x => x.Key, x => x.Value);
         }
 
         public BrokerTopology GetBrokerTopology()

--- a/src/MassTransit.AmazonSqsTransport/Topology/Settings/QueueErrorSettings.cs
+++ b/src/MassTransit.AmazonSqsTransport/Topology/Settings/QueueErrorSettings.cs
@@ -1,5 +1,6 @@
 ﻿namespace MassTransit.AmazonSqsTransport.Topology.Settings
 {
+    using System.Linq;
     using Builders;
     using Configurators;
 
@@ -11,7 +12,7 @@
         public QueueErrorSettings(EntitySettings source, string queueName)
             : base(queueName, source.Durable, source.AutoDelete)
         {
-            QueueTags = source.Tags;
+            QueueTags = source.Tags?.ToDictionary(x => x.Key, x => x.Value);
         }
 
         public BrokerTopology GetBrokerTopology()


### PR DESCRIPTION
Queue tags have to be copied otherwise changing setup for one queue (say error) makes changes to all other queues (base and dead-letter).