### PR TITLE
Correction to MySqlLockStatementProvider

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MySqlLockStatementProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MySqlLockStatementProvider.cs
@@ -3,11 +3,10 @@
     public class MySqlLockStatementProvider :
         SqlLockStatementProvider
     {
-        const string DefaultSchemaName = "public";
-        const string DefaultRowLockStatement = "SELECT * FROM {1} WHERE {2} = \"@p0\" FOR UPDATE";
+        const string DefaultRowLockStatement = "SELECT * FROM `{1}` WHERE `{2}` = @p0 FOR UPDATE";
 
         public MySqlLockStatementProvider(bool enableSchemaCaching = true)
-            : base(DefaultSchemaName, DefaultRowLockStatement, enableSchemaCaching)
+            : base(string.Empty, DefaultRowLockStatement, enableSchemaCaching)
         {
         }
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

While implementing a requirement at work, using state machines and integrating with MySQL through EF Core, I did not get the expected behaviour. I investigated the problem and concluded that it was due to the SQL locking statement. It is being assumed that the `CorrelationId` is a string type, which obviously may not be true.

I tested out the integration with 3 databases (SQL Server, MySQL, PostgreSQL), with the default entity's configuration, and the comparison between all of them shows they work **perfectly** with the `SqlServerLockStatementProvider `, `PostgresLockStatementProvider` and the **changed version** of `MySqlLockStatementProvider`, but not with the original statement. Check [testing source code](https://github.com/tgdraugr/StateMachinesTesting). I used the "most common" MySQL providers listed [here](https://docs.microsoft.com/en-us/ef/core/providers/?tabs=dotnet-core-cli), except for Devart, which is paid.

I'll leave some images of the test results 😎

### Using Pomelo Foundation's library, with the current MySQL lock statement
![image](https://user-images.githubusercontent.com/20600912/117071363-eeb2f480-ad26-11eb-93b9-7a686a1b5ea7.png)

### Using Pomelo Foundation's library, with the new/changed MySQL lock statement
![image](https://user-images.githubusercontent.com/20600912/117071980-b65fe600-ad27-11eb-8c37-e66a582c5acc.png)

### Using Oracle's library, with the current MySQL lock statement
![image](https://user-images.githubusercontent.com/20600912/117072086-dc858600-ad27-11eb-9c48-ee8c60b440fa.png)

### Using Oracle's library, with the new/changed MySQL lock statement
![image](https://user-images.githubusercontent.com/20600912/117072214-0343bc80-ad28-11eb-9e8b-f794b1a56712.png)

Thanks 👍 