### PR TITLE
Add ASB transport with Managed Identity code sample to docs

### DIFF
--- a/docs/usage/transports/azure-sb.md
+++ b/docs/usage/transports/azure-sb.md
@@ -36,7 +36,7 @@ namespace ServiceBusConsoleListener
                 {
                     var settings = new HostSettings
                     {
-                        ServiceUri = new Uri("service-bus-service-uri"),
+                        ServiceUri = new Uri("sb://your-service-bus-service-bus-namespace.servicebus.windows.net"/),
                         TokenProvider = TokenProvider.CreateManagedIdentityTokenProvider()
                     };
                     cfg.Host(settings);

--- a/docs/usage/transports/azure-sb.md
+++ b/docs/usage/transports/azure-sb.md
@@ -13,7 +13,7 @@ Additional host properties include:
 | TokenProvider         | Use a specific token provider, such as a managed identity token provider, to access the namespace
 | TransportType         | Change the transport type from the default (AMQP) to use WebSockets
 
-The following example show how to configure Azure Service Bus using an Azure Managed Identity:
+The following example shows how to configure Azure Service Bus using an Azure Managed Identity:
 
 ```csharp
 namespace ServiceBusConsoleListener
@@ -36,7 +36,7 @@ namespace ServiceBusConsoleListener
                 {
                     var settings = new HostSettings
                     {
-                        ServiceUri = new Uri("sb://your-service-bus-service-bus-namespace.servicebus.windows.net"/),
+                        ServiceUri = new Uri("sb://your-service-bus-namespace.servicebus.windows.net"/),
                         TokenProvider = TokenProvider.CreateManagedIdentityTokenProvider()
                     };
                     cfg.Host(settings);

--- a/docs/usage/transports/azure-sb.md
+++ b/docs/usage/transports/azure-sb.md
@@ -13,6 +13,42 @@ Additional host properties include:
 | TokenProvider         | Use a specific token provider, such as a managed identity token provider, to access the namespace
 | TransportType         | Change the transport type from the default (AMQP) to use WebSockets
 
+The following example show how to configure Azure Service Bus using an Azure Managed Identity:
+
+```csharp
+namespace ServiceBusConsoleListener
+{
+    using System;
+    using System.Threading.Tasks;
+    using MassTransit;
+    using MassTransit.Azure.ServiceBus.Core.Configurators;
+    using Microsoft.Azure.ServiceBus.Primitives;
+    using Microsoft.Extensions.DependencyInjection;
+
+    public class Program
+    {
+        public static async Task Main()
+        {
+            var services = new ServiceCollection();
+            services.AddMassTransit(x =>
+            {
+                x.UsingAzureServiceBus((context, cfg) =>
+                {
+                    var settings = new HostSettings
+                    {
+                        ServiceUri = new Uri("service-bus-service-uri"),
+                        TokenProvider = TokenProvider.CreateManagedIdentityTokenProvider()
+                    };
+                    cfg.Host(settings);
+                });
+            });
+        }
+    }
+}
+
+```
+
+During local development, in the case of Visual Studio, you can configure the account to use under Options -> Azure Service Authentication. Note that your Azure Active Directory user needs explicit access to the resource and have the 'Azure Service Bus Data Owner' role assigned.
 
 Azure Service Bus queues includes an extensive set a properties that can be configured. All of these are optional, MassTransit uses sensible defaults, but the control is there when needed.
 


### PR DESCRIPTION
This PR adds some documentation and a code sample on how to configure the Azure Service Bus transport using a Managed Identity and how to make it work during local development.

I wasn't sure if I should inline the code sample or put it under /docs/code/transports/xxx.cs and reference it, as both methods are in use in this file. Let me know if a reference to the code file is preferred.