### PR TITLE
Move AddConsumer call into AddMassTransit in scoped.md

### DIFF
--- a/docs/advanced/middleware/scoped.md
+++ b/docs/advanced/middleware/scoped.md
@@ -140,10 +140,10 @@ public class Startup
     {
         services.AddScoped<MyDependency>();
 
-        services.AddConsumer<MyConsumer>();
-
         services.AddMassTransit(x =>
         {
+            x.AddConsumer<MyConsumer>();
+
             x.UsingRabbitMq((context, cfg) =>
             {
                 cfg.UseSendFilter(typeof(MySendFilter<>), context);


### PR DESCRIPTION
The AddConsumer extension method doesn't exist for `IServiceCollection`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
