### PR TITLE
Azure blob

### DIFF
--- a/src/Persistence/MassTransit.Azure.Storage/Configuration/AzureStorageConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.Azure.Storage/Configuration/AzureStorageConfigurationExtensions.cs
@@ -3,6 +3,7 @@ namespace MassTransit.Azure.Storage
     using MessageData;
     using global::Azure.Storage.Blobs;
 
+
     public static class AzureStorageConfigurationExtensions
     {
         public static AzureStorageMessageDataRepository CreateMessageDataRepository(this BlobServiceClient account, string containerName)

--- a/src/Persistence/MassTransit.Azure.Storage/Configuration/AzureStorageConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.Azure.Storage/Configuration/AzureStorageConfigurationExtensions.cs
@@ -1,14 +1,13 @@
 namespace MassTransit.Azure.Storage
 {
     using MessageData;
-    using Microsoft.Azure.Storage;
-
+    using global::Azure.Storage.Blobs;
 
     public static class AzureStorageConfigurationExtensions
     {
-        public static AzureStorageMessageDataRepository CreateMessageDataRepository(this CloudStorageAccount account, string containerName)
+        public static AzureStorageMessageDataRepository CreateMessageDataRepository(this BlobServiceClient account, string containerName)
         {
-            return new AzureStorageMessageDataRepository(account.BlobEndpoint, containerName, account.Credentials, new NewIdBlobNameGenerator());
+            return new AzureStorageMessageDataRepository(account, containerName, new NewIdBlobNameGenerator());
         }
     }
 }

--- a/src/Persistence/MassTransit.Azure.Storage/MassTransit.Azure.Storage.csproj
+++ b/src/Persistence/MassTransit.Azure.Storage/MassTransit.Azure.Storage.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>

--- a/src/Persistence/MassTransit.Azure.Storage/MassTransit.Azure.Storage.csproj
+++ b/src/Persistence/MassTransit.Azure.Storage/MassTransit.Azure.Storage.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />

--- a/src/Persistence/MassTransit.Azure.Storage/MessageData/AzureStorageMessageDataRepository.cs
+++ b/src/Persistence/MassTransit.Azure.Storage/MessageData/AzureStorageMessageDataRepository.cs
@@ -11,6 +11,7 @@ namespace MassTransit.Azure.Storage.MessageData
     using global::Azure.Identity;
     using global::Azure.Storage;
     using global::Azure.Storage.Blobs;
+    using global::Azure.Storage.Blobs.Models;
     using Util;
 
 

--- a/src/Persistence/MassTransit.Azure.Storage/MessageData/AzureStorageMessageDataRepository.cs
+++ b/src/Persistence/MassTransit.Azure.Storage/MessageData/AzureStorageMessageDataRepository.cs
@@ -8,9 +8,11 @@ namespace MassTransit.Azure.Storage.MessageData
     using Context;
     using MassTransit.MessageData;
     using global::Azure;
+    using global::Azure.Identity;
+    using global::Azure.Storage;
     using global::Azure.Storage.Blobs;
-    using global::Azure.Storage.Blobs.Models;
     using Util;
+
 
     public class AzureStorageMessageDataRepository :
         IMessageDataRepository,
@@ -18,6 +20,31 @@ namespace MassTransit.Azure.Storage.MessageData
     {
         private readonly BlobContainerClient _container;
         readonly IBlobNameGenerator _nameGenerator;
+
+        public AzureStorageMessageDataRepository(string connectionString, string containerName)
+            : this(new BlobServiceClient(connectionString), containerName)
+        {
+        }
+
+        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string accountName, string accountKey)
+            : this(new BlobServiceClient(serviceUri, new StorageSharedKeyCredential(accountName, accountKey)), containerName)
+        {
+        }
+
+        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string signature)
+            : this(new BlobServiceClient(serviceUri, new AzureSasCredential(signature)), containerName)
+        {
+        }
+
+        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string tenantId, string clientId, string clientSecret)
+            : this(new BlobServiceClient(serviceUri, new ClientSecretCredential(tenantId, clientId, clientSecret)), containerName)
+        {
+        }
+
+        public AzureStorageMessageDataRepository(BlobServiceClient blobServiceClient, string containerName)
+            : this(blobServiceClient, containerName, new NewIdBlobNameGenerator())
+        {
+        }
 
         public AzureStorageMessageDataRepository(BlobServiceClient blobServiceClient, string containerName, IBlobNameGenerator nameGenerator)
         {

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
@@ -2,7 +2,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Storage;
+    using Azure.Storage.Blobs;
     using NUnit.Framework;
     using Storage;
     using Storage.MessageData;
@@ -38,7 +38,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
         public Sending_a_message_with_data()
         {
-            var account = CloudStorageAccount.Parse(Configuration.StorageAccount);
+            var account = new BlobServiceClient(Configuration.StorageAccount);
             _repository = account.CreateMessageDataRepository("message-data");
         }
 

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
@@ -2,7 +2,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 {
     using System;
     using System.Threading.Tasks;
-    using Azure.Storage.Blobs;
+    using global::Azure.Storage.Blobs;
     using NUnit.Framework;
     using Storage;
     using Storage.MessageData;


### PR DESCRIPTION
The scope of this PR is to update MassTransit.Azure.Storage to remove the dependency on the deprecated package `Microsoft.Azure.Storage` with its replacement `Azure.Storage.Blobs`.

This resulted in the following high level changes:
- The extension method `CreateMessageDataRepository` now extends the class `BlobServiceClient`. Existing consumers of this MassTransit library will need refactor their code to reference this type
- The `BlobServiceClient` instance is responsible for identifying the storage container and applying the necessary credentials; there are several overloads available to allow for flexibility in specifying the container, connection string, credentials and so on
- `Get` behaves slightly differently to my knowledge. It parses the URI in the message (to resolve the blob name) however it assumes that the storage container is shared between sender and consumer; I think in the current version this is not required (assuming the connection string/credentials provide access). I don't know if that's an issue however - I essentially did this because I can't see a way of instantiating a blob object using the credentials in `BlobServiceClient` directly via the URI.

Lastly I noticed that I had to set `MessageDataDefaults.Threshold = 0;` in the integration test in order to validate `Put` _and_ `Get`; otherwise `Get` isn't invoked. I didn't commit this yet because this value is static and I wasn't sure how it would affect other tests.

If this approach is on track I'll also update the documentation to reflect these changes.