### PR TITLE
Removes enthusiastic request id clearing.

### DIFF
--- a/src/MassTransit/Automatonymous/MassTransitStateMachine.cs
+++ b/src/MassTransit/Automatonymous/MassTransitStateMachine.cs
@@ -219,10 +219,7 @@
                     .CancelRequestTimeout(request)
                     .ClearRequest(request),
                 When(request.Faulted)
-                    .CancelRequestTimeout(request)
-                    .ClearRequest(request),
-                When(request.TimeoutExpired, request.EventFilter)
-                    .ClearRequest(request));
+                    .CancelRequestTimeout(request));
         }
 
         /// <summary>
@@ -288,10 +285,7 @@
                     .CancelRequestTimeout(request)
                     .ClearRequest(request),
                 When(request.Faulted)
-                    .CancelRequestTimeout(request)
-                    .ClearRequest(request),
-                When(request.TimeoutExpired, request.EventFilter)
-                    .ClearRequest(request));
+                    .CancelRequestTimeout(request));
         }
 
         /// <summary>


### PR DESCRIPTION
On receipt of Faulted or Timeout request events it will no longer clear the request id from the state instance so that a subsequent Completed request event is still accepted after failure or timeout.

As discussed on Discord: https://discord.com/channels/682238261753675864/682238261753675868/802175993912492082