### PR TITLE
Add service distribution support (unfinished)

### DIFF
--- a/src/MassTransit/Conductor/Client/IServiceClientMessageCache.cs
+++ b/src/MassTransit/Conductor/Client/IServiceClientMessageCache.cs
@@ -1,9 +1,11 @@
 namespace MassTransit.Conductor.Client
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Clients;
+    using Contexts;
 
 
     /// <summary>
@@ -15,6 +17,9 @@ namespace MassTransit.Conductor.Client
         where TMessage : class
     {
         Task<IRequestSendEndpoint<TMessage>> GetServiceSendEndpoint(ClientFactoryContext clientFactoryContext, TMessage message,
+            ConsumeContext consumeContext = default, CancellationToken cancellationToken = default);
+
+        Task<IRequestSendEndpoint<TMessage>> GetServiceSendEndpoint(ClientFactoryContext clientFactoryContext, object values,
             ConsumeContext consumeContext = default, CancellationToken cancellationToken = default);
     }
 

--- a/src/MassTransit/Conductor/Client/IServiceInstanceCache.cs
+++ b/src/MassTransit/Conductor/Client/IServiceInstanceCache.cs
@@ -10,7 +10,7 @@ namespace MassTransit.Conductor.Client
     public interface IServiceInstanceCache :
         IConnectCacheValueObserver<ServiceInstanceContext>
     {
-        Task<ServiceInstanceContext> GetOrAdd(Guid instanceId, InstanceInfo instance = default);
+        Task<ServiceInstanceContext> GetOrAdd(Guid instanceId, Uri instanceServiceEndpoint, InstanceInfo instance = default);
 
         void Remove(Guid instanceId);
     }

--- a/src/MassTransit/Conductor/Client/ServiceClientRequestSendEndpoint.cs
+++ b/src/MassTransit/Conductor/Client/ServiceClientRequestSendEndpoint.cs
@@ -36,7 +36,7 @@ namespace MassTransit.Conductor.Client
                 : await _messageClient.OrCanceled(cancellationToken).ConfigureAwait(false);
 
             IRequestSendEndpoint<TMessage> sendEndpoint = await messageClient
-                .GetServiceSendEndpoint(_clientFactoryContext, default, _consumeContext, cancellationToken)
+                .GetServiceSendEndpoint(_clientFactoryContext, values, _consumeContext, cancellationToken)
                 .ConfigureAwait(false);
 
             // TODO need to add ServiceInstanceContext at some point...

--- a/src/MassTransit/Conductor/Contexts/ServiceInstanceContext.cs
+++ b/src/MassTransit/Conductor/Contexts/ServiceInstanceContext.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Conductor.Contexts
 {
     using System;
+    using System.Collections.Generic;
     using GreenPipes;
 
 
@@ -15,6 +16,16 @@ namespace MassTransit.Conductor.Contexts
         /// Unique identifier for the service instance
         /// </summary>
         Guid InstanceId { get; }
+
+        /// <summary>
+        /// User defined attributes of the service instance
+        /// </summary>
+        IReadOnlyDictionary<string, string> InstanceAttributes { get; }
+
+        /// <summary>
+        /// Endpoint uri of the service instance
+        /// </summary>
+        Uri Endpoint { get; }
 
         /// <summary>
         /// The instance start timestamp

--- a/src/MassTransit/Conductor/Distribution/ConsistentHashDistributionStrategy.cs
+++ b/src/MassTransit/Conductor/Distribution/ConsistentHashDistributionStrategy.cs
@@ -4,10 +4,10 @@ namespace MassTransit.Conductor.Distribution
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
-
+    using System.Threading.Tasks;
 
     public class ConsistentHashDistributionStrategy<T> :
-        IDistributionStrategy<T>
+        IDistributionStrategy<T, object>
         where T : class
     {
         const byte DefaultReplicationCount = 160;
@@ -93,9 +93,14 @@ namespace MassTransit.Conductor.Distribution
             }
         }
 
-        public T GetNode(byte[] data)
+        public virtual Task<T> GetNode(object message)
         {
-            return GetNode((int)_hashGenerator.Hash(data));
+            throw new NotImplementedException();
+
+            // TODO use the message to generate the hash key
+            // var correlationId = NewId.NextGuid();
+
+            // return Task.FromResult(GetNode((int)_hashGenerator.Hash(correlationId.ToByteArray())));
         }
 
         Lazy<int[]> RebuildKeyCache()
