### PR TITLE
Improve checkpoint concurrency for Riders

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/Contexts/ConsumerLockContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Contexts/ConsumerLockContext.cs
@@ -42,7 +42,7 @@ namespace MassTransit.KafkaIntegration.Contexts
 
             foreach (var partition in partitions)
             {
-                if (_data.TryAdd(partition.Partition, p => new PartitionCheckpointData(consumer, _timeout, _maxCount)))
+                if (_data.TryAdd(partition.Partition, p => new PartitionCheckpointData(partition, consumer, _timeout, _maxCount)))
                     LogContext.Info?.Log("Partition: {PartitionId} was assigned", partition);
             }
         }
@@ -62,59 +62,80 @@ namespace MassTransit.KafkaIntegration.Contexts
         sealed class PartitionCheckpointData
         {
             readonly IConsumer<TKey, TValue> _consumer;
-            readonly ushort _maxCount;
+            readonly object _lock;
+            readonly int _maxCount;
+            readonly TopicPartition _partition;
             readonly TimeSpan _timeout;
             readonly Stopwatch _timer;
-            ConsumeResult<TKey, TValue> _current;
+            bool _commitIsRequired;
+            Offset _offset;
             ushort _processed;
 
-            public PartitionCheckpointData(IConsumer<TKey, TValue> consumer, TimeSpan timeout, ushort maxCount)
+            public PartitionCheckpointData(TopicPartition partition, IConsumer<TKey, TValue> consumer, TimeSpan timeout, ushort maxCount)
             {
+                _partition = partition;
                 _consumer = consumer;
                 _timeout = timeout;
                 _maxCount = maxCount;
                 _processed = 0;
                 _timer = Stopwatch.StartNew();
+                _lock = new object();
+                _commitIsRequired = false;
             }
 
             public bool TryCheckpoint(ConsumeResult<TKey, TValue> result)
             {
                 void Reset()
                 {
-                    _current = default;
                     _processed = 0;
+                    _commitIsRequired = false;
                     _timer.Restart();
                 }
 
-                _current = result;
-                _processed += 1;
+                lock (_lock)
+                {
+                    if (_offset < result.Offset)
+                    {
+                        _offset = result.Offset;
+                        _commitIsRequired = true;
+                    }
 
-                if (_processed < _maxCount && _timer.Elapsed < _timeout)
-                    return false;
+                    _processed += 1;
 
-                LogContext.Debug?.Log("Partition: {PartitionId} updating checkpoint with offset: {Offset}", _current.Partition, _current.Offset);
-                _consumer.Commit(_current);
-                Reset();
-                return true;
+                    if (_processed < _maxCount && _timer.Elapsed < _timeout)
+                        return false;
+
+                    CommitIfRequired();
+                    Reset();
+                    return true;
+                }
             }
 
             public void Close(TopicPartitionOffset partition)
             {
                 try
                 {
-                    if (_current == default)
-                        return;
-
-                    LogContext.Debug?.Log("Partition: {PartitionId} updating checkpoint with offset: {Offset}", _current.Partition, _current.Offset);
-                    _consumer.Commit(_current);
+                    lock (_lock)
+                        CommitIfRequired();
                 }
                 finally
                 {
                     _timer.Stop();
-                    _current = null;
+                    _offset = default;
+                    _commitIsRequired = false;
 
                     LogContext.Info?.Log("Partition: {PartitionId} was closed", partition.TopicPartition);
                 }
+            }
+
+            void CommitIfRequired()
+            {
+                if (!_commitIsRequired)
+                    return;
+
+                var offset = _offset + 1;
+                LogContext.Debug?.Log("Partition: {PartitionId} updating checkpoint with offset: {Offset}", _partition, offset);
+                _consumer.Commit(new[] {new TopicPartitionOffset(_partition, offset)});
             }
         }
     }

--- a/tests/MassTransit.KafkaIntegration.Tests/Receive_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Receive_Specs.cs
@@ -5,14 +5,12 @@ namespace MassTransit.KafkaIntegration.Tests
     using System.Threading.Tasks;
     using Confluent.Kafka;
     using Context;
-    using GreenPipes.Internals.Extensions;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
     using Serializers;
     using TestFramework;
-    using Testing;
 
 
     public class Receive_Specs :
@@ -43,7 +41,6 @@ namespace MassTransit.KafkaIntegration.Tests
 
                         k.TopicEndpoint<KafkaMessage>(Topic, nameof(Receive_Specs), c =>
                         {
-                            c.AutoOffsetReset = AutoOffsetReset.Earliest;
                             c.ConfigureConsumer<KafkaMessageConsumer>(context);
                         });
                     });
@@ -76,6 +73,81 @@ namespace MassTransit.KafkaIntegration.Tests
                 };
 
                 await p.ProduceAsync(Topic, message);
+
+                ConsumeContext<KafkaMessage> result = await taskCompletionSource.Task;
+
+                Assert.AreEqual(message.Value.Text, result.Message.Text);
+                Assert.AreEqual(sendContext.MessageId, result.MessageId);
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+
+                Assert.That(await observer.Messages.Any<KafkaMessage>());
+            }
+            finally
+            {
+                await busControl.StopAsync(TestCancellationToken);
+
+                await provider.DisposeAsync();
+            }
+        }
+
+        [Test]
+        public async Task Should_receive_concurrently()
+        {
+            TaskCompletionSource<ConsumeContext<KafkaMessage>> taskCompletionSource = GetTask<ConsumeContext<KafkaMessage>>();
+            var services = new ServiceCollection();
+            services.AddSingleton(taskCompletionSource);
+
+            services.TryAddSingleton<ILoggerFactory>(LoggerFactory);
+            services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
+
+            services.AddMassTransit(x =>
+            {
+                x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+                x.AddRider(rider =>
+                {
+                    rider.AddConsumer<KafkaMessageConsumer>();
+
+                    rider.UsingKafka((context, k) =>
+                    {
+                        k.Host("localhost:9092");
+
+                        k.TopicEndpoint<KafkaMessage>(Topic, nameof(Receive_Specs), c =>
+                        {
+                            c.ConfigureConsumer<KafkaMessageConsumer>(context);
+
+                            c.CheckpointMessageCount = 10;
+                            c.ConcurrencyLimit = 100;
+                        });
+                    });
+                });
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            var busControl = provider.GetRequiredService<IBusControl>();
+
+            var observer = GetConsumeObserver();
+            busControl.ConnectConsumeObserver(observer);
+
+            await busControl.StartAsync(TestCancellationToken);
+
+            try
+            {
+                var config = new ProducerConfig {BootstrapServers = "localhost:9092"};
+
+                using IProducer<Null, KafkaMessage> p = new ProducerBuilder<Null, KafkaMessage>(config)
+                    .SetValueSerializer(new MassTransitJsonSerializer<KafkaMessage>())
+                    .Build();
+
+                var kafkaMessage = new KafkaMessageClass("test");
+                var sendContext = new MessageSendContext<KafkaMessage>(kafkaMessage);
+                var message = new Message<Null, KafkaMessage>
+                {
+                    Value = kafkaMessage,
+                    Headers = DictionaryHeadersSerialize.Serializer.Serialize(sendContext)
+                };
+
+                await Task.WhenAll(Enumerable.Range(0, 100).Select(x => p.ProduceAsync(Topic, message)));
 
                 ConsumeContext<KafkaMessage> result = await taskCompletionSource.Task;
 


### PR DESCRIPTION
Improve riders checkpoint concurrency:

- Always use highest offset
- Do not commit if higher offset has been already committed

Related to: https://github.com/MassTransit/MassTransit/issues/2296