### PR TITLE
Do not use scoped filters for Fault messages

### DIFF
--- a/src/Containers/MassTransit.AutofacIntegration/ScopeProviders/AutofacFilterContextScopeProvider.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/ScopeProviders/AutofacFilterContextScopeProvider.cs
@@ -45,6 +45,9 @@ namespace MassTransit.AutofacIntegration.ScopeProviders
             where TContext : class, PipeContext
             where T : class
         {
+            if (typeof(T).HasInterface<Fault>())
+                return;
+
             if (!scopedType.IsGenericType || !scopedType.IsGenericTypeDefinition)
                 throw new ArgumentException("The scoped filter must be a generic type definition", nameof(scopedType));
 

--- a/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ScopeProviders/DependencyInjectionFilterContextScopeProvider.cs
+++ b/src/Containers/MassTransit.ExtensionsDependencyInjectionIntegration/ScopeProviders/DependencyInjectionFilterContextScopeProvider.cs
@@ -43,6 +43,9 @@ namespace MassTransit.ExtensionsDependencyInjectionIntegration.ScopeProviders
             where TContext : class, PipeContext
             where T : class
         {
+            if (typeof(T).HasInterface<Fault>())
+                return;
+
             if (!scopedType.IsGenericType || !scopedType.IsGenericTypeDefinition)
                 throw new ArgumentException("The scoped filter must be a generic type definition", nameof(scopedType));
 

--- a/src/MassTransit.TestFramework/Messages/PingMessage.cs
+++ b/src/MassTransit.TestFramework/Messages/PingMessage.cs
@@ -1,15 +1,3 @@
-// 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the
-// License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
 namespace MassTransit.TestFramework.Messages
 {
     using System;

--- a/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_ScopePublish.cs
+++ b/tests/MassTransit.Containers.Tests/Autofac_Tests/Autofac_ScopePublish.cs
@@ -132,6 +132,7 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         {
             var builder = new ContainerBuilder();
             builder.RegisterInstance(TaskCompletionSource);
+            builder.RegisterInstance(Marker);
 
             builder.AddMassTransit(ConfigureRegistration);
 
@@ -147,50 +148,6 @@ namespace MassTransit.Containers.Tests.Autofac_Tests
         protected override void ConfigureFilter(IPublishPipelineConfigurator configurator)
         {
             AutofacFilterExtensions.UsePublishFilter(configurator, typeof(ScopedFilter<>), Registration);
-        }
-
-        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
-        {
-            configurator.UseLifetimeScope(_container);
-
-            base.ConfigureInMemoryReceiveEndpoint(configurator);
-        }
-
-        protected override IBusRegistrationContext Registration => _container.Resolve<IBusRegistrationContext>();
-    }
-
-    [TestFixture]
-    public class Autofac_Publish_Filter_Fault_New :
-        Common_Publish_Filter_Fault
-    {
-        readonly IContainer _container;
-
-        public Autofac_Publish_Filter_Fault_New()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterInstance(TaskCompletionSource);
-
-            builder.AddMassTransit(ConfigureRegistration);
-
-            _container = builder.Build();
-        }
-
-        [OneTimeTearDown]
-        public async Task Close_container()
-        {
-            await _container.DisposeAsync();
-        }
-
-        protected override void ConfigureFilter(IPublishPipelineConfigurator configurator)
-        {
-            AutofacFilterExtensions.UsePublishFilter(configurator, typeof(ScopedFilter<>), Registration);
-        }
-
-        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
-        {
-            configurator.UseMessageLifetimeScope(_container);
-
-            base.ConfigureInMemoryReceiveEndpoint(configurator);
         }
 
         protected override IBusRegistrationContext Registration => _container.Resolve<IBusRegistrationContext>();


### PR DESCRIPTION
Do not use scoped filter for `Fault` messages.
Related to: https://github.com/MassTransit/MassTransit/issues/2562
