### PR TITLE
Use Atomic operation for DeliveryComplete in Receiver

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/Transport/KafkaMessageReceiver.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Transport/KafkaMessageReceiver.cs
@@ -100,7 +100,7 @@
 
         void HandleKafkaError(IConsumer<TKey, TValue> consumer, Error error)
         {
-            if (_cancellationTokenSource.Token.IsCancellationRequested)
+            if (_cancellationTokenSource.IsCancellationRequested)
                 return;
             var activeDispatchCount = _dispatcher.ActiveDispatchCount;
             EnabledLogger? logger = error.IsFatal ? LogContext.Critical : LogContext.Error;


### PR DESCRIPTION
Update Azure SB receiver:
```csharp
if (_deliveryComplete.Task.IsCompleted)
   requiresRecycle = false;
else
   _deliveryComplete.TrySetResult(false);
```
with atomic operation:
```csharp
if (!_deliveryComplete.TrySetResult(false))
   requiresRecycle = false;
```