### PR TITLE
add documentation about TemporaryEndpointDefinition

### DIFF
--- a/docs/code/usage/UsageConsumerTemporaryEndpoint.cs
+++ b/docs/code/usage/UsageConsumerTemporaryEndpoint.cs
@@ -1,0 +1,22 @@
+namespace UsageConsumerTemporaryEndpoint
+{
+    using System;
+    using System.Threading.Tasks;
+    using UsageConsumer;
+    using MassTransit;
+
+    public class Program
+    {
+        public static async Task Main()
+        {
+            var busControl = Bus.Factory.CreateUsingRabbitMq(cfg =>
+            {
+                // ensures the receive endpoint is deleted when the bus is stopped
+                cfg.ReceiveEndpoint(new TemporaryEndpointDefinition(), e =>
+                {
+                    e.Consumer<SubmitOrderConsumer>();
+                });
+            });
+        }
+    }
+}

--- a/docs/usage/consumers.md
+++ b/docs/usage/consumers.md
@@ -64,6 +64,12 @@ If using the default or delegate consumer factory and the consumer supports eith
 When using a container, it is responsible for consumer disposal when the scope is disposed.
 :::
 
+### Temporary Consumers
+
+Some consumers only need to receive messages while connected, and any messages published while disconnected should be discarded. This is achieved by using a TemporaryEndpointDefinition as the endpoint definition.
+
+<<< @/docs/code/usage/UsageConsumerTemporaryEndpoint.cs
+
 ### Connect Consumers
 
 Once a bus has been configured, the receive endpoints have been created and cannot be modified. However, the bus creates a temporary, auto-delete endpoint for itself. Consumers can be connected to the bus endpoint using any of the `Connect` methods. The bus endpoint is designed to receive responses (via the request client, see the [requests](/usage/requests) section) and **messages sent directly to the bus endpoint**.

--- a/docs/usage/transports/rabbitmq.md
+++ b/docs/usage/transports/rabbitmq.md
@@ -119,5 +119,5 @@ The following recommendations should be considered _best practices_ for building
   - Messages from the queue will be load balanced across all instances (the _competing consumer_ pattern)
 - If a consumer exception is thrown, the faulted message will be moved to an error queue, which is named with the \_error suffix.
 - The number of concurrently processed messages can be up to the _PrefetchCount_, depending upon the number of cores available.
-- For temporary receive endpoints, set _AutoDelete = true_ and _Durable = false_
+- For temporary receive endpoints that should be deleted when the bus is stopped, use _TemporaryEndpointDefinition_ as the receive endpoint definition.
 - To configure _PrefetchCount_ higher than the desired concurrent message count, add _UseConcurrencyLimit(n)_ to the configuration. _This must be added before any consumers are configured._ Depending upon your consumer duration, higher values may greatly improve overall message throughput.


### PR DESCRIPTION
Adds documentation about using the `TemporaryEndpointDefinition` class.

Since simply setting `AutoDelete = true, Durable = false` will leave behind an exchange, I also thought it made sense to edit the RabbitMQ best practices to suggest TemporaryEndpointDefinition instead of just setting those properties.