### PR TITLE
Add "body-bytes" diagnostics activity tag

### DIFF
--- a/src/MassTransit/Logging/DiagnosticHeaders.cs
+++ b/src/MassTransit/Logging/DiagnosticHeaders.cs
@@ -15,6 +15,7 @@ namespace MassTransit.Logging
         public const string InputAddress = "input-address";
         public const string ConversationId = "conversation-id";
         public const string TrackingNumber = "tracking-number";
+        public const string BodyBytes = "body-bytes";
 
         public const string SourceHostMachine = "source-host-machine";
         public const string MessageTypes = "message-types";

--- a/src/MassTransit/Logging/EnabledDiagnosticSource.cs
+++ b/src/MassTransit/Logging/EnabledDiagnosticSource.cs
@@ -47,7 +47,7 @@ namespace MassTransit.Logging
                 activity.AddTag(DiagnosticHeaders.SourceAddress, context.SourceAddress.ToString());
             if (context.DestinationAddress != null)
                 activity.AddTag(DiagnosticHeaders.DestinationAddress, context.DestinationAddress.ToString());
-            if (context is MessageSendContext<T> messageSendContext)
+            if (context is MessageSendContext<T> messageSendContext && messageSendContext.Serializer != null)
                 activity.AddTag(DiagnosticHeaders.BodyBytes, messageSendContext.Body.LongLength.ToString());
 
             if (tags != null)

--- a/src/MassTransit/Logging/EnabledDiagnosticSource.cs
+++ b/src/MassTransit/Logging/EnabledDiagnosticSource.cs
@@ -47,6 +47,8 @@ namespace MassTransit.Logging
                 activity.AddTag(DiagnosticHeaders.SourceAddress, context.SourceAddress.ToString());
             if (context.DestinationAddress != null)
                 activity.AddTag(DiagnosticHeaders.DestinationAddress, context.DestinationAddress.ToString());
