### PR TITLE
Fix BlobContainerClient Uri creation #2149

### DIFF
--- a/src/Transports/MassTransit.EventHubIntegration/Configuration/Configurators/EventHubEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/Configuration/Configurators/EventHubEndpointConfigurator.cs
@@ -118,7 +118,7 @@ namespace MassTransit.EventHubIntegration.Configurators
             if (!string.IsNullOrWhiteSpace(_storageSettings.ConnectionString))
                 return new BlobContainerClient(_storageSettings.ConnectionString, containerName, blobClientOptions);
 
-            var uri = new Uri(_storageSettings.ContainerUri, new Uri(containerName));
+            var uri = new Uri(_storageSettings.ContainerUri, containerName);
             if (_storageSettings.TokenCredential != null)
                 return new BlobContainerClient(uri, _storageSettings.TokenCredential, blobClientOptions);
 


### PR DESCRIPTION
Fix Url creation for block container in EventHub Rider to address the issue: https://github.com/MassTransit/MassTransit/issues/2149