### PR TITLE
Docs - Added details about custom DbConfiguration EF Saga Persistance

### DIFF
--- a/docs/usage/sagas/ef.md
+++ b/docs/usage/sagas/ef.md
@@ -59,6 +59,10 @@ public class OrderStateDbContext :
 }
 ```
 
+::: warning Important
+In case your application has its own `DbContext` with a custom `DbConfiguration`, it is mandatory to use the config file / static method call approach in order to set the `DbConfiguration`. More details can be found on [Code-based configuration - Setting DbConfiguration explicitly](https://docs.microsoft.com/en-us/ef/ef6/fundamentals/configuring/code-based#setting-dbconfiguration-explicitly).
+:::
+
 ### Container Integration
 
 Once the class map and associated _DbContext_ class have been created, the saga repository can be configured with the saga registration, which is done using the configuration method passed to _AddMassTransit_. The following example shows how the repository is configured for using Microsoft Dependency Injection Extensions, which are used by default with Entity Framework.


### PR DESCRIPTION
Added section in which we are specifying that config file or static method call approach is mandatory when having multiple DbContexts.

In case the Saga's DbContext initializes before the application's DbContext, you will be unable to use the latter for the entire of the application's lifetime.

You will receive exceptions similar to:
```
System.InvalidOperationException: 
The default DbConfiguration instance was used by the Entity Framework before the 'XDbConfiguration' type was discovered. An instance of 'XDbConfiguration' must be set at application start before using any Entity Framework features or must be registered in the application's config file. See http://go.microsoft.com/fwlink/?LinkId=260883 for more information.
```