### PR TITLE
Allow namespace in AzureServiceBus connectionString

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configurators/ServiceBusHostConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configurators/ServiceBusHostConfigurator.cs
@@ -21,7 +21,7 @@
         {
             var builder = new ServiceBusConnectionStringBuilder(connectionString);
 
-            var serviceUri = new Uri(builder.Endpoint);
+            var serviceUri = GetFullEndpointUri(connectionString);
 
             _settings = new HostSettings
             {
@@ -68,6 +68,13 @@
         public int RetryLimit
         {
             set => _settings.RetryLimit = value;
+        }
+
+        public Uri GetFullEndpointUri(string connectionString) {
+            var endpoint = "endpoint=";
+            var startIndex = connectionString.IndexOf(endpoint, StringComparison.InvariantCultureIgnoreCase) + endpoint.Length;
+            var lengthOfEndpoint = connectionString.IndexOf(";", startIndex) - endpoint.Length;
+            return new Uri(connectionString.Substring(startIndex, lengthOfEndpoint));
         }
     }
 }


### PR DESCRIPTION
This is just a simple fix to use the full URI provided in the Azure Service Bus connection string. For 'namespacing' topics and queues. 

Verified that it works using the following test:

```
 [Fact]
        public void Test1()
        {
            var test = new ServiceBusHostConfigurator("endpoint=sb://my-endpoint.servicebus.windows.net/someNamespace;SharedAccessKeyName=SomeKeyName;SharedAccessKey=SomeKey");
            Assert.True("sb://my-endpoint.servicebus.windows.net/someNamespace".Equals(test._settings.ServiceUri.ToString(), System.StringComparison.CurrentCultureIgnoreCase));
           // Note: I made the _settings field public temporarily to test
        }
```

Which gave the following value: "sb://my-endpoint.servicebus.windows.net/someNamespace"