### PR TITLE
Change Log Level

### DIFF
--- a/src/MassTransit/Policies/PipeRetryExtensions.cs
+++ b/src/MassTransit/Policies/PipeRetryExtensions.cs
@@ -83,7 +83,7 @@ namespace MassTransit.Policies
         {
             while (context.CancellationToken.IsCancellationRequested == false)
             {
-                LogContext.Debug?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                LogContext.Error?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {
@@ -117,7 +117,7 @@ namespace MassTransit.Policies
         {
             while (context.CancellationToken.IsCancellationRequested == false)
             {
-                LogContext.Debug?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                LogContext.Error?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {

--- a/src/MassTransit/Policies/PipeRetryExtensions.cs
+++ b/src/MassTransit/Policies/PipeRetryExtensions.cs
@@ -83,7 +83,7 @@ namespace MassTransit.Policies
         {
             while (context.CancellationToken.IsCancellationRequested == false)
             {
-                LogContext.Error?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                LogContext.Warning?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {
@@ -117,7 +117,7 @@ namespace MassTransit.Policies
         {
             while (context.CancellationToken.IsCancellationRequested == false)
             {
-                LogContext.Error?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                LogContext.Warning?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {

--- a/src/MassTransit/Transports/TransportLogMessages.cs
+++ b/src/MassTransit/Transports/TransportLogMessages.cs
@@ -13,10 +13,10 @@ namespace MassTransit.Transports
         public static readonly LogMessage<string> ConnectedHost = LogContext.Define<string>(LogLevel.Information,
             "Connected: {Host}");
 
-        public static readonly LogMessage<string> DisconnectHost = LogContext.Define<string>(LogLevel.Error,
+        public static readonly LogMessage<string> DisconnectHost = LogContext.Define<string>(LogLevel.Information,
             "Disconnect: {Host}");
 
-        public static readonly LogMessage<string> DisconnectedHost = LogContext.Define<string>(LogLevel.Error,
+        public static readonly LogMessage<string> DisconnectedHost = LogContext.Define<string>(LogLevel.Information,
             "Disconnected: {Host}");
 
         public static readonly LogMessage<Uri> ConnectReceiveEndpoint = LogContext.Define<Uri>(LogLevel.Debug,

--- a/src/MassTransit/Transports/TransportLogMessages.cs
+++ b/src/MassTransit/Transports/TransportLogMessages.cs
@@ -7,16 +7,16 @@ namespace MassTransit.Transports
 
     public static class TransportLogMessages
     {
-        public static readonly LogMessage<string> ConnectHost = LogContext.Define<string>(LogLevel.Debug,
+        public static readonly LogMessage<string> ConnectHost = LogContext.Define<string>(LogLevel.Information,
             "Connect: {Host}");
 
-        public static readonly LogMessage<string> ConnectedHost = LogContext.Define<string>(LogLevel.Debug,
+        public static readonly LogMessage<string> ConnectedHost = LogContext.Define<string>(LogLevel.Information,
             "Connected: {Host}");
 
-        public static readonly LogMessage<string> DisconnectHost = LogContext.Define<string>(LogLevel.Debug,
+        public static readonly LogMessage<string> DisconnectHost = LogContext.Define<string>(LogLevel.Error,
             "Disconnect: {Host}");
 
-        public static readonly LogMessage<string> DisconnectedHost = LogContext.Define<string>(LogLevel.Debug,
+        public static readonly LogMessage<string> DisconnectedHost = LogContext.Define<string>(LogLevel.Error,
             "Disconnected: {Host}");
 
         public static readonly LogMessage<Uri> ConnectReceiveEndpoint = LogContext.Define<Uri>(LogLevel.Debug,


### PR DESCRIPTION
ConnectHost Event LogLevel Change To Information  
DisconnectHost Event LogLevel Change To Error  
RetryConnect LogLevel Change To Error  

The ConnectHost Event Is Important,It Should be Information    
RetryConnect LogLevel Is Very Important,It Should be Error 

why:debug level log usually be ignored in production environment(like ELK),but we need the connect error log