### PR TITLE
Allow namespace in AzureServiceBus connectionString (related to #2055)

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configurators/ServiceBusHostConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configurators/ServiceBusHostConfigurator.cs
@@ -21,7 +21,7 @@
         {
             var builder = new ServiceBusConnectionStringBuilder(connectionString);
 
-            var serviceUri = new Uri(builder.Endpoint);
+            var serviceUri = GetFullEndpointUri(connectionString);
 
             _settings = new HostSettings
             {
@@ -68,6 +68,28 @@
         public int RetryLimit
         {
             set => _settings.RetryLimit = value;
+        }
+
+        // Code copied from: https://github.com/Azure/azure-service-bus-dotnet/blob/8f619194132faab19507811f38137a9a8582f488/src/Microsoft.Azure.ServiceBus/ServiceBusConnectionStringBuilder.cs#L294
+        private Uri GetFullEndpointUri(string connectionString) {
+            var keyValuePairs = connectionString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var keyValuePair in keyValuePairs)
+            {
+                // Now split based on the _first_ '='
+                var keyAndValue = keyValuePair.Split(new[] { '=' }, 2);
+                var key = keyAndValue[0];
+                if (keyAndValue.Length != 2)
+                {
+                    throw new UriFormatException($"Value for the connection string parameter name '{key}' was not found.");
+                }
+
+                var value = keyAndValue[1].Trim();
+                if (key.Equals("Endpoint", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new Uri(value);
+                }
+            }
+            return null;
         }
     }
 }

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/ServiceBusHostConfigurator_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/ServiceBusHostConfigurator_Specs.cs
@@ -1,0 +1,38 @@
+namespace MassTransit.Azure.ServiceBus.Core.Tests
+{
+    using System.Threading.Tasks;
+    using MassTransit.Azure.ServiceBus.Core.Configurators;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    public class Service_bus_host_settings_from_connection_string
+    {
+        [Test]
+        public async Task Should_succeed_with_simple_endpoint()
+        {
+            var connectionString = "Endpoint=sb://my-endpoint.servicebus.windows.net;SharedAccessKeyName=SomeKeyName;SharedAccessKey=SomeKey";
+            var configurator = new ServiceBusHostConfigurator(connectionString);
+
+            Assert.That(configurator.Settings.ServiceUri.ToString(), Is.EqualTo("sb://my-endpoint.servicebus.windows.net/"));
+        }
+
+        [Test]
+        public async Task Should_succeed_with_endpoint_at_the_end_without_semicolon()
+        {
+            var connectionString = "SharedAccessKeyName=SomeKeyName;SharedAccessKey=SomeKey;Endpoint=sb://my-endpoint.servicebus.windows.net";
+            var configurator = new ServiceBusHostConfigurator(connectionString);
+
+            Assert.That(configurator.Settings.ServiceUri.ToString(), Is.EqualTo("sb://my-endpoint.servicebus.windows.net/"));
+        }
+
+        [Test]
+        public async Task Endpoint_should_include_namespace()
+        {
+            var connectionString = "Endpoint=sb://my-endpoint.servicebus.windows.net/someNamespace;SharedAccessKeyName=SomeKeyName;SharedAccessKey=SomeKey";
+            var configurator = new ServiceBusHostConfigurator(connectionString);
+
+            Assert.That(configurator.Settings.ServiceUri.ToString(), Is.EqualTo("sb://my-endpoint.servicebus.windows.net/someNamespace"));
+        }
+    }
+}


### PR DESCRIPTION
This is just a simple fix to use the full URI provided in the Azure Service Bus connection string for 'namespacing' topics and queues.

I mostly copied the code from the official [Azure connection string parser](https://github.com/Azure/azure-service-bus-dotnet/blob/8f619194132faab19507811f38137a9a8582f488/src/Microsoft.Azure.ServiceBus/ServiceBusConnectionStringBuilder.cs#L294) and created some Unit tests. 
