### PR TITLE
Update automatonymous.md

### DIFF
--- a/docs/usage/sagas/automatonymous.md
+++ b/docs/usage/sagas/automatonymous.md
@@ -75,7 +75,7 @@ public class OrderStateMachine :
 }
 ```
 
-This results in the following values: 0 - Initial, 1 - Final, 2 - Submitted, 3 - Accepted
+This results in the following values: 0 - None, 1 - Initial, 2 - Final, 3 - Submitted, 4 - Accepted
 
 ### State
 


### PR DESCRIPTION
The code in `StateAccessorIndex` (and the comment above the `InstanceState` method in `AutomatonymousStateMachine` class) indicate there is also the `null` state that precedes the two built-in states and any other states the use may define. Hence, I believe it would be beneficial for the documentation to reflect that.
