### PR TITLE
Use member notation for extension method, add UseInMemoryScheduler ov…

### DIFF
--- a/src/Scheduling/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
+++ b/src/Scheduling/MassTransit.QuartzIntegration/QuartzIntegrationExtensions.cs
@@ -50,12 +50,17 @@
         public static Uri UseInMemoryScheduler(this IBusFactoryConfigurator configurator, ISchedulerFactory schedulerFactory, IJobFactory jobFactory,
             out Task<IScheduler> schedulerTask, string queueName = "quartz")
         {
-            return UseInMemoryScheduler(configurator, out schedulerTask, options =>
+            return configurator.UseInMemoryScheduler(out schedulerTask, options =>
             {
                 options.SchedulerFactory = schedulerFactory;
                 options.QueueName = queueName;
                 options.JobFactory = jobFactory;
             });
+        }
+
+        public static Uri UseInMemoryScheduler(this IBusFactoryConfigurator configurator, Action<InMemorySchedulerOptions> configure)
+        {
+            return configurator.UseInMemoryScheduler(out _, configure);
         }
 
         public static Uri UseInMemoryScheduler(this IBusFactoryConfigurator configurator, out Task<IScheduler> schedulerTask,


### PR DESCRIPTION
Disable sсheduler start can be configured only with `out Task<IScheduler>, Action<InMemorySchedulerOptions>`

I don't need a scheduler and create a shortcut

Also i think that parameter-based `UseInMemoryScheduler` can be deprecated and removed in... 8 version?
Like OpenTelemetry `SamplingParameters` does