### PR TITLE
Fixed exception on batch collector

### DIFF
--- a/src/MassTransit/Pipeline/ConsumerFactories/BatchCollector.cs
+++ b/src/MassTransit/Pipeline/ConsumerFactories/BatchCollector.cs
@@ -145,7 +145,7 @@ namespace MassTransit.Pipeline.ConsumerFactories
                 if (_collectors.TryGetValue(key, out BatchConsumer<TMessage> consumer))
                 {
                     if (context.GetRetryAttempt() > 0)
-                        await _currentConsumer.ForceComplete().ConfigureAwait(false);
+                        await consumer.ForceComplete().ConfigureAwait(false);
                 }
 
                 if (consumer == null || consumer.IsCompleted)


### PR DESCRIPTION
Fixes the following exception:

```
System.NullReferenceException: 
   at MassTransit.Pipeline.ConsumerFactories.BatchCollector`2.Add(ConsumeContext`1 context)
   at MassTransit.Util.ChannelExecutor.Future`1.Run()
   at MassTransit.Util.ChannelExecutor.Run[T](Func`1 method, CancellationToken cancellationToken)
   at MassTransit.Pipeline.ConsumerFactories.BatchConsumerFactory`2.Send[T](ConsumeContext`1 context, IPipe`1 next)
   at MassTransit.Pipeline.Filters.ConsumerMessageFilter`2.GreenPipes.IFilter<MassTransit.ConsumeContext<TMessage>>.Send(ConsumeContext`1 context, IPipe`1 next)
```