### PR TITLE
Scoped Filters example won't compile

### DIFF
--- a/docs/advanced/middleware/scoped.md
+++ b/docs/advanced/middleware/scoped.md
@@ -151,7 +151,7 @@ public class Startup
                 cfg.ReceiveEndpoint("input-queue", e =>
                 {
                     e.UseConsumeFilter(typeof(MyConsumeFilter<>), context);
-                    e.ConfigureConsumer<MyConsumer>();
+                    e.ConfigureConsumer<MyConsumer>(context);
                 });
             });
         });
@@ -175,7 +175,7 @@ The updated receive endpoint configuration using the InMemoryOutbox is shown bel
                     e.UseInMemoryOutbox();
 
                     e.UseConsumeFilter(typeof(MyConsumeFilter<>), context);
-                    e.ConfigureConsumer<MyConsumer>();
+                    e.ConfigureConsumer<MyConsumer>(context);
                 });
 ```
 


### PR DESCRIPTION
When trying the example code on the Scoped Filters page, I noticed the compiler complaining that `ConfigureConsumer` calls need an `IRegistration` instance. I fixed it by passing the existing `context`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
