### PR TITLE
SQS Transport discovers best credentials

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Transport/Connection.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Transport/Connection.cs
@@ -23,12 +23,12 @@ namespace MassTransit.AmazonSqsTransport.Transport
 
         public IAmazonSQS CreateAmazonSqsClient()
         {
-            return new AmazonSQSClient(_credentials, _amazonSqsConfig);
+            return _credentials == null ? new AmazonSQSClient(_amazonSqsConfig) : new AmazonSQSClient(_credentials, _amazonSqsConfig);
         }
 
         public IAmazonSimpleNotificationService CreateAmazonSnsClient()
         {
-            return new AmazonSimpleNotificationServiceClient(_credentials, _amazonSnsConfig);
+            return _credentials == null ? new AmazonSimpleNotificationServiceClient(_amazonSnsConfig) : new AmazonSimpleNotificationServiceClient(_credentials, _amazonSnsConfig);
         }
     }
 }


### PR DESCRIPTION
AmazonSqsTransport Connection will use AWSSDK mechanism to discover best credentials if none are provided.

after removing AccessKey and SecretKey both Publish and Send still work

![image](https://user-images.githubusercontent.com/10220151/89028859-0affac00-d325-11ea-87ba-74ab5469a612.png)

