### PR TITLE
Check value bytes instead of value length.

### DIFF
--- a/src/MassTransit/MessageDataExtensions.cs
+++ b/src/MassTransit/MessageDataExtensions.cs
@@ -19,7 +19,8 @@
             if (value == null)
                 return EmptyMessageData<string>.Instance;
 
-            if (value.Length < MessageDataDefaults.Threshold && !MessageDataDefaults.AlwaysWriteToRepository)
+            var bytesCount = Encoding.UTF8.GetByteCount(value);
+            if (bytesCount < MessageDataDefaults.Threshold && !MessageDataDefaults.AlwaysWriteToRepository)
                 return new StringInlineMessageData(value);
 
             byte[] bytes = Encoding.UTF8.GetBytes(value);
@@ -28,7 +29,7 @@
 
             var address = await repository.Put(ms, default, cancellationToken).ConfigureAwait(false);
 
-            if (value.Length < MessageDataDefaults.Threshold)
+            if (bytesCount < MessageDataDefaults.Threshold)
                 return new StringInlineMessageData(value, address);
 
             return new StoredMessageData<string>(address, value);
@@ -69,7 +70,8 @@
             if (value == null)
                 return EmptyMessageData<string>.Instance;
 
-            if (value.Length < MessageDataDefaults.Threshold && !MessageDataDefaults.AlwaysWriteToRepository)
+            var bytesCount = Encoding.UTF8.GetByteCount(value);
+            if (bytesCount < MessageDataDefaults.Threshold && !MessageDataDefaults.AlwaysWriteToRepository)
                 return new StringInlineMessageData(value);
 
             byte[] bytes = Encoding.UTF8.GetBytes(value);
@@ -78,7 +80,7 @@
 
             var address = await repository.Put(ms, timeToLive, cancellationToken).ConfigureAwait(false);
 
-            if (value.Length < MessageDataDefaults.Threshold)
+            if (bytesCount < MessageDataDefaults.Threshold)
                 return new StringInlineMessageData(value, address);
 
             return new StoredMessageData<string>(address, value);


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Hello,

This Pull Request solves the problem described below.

Problem occurs while using some Bus Provider with message size limit.

For example let's take Azure Service Bus (Standard Plan) with configuration in app:

MessageDataDefaults.Threshold = 256000;
MessageDataDefaults.AlwaysWriteToRepository = false;

Message size limit in Standard Plan is 256000 bytes. Actual algorithm treat every text character as one byte but when we pass some special characters eg. "ćśąęóźż", every character takes 2 bytes. When we pass text eg. "ć" character repeated 150000 times, data size will be 300000 bytes but actual algorithm will treat it as 150000 bytes and it will send it as normal message which cause throwing MessageSizeExceededException.