### PR TITLE
Fix #2143 call of ConsumerConfigurator in ConsumerTestHarness at ConfigureReceiveEndpoint

### DIFF
--- a/src/MassTransit/Testing/ConsumerTestHarness.cs
+++ b/src/MassTransit/Testing/ConsumerTestHarness.cs
@@ -50,7 +50,7 @@
         {
             var decorator = new TestConsumerFactoryDecorator<TConsumer>(_consumerFactory, _consumed);
 
-            configurator.Consumer(decorator);
+            configurator.Consumer(decorator, c => _configure?.Invoke(c));
         }
 
         protected virtual void ConfigureNamedReceiveEndpoint(IBusFactoryConfigurator configurator, string queueName)


### PR DESCRIPTION
Invoke and provide `ConsumerConfigurator` at connect of Consumer in `ConfigureReceiveEndpoint` at `ConsumerTestHarness`. 

Now matches the implementation of `ConfigureNamedReceiveEndpoint`.

Fixes the following issue:
https://github.com/MassTransit/MassTransit/issues/2143