### PR TITLE
Fix broken relative reference

### DIFF
--- a/docs/advanced/topology/rabbitmq.md
+++ b/docs/advanced/topology/rabbitmq.md
@@ -243,5 +243,5 @@ The exchanges and queues for the send example are shown.
 
 ![rabbitmq-send-topology](/rabbitmq-send-topology.png)
 
-> Note that the broker topology can now be configured using the [topology](../advanced/topology/README.md) API.
+> Note that the broker topology can now be configured using the [topology](../topology/README.md) API.
 


### PR DESCRIPTION
To verify that the fix was applied correctly I built the VuePress project locally. I navigated to the fixed [rabbitmq.html#broker-topology](http://localhost:8080/advanced/topology/rabbitmq.html#broker-topology) page and I clicked on the link to confirm that it actually referred to the [topology](http://localhost:8080/advanced/topology/) page .

![image](https://user-images.githubusercontent.com/74075390/107155602-9a8fb280-6979-11eb-8e29-aa1616392618.png)