@@ -158,6 +163,11 @@ namespace MassTransit.Conductor.Distribution
                 throw new Exception("Something went seriously wrong here");
 
             return end;
+        }
+
+        public virtual Task<IEnumerable<T>> GetAvailableNodes()
+        {
+            return Task.FromResult<IEnumerable<T>>(_circle.Values);
         }
     }
 }

--- a/src/MassTransit/Conductor/Distribution/RoundRobinDistributionStrategy.cs
+++ b/src/MassTransit/Conductor/Distribution/RoundRobinDistributionStrategy.cs
@@ -1,0 +1,28 @@
+﻿namespace MassTransit.Conductor.Distribution
+{
+    using System.Threading.Tasks;
+    using Contexts;
+
+    public class RoundRobinDistributionStrategy : ServiceDistributionStrategy<object>
+    {
+        private int _currentIndex = 0;
+        private object lockObject;
+
+        public override Task<ServiceInstanceContext> GetNode(object message)
+        {
+            if (ServiceInstances.Count == 0)
+            {
+                return Task.FromResult<ServiceInstanceContext>(null);
+            }
+
+            int index;
+            lock (lockObject)
+            {
+                _currentIndex = (_currentIndex + 1) % ServiceInstances.Count;
+                index = _currentIndex;
+            }
+
+            return Task.FromResult(ServiceInstances[index]);
+        }
+    }
+}

--- a/src/MassTransit/Conductor/Distribution/ServiceDistributionStrategy.cs
+++ b/src/MassTransit/Conductor/Distribution/ServiceDistributionStrategy.cs
@@ -1,0 +1,48 @@
+﻿namespace MassTransit.Conductor.Distribution
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Contexts;
+
+    public abstract class ServiceDistributionStrategy<TMessage> : IDistributionStrategy<ServiceInstanceContext, TMessage>
+    {
+        private readonly List<ServiceInstanceContext> _serviceInstances;
+
+        public List<ServiceInstanceContext> ServiceInstances { get => _serviceInstances; }
+
+        public ServiceDistributionStrategy()
+        {
+
+        }
+
+        public void Add(ServiceInstanceContext node)
+        {
+            _serviceInstances.Add(node);
+        }
+
+        /// <summary>
+        /// Use this method to select a node to send the message to.
+        /// The property <see cref="ServiceInstances"/> contains all discovered instances.
+        /// Return null if no node is available.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public abstract Task<ServiceInstanceContext> GetNode(TMessage message);
+
+        public virtual Task<IEnumerable<ServiceInstanceContext>> GetAvailableNodes()
+        {
+            // all nodes are available by default
+            return Task.FromResult<IEnumerable<ServiceInstanceContext>>(ServiceInstances);
+        }
+
+        public void Init(IEnumerable<ServiceInstanceContext> nodes)
+        {
+            _serviceInstances.AddRange(nodes);
+        }
+
+        public void Remove(ServiceInstanceContext node)
+        {
+            _serviceInstances.Remove(node);
+        }
+    }
+}

--- a/src/MassTransit/Conductor/IDistributionStrategy.cs
+++ b/src/MassTransit/Conductor/IDistributionStrategy.cs
@@ -1,13 +1,15 @@
 ﻿namespace MassTransit.Conductor
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
 
     /// <summary>
     /// A distribution strategy is used to distribute messages across a set of nodes
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface IDistributionStrategy<T>
+    /// <typeparam name="TSelector"></typeparam>
+    public interface IDistributionStrategy<T, in TSelector>
     {
         /// <summary>
         /// Adds a range of nodes to the distribution pool
@@ -28,10 +30,15 @@
         void Remove(T node);
 
         /// <summary>
-        /// Returns the node for the given data block
+        /// Returns the node for the given selector
         /// </summary>
-        /// <param name="data">The data block used to select the node</param>
-        /// <returns>The element for the specified data block</returns>
-        T GetNode(byte[] data);
+        /// <param name="data">The data used to select the node</param>
+        /// <returns>The element for the specified selector</returns>
+        Task<T> GetNode(TSelector data);
+
+        /// <summary>
+        /// Returns all nodes that are available and ready to recieve jobs
+        /// </summary>
+        Task<IEnumerable<T>> GetAvailableNodes();
     }
 }

