### PR TITLE
Decode RabbitMQ username and password before passing to RabbitMQ Client

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -153,15 +153,20 @@ namespace MassTransit.RabbitMqTransport
             if (!string.IsNullOrEmpty(address.UserInfo))
             {
                 var parts = address.UserInfo.Split(':');
-                hostSettings.Username = parts[0];
+                hostSettings.Username = UriDecode(parts[0]);
 
                 if (parts.Length >= 2)
-                    hostSettings.Password = parts[1];
+                    hostSettings.Password = UriDecode(parts[1]);
             }
 
             hostSettings.Heartbeat = TimeSpan.FromSeconds(hostAddress.Heartbeat ?? (ushort)0);
 
             return hostSettings;
+        }
+
+        private static string UriDecode(string uri)
+        {
+            return System.Uri.UnescapeDataString(uri.Replace("+", "%2B"));
         }
     }
 }

--- a/tests/MassTransit.RabbitMqTransport.Tests/RabbitMqAddress_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/RabbitMqAddress_Specs.cs
@@ -439,4 +439,33 @@ namespace MassTransit.RabbitMqTransport.Tests
             _receiveSettings = _uri.GetReceiveSettings();
         }
     }
+
+    [TestFixture]
+    public class Given_encoded_credentials_are_provided_in_the_uri
+    {
+        [Test]
+        public void Should_have_decoded_password()
+        {
+            _hostSettings.Password.ShouldBe(ExpectedPassword);
+        }
+
+        [Test]
+        public void Should_have_decoded_username()
+        {
+            _hostSettings.Username.ShouldBe(ExpectedUsername);
+        }
+
+        const string EncodedUsername = "te%24t";
+        const string ExpectedUsername = "te$t";
+        const string EncodedPassword = "Pa%24%24word";
+        const string ExpectedPassword = "Pa$$word";
+        readonly Uri _uri = new Uri($"rabbitmq://{EncodedUsername}:{EncodedPassword}@some_server");
+        RabbitMqHostSettings _hostSettings;
+
+        [OneTimeSetUp]
+        public void WhenParsed()
+        {
+            _hostSettings = _uri.GetHostSettings();
+        }
+    }
 }


### PR DESCRIPTION
When providing an encoded URI to the `RabbitMQ.Client` by setting the public `Uri` property, the RMQ client calls the private method `SetUri` in `ConnectionFactory`. This method explodes the Uri to obtain the username and password and escapes as necessary

For example:

> rabbitmq://te%24t:Pa%24%24word@localhost

results in a username and password of `te$t` and `Pa$$word` respectively 

We have found that providing `RabbitMqBusFactoryConfigurator` with an encoded Uri does not call the `SetUri` method in the client library. Instead, the username and password are set as they are provided

The PR will add a call to decode the username and password obtained from exploding the Uri passed to the `RabbitMqBusFactoryConfigurator` 

I have handled this in the calling application up to now, but thought I would suggest the change here as well
