### PR TITLE
Update README.md

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -268,7 +268,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 $ dotnet run
 ```
 
-The output should have changed to show the message consumer generating the output (again, press Control+C to exit). Notice that the bus address now starts with `rabbitmq`.
+The output should have changed to show the message consumer generating the output (again, press Control+C to exit). Notice that the bus address now starts with `sb`.
 
 ``` {11}
 Building...


### PR DESCRIPTION
Bus address should start with sb for Azure Service Bus instead of rabbitmq.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
