### PR TITLE
Support SQS queue attributes in error and dead letter queues.

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Topology/Settings/QueueDeadLetterSettings.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Topology/Settings/QueueDeadLetterSettings.cs
@@ -19,7 +19,7 @@
         {
             var builder = new PublishEndpointBrokerTopologyBuilder();
 
-            builder.CreateQueue(EntityName, Durable, AutoDelete, null, null, QueueTags);
+            builder.CreateQueue(EntityName, Durable, AutoDelete, QueueAttributes, QueueSubscriptionAttributes, QueueTags);
 
             return builder.BuildBrokerTopology();
         }

--- a/src/Transports/MassTransit.AmazonSqsTransport/Topology/Settings/QueueErrorSettings.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Topology/Settings/QueueErrorSettings.cs
@@ -19,7 +19,7 @@
         {
             var builder = new PublishEndpointBrokerTopologyBuilder();
 
-            builder.CreateQueue(EntityName, Durable, AutoDelete, null, null, QueueTags);
+            builder.CreateQueue(EntityName, Durable, AutoDelete, QueueAttributes, QueueSubscriptionAttributes, QueueTags);
 
             return builder.BuildBrokerTopology();
         }


### PR DESCRIPTION
Some of my SQS queues have encryption enabled, but skipped and error queues are created without encryption and without a way of overriding. This change allows me to specify extra attributes (such as the KMS key id) via the callbacks ConfigureErrorSettings and ConfigureDeadLetterSettings in AmazonSqsSendTopology.