### PR TITLE
Prometheus Docs Tweak

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build and Deploy
     runs-on: ubuntu-latest
+    if: (github.ref == 'refs/heads/develop') && github.repository == 'MassTransit/MassTransit'
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -29,7 +30,7 @@ jobs:
           git fetch https://github.com/MassTransit/masstransit.github.io.git
           git checkout 220443cd2ab45d486fcee10a65669aff0bda31ab
           git checkout -b master
-          git add . 
+          git add .
           git commit -am "Deploy Documentation"
           git push --force --set-upstream https://${{secrets.PHATBOYG_PAT}}:x-oauth-basic@github.com/MassTransit/masstransit.github.io.git master
 


### PR DESCRIPTION
This PR adds a few more helpful comments around the prometheus docs, and it also prevents the doc build from running unless this is the MassTransit/MassTransit repo and its the `develop` branch.