### PR TITLE
MassTransit with SimpleInjector 5 integration

### DIFF
--- a/src/Containers/MassTransit.SimpleInjectorIntegration/MassTransit.SimpleInjectorIntegration.csproj
+++ b/src/Containers/MassTransit.SimpleInjectorIntegration/MassTransit.SimpleInjectorIntegration.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-        <PackageReference Include="SimpleInjector" Version="[4.10.2,5.0.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="SimpleInjector" Version="5.0.3" />
         <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/MassTransit.Containers.Tests/SimpleInjectorTestHarness_Specs.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjectorTestHarness_Specs.cs
@@ -4,7 +4,6 @@ namespace MassTransit.Containers.Tests
     using NUnit.Framework;
     using Scenarios;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
     using TestFramework.Messages;
     using Testing;
 
@@ -16,7 +15,7 @@ namespace MassTransit.Containers.Tests
         public async Task Should_support_the_test_harness()
         {
             var container = new Container();
-            container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            container.SetRequiredOptions();
 
             container.AddMassTransitInMemoryTestHarness(cfg =>
             {
@@ -40,7 +39,7 @@ namespace MassTransit.Containers.Tests
             {
                 await harness.Stop();
 
-                container.Dispose();
+                await container.DisposeAsync();
             }
         }
     }

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Specs.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Specs.cs
@@ -1,19 +1,19 @@
 ﻿namespace MassTransit.Containers.Tests
 {
+    using System.Threading.Tasks;
     using NUnit.Framework;
     using Saga;
     using Scenarios;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     public class SimpleInjector_Consumer :
         When_registering_a_consumer
     {
         [TearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         readonly Container _container;
@@ -21,7 +21,7 @@
         public SimpleInjector_Consumer()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(cfg => cfg.AddConsumer<SimpleConsumer>());
 
@@ -42,9 +42,9 @@
         When_registering_a_saga
     {
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         readonly Container _container;
@@ -52,7 +52,7 @@
         public SimpleInjector_Saga()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
             _container.RegisterInMemorySagaRepository<SimpleSaga>();
         }
 

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjectorContainerOptionSetter.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjectorContainerOptionSetter.cs
@@ -9,6 +9,7 @@
         {
             container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
             container.Options.EnableAutoVerification = false;
+            container.Options.ResolveUnregisteredConcreteTypes = true;
         }
     }
 }

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjectorContainerOptionSetter.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjectorContainerOptionSetter.cs
@@ -1,0 +1,14 @@
+﻿namespace MassTransit.Containers.Tests
+{
+    using SimpleInjector;
+    using SimpleInjector.Lifestyles;
+
+    internal static class SimpleInjectorContainerOptionSetter
+    {
+        public static void SetRequiredOptions(this Container container)
+        {
+            container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            container.Options.EnableAutoVerification = false;
+        }
+    }
+}

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Conductor.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Conductor.cs
@@ -1,10 +1,10 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
+    using System.Threading.Tasks;
     using Common_Tests;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     public class SimpleInjector_Conductor :
@@ -16,14 +16,14 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
             : base(instanceEndpoint)
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
             _container.AddMassTransit(ConfigureRegistration);
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         protected override void ConfigureServiceEndpoints(IBusFactoryConfigurator<IInMemoryReceiveEndpointConfigurator> configurator)

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ConsumeContext.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ConsumeContext.cs
@@ -5,7 +5,6 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
     using Common_Tests.ConsumeContextTestSubjects;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     public class SimpleInjector_ConsumeContext :
@@ -20,7 +19,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
             TaskCompletionSource<ISendEndpointProvider> publishEndpointTask = GetTask<ISendEndpointProvider>();
 
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.RegisterInstance(pingTask);
             _container.RegisterInstance(sendEndpointProviderTask);
@@ -37,9 +36,9 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         protected override Task<ISendEndpointProvider> SendEndpointProvider => _container.GetInstance<TaskCompletionSource<ISendEndpointProvider>>().Task;
 
         [OneTimeTearDown]
-        public void TearDown()
+        public async Task TearDown()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
     }
 
@@ -56,7 +55,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
             TaskCompletionSource<ISendEndpointProvider> publishEndpointTask = GetTask<ISendEndpointProvider>();
 
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.RegisterInstance(pingTask);
             _container.RegisterInstance(sendEndpointProviderTask);
@@ -73,9 +72,9 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         protected override Task<ISendEndpointProvider> SendEndpointProvider => _container.GetInstance<TaskCompletionSource<ISendEndpointProvider>>().Task;
 
         [OneTimeTearDown]
-        public void TearDown()
+        public async Task TearDown()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
     }
 