--- a/src/MassTransit/Conductor/Server/IServiceInstance.cs
+++ b/src/MassTransit/Conductor/Server/IServiceInstance.cs
@@ -1,12 +1,13 @@
 namespace MassTransit.Conductor.Server
 {
     using System;
-
+    using System.Collections.Generic;
 
     public interface IServiceInstance
     {
         Guid InstanceId { get; }
         string InstanceName { get; }
+        IReadOnlyDictionary<string, string> InstanceAttributes { get; }
 
         IServiceEndpoint CreateServiceEndpoint(IReceiveEndpointConfigurator configurator);
     }

--- a/src/MassTransit/Conductor/Server/ServiceEndpoint.cs
+++ b/src/MassTransit/Conductor/Server/ServiceEndpoint.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Conductor.Server
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Context;
     using Contexts;
@@ -73,7 +74,7 @@ namespace MassTransit.Conductor.Server
             var serviceInfo = new ServiceEndpointServiceInfo(_serviceAddress.Value);
             _serviceInfo.TrySetResult(serviceInfo);
 
-            var instanceInfo = new ServiceEndpointInstanceInfo(_instance.InstanceId, Started);
+            var instanceInfo = new ServiceEndpointInstanceInfo(_instance.InstanceId, _instance.InstanceAttributes, Started);
             _instanceInfo.TrySetResult(instanceInfo);
 
             try
@@ -161,13 +162,16 @@ namespace MassTransit.Conductor.Server
         class ServiceEndpointInstanceInfo :
             InstanceInfo
         {
-            public ServiceEndpointInstanceInfo(Guid instanceId, DateTime? started)
+            public ServiceEndpointInstanceInfo(Guid instanceId, IReadOnlyDictionary<string, string> instanceAttributes, DateTime? started)
             {
                 InstanceId = instanceId;
+                InstanceAttributes = instanceAttributes;
                 Started = started;
             }
 
             public Guid InstanceId { get; }
+
+            public IReadOnlyDictionary<string, string> InstanceAttributes { get; }
 
             public DateTime? Started { get; }
         }

--- a/src/MassTransit/Conductor/Server/ServiceInstance.cs
+++ b/src/MassTransit/Conductor/Server/ServiceInstance.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Conductor.Server
 {
     using System;
+    using System.Collections.Generic;
     using Util;
 
 
@@ -9,18 +10,20 @@ namespace MassTransit.Conductor.Server
     {
         readonly IServiceInstanceClientCache _clientCache;
 
-        public ServiceInstance()
+        public ServiceInstance(IReadOnlyDictionary<string, string> instanceAttributes)
         {
             var instanceId = NewId.Next();
 
             InstanceId = instanceId.ToGuid();
             InstanceName = instanceId.ToString(FormatUtil.Formatter);
+            InstanceAttributes = instanceAttributes;
 
             _clientCache = new ServiceInstanceClientCache();
         }
 
         public Guid InstanceId { get; }
         public string InstanceName { get; }
+        public IReadOnlyDictionary<string, string> InstanceAttributes { get; }
 
         public IServiceEndpoint CreateServiceEndpoint(IReceiveEndpointConfigurator configurator)
         {

--- a/src/MassTransit/Conductor/ServiceInstanceOptions.cs
+++ b/src/MassTransit/Conductor/ServiceInstanceOptions.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Conductor
 {
     using System;
+    using System.Collections.Generic;
     using Configuration;
     using JobService;
     using MassTransit.Definition;
@@ -12,11 +13,15 @@ namespace MassTransit.Conductor
         public ServiceInstanceOptions()
         {
             EndpointNameFormatter = DefaultEndpointNameFormatter.Instance;
+            _instanceAttributes = new Dictionary<string, string>();
         }
 
         public bool InstanceEndpointEnabled { get; private set; }
         public bool InstanceServiceEndpointEnabled { get; private set; }
         public IEndpointNameFormatter EndpointNameFormatter { get; private set; }
+        public IReadOnlyDictionary<string, string> InstanceAttributes { get => _instanceAttributes; }
+
+        private readonly Dictionary<string, string> _instanceAttributes;
 
         /// <summary>
         /// Create a single instance-specific control endpoint. By default, each service endpoint has
@@ -57,6 +62,16 @@ namespace MassTransit.Conductor
         public ServiceInstanceOptions SetEndpointNameFormatter(IEndpointNameFormatter endpointNameFormatter)
         {
             EndpointNameFormatter = endpointNameFormatter;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Add an instance attribute which can be used for routing using a ServiceDistributionStrategy.
+        /// </summary>
+        public ServiceInstanceOptions AddInstanceAttribute(string key, string value)
+        {
+            _instanceAttributes.Add(key, value);
 
             return this;
         }

--- a/src/MassTransit/ConductorConfigurationExtensions.cs
+++ b/src/MassTransit/ConductorConfigurationExtensions.cs
@@ -37,7 +37,7 @@ namespace MassTransit
         {
             IServiceInstanceTransportConfigurator<TEndpointConfigurator> transportConfigurator = Cached<TEndpointConfigurator>.Instance;
 
-            var instance = new ServiceInstance();
+            var instance = new ServiceInstance(options.InstanceAttributes);
 
             if (options.InstanceEndpointEnabled)
             {

--- a/tests/MassTransit.Tests/Conductor/Hash_Specs.cs
+++ b/tests/MassTransit.Tests/Conductor/Hash_Specs.cs
@@ -3,6 +3,7 @@ namespace MassTransit.Tests.Conductor
     using System;
     using System.Linq;
     using System.Text;
+    using System.Threading.Tasks;
     using Contracts.Conductor;
     using MassTransit.Conductor.Distribution;
     using NUnit.Framework;
@@ -12,7 +13,7 @@ namespace MassTransit.Tests.Conductor
     public class An_empty_hash
     {
         [Test]
-        public void Should_initialize_with_the_same_results()
+        public async Task Should_initialize_with_the_same_results()
         {
             InstanceInfo nodeA = new Node {InstanceId = NewId.NextGuid()};
             InstanceInfo nodeB = new Node {InstanceId = NewId.NextGuid()};
@@ -41,18 +42,18 @@ namespace MassTransit.Tests.Conductor
 
             byte[] key = NewId.NextGuid().ToByteArray();
 
-            var resultA = serverA.GetNode(key);
-            var resultB = serverB.GetNode(key);
-            var resultC = serverC.GetNode(key);
+            var resultA = await serverA.GetNode(key);
+            var resultB = await serverB.GetNode(key);
+            var resultC = await serverC.GetNode(key);
 
             Assert.That(resultA.InstanceId, Is.EqualTo(resultB.InstanceId));
             Assert.That(resultA.InstanceId, Is.EqualTo(resultC.InstanceId));
 
             key = Guid.NewGuid().ToByteArray();
 
-            resultA = serverA.GetNode(key);
-            resultB = serverB.GetNode(key);
-            resultC = serverC.GetNode(key);
+            resultA = await serverA.GetNode(key);
+            resultB = await serverB.GetNode(key);
+            resultC = await serverC.GetNode(key);
 
             Assert.That(resultA.InstanceId, Is.EqualTo(resultB.InstanceId));
             Assert.That(resultA.InstanceId, Is.EqualTo(resultC.InstanceId));


### PR DESCRIPTION
Hi,
this PR intends to add a way for the user to select which service instances recieve which messages.

For example, if the user only wants a message to be sent to service instances within the same region, he would now be able to implement this.
This is useful for example in video encoding because you dont want videos to be encoded and stored in the wrong region. 
```csharp
public class RoundRobinDistributionStrategy : ServiceDistributionStrategy<VideoEncodingCommand>
{
    public override async Task<ServiceInstanceContext> GetNode(VideoEncodingCommand message)
    {
        return ServiceInstances
            .Where(x => x.InstanceAttributes["region"] == message.DestinationRegion)
            .FirstOrDefault();
    }
}
```

There are more complex examples for example round robin distribution:
```csharp
public class RoundRobinDistributionStrategy : ServiceDistributionStrategy<object>
{
    private int _currentIndex = 0;
    private object lockObject;

    public override Task<ServiceInstanceContext> GetNode(object message)
    {
        if (ServiceInstances.Count == 0)
        {
            return Task.FromResult<ServiceInstanceContext>(null);
        }

        int index;
        lock (lockObject)
        {
            _currentIndex = (_currentIndex + 1) % ServiceInstances.Count;
            index = _currentIndex;
        }

        return Task.FromResult(ServiceInstances[index]);
    }
}
```
The PR only contains only the unfinished core concept and i dont know how to proceed because i dont really know much about the architecture of MassTransit, especially the configuration side, for example how the `ServiceClientMessageCache` can get the corresponding `DistributionStrategy`. And also i dont know how to make this compatible with the `object values` overload.

What do you think about this? Thanks in advance :)
