### PR TITLE
Update Class_Specs.cs

### DIFF
--- a/tests/MassTransit.Tests/Initializers/Class_Specs.cs
+++ b/tests/MassTransit.Tests/Initializers/Class_Specs.cs
@@ -55,20 +55,32 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_initialize_with_readonly_properties()
         {
-            var model = new ReadWriteReadOnly {ReadWrite = "Some Property Value"};
+            var model1 = new {ReadWrite = "Some Property Value"};
 
-            InitializeContext<ReadWriteReadOnly> context = await MessageInitializerCache<ReadWriteReadOnly>.Initialize(model);
+            var model2 = new ReadWriteReadOnly {ReadWrite = "Some Property Value"};
 
-            Assert.That(context.Message, Is.Not.Null);
+            InitializeContext<IReadWriteReadOnly> model1_working1 = await MessageInitializerCache<IReadWriteReadOnly>.Initialize(model1);
+
+            InitializeContext<ReadWriteReadOnly> model1_working2 = await MessageInitializerCache<ReadWriteReadOnly>.Initialize(model1);
+
+            InitializeContext<IReadWriteReadOnly> model2_working3 = await MessageInitializerCache<IReadWriteReadOnly>.Initialize(model2);
+
+            InitializeContext<ReadWriteReadOnly> model2_broken1 = await MessageInitializerCache<ReadWriteReadOnly>.Initialize(model2);
         }
 
-
-        public class ReadWriteReadOnly
+        public class ReadWriteReadOnly : IReadWriteReadOnly
         {
             public string ReadWrite { get; set; }
-
             public string ReadOnly => ReadWrite;
         }
+
+
+        public interface IReadWriteReadOnly
+        {
+            string ReadWrite { get; set; }
+            string ReadOnly => ReadWrite;
+        }
+
 
         public interface Report
         {

--- a/tests/MassTransit.Tests/Initializers/Class_Specs.cs
+++ b/tests/MassTransit.Tests/Initializers/Class_Specs.cs
@@ -52,6 +52,23 @@ namespace MassTransit.Tests.Initializers
             Assert.That(context.Message.Address.City, Is.EqualTo("Dallas"));
         }
 
+        [Test]
+        public async Task Should_initialize_with_readonly_properties()
+        {
+            var model = new ReadWriteReadOnly {ReadWrite = "Some Property Value"};
+
+            InitializeContext<ReadWriteReadOnly> context = await MessageInitializerCache<ReadWriteReadOnly>.Initialize(model);
+
+            Assert.That(context.Message, Is.Not.Null);
+        }
+
+
+        public class ReadWriteReadOnly
+        {
+            public string ReadWrite { get; set; }
+
+            public string ReadOnly => ReadWrite;
+        }
 
         public interface Report
         {


### PR DESCRIPTION
Reproducing Error:
```
System.ArgumentException : The property does not have an accessible set method: ReadOnly
   at MassTransit.Internals.Reflection.WriteProperty`2..ctor(Type implementationType, PropertyInfo propertyInfo) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Internals\Reflection\WriteProperty.cs:line 22
   at MassTransit.Internals.Reflection.WritePropertyCache`1.GetWriteProperty[TProperty](String name) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Internals\Reflection\WritePropertyCache.cs:line 66
   at MassTransit.Internals.Reflection.WritePropertyCache`1.MassTransit.Internals.Reflection.IWritePropertyCache<T>.GetProperty[TProperty](PropertyInfo propertyInfo) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Internals\Reflection\WritePropertyCache.cs:line 48
   at MassTransit.Internals.Reflection.WritePropertyCache`1.GetProperty[TProperty](PropertyInfo propertyInfo) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Internals\Reflection\WritePropertyCache.cs:line 84
   at MassTransit.Initializers.PropertyInitializers.CopyPropertyInitializer`3..ctor(PropertyInfo messagePropertyInfo, PropertyInfo inputPropertyInfo) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\PropertyInitializers\CopyPropertyInitializer.cs:line 31
   at MassTransit.Initializers.Conventions.DefaultInitializerConvention`2.TryGetPropertyInitializer[TProperty](PropertyInfo propertyInfo, IPropertyInitializer`2& initializer) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\Conventions\DefaultInitializerConvention.cs:line 40
   at MassTransit.Initializers.Conventions.InitializerConvention`1.TryGetPropertyInitializer[TInput,TProperty](PropertyInfo propertyInfo, IPropertyInitializer`2& initializer) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\Conventions\InitializerConvention.cs:line 21
   at MassTransit.Initializers.Conventions.InitializerConvention.TryGetPropertyInitializer[TMessage,TInput,TProperty](PropertyInfo propertyInfo, IPropertyInitializer`2& initializer) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\Conventions\InitializerConvention.cs:line 76
   at MassTransit.Initializers.Factories.PropertyInitializerInspector`3.Apply(IMessageInitializerBuilder`2 builder, IInitializerConvention convention) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\Factories\PropertyInitializerInspector.cs:line 24
   at MassTransit.Initializers.Factories.MessageInitializerFactory`2.CreateMessageInitializer() in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\Factories\MessageInitializerFactory.cs:line 39
   at MassTransit.Initializers.MessageInitializerCache`1.CreateMessageInitializer(Type inputType) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\MessageInitializerCache.cs:line 44
   at MassTransit.Initializers.MessageInitializerCache`1.<>c__DisplayClass2_0.<MassTransit.Initializers.IMessageInitializerCache<TMessage>.GetInitializer>b__0() in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\MessageInitializerCache.cs:line 30
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at MassTransit.Initializers.MessageInitializerCache`1.MassTransit.Initializers.IMessageInitializerCache<TMessage>.GetInitializer(Type inputType) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\MessageInitializerCache.cs:line 35
   at MassTransit.Initializers.MessageInitializerCache`1.Initialize(Object values, CancellationToken cancellationToken) in D:\Dev\Work\GitHub\MassTransit\src\MassTransit\Initializers\MessageInitializerCache.cs:line 76
   at MassTransit.Tests.Initializers.Initializing_a_regular_class.Should_initialize_with_readonly_properties() in D:\Dev\Work\GitHub\MassTransit\tests\MassTransit.Tests\Initializers\Class_Specs.cs:line 60
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.GetResult()
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()
```