### PR TITLE
MassTransit.Analyzers should not interfere with projects that don't depend on MT

### DIFF
--- a/tests/MassTransit.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/tests/MassTransit.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -109,12 +109,12 @@ namespace MassTransit.Analyzers.Tests
         /// <returns>
         /// A Tuple containing the Documents produced from the sources and their TextSpans if relevant
         /// </returns>
-        static Document[] GetDocuments(string[] sources, string language)
+        static Document[] GetDocuments(string[] sources, string language, bool includeMassTransit = true)
         {
             if (language != LanguageNames.CSharp && language != LanguageNames.VisualBasic)
                 throw new ArgumentException("Unsupported Language");
 
-            var project = CreateProject(sources, language);
+            var project = CreateProject(sources, language, includeMassTransit);
             Document[] documents = project.Documents.ToArray();
 
             if (sources.Length != documents.Length)
@@ -139,8 +139,9 @@ namespace MassTransit.Analyzers.Tests
         /// </summary>
         /// <param name="sources">Classes in the form of strings</param>
         /// <param name="language">The language the source code is in</param>
+        /// <param name="includeMassTransit">Whether the resulting Project has a dependency on MassTransit or not</param>
         /// <returns>A Project created out of the Documents created from the source strings</returns>
-        static Project CreateProject(string[] sources, string language = LanguageNames.CSharp)
+        static Project CreateProject(string[] sources, string language = LanguageNames.CSharp, bool includeMassTransit = true)
         {
             var fileNamePrefix = DefaultFilePathPrefix;
             var fileExt = language == LanguageNames.CSharp ? CSharpDefaultFileExt : VisualBasicDefaultExt;
@@ -157,10 +158,14 @@ namespace MassTransit.Analyzers.Tests
                 .AddMetadataReference(projectId, CollectionsReference)
                 .AddMetadataReference(projectId, RuntimeReference)
                 .AddMetadataReference(projectId, NetStandardReference)
-                .AddMetadataReference(projectId, MassTransitReference)
-                .AddMetadataReference(projectId, GreenPipesReference)
-                .AddMetadataReference(projectId, NewIdReference)
                 .AddMetadataReference(projectId, SystemPrivateUriReference);
+
+            if (includeMassTransit)
+            {
+                solution = solution.AddMetadataReference(projectId, MassTransitReference)
+                    .AddMetadataReference(projectId, GreenPipesReference)
+                    .AddMetadataReference(projectId, NewIdReference);
+            }
 
             var count = 0;
             foreach (var source in sources)

--- a/tests/MassTransit.Analyzers.Tests/MessageContractAnalyzerUnitTests.cs
+++ b/tests/MassTransit.Analyzers.Tests/MessageContractAnalyzerUnitTests.cs
@@ -129,6 +129,30 @@ namespace ConsoleApplication1
         }
 
         [Test]
+        public void WhenNotUsingMassTransitSymbols_ShouldNotInterfere()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        static void Main()
+        {
+            var test = new { Module = 13, Index = 412 };
+        }
+    }
+}
+";
+
+            VerifyCSharpDiagnosticWithoutMassTransit(test);
+        }
+
+        [Test]
         public void WhenActivatingGenericContractAreStructurallyIncompatibleAndNoMissingProperties_ShouldHaveDiagnostic()
         {
             var test = Usings + @"
@@ -2188,7 +2212,7 @@ namespace ConsoleApplication1
 
     public interface Bar
     {
-        
+
     }
 }
 ";

--- a/tests/MassTransit.Analyzers.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/tests/MassTransit.Analyzers.Tests/Verifiers/DiagnosticVerifier.cs
@@ -125,6 +125,13 @@ namespace MassTransit.Analyzers.Tests
             VerifyDiagnostics(sources, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
         }
 
+        protected void VerifyCSharpDiagnosticWithoutMassTransit(string source, params DiagnosticResult[] expected)
+        {
+            var analyzer = GetCSharpDiagnosticAnalyzer();
+            Diagnostic[] diagnostics = GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(new []{ source }, LanguageNames.CSharp, includeMassTransit: false));
+            VerifyDiagnosticResults(diagnostics, analyzer, expected);
+        }
+
         /// <summary>
         /// General method that gets a collection of actual diagnostics found in the source after the analyzer is run,
         /// then verifies each of them.


### PR DESCRIPTION
Hi.

I have a solution with multiple projects where we reference the analyzers in a MSBuild Directory.Build.props file.

This makes it so that all projects share the same analyzers. When trying to add `MassTransit.Analyzers` globally to all my projects, I discovered it throws when it tries to (incorrectly?) analyze an expression outside of a Publish/GetResponse, etc method.

I manage to create a test that reproduces the issue which is what this PR includes.

If we define how we should handle these cases I'll be happy to give the implementation a go, although I've never written an analyzer.

I think there are two things that we may cover:

1. The analyzer shouldn't be considering the code's test as something to analyze since it is not an Anonymous object used in the context of sending a message (not 100% sure this is correct tho)
2. We shouldn't even attempt to analyze anything if the target project doesn't depend on MassTransit (how does this work with transitive dependencies? I think `Compilation` has the complete list of References, but not sure)

I was thinking there should be a quick way to "skip" projects that don't reference any `MassTransit.*` package?

I did have to change a bit the testing infrastructure in order to be able to create a testing scenario that doesn't include the dependency to MassTransit packages.

Feel free to edit/rename/etc.

Leo.