### PR TITLE
Streams can be added as message data

### DIFF
--- a/src/MassTransit.Analyzers/Helpers/TypeConversionHelper.cs
+++ b/src/MassTransit.Analyzers/Helpers/TypeConversionHelper.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Analyzers.Helpers
 {
     using System;
+    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -170,6 +171,10 @@ namespace MassTransit.Analyzers.Helpers
                     }
 
                     if (messageDataType.SpecialType == SpecialType.System_String && sourceSymbol.SpecialType == SpecialType.System_String)
+                        return true;
+
+                    INamedTypeSymbol streamType = _semanticModel.Compilation.GetTypeByMetadataName(typeof(Stream).FullName);
+                    if (SymbolEqualityComparer.Default.Equals(messageDataType, streamType) && sourceSymbol.ImplementsType(streamType))
                         return true;
 
                     return false;

--- a/src/MassTransit/Initializers/PropertyConverters/MessageDataPropertyConverter.cs
+++ b/src/MassTransit/Initializers/PropertyConverters/MessageDataPropertyConverter.cs
@@ -1,5 +1,6 @@
 namespace MassTransit.Initializers.PropertyConverters
 {
+    using System.IO;
     using System.Text;
     using System.Threading.Tasks;
     using MessageData.Values;
@@ -10,9 +11,11 @@ namespace MassTransit.Initializers.PropertyConverters
         IPropertyConverter<MessageData<byte[]>, MessageData<byte[]>>,
         IPropertyConverter<MessageData<byte[]>, MessageData<string>>,
         IPropertyConverter<MessageData<string>, MessageData<string>>,
+        IPropertyConverter<MessageData<Stream>, MessageData<Stream>>,
         IPropertyConverter<MessageData<string>, string>,
         IPropertyConverter<MessageData<byte[]>, string>,
-        IPropertyConverter<MessageData<byte[]>, byte[]>
+        IPropertyConverter<MessageData<byte[]>, byte[]>,
+        IPropertyConverter<MessageData<Stream>, Stream>
     {
         public Task<MessageData<byte[]>> Convert<T>(InitializeContext<T> context, byte[] input)
             where T : class
@@ -72,6 +75,23 @@ namespace MassTransit.Initializers.PropertyConverters
                 return TaskUtil.Default<MessageData<string>>();
 
             return Task.FromResult<MessageData<string>>(new PutMessageData<string>(input));
+        }
+
+        public Task<MessageData<Stream>> Convert<T>(InitializeContext<T> context, Stream input)
+            where T : class
+        {
+            if (input == null)
+                return TaskUtil.Default<MessageData<Stream>>();
+
+            return Task.FromResult<MessageData<Stream>>(new PutMessageData<Stream>(input));
+        }
+
+        public Task<MessageData<Stream>> Convert<T>(InitializeContext<T> context, MessageData<Stream> input)
+            where T : class
+        {
+            return input != null
+                ? Task.FromResult(input)
+                : TaskUtil.Default<MessageData<Stream>>();
         }
     }
 }

--- a/src/MassTransit/Initializers/PropertyProviders/PropertyProviderFactory.cs
+++ b/src/MassTransit/Initializers/PropertyProviders/PropertyProviderFactory.cs
@@ -2,6 +2,7 @@ namespace MassTransit.Initializers.PropertyProviders
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Reflection;
     using System.Threading.Tasks;
     using Internals.Extensions;
