### PR TITLE
InMemoryRepository race condition

### DIFF
--- a/src/MassTransit/Saga/InMemoryRepository/InMemorySagaRepositoryContext.cs
+++ b/src/MassTransit/Saga/InMemoryRepository/InMemorySagaRepositoryContext.cs
@@ -72,7 +72,13 @@ namespace MassTransit.Saga.InMemoryRepository
                 if (_sagas[instance.CorrelationId] != null)
                     return default;
 
-                return await _factory.CreateSagaConsumeContext(_sagas, _context, instance, SagaConsumeContextMode.Insert).ConfigureAwait(false);
+                SagaConsumeContext<TSaga, TMessage> consumeContext =
+                    await _factory.CreateSagaConsumeContext(_sagas, _context, instance, SagaConsumeContextMode.Insert).ConfigureAwait(false);
+
+                _sagas.Release();
+                _sagasLocked = false;
+
+                return consumeContext;
             }
 
             await _sagas.MarkInUse(_context.CancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This fix is for InMemoryRepository. I mentioned this one on Discord too.

If automatonymous saga's "InsertOnInitial" property set true and Raise an event instead of publish message for trigger the machine, a race condition happens on saga context deletion and waits on semaphore.

This condition blocks saga's consumer.
