### PR TITLE
Scoped filter registration is not more required

### DIFF
--- a/docs/advanced/middleware/scoped.md
+++ b/docs/advanced/middleware/scoped.md
@@ -38,7 +38,6 @@ public class Startup
     {
       	//other configuration
       	services.AddScoped<IMyDependency, MyDependency>(); //register dependency
-        services.AddScoped(typeof(MySendFilter<>)); //register generic filter
           
         services.AddMassTransit(x =>
         {

--- a/src/Containers/MassTransit.AutofacIntegration/ScopeProviders/ActivatorUtils.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/ScopeProviders/ActivatorUtils.cs
@@ -1,0 +1,76 @@
+namespace MassTransit.AutofacIntegration.ScopeProviders
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.Reflection;
+    using Autofac;
+
+
+    class ActivatorUtils
+    {
+        readonly ConcurrentDictionary<Type, ParameterInfo[]> _cache = new ConcurrentDictionary<Type, ParameterInfo[]>();
+
+        ActivatorUtils()
+        {
+        }
+
+        static ActivatorUtils Instance { get; } = new ActivatorUtils();
+
+        object[] GetParameters<T>(IComponentContext context)
+            where T : class
+        {
+            ParameterInfo[] parameters = _cache.GetOrAdd(typeof(T), t => GetParameterInfos(t, context));
+            var result = new object[parameters.Length];
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+
+                result[i] = parameter.IsOptional
+                    ? context.ResolveOptional(parameter.ParameterType) ?? parameter.DefaultValue
+                    : context.Resolve(parameter.ParameterType);
+            }
+
+            return result;
+        }
+
+        static ParameterInfo[] GetParameterInfos(Type instanceType, IComponentContext context)
+        {
+            var result = new ParameterInfo[0];
+
+            var emptyConstructorIsExists = false;
+
+            foreach (var constructor in instanceType
+                .GetTypeInfo()
+                .DeclaredConstructors
+                .Where(c => !c.IsStatic && c.IsPublic))
+            {
+                ParameterInfo[] parameters = constructor.GetParameters();
+                if (parameters.Length == 0)
+                    emptyConstructorIsExists = true;
+
+                if (!parameters.All(x => x.IsOptional || context.IsRegistered(x.ParameterType)))
+                    continue;
+
+                if (parameters.Length > result.Length)
+                    result = parameters;
+            }
+
+            if (result.Length == 0 && !emptyConstructorIsExists)
+                throw new ConfigurationException($"Can not resolve instance: {instanceType}");
+
+            return result;
+        }
+
+        public static T GetOrCreateInstance<T>(IComponentContext context)
+            where T : class
+        {
+            if (context.TryResolve<T>(out var instance))
+                return instance;
+
+            object[] parameters = Instance.GetParameters<T>(context);
+            return (T)Activator.CreateInstance(typeof(T), parameters);
+        }
+    }
+}

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ScopeProviders/DependencyInjectionFilterContextScopeProvider.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ScopeProviders/DependencyInjectionFilterContextScopeProvider.cs
@@ -9,7 +9,7 @@ namespace MassTransit.ExtensionsDependencyInjectionIntegration.ScopeProviders
 
     public class DependencyInjectionFilterContextScopeProvider<TFilter, TContext> :
         IFilterContextScopeProvider<TContext>
-        where TFilter : IFilter<TContext>
+        where TFilter : class, IFilter<TContext>
         where TContext : class, PipeContext
     {
         readonly IServiceProvider _serviceProvider;
@@ -34,8 +34,7 @@ namespace MassTransit.ExtensionsDependencyInjectionIntegration.ScopeProviders
             {
                 Context = context;
                 _scope = context.TryGetPayload(out IServiceProvider provider)
-                    ? new NoopScope(provider)
-                    : context.TryGetPayload(out ConsumeContext consumeContext) && consumeContext.TryGetPayload(out provider)
+                    || context.TryGetPayload(out ConsumeContext consumeContext) && consumeContext.TryGetPayload(out provider)
                         ? new NoopScope(provider)
                         : serviceProvider.CreateScope();
             }
@@ -47,7 +46,7 @@ namespace MassTransit.ExtensionsDependencyInjectionIntegration.ScopeProviders
                 return default;
             }
 
-            public IFilter<TContext> Filter => _scope.ServiceProvider.GetRequiredService<TFilter>();
+            public IFilter<TContext> Filter => ActivatorUtilities.GetServiceOrCreateInstance<TFilter>(_scope.ServiceProvider);
 
             public TContext Context { get; }
 

--- a/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_Consumer.cs
+++ b/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_Consumer.cs
@@ -113,7 +113,6 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         {
             var builder = new ContainerBuilder();
             builder.Register(_ => new MyId(Guid.NewGuid())).InstancePerLifetimeScope();
-            builder.RegisterGeneric(typeof(ScopedFilter<>)).InstancePerLifetimeScope();
             builder.RegisterInstance(TaskCompletionSource);
             builder.AddMassTransit(ConfigureRegistration);
             _container = builder.Build();

--- a/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_ScopePublish.cs
+++ b/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_ScopePublish.cs
@@ -56,7 +56,6 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         {
             var builder = new ContainerBuilder();
             builder.Register(_ => new MyId(Guid.NewGuid())).InstancePerLifetimeScope();
-            builder.RegisterGeneric(typeof(ScopedFilter<>)).InstancePerLifetimeScope();
             builder.RegisterInstance(TaskCompletionSource);
 
             builder.AddMassTransit(ConfigureRegistration);

--- a/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_ScopeSend.cs
+++ b/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_ScopeSend.cs
@@ -56,7 +56,6 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         {
             var builder = new ContainerBuilder();
             builder.Register(_ => new MyId(Guid.NewGuid())).InstancePerLifetimeScope();
-            builder.RegisterGeneric(typeof(ScopedFilter<>)).InstancePerLifetimeScope();
             builder.RegisterInstance(TaskCompletionSource);
 
             builder.AddMassTransit(ConfigureRegistration);

--- a/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Consumer.cs
+++ b/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_Consumer.cs
@@ -87,7 +87,6 @@ namespace MassTransit.Containers.Tests.DependencyInjection_Tests
         {
             var services = new ServiceCollection();
             services.AddScoped(_ => new MyId(Guid.NewGuid()));
-            services.AddScoped(typeof(ScopedFilter<>));
             services.AddSingleton(TaskCompletionSource);
             services.AddMassTransit(ConfigureRegistration);
             _provider = services.BuildServiceProvider(true);

--- a/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_ScopePublish.cs
+++ b/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_ScopePublish.cs
@@ -55,7 +55,6 @@ namespace MassTransit.Containers.Tests.DependencyInjection_Tests
             var services = new ServiceCollection();
             services.AddScoped(_ => new MyId(Guid.NewGuid()));
             services.AddSingleton(TaskCompletionSource);
-            services.AddScoped(typeof(ScopedFilter<>));
 
             services.AddMassTransit(ConfigureRegistration);
 

--- a/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_ScopeSend.cs
+++ b/tests/MassTransit.Containers.Tests/DependencyInjection_Tests/DependencyInjection_ScopeSend.cs
@@ -55,7 +55,6 @@ namespace MassTransit.Containers.Tests.DependencyInjection_Tests
             var services = new ServiceCollection();
             services.AddScoped(_ => new MyId(Guid.NewGuid()));
             services.AddSingleton(TaskCompletionSource);
-            services.AddScoped(typeof(ScopedFilter<>));
 
             services.AddMassTransit(ConfigureRegistration);
 


### PR DESCRIPTION
Create scoped filters at runtime using ActivatorUtils for MSDI, and custom factory for Autofac