### PR TITLE
Fix typo in docs/usage/exceptions.md

### DIFF
--- a/docs/usage/exceptions.md
+++ b/docs/usage/exceptions.md
@@ -268,7 +268,7 @@ Beyond that built-in customization, the individual filters can be added/configur
 ```cs
 cfg.ReceiveEndpoint("input-queue", ec =>
 {
-    ec..ConfigureError(x =>
+    ec.ConfigureError(x =>
     {
         x.UseFilter(new GenerateFaultFilter());
         x.UseFilter(new ErrorTransportFilter());


### PR DESCRIPTION
Fix minor typo in the documentation docs/usage/exceptions.md