### PR TITLE
new addconsumers methods

### DIFF
--- a/src/MassTransit/Configuration/RegistrationExtensions.cs
+++ b/src/MassTransit/Configuration/RegistrationExtensions.cs
@@ -39,12 +39,23 @@ namespace MassTransit
         /// <param name="assemblies">The assemblies to scan for consumers</param>
         public static void AddConsumers(this IRegistrationConfigurator configurator, params Assembly[] assemblies)
         {
+            AddConsumers(configurator, filter: null, assemblies);
+        }
+
+        /// <summary>
+        /// Adds all consumers that match the given filter in the specified assemblies
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filter"></param>
+        /// <param name="assemblies">The assemblies to scan for consumers</param>
+        public static void AddConsumers(this IRegistrationConfigurator configurator, Func<Type, bool> filter, params Assembly[] assemblies)
+        {
             if (assemblies.Length == 0)
                 assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
             var types = AssemblyTypeCache.FindTypes(assemblies, TypeMetadataCache.IsConsumerOrDefinition).GetAwaiter().GetResult();
 
-            AddConsumers(configurator, types.FindTypes(TypeClassification.Concrete | TypeClassification.Closed).ToArray());
+            AddConsumers(configurator, filter, types.FindTypes(TypeClassification.Concrete | TypeClassification.Closed).ToArray());
         }
 
         /// <summary>
@@ -96,17 +107,31 @@ namespace MassTransit
         /// <param name="types">The state machine types to add</param>
         public static void AddConsumers(this IRegistrationConfigurator configurator, params Type[] types)
         {
+            AddConsumers(configurator, filter: null, types);
+        }
+
+        /// <summary>
+        /// Adds the specified consumer types which match the given filter
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="filter"></param>
+        /// <param name="types">The consumer types to add</param>
+        public static void AddConsumers(this IRegistrationConfigurator configurator, Func<Type, bool> filter, params Type[] types)
+        {
+            filter ??= t => true;
+
             IEnumerable<Type> consumerTypes = types.Where(TypeMetadataCache.HasConsumerInterfaces);
             IEnumerable<Type> consumerDefinitionTypes = types.Where(x => x.HasInterface(typeof(IConsumerDefinition<>)));
 
             var consumers = from c in consumerTypes
-                join d in consumerDefinitionTypes on c equals d.GetClosingArgument(typeof(IConsumerDefinition<>)) into dc
-                from d in dc.DefaultIfEmpty()
-                select new
-                {
-                    ConsumerType = c,
-                    DefinitionType = d
-                };
+                            join d in consumerDefinitionTypes on c equals d.GetClosingArgument(typeof(IConsumerDefinition<>)) into dc
+                            from d in dc.DefaultIfEmpty()
+                            where filter(c)
+                            select new
+                                   {
+                                       ConsumerType = c,
+                                       DefinitionType = d
+                                   };
 
             foreach (var consumer in consumers)
                 configurator.AddConsumer(consumer.ConsumerType, consumer.DefinitionType);


### PR DESCRIPTION
**Pull Request Reason:**
Need to filter when collectively injecting consumer classes

**Scenario:**
In my project there are a lot of `Consumer` and `ConsumerDefinition` classes. These consumers listen and consume the messages coming from two bus instances. Therefore, I injected multiple buses. To configure the buses I used `busConfigurator.AddConsumers(myAssemblyCollection);` method. However, at this point I have a special case which requires a consumer which should be bound to only one bus. MassTransit currently cannot filter the consumers during injection. As a result; when I use multiple busses and want to inject the consumers collectively, I am not able to do that.

_My offer is_,
Below extention methods already exist:
`AddConsumers(this IRegistrationConfigurator configurator, params Assembly[] assemblies)`
`AddConsumers(this IRegistrationConfigurator configurator, params Type[] types)`

Overload methods could be created with filter parameter such as below:
`AddConsumers(this IRegistrationConfigurator configurator, Func<Type, bool> filter, params Assembly[] assemblies)`
`AddConsumers(this IRegistrationConfigurator configurator, Func<Type, bool> filter, params Type[] types)`

By using these methods, I can configure my second bus like below:
`busConfigurator.AddConsumers(myAssemblyCollection, type => ! type.Namespace.StartWith("XXX.OnlyForFirstBus"));`