@@ -92,7 +91,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
             TaskCompletionSource<ISendEndpointProvider> publishEndpointTask = GetTask<ISendEndpointProvider>();
 
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.RegisterInstance(pingTask);
             _container.RegisterInstance(sendEndpointProviderTask);
@@ -107,9 +106,9 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         protected override Task<ISendEndpointProvider> SendEndpointProvider => _container.GetInstance<TaskCompletionSource<ISendEndpointProvider>>().Task;
 
         [OneTimeTearDown]
-        public void TearDown()
+        public async Task TearDown()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
     }
 }

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Consumer.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Consumer.cs
@@ -19,7 +19,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
             _container.Verify();
         }
 
-        [TearDown]
+        [OneTimeTearDown]
         public async Task Close_container()
         {
             await _container.DisposeAsync();

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Consumer.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Consumer.cs
@@ -1,12 +1,12 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Common_Tests;
     using GreenPipes;
     using NUnit.Framework;
     using Scenarios;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     [TestFixture]
@@ -20,9 +20,9 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         }
 
         [TearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         readonly Container _container;
@@ -30,7 +30,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_Consumer()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(cfg =>
             {
@@ -60,9 +60,9 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         Common_Consumer_Endpoint
     {
         [TearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         readonly Container _container;
@@ -70,7 +70,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_Consumer_Endpoint()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(cfg =>
             {

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Courier.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Courier.cs
@@ -3,7 +3,6 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
     using Common_Tests;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
     using TestFramework.Courier;
 
 
@@ -22,7 +21,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjectorCourier_ExecuteActivity()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
             _container.AddMassTransit(cfg =>
             {
                 cfg.AddExecuteActivity<SetVariableActivity, SetVariableArguments>();
@@ -49,7 +48,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjectorCourier_ExecuteActivity_Endpoint()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
             _container.AddMassTransit(cfg =>
             {
                 cfg.AddExecuteActivity<SetVariableActivity, SetVariableArguments>()
@@ -78,7 +77,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjectorCourier_Activity()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
             _container.AddMassTransit(cfg =>
             {
                 cfg.AddActivity<TestActivity, TestArguments, TestLog>();
@@ -88,7 +87,6 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 
         protected override IBusRegistrationContext Registration => _container.GetInstance<IBusRegistrationContext>();
     }
-
 
     [TestFixture]
     public class SimpleInjectorCourier_Activity_Endpoint :
@@ -105,7 +103,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjectorCourier_Activity_Endpoint()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
             _container.AddMassTransit(cfg =>
             {
                 cfg.AddActivity<TestActivity, TestArguments, TestLog>()

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Discovery.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Discovery.cs
@@ -5,7 +5,6 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
     using Common_Tests.Discovery;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
     using TestFramework.Messages;
 
 
@@ -24,7 +23,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_Discovery()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(x =>
             {

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Mediator.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Mediator.cs
@@ -1,10 +1,10 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
+    using System.Threading.Tasks;
     using Common_Tests;
     using Mediator;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     [TestFixture]
@@ -16,14 +16,14 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_Mediator()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
             _container.AddMediator(ConfigureRegistration);
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         protected override IMediator Mediator => _container.GetInstance<IMediator>();

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_RequestClient.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_RequestClient.cs
@@ -3,7 +3,6 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
     using Common_Tests;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     [TestFixture]
@@ -21,7 +20,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_RequestClient_Context()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(x =>
             {

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Saga.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Saga.cs
@@ -1,10 +1,10 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
+    using System.Threading.Tasks;
     using Common_Tests;
     using NUnit.Framework;
     using Saga;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     [TestFixture]
@@ -22,15 +22,15 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_Saga()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(ConfigureRegistration);
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         protected override IBusRegistrationContext Registration => _container.GetInstance<IBusRegistrationContext>();
@@ -57,7 +57,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_Saga_Endpoint()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(ConfigureRegistration);
         }

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_SagaStateMachine.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_SagaStateMachine.cs
@@ -1,9 +1,9 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
+    using System.Threading.Tasks;
     using Common_Tests;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
     using TestFramework.Sagas;
 
 
@@ -22,7 +22,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_SagaStateMachine()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(ConfigureRegistration);
 
@@ -30,9 +30,9 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         protected override IBusRegistrationContext Registration => _container.GetInstance<IBusRegistrationContext>();

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Scope.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_Scope.cs
@@ -1,11 +1,11 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Common_Tests;
     using GreenPipes;
     using NUnit.Framework;
     using SimpleInjector;
-    using SimpleInjector.Lifestyles;
 
 
     [TestFixture]
@@ -23,7 +23,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_Scope()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(cfg =>
             {
@@ -32,9 +32,9 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _container.Dispose();
+            await _container.DisposeAsync();
         }
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ScopePublish.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ScopePublish.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Common_Tests;
     using GreenPipes;
     using NUnit.Framework;
@@ -24,7 +25,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_ScopePublish()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(cfg =>
             {
@@ -34,10 +35,10 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _childContainer.Dispose();
-            _container.Dispose();
+            await _childContainer.DisposeAsync();
+            await _container.DisposeAsync();
         }
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ScopeRequestClient.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ScopeRequestClient.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Common_Tests;
     using GreenPipes;
     using NUnit.Framework;
@@ -26,7 +27,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_ScopeRequestClient()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(cfg =>
             {
@@ -38,10 +39,10 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _childContainer.Dispose();
-            _container.Dispose();
+            await _childContainer.DisposeAsync();
+            await _container.DisposeAsync();
         }
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)

--- a/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ScopeSend.cs
+++ b/tests/MassTransit.Containers.Tests/SimpleInjector_Tests/SimpleInjector_ScopeSend.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Containers.Tests.SimpleInjector_Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Common_Tests;
     using GreenPipes;
     using NUnit.Framework;
@@ -24,7 +25,7 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         public SimpleInjector_ScopeSend()
         {
             _container = new Container();
-            _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+            _container.SetRequiredOptions();
 
             _container.AddMassTransit(cfg =>
             {
@@ -34,10 +35,10 @@ namespace MassTransit.Containers.Tests.SimpleInjector_Tests
         }
 
         [OneTimeTearDown]
-        public void Close_container()
+        public async Task Close_container()
         {
-            _childContainer.Dispose();
-            _container.Dispose();
+            await _childContainer.DisposeAsync();
+            await _container.DisposeAsync();
         }
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)


### PR DESCRIPTION
**Project MassTransit.SimpleInjectorIntegration:**
- Replaced reference to SimpleInjector v4.10.2 with v5.0.3.

**Project MassTransit.Containers.Tests:**
- Created extension method to disable auto-verification (in SIv5 is *on* by default)
```csharp
namespace MassTransit.Containers.Tests
{
    using SimpleInjector;
    using SimpleInjector.Lifestyles;

    internal static class SimpleInjectorContainerOptionSetter
    {
        public static void SetRequiredOptions(this Container container)
        {
            container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
            container.Options.EnableAutoVerification = false;
        }
    }
}
```
- Replaced all occurrences of
```csharp
    _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle(); 
```
with
```csharp
    _container.SetRequiredOptions();
```
- Changed `_container.Dispose()` with `_container.DisposeAsync()` in `[TearDown]/[OneTimeTearDown]` methods.\
For example:
```csharp
[TearDown]
public void Close_container()
{
    _container.Dispose();
}
```
becomes
```csharp
[TearDown]
public async Task Close_container()
{
    await _container.DisposeAsync();
}
```

*All tests under namespace `MassTransit.Containers.Tests.SimpleInjector_Tests` passed!* :heavy_check_mark:

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
