### PR TITLE
check for null passwords when probing RabbitMqHost

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Transport/RabbitMqHost.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Transport/RabbitMqHost.cs
@@ -73,7 +73,7 @@ namespace MassTransit.RabbitMqTransport.Transport
                 _hostConfiguration.Settings.Port,
                 _hostConfiguration.Settings.VirtualHost,
                 _hostConfiguration.Settings.Username,
-                Password = new string('*', _hostConfiguration.Settings.Password.Length),
+                Password = new string('*', _hostConfiguration.Settings.Password?.Length ?? 0),
                 _hostConfiguration.Settings.Heartbeat,
                 _hostConfiguration.Settings.Ssl
             });


### PR DESCRIPTION
While experimenting with MassTransit 7.1.1, I ran into a NullReferenceException while trying to probe the bus.

To be completely honest, I did not test this code change. But, the following is a minimal reproduction of a NullReferenceException that occurs when calling GetProbeResult with the RabbitMQ transport.

```csharp
using System;
using GreenPipes;
using GreenPipes.Introspection;
using MassTransit;

namespace MTTest
{
    class Program
    {
        static void Main()
        {
            var busControl = Bus.Factory.CreateUsingRabbitMq(cfg =>
            {
                cfg.Host("localhost", c =>
                {
                    // uncommenting this avoids the NullReferenceException:
                    // c.Password("");
                });
            });
            busControl.GetProbeResult();
        }
    }
}
```

This code results in the following NullReferenceException:

```csharp
An unhandled exception of type 'System.NullReferenceException' occurred in MassTransit.RabbitMqTransport.dll: 'Object reference not set to an instance of an object.'
   at MassTransit.RabbitMqTransport.Transport.RabbitMqHost.Probe(ProbeContext context)
   at MassTransit.Transports.BaseHost.GreenPipes.IProbeSite.Probe(ProbeContext context)
   at MassTransit.MassTransitBus.GreenPipes.IProbeSite.Probe(ProbeContext context)
   at GreenPipes.IntrospectionExtensions.GetProbeResult(IProbeSite probeSite, CancellationToken cancellationToken)
   at MTTest.Program.Main(String[] args) in /Users/stephen/src/bitbucket.org/bitcentral/mttest/MTTest/Program.cs:line 19
```

Since adding an empty password resolves the NullReferenceException, I'm reasonably certain this exception is caused by unconditionally accessing `Password.Length`.