### PR TITLE
Fix DeadLetterQueueExceptionFilter summary comment referencing wrong queue

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Pipeline/DeadLetterQueueExceptionFilter.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Pipeline/DeadLetterQueueExceptionFilter.cs
@@ -5,7 +5,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Pipeline
 
 
     /// <summary>
-    /// Moves a faulted message to the dead-letter queue, rather than the _skipped queue
+    /// Moves a faulted message to the dead-letter queue, rather than the _error queue
     /// </summary>
     public class DeadLetterQueueExceptionFilter :
         IFilter<ExceptionReceiveContext>


### PR DESCRIPTION
Simple fix: 
> Moves a faulted message to the dead-letter queue, rather than the ~_skipped~ _error queue