### PR TITLE
Fix error in Message Type Filters documentation

### DIFF
--- a/docs/advanced/middleware/custom.md
+++ b/docs/advanced/middleware/custom.md
@@ -160,7 +160,7 @@ public class MessageFilter<T> :
         var scope = context.CreateFilterScope("messageFilter");
     }
 
-    public async Task Send(T context, IPipe<T> next)
+    public async Task Send(ConsumeContext<T> context, IPipe<ConsumeContext<T>> next)
     {
         // do something
 


### PR DESCRIPTION
When the message type is used in the filter, the Send signature uses ConsumeContext<T> instead of T directly.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