@@ -359,11 +360,20 @@ namespace MassTransit.Initializers.PropertyProviders
 
             public bool TryGetConverter<T, TProperty>(out IPropertyConverter<T, TProperty> converter)
             {
-                if (typeof(TValue) == typeof(string) || typeof(TValue) == typeof(byte[]))
+                if (typeof(TValue) == typeof(string) || typeof(TValue) == typeof(byte[]) || typeof(Stream).IsAssignableFrom(typeof(TValue)))
                 {
                     if (typeof(T).ClosesType(typeof(MessageData<>), out Type[] types) && types[0] == typeof(string))
                     {
                         if (typeof(TProperty) == typeof(string) || typeof(TProperty) == typeof(MessageData<string>))
+                        {
+                            converter = new MessageDataPropertyConverter() as IPropertyConverter<T, TProperty>;
+                            return converter != null;
+                        }
+                    }
+
+                    if (typeof(T).ClosesType(typeof(MessageData<>), out types) && typeof(Stream).IsAssignableFrom(types[0]))
+                    {
+                        if (typeof(Stream).IsAssignableFrom(typeof(TProperty)) || typeof(TProperty) == typeof(MessageData<Stream>))
                         {
                             converter = new MessageDataPropertyConverter() as IPropertyConverter<T, TProperty>;
                             return converter != null;

--- a/src/MassTransit/MessageData/PropertyProviders/MessageDataConverter.cs
+++ b/src/MassTransit/MessageData/PropertyProviders/MessageDataConverter.cs
@@ -1,8 +1,12 @@
 ﻿namespace MassTransit.MessageData.PropertyProviders
 {
+    using System.IO;
+
+
     public static class MessageDataConverter
     {
         public static readonly IMessageDataConverter<string> String = new StringMessageDataConverter();
         public static readonly IMessageDataConverter<byte[]> ByteArray = new ByteArrayMessageDataConverter();
+        public static readonly IMessageDataConverter<Stream> Stream = new StreamMessageDataConverter();
     }
 }

--- a/src/MassTransit/MessageData/PropertyProviders/MessageDataFactory.cs
+++ b/src/MassTransit/MessageData/PropertyProviders/MessageDataFactory.cs
@@ -1,6 +1,7 @@
 ﻿namespace MassTransit.MessageData.PropertyProviders
 {
     using System;
+    using System.IO;
     using System.Threading;
     using Metadata;
     using Values;
@@ -15,6 +16,9 @@
 
             if (typeof(T) == typeof(byte[]))
                 return (MessageData<T>)new GetMessageData<byte[]>(address, repository, MessageDataConverter.ByteArray, cancellationToken);
+
+            if (typeof(T) == typeof(Stream))
+                return (MessageData<T>)new GetMessageData<Stream>(address, repository, MessageDataConverter.Stream, cancellationToken);
 
             throw new MessageDataException("Unsupported message data type: " + TypeMetadataCache<T>.ShortName);
         }

--- a/src/MassTransit/MessageData/PropertyProviders/PutMessageDataPropertyProvider.cs
+++ b/src/MassTransit/MessageData/PropertyProviders/PutMessageDataPropertyProvider.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.MessageData.PropertyProviders
 {
     using System;
+    using System.IO;
     using System.Threading.Tasks;
     using GreenPipes;
     using Initializers;
@@ -84,6 +85,15 @@ namespace MassTransit.MessageData.PropertyProviders
                     MessageData<byte[]> messageData = timeToLive.HasValue
                         ? await _repository.PutBytes(bytesValue, timeToLive.Value, context.CancellationToken).ConfigureAwait(false)
                         : await _repository.PutBytes(bytesValue, context.CancellationToken).ConfigureAwait(false);
+
+                    return (MessageData<TValue>)messageData;
+                }
+
+                if (value is Stream streamValue)
+                {
+                    MessageData<Stream> messageData = timeToLive.HasValue
+                        ? await _repository.PutStream(streamValue, timeToLive.Value, context.CancellationToken).ConfigureAwait(false)
+                        : await _repository.PutStream(streamValue, default, context.CancellationToken).ConfigureAwait(false);
 
                     return (MessageData<TValue>)messageData;
                 }

--- a/src/MassTransit/MessageData/PropertyProviders/StreamMessageDataConverter.cs
+++ b/src/MassTransit/MessageData/PropertyProviders/StreamMessageDataConverter.cs
@@ -1,0 +1,15 @@
+namespace MassTransit.MessageData.PropertyProviders
+{
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+
+    public class StreamMessageDataConverter : IMessageDataConverter<Stream>
+    {
+        public Task<Stream> Convert(Stream stream, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(stream);
+        }
+    }
+}

--- a/src/MassTransit/MessageDataExtensions.cs
+++ b/src/MassTransit/MessageDataExtensions.cs
@@ -55,6 +55,12 @@
             return new StoredMessageData<byte[]>(address, bytes);
         }
 
+        public static Task<MessageData<Stream>> PutStream(this IMessageDataRepository repository, Stream stream,
+            CancellationToken cancellationToken = default)
+        {
+            return PutStream(repository, stream, default, cancellationToken);
+        }
+
         public static async Task<MessageData<string>> PutString(this IMessageDataRepository repository, string value, TimeSpan timeToLive,
             CancellationToken cancellationToken = default)
         {
@@ -97,6 +103,19 @@
                 return new BytesInlineMessageData(bytes, address);
 
             return new StoredMessageData<byte[]>(address, bytes);
+        }
+
+        public static async Task<MessageData<Stream>> PutStream(this IMessageDataRepository repository, Stream stream, TimeSpan timeToLive,
+            CancellationToken cancellationToken = default)
+        {
+            if (repository == null)
+                throw new ArgumentNullException(nameof(repository));
+            if (stream == null)
+                return EmptyMessageData<Stream>.Instance;
+
+            var address = await repository.Put(stream, timeToLive, cancellationToken).ConfigureAwait(false);
+
+            return new StoredMessageData<Stream>(address, stream);
         }
 
         public static async Task<MessageData<string>> GetString(this IMessageDataRepository repository, Uri address,

--- a/src/MassTransit/Serialization/JsonConverters/MessageDataJsonConverter.cs
+++ b/src/MassTransit/Serialization/JsonConverters/MessageDataJsonConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace MassTransit.Serialization.JsonConverters
 {
     using System;
+    using System.IO;
     using Internals.Extensions;
     using MessageData;
     using MessageData.Values;
@@ -31,7 +32,7 @@
             if (objectType.ClosesType(typeof(MessageData<>), out Type[] dataTypes))
             {
                 var elementType = dataTypes[0];
-                if (elementType == typeof(string) || elementType == typeof(byte[]))
+                if (elementType == typeof(string) || elementType == typeof(byte[]) || elementType == typeof(Stream))
                     return (IConverter)Activator.CreateInstance(typeof(CachedConverter<>).MakeGenericType(elementType));
 
                 throw new MessageDataException("The message data type is not supported: " + TypeMetadataCache.GetShortName(elementType));

--- a/tests/MassTransit.Analyzers.Tests/MessageDataInitializer_Specs.cs
+++ b/tests/MassTransit.Analyzers.Tests/MessageDataInitializer_Specs.cs
@@ -17,6 +17,7 @@ namespace ConsoleApplication1
         Guid Id { get; }
         string CustomerId { get; }
         MessageData<string> Document { get; }
+        MessageData<Stream> Stream { get; }
     }
 }
 ";
@@ -25,6 +26,7 @@ namespace ConsoleApplication1
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using MassTransit;
 ";
 
@@ -51,10 +53,10 @@ namespace ConsoleApplication1
             {
                 Id = "MCA0003",
                 Message =
-                    "Anonymous type is missing properties that are in the message contract 'ProcessDocument'. The following properties are missing: Id, CustomerId, Document.",
+                    "Anonymous type is missing properties that are in the message contract 'ProcessDocument'. The following properties are missing: Id, CustomerId, Document, Stream.",
                 Severity = DiagnosticSeverity.Info,
                 Locations =
-                    new[] {new DiagnosticResultLocation("Test0.cs", 25, 48)}
+                    new[] {new DiagnosticResultLocation("Test0.cs", 27, 48)}
             };
 
             VerifyCSharpDiagnostic(test, expected);
@@ -76,7 +78,8 @@ namespace ConsoleApplication1
             {
                 InVar.Id,
                 CustomerId = ""53051996-AEEC-4EF1-BCFD-7835F17BA8E7"",
-                Document = 72
+                Document = 72,
+                Stream = 42
             });
         }
     }
@@ -86,10 +89,10 @@ namespace ConsoleApplication1
             {
                 Id = "MCA0001",
                 Message =
-                    "Anonymous type does not map to message contract 'ProcessDocument'. The following properties of the anonymous type are incompatible: Document.",
+                    "Anonymous type does not map to message contract 'ProcessDocument'. The following properties of the anonymous type are incompatible: Document, Stream.",
                 Severity = DiagnosticSeverity.Error,
                 Locations =
-                    new[] {new DiagnosticResultLocation("Test0.cs", 25, 48)}
+                    new[] {new DiagnosticResultLocation("Test0.cs", 27, 48)}
             };
 
             VerifyCSharpDiagnostic(test, expected);
@@ -106,12 +109,41 @@ namespace ConsoleApplication1
         static async Task Main()
         {
             var bus = Bus.Factory.CreateUsingInMemory(cfg => { });
+            Stream testStream = new MemoryStream();
 
             await bus.Publish<ProcessDocument>(new
             {
                 InVar.Id,
                 CustomerId = ""53051996-AEEC-4EF1-BCFD-7835F17BA8E7"",
-                Document = ""This would be a really big document typically""
+                Document = ""This would be a really big document typically"",
+                Stream = testStream
+            });
+        }
+    }
+}
+";
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [Test]
+        public void WhenTypesAreStructurallyCompatibleAndInherited_ShouldNotHaveDiagnostic()
+        {
+            var test = Usings + MessageContracts + @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        static async Task Main()
+        {
+            var bus = Bus.Factory.CreateUsingInMemory(cfg => { });
+            MemoryStream testStream = new MemoryStream();
+
+            await bus.Publish<ProcessDocument>(new
+            {
+                InVar.Id,
+                CustomerId = ""53051996-AEEC-4EF1-BCFD-7835F17BA8E7"",
+                Document = ""This would be a really big document typically"",
+                Stream = testStream
             });
         }
     }


### PR DESCRIPTION
Added ability to use streams as message data

* Modified analyser and tests so it does not warn about using Stream in MessageData initializers
* Added unit tests for `MessageData<Stream>` initialisation
* Added unit tests for decoding stream message data
* Added unit tests for `FileSystemMessageDataRepository` and `InMemoryMessageDataRepository`

Briefly tested with `MongoDbMessageDataRepository` which passed data successfully but have not generated unit tests for this.
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
