### PR TITLE
Updated Minimal required message for interop

### DIFF
--- a/docs/architecture/interoperability.md
+++ b/docs/architecture/interoperability.md
@@ -85,8 +85,6 @@ This is a minimal message:
 
 ```json
 {
-    "destinationAddress": "rabbitmq://localhost/input_queue",
-    "headers": {},
     "message": {
         "value": "Some Value",
         "customerId": 27


### PR DESCRIPTION
I've tested with a legacy producer and can confirm the minimal event format only needs a "message" object and a "messageType" property.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
