### PR TITLE
Aligned example code with expected types

### DIFF
--- a/docs/advanced/courier/builder.md
+++ b/docs/advanced/courier/builder.md
@@ -14,18 +14,18 @@ Developers are discouraged from directly implementing the *RoutingSlip* message 
 
 ```csharp
 var builder = new RoutingSlipBuilder(NewId.NextGuid());
-builder.AddActivity("DownloadImage", "rabbitmq://localhost/execute_downloadimage", 
+builder.AddActivity("DownloadImage", new Uri("rabbitmq://localhost/execute_downloadimage"), 
     new
     {
         ImageUri = new Uri("http://images.google.com/someImage.jpg")
     });
-builder.AddActivity("FilterImage", "rabbitmq://localhost/execute_filterimage");
-builder.AddVariable("WorkPath", "\\dfs\work");
+builder.AddActivity("FilterImage", new Uri("rabbitmq://localhost/execute_filterimage"));
+builder.AddVariable("WorkPath", @"\dfs\work");
 
 var routingSlip = builder.Build();
 ```
 
-Each activity requires a name for display purposes and a URI specifying the execution address. The execution address is where the routing slip should be sent to execute the activity. For each activity, arguments can be specified that are stored and presented to the activity via the activity arguments interface type specify by the first argument of the *Activity* interface. The activities added to the routing slip are combined into an *Itinerary*, which is the list of activities to be executed, and stored in the routing slip.
+Each activity requires a name for display purposes and a URI specifying the execution address. The execution address is where the routing slip should be sent to execute the activity. For each activity, arguments can be specified that are stored and presented to the activity via the activity arguments interface type specify by the first argument of the *IActivity* interface. The activities added to the routing slip are combined into an *Itinerary*, which is the list of activities to be executed, and stored in the routing slip.
 
 > Managing the inventory of available activities, as well as their names and execution addresses, is the responsibility of the application and is not part of the MassTransit Courier. Since activities are application specific, and the business logic to determine which activities to execute and in what order is part of the application domain, the details are left to the application developer.
 
@@ -42,7 +42,7 @@ To specify an explicit activity argument, specify the argument value while addin
 
 ```csharp
 var builder = new RoutingSlipBuilder(NewId.NextGuid());
-builder.AddActivity("DownloadImage", "rabbitmq://localhost/execute_downloadimage", new
+builder.AddActivity("DownloadImage", new Uri("rabbitmq://localhost/execute_downloadimage"), new
     {
         ImageUri = new Uri("http://images.google.com/someImage.jpg")
     });
@@ -52,7 +52,7 @@ To specify an implicit activity argument, add a variable to the routing slip wit
 
 ```csharp
 var builder = new RoutingSlipBuilder(NewId.NextGuid());
-builder.AddActivity("DownloadImage", "rabbitmq://localhost/execute_downloadimage");
+builder.AddActivity("DownloadImage", new Uri("rabbitmq://localhost/execute_downloadimage"));
 builder.AddVariable("ImageUri", "http://images.google.com/someImage.jpg");
 ```
 
@@ -62,15 +62,15 @@ First, the routing slip would be built without the argument value.
 
 ```csharp
 var builder = new RoutingSlipBuilder(NewId.NextGuid());
-builder.AddActivity("DownloadImage", "rabbitmq://localhost/execute_downloadimage");
-builder.AddActivity("ProcessImage", "rabbitmq://localhost/execute_processimage");
+builder.AddActivity("DownloadImage", new Uri("rabbitmq://localhost/execute_downloadimage"));
+builder.AddActivity("ProcessImage", new Uri("rabbitmq://localhost/execute_processimage"));
 builder.AddVariable("ImageUri", "http://images.google.com/someImage.jpg");
 ```
 
 Then, the first activity would add the variable to the routing slip on completion.
 
 ```csharp
-Task Execute(ExecuteContext<DownloadImageArguments> context)
+async Task<ExecutionResult> Execute(ExecuteContext<DownloadImageArguments> context)
 {
     ...
     return context.CompletedWithVariables(new { ImagePath = ...});
@@ -80,7 +80,7 @@ Task Execute(ExecuteContext<DownloadImageArguments> context)
 The process image activity would then use that variable as an argument value.
 
 ```csharp
-Task Execute(ExecuteContext<ProcessImageArguments> context)
+async Task<ExecutionResult> Execute(ExecuteContext<ProcessImageArguments> context)
 {
     var path = context.Arguments.ImagePath;
 }


### PR DESCRIPTION
The AddActivity method appears to take a Uri instead of a string. The example variable contains a non-escaped slash. The Execute examples didn't show a proper return type.
