### PR TITLE
Patches AmazonSqsMessageReceiver to report errors back to ReceiveTransport

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsHostConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsHostConfiguration.cs
@@ -42,6 +42,7 @@
             ReceiveTransportRetryPolicy = Retry.CreatePolicy(x =>
             {
                 x.Handle<AmazonSqsTransportException>();
+                x.Handle<AmazonSqsConnectionException>();
 
                 x.Exponential(1000, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(3));
             });

--- a/src/Transports/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsMessageReceiver.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Pipeline/AmazonSqsMessageReceiver.cs
@@ -46,7 +46,8 @@ namespace MassTransit.AmazonSqsTransport.Pipeline
             _dispatcher = context.CreateReceivePipeDispatcher();
             _dispatcher.ZeroActivity += HandleDeliveryComplete;
 
-            Task.Run(Consume);
+            var task = Task.Run(Consume);
+            SetCompleted(task);
         }
 
         long DeliveryMetrics.DeliveryCount => _dispatcher.DispatchCount;
@@ -68,13 +69,12 @@ namespace MassTransit.AmazonSqsTransport.Pipeline
             catch (Exception exception)
             {
                 LogContext.Error?.Log(exception, "Consume Loop faulted");
+                throw;
             }
             finally
             {
                 await executor.DisposeAsync().ConfigureAwait(false);
             }
-
-            SetCompleted(TaskUtil.Completed);
         }
 
         protected override async Task StopAgent(StopContext context)


### PR DESCRIPTION
I closed my previous PR and raised this one instead. 

As discussed, currently, if polling SQS fails for whatever reason, AmazonSqsMessageReceiver will quietly complete without errors. Because it completes without errors, the retry logic in ReceiveTransport does not kick in and the transport just stops pulling messages from SQS forever -- the only possible recovery from this error is by restarting the application. I had this happen to 10 of my services at the same time during a small network hiccup. :-)

If I understand correctly, by setting the Consume task as the completed task, any exceptions (if raised) will flow back to the ReceiveTransport and be handled there by the retry policy there. I also added the AmazonSqsConnectionException  to the list of handled exceptions, as this is the exception being thrown by the polling routine.