+            if (context is MessageSendContext<T> messageSendContext)
+                activity.AddTag(DiagnosticHeaders.BodyBytes, messageSendContext.Body.LongLength.ToString());
 
             if (tags != null)
             {

--- a/src/MassTransit/Logging/EnabledDiagnosticSource.cs
+++ b/src/MassTransit/Logging/EnabledDiagnosticSource.cs
@@ -47,8 +47,6 @@ namespace MassTransit.Logging
                 activity.AddTag(DiagnosticHeaders.SourceAddress, context.SourceAddress.ToString());
             if (context.DestinationAddress != null)
                 activity.AddTag(DiagnosticHeaders.DestinationAddress, context.DestinationAddress.ToString());
-            if (context is MessageSendContext<T> messageSendContext && messageSendContext.Serializer != null)
-                activity.AddTag(DiagnosticHeaders.BodyBytes, messageSendContext.Body.LongLength.ToString());
 
             if (tags != null)
             {

--- a/src/MassTransit/Logging/TransportDiagnosticSourceExtensions.cs
+++ b/src/MassTransit/Logging/TransportDiagnosticSourceExtensions.cs
@@ -8,6 +8,13 @@ namespace MassTransit.Logging
 
     public static class TransportDiagnosticSourceExtensions
     {
+        public static void AddSendContextHeadersPostSend<T>(this StartedActivityContext activity, SendContext<T> context)
+            where T : class
+        {
+            if (context is MessageSendContext<T> messageSendContext && messageSendContext.Serializer != null)
+                activity?.AddTag(DiagnosticHeaders.BodyBytes, messageSendContext.Body.LongLength.ToString());
+        }
+
         public static void AddConsumeContextHeaders(this StartedActivityContext activity, ConsumeContext context)
         {
             activity.AddTag(DiagnosticHeaders.MessageId, context.MessageId);

--- a/src/MassTransit/Transports/InMemory/InMemorySendTransport.cs
+++ b/src/MassTransit/Transports/InMemory/InMemorySendTransport.cs
@@ -47,6 +47,7 @@ namespace MassTransit.Transports.InMemory
                 await _context.Exchange.Send(transportMessage).ConfigureAwait(false);
 
                 context.LogSent();
+                activity.AddSendContextHeadersPostSend(context);
 
                 if (_context.SendObservers.Count > 0)
                     await _context.SendObservers.PostSend(context).ConfigureAwait(false);

--- a/src/Transports/MassTransit.ActiveMqTransport/Transport/ActiveMqSendTransport.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/Transport/ActiveMqSendTransport.cs
@@ -118,6 +118,7 @@
                     await publishTask.OrCanceled(context.CancellationToken).ConfigureAwait(false);
 
                     context.LogSent();
+                    activity.AddSendContextHeadersPostSend(context);
 
                     if (_context.SendObservers.Count > 0)
                         await _context.SendObservers.PostSend(context).ConfigureAwait(false);

--- a/src/Transports/MassTransit.AmazonSqsTransport/Transport/QueueSendTransport.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Transport/QueueSendTransport.cs
@@ -94,6 +94,7 @@
                     await context.SendMessage(_context.EntityName, message, sendContext.CancellationToken).ConfigureAwait(false);
 
                     sendContext.LogSent();
+                    activity.AddSendContextHeadersPostSend(sendContext);
 
                     if (_context.SendObservers.Count > 0)
                         await _context.SendObservers.PostSend(sendContext).ConfigureAwait(false);

--- a/src/Transports/MassTransit.AmazonSqsTransport/Transport/TopicSendTransport.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Transport/TopicSendTransport.cs
@@ -83,6 +83,7 @@
                     await context.Publish(request, sendContext.CancellationToken).ConfigureAwait(false);
 
                     sendContext.LogSent();
+                    activity.AddSendContextHeadersPostSend(sendContext);
 
                     if (_context.SendObservers.Count > 0)
                         await _context.SendObservers.PostSend(sendContext).ConfigureAwait(false);

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Transport/ServiceBusSendTransport.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Transport/ServiceBusSendTransport.cs
@@ -93,6 +93,7 @@
                     await clientContext.Send(brokeredMessage).ConfigureAwait(false);
 
                     context.LogSent();
+                    activity.AddSendContextHeadersPostSend(context);
 
                     if (_context.SendObservers.Count > 0)
                         await _context.SendObservers.PostSend(context).ConfigureAwait(false);

--- a/src/Transports/MassTransit.EventHubIntegration/Transport/EventHubProducer.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/Transport/EventHubProducer.cs
@@ -82,6 +82,7 @@ namespace MassTransit.EventHubIntegration
                 await _context.Produce(new[] {eventData}, options, context.CancellationToken).ConfigureAwait(false);
 
                 context.LogSent();
+                activity.AddSendContextHeadersPostSend(context);
 
                 if (_context.SendObservers.Count > 0)
                     await _context.SendObservers.PostSend(context).ConfigureAwait(false);
@@ -178,6 +179,7 @@ namespace MassTransit.EventHubIntegration
                     await FlushAsync(eventDataBatch);
 
                 context.LogSent();
+                activity.AddSendContextHeadersPostSend(context);
 
                 if (_context.SendObservers.Count > 0)
                     await Task.WhenAll(contexts.Select(c => _context.SendObservers.PostSend(c))).ConfigureAwait(false);

--- a/src/Transports/MassTransit.KafkaIntegration/Transport/TopicProducer.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Transport/TopicProducer.cs
@@ -75,6 +75,7 @@ namespace MassTransit.KafkaIntegration.Transport
                 await _context.Produce(topic, message, context.CancellationToken).ConfigureAwait(false);
 
                 context.LogSent();
+                activity.AddSendContextHeadersPostSend(context);
 
                 if (_context.SendObservers.Count > 0)
                     await _context.SendObservers.PostSend(context).ConfigureAwait(false);

--- a/src/Transports/MassTransit.RabbitMqTransport/Transport/RabbitMqSendTransport.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Transport/RabbitMqSendTransport.cs
@@ -141,6 +141,7 @@
                     await publishTask.OrCanceled(context.CancellationToken).ConfigureAwait(false);
 
                     context.LogSent();
+                    activity.AddSendContextHeadersPostSend(context);
 
                     if (_context.SendObservers.Count > 0)
                         await _context.SendObservers.PostSend(context).ConfigureAwait(false);


### PR DESCRIPTION
We're having problems with our payloads being too big and calls failing because of that. That can happen over time because the data is growing. Right now we only react to when that happens afterwards. With this extra tag we can be proactive using queries in Application Insights to find payloads that are closing in to the RabbitMQ limit.

I've tested this by copying the MassTransit code to my own lab project that writes to Application Insights.

Screenshot from Application Insights:
![image](https://user-images.githubusercontent.com/1074097/98041500-50e77700-1e22-11eb-8c52-f3132c01b60c.png)