### PR TITLE
Added null check to prevent exception masking when BeginTransaction throws

### DIFF
--- a/src/Persistence/MassTransit.NHibernateIntegration/Saga/NHibernateSagaRepositoryContextFactory.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration/Saga/NHibernateSagaRepositoryContextFactory.cs
@@ -42,7 +42,7 @@ namespace MassTransit.NHibernateIntegration.Saga
             }
             catch (Exception)
             {
-                if (transaction.IsActive)
+                if (transaction != null && transaction.IsActive)
                 {
                     try
                     {


### PR DESCRIPTION
This is intended to prevent the following exception when session.BeginTransaction() fails:

```
System.NullReferenceException: Object reference not set to an instance of an object.
    at MassTransit.NHibernateIntegration.Saga.NHibernateSagaRepositoryContextFactory`1.Send[T](ConsumeContext`1 context, IPipe`1 next)
    at MassTransit.Saga.Pipeline.Filters.CorrelatedSagaFilter`2.GreenPipes.IFilter<MassTransit.ConsumeContext<TMessage>>.Send(ConsumeContext`1 context, IPipe`1 next)
    at MassTransit.Saga.Pipeline.Filters.CorrelatedSagaFilter`2.GreenPipes.IFilter<MassTransit.ConsumeContext<TMessage>>.Send(ConsumeContext`1 context, IPipe`1 next)
    at MassTransit.Pipeline.Filters.InMemoryOutboxFilter`2.Send(TContext context, IPipe`1 next)
    at MassTransit.Pipeline.Filters.InMemoryOutboxFilter`2.Send(TContext context, IPipe`1 next)
    at GreenPipes.Filters.RetryFilter`1.GreenPipes.IFilter<TContext>.Send(TContext context, IPipe`1 next)
    at GreenPipes.Filters.RetryFilter`1.GreenPipes.IFilter<TContext>.Send(TContext context, IPipe`1 next)
    at GreenPipes.Filters.TeeFilter`1.<>c__DisplayClass5_0.<<Send>g__SendAsync|1>d.MoveNext()
    --- End of stack trace from previous location where exception was thrown ---
    at GreenPipes.Filters.OutputPipeFilter`2.SendToOutput(IPipe`1 next, TOutput pipeContext)
    at GreenPipes.Filters.OutputPipeFilter`2.SendToOutput(IPipe`1 next, TOutput pipeContext)
    at GreenPipes.Filters.DynamicFilter`1.<>c__DisplayClass10_0.<<Send>g__SendAsync|0>d.MoveNext()
    --- End of stack trace from previous location where exception was thrown ---
    at MassTransit.Pipeline.Filters.DeserializeFilter.Send(ReceiveContext context, IPipe`1 next)
    at GreenPipes.Filters.RescueFilter`2.GreenPipes.IFilter<TContext>.Send(TContext context, IPipe`1 next)
```
