### PR TITLE
Added MySqlLockStateProvider

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MySqlLockStatementProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MySqlLockStatementProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MassTransit.EntityFrameworkCoreIntegration
+{
+    public class MySqlLockStatementProvider :
+        SqlLockStatementProvider
+    {
+        const string DefaultSchemaName = "public";
+        const string DefaultRowLockStatement = "SELECT * FROM {1} WHERE {2} = \"@p0\" FOR UPDATE";
+
+        public MySqlLockStatementProvider(bool enableSchemaCaching = true)
+            : base(DefaultSchemaName, DefaultRowLockStatement, enableSchemaCaching)
+        {
+        }
+    }
+}


### PR DESCRIPTION
I added a Locking statement provider for Mysql in Entity Framework Core,
I verified it to work by both executing the query directly to a test database and also used it in a POC Implementation using a Automatonymous state machine. 