### PR TITLE
Consume filters cannot pass customer CancellationTokens to consumers when using DI

### DIFF
--- a/tests/MassTransit.Containers.Tests/Scenarios/SimpleConsumer.cs
+++ b/tests/MassTransit.Containers.Tests/Scenarios/SimpleConsumer.cs
@@ -43,21 +43,25 @@ namespace MassTransit.Containers.Tests.Scenarios
         static readonly TaskCompletionSource<SimplerConsumer> _consumerCreated = TaskUtil.GetTask<SimplerConsumer>();
 
         readonly TaskCompletionSource<SimpleMessageInterface> _received;
+        readonly TaskCompletionSource<ConsumeContext<SimpleMessageInterface>> _receivedConsumeContext;
 
         public SimplerConsumer()
         {
             _received = TaskUtil.GetTask<SimpleMessageInterface>();
+            _receivedConsumeContext = TaskUtil.GetTask<ConsumeContext<SimpleMessageInterface>>();
 
             _consumerCreated.TrySetResult(this);
         }
 
         public Task<SimpleMessageInterface> Last => _received.Task;
+        public Task<ConsumeContext<SimpleMessageInterface>> LastContext => _receivedConsumeContext.Task;
 
         public static Task<SimplerConsumer> LastConsumer => _consumerCreated.Task;
 
         public async Task Consume(ConsumeContext<SimpleMessageInterface> message)
         {
             _received.TrySetResult(message.Message);
+            _receivedConsumeContext.TrySetResult(message);
         }
     }
 }


### PR DESCRIPTION
As discussed in [Discord](https://discord.com/channels/682238261753675864/682238261753675868/824696138241409085), it seems that if I try to pass a cancelled CancellationToken to a consumer via a consume filter, it doesn't work when using the Microsoft DI container.

While writing this test, I tried to make the test more general by making a new context and adding a new payload, but the new payload _did_ always show up in the consumer. I'm not sure if I misunderstand payloads or if this problem is specific to the CancellationToken.

This PR contains a failing test. I did my best to follow the existing testing pattern, but I'm sure I did a few things "wrong" here.

<details>
<summary>Sample code demonstrating the issue</summary>

```
#define USE_DI

// When the consumer receives this token, it is not cancelled.
// Comment the #define above to use non-container configuration,
// and the consumer will receive a cancelled token instead.

using System.Threading;
using System.Threading.Tasks;
using GreenPipes;
using MassTransit;
using MassTransit.Context;
using Microsoft.AspNetCore.Hosting;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Hosting;
using Microsoft.Extensions.Logging;
using Newtonsoft.Json;

namespace masstransit_cancel_context
{
    public class Program
    {
        public static void Main(string[] args) =>
            CreateHostBuilder(args).Build().Run();

        public static IHostBuilder CreateHostBuilder(string[] args) =>
            Host.CreateDefaultBuilder(args)
                .ConfigureServices((hostContext, services) =>
                {
#if USE_DI
                    services.AddMassTransitHostedService();
                    services.AddMassTransit(x =>
                    {
                        x.AddConsumer<MyConsumer>();
                        x.UsingInMemory((context, cfg) =>
                        {
                            cfg.ReceiveEndpoint("MyConsumer", e =>
                            {
                                e.UseConsumeFilter(typeof(CancellationFilter<>), context);
                                e.ConfigureConsumer<MyConsumer>(context);
                                e.DiscardSkippedMessages();
                                e.DiscardFaultedMessages();
                            });
                        });
                    })
#else
                    services.AddHostedService<LonelyBusService>();
                    services.AddSingleton<IBusControl>(Bus.Factory.CreateUsingInMemory(c =>
                    {
                        c.ReceiveEndpoint("MyConsumer", e =>
                        {
                            e.UseFilter(new CancellationFilter<MyMessage>());
                            e.Consumer<MyConsumer>();
                            e.DiscardSkippedMessages();
                            e.DiscardFaultedMessages();
                        });
                    }));
#endif
                    ;

                    services.AddHostedService<SendMessages>();
                });
    }

    public class LonelyBusService : IHostedService
    {
        private IBusControl bus;

        public LonelyBusService(IBusControl bus)
        {
            this.bus = bus;
        }

        public async Task StartAsync(CancellationToken cancellationToken)
        {
            await this.bus.StartAsync();
        }

        public async Task StopAsync(CancellationToken cancellationToken)
        {
            await this.bus.StopAsync();
        }
    }

    public interface MyMessage { }

    public class MyConsumer : IConsumer<MyMessage>
    {
#if USE_DI
        private ILogger<MyConsumer> log;
        public MyConsumer(ILogger<MyConsumer> log) => this.log = log;
#endif
        public Task Consume(ConsumeContext<MyMessage> context)
        {
            // When this logs, the token is not cancelled, but it should be because
            // the filter should have passed a CancellationContext to this consumer
#if USE_DI
            log.LogInformation("Consumer Cancelled = {Cancelled}", context.CancellationToken.IsCancellationRequested);
#endif
            return Task.CompletedTask;
        }
    }

    /// <summary>
    /// Supposed to replace the context's CancellationToken with one that is already cancelled.
    /// </summary>
    public class CancellationFilter<T> : IFilter<ConsumeContext<T>> where T : class
    {
#if USE_DI
        private readonly ILogger<CancellationFilter<T>> log;
        public CancellationFilter(ILogger<CancellationFilter<T>> log) => this.log = log;
#endif
        public void Probe(ProbeContext context) => context.CreateFilterScope("cancellationFilter");
        public async Task Send(ConsumeContext<T> context, IPipe<ConsumeContext<T>> next)
        {
            using (var cts = new CancellationTokenSource())
            {
                cts.Cancel();
                var newContext = new CancellableContext(context, cts.Token);

                // prove that this context's CancellationToken is already cancelled
#if USE_DI
                log.LogInformation("CancellationFilter Cancelled = {IsCancellationRequested}", newContext.CancellationToken.IsCancellationRequested);
#endif

                // send the context with the cancelled token to the consumer
                await next.Send(newContext);
            }
        }

        /// <summary>
        /// Replaces just the CancellationToken
        /// </summary>
        class CancellableContext : ConsumeContextProxy<T>
        {
            public override CancellationToken CancellationToken { get; }
            public CancellableContext(ConsumeContext<T> context, CancellationToken cancelProcessing) : base(context)
            {
                CancellationToken = cancelProcessing;
            }
        }
    }

    /// <summary>
    /// Publishes a message every second so watching the logs demonstrates the
    /// problem.
    /// </summary>
    public class SendMessages : BackgroundService
    {
        private readonly ILogger<SendMessages> log;
        private IBus bus;
        public SendMessages(ILogger<SendMessages> log, IBusControl bus)
        {
            this.log = log;
            this.bus = bus;
        }
        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
        {
            //while (!stoppingToken.IsCancellationRequested)
            {
                var result = bus.GetProbeResult();
                log.LogInformation("Probe: {0}", JsonConvert.SerializeObject(result, Formatting.Indented));
                await bus.Publish<MyMessage>(new { });
                await Task.Delay(1000);
            }
        }
    }
}
```

</details>