### PR TITLE
Fix for exception binder overloads calling wrong activity

### DIFF
--- a/src/MassTransit/Automatonymous/SendExtensions.cs
+++ b/src/MassTransit/Automatonymous/SendExtensions.cs
@@ -222,7 +222,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TException> SendAsync<TInstance, TException, TMessage>(
@@ -232,7 +232,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TException> Send<TInstance, TException, TMessage>(
@@ -285,7 +285,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Send<TInstance, TData, TException, TMessage>(
@@ -296,7 +296,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> SendAsync<TInstance, TData, TException, TMessage>(
@@ -307,7 +307,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> SendAsync<TInstance, TData, TException, TMessage>(
@@ -318,7 +318,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Send<TInstance, TData, TException, TMessage>(
@@ -562,7 +562,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TException> SendAsync<TInstance, TException, TMessage>(
@@ -572,7 +572,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TException> Send<TInstance, TException, TMessage>(
@@ -625,7 +625,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Send<TInstance, TData, TException, TMessage>(
@@ -636,7 +636,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> SendAsync<TInstance, TData, TException, TMessage>(
@@ -647,7 +647,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(destinationAddressProvider, x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(destinationAddressProvider, x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> SendAsync<TInstance, TData, TException, TMessage>(
@@ -658,7 +658,7 @@
             where TMessage : class
             where TException : Exception
         {
-            return source.Add(new SendActivity<TInstance, TData, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
+            return source.Add(new FaultedSendActivity<TInstance, TData, TException, TMessage>(x => destinationAddressProvider(x.Instance, x.Data), x => message, contextCallback));
         }
 
         public static ExceptionActivityBinder<TInstance, TData, TException> Send<TInstance, TData, TException, TMessage>(


### PR DESCRIPTION
Hi Chris,

I fixed these overloads. They call FaultedSendActivity now.