### PR TITLE
improve documentation of GetRetryAttempt and GetRetryCount

### DIFF
--- a/src/MassTransit/RetryContextExtensions.cs
+++ b/src/MassTransit/RetryContextExtensions.cs
@@ -6,8 +6,8 @@
     public static class RetryContextExtensions
     {
         /// <summary>
-        /// If within a retry attempt, the return value is greater than zero and indicates the number of retry attempts
-        /// that have occurred.
+        /// If within a retry attempt, the return value is greater than zero and indicates the number of the retry attempt
+        /// in progress.
         /// </summary>
         /// <param name="context"></param>
         /// <returns>The retry attempt number, 0 = first time, >= 1 = retry</returns>
@@ -17,11 +17,10 @@
         }
 
         /// <summary>
-        /// If within a retry attempt, the return value is greater than zero and indicates the number of retry attempts
-        /// that have occurred.
+        /// If within a retry attempt, the return value indicates the number of retry attempts that have already occurred.
         /// </summary>
         /// <param name="context"></param>
-        /// <returns>The retry attempt number, 0 = first time, >= 1 = retry</returns>
+        /// <returns>The number of retries that have already been attempted, 0 = first time, 0 = first retry, >= 1 = subsequent retry</returns>
         public static int GetRetryCount(this ConsumeContext context)
         {
             return context.TryGetPayload(out ConsumeRetryContext retryContext) ? retryContext.RetryCount : 0;

--- a/src/MassTransit/RetryContextExtensions.cs
+++ b/src/MassTransit/RetryContextExtensions.cs
@@ -20,7 +20,7 @@
         /// If within a retry attempt, the return value indicates the number of retry attempts that have already occurred.
         /// </summary>
         /// <param name="context"></param>
-        /// <returns>The number of retries that have already been attempted, 0 = first time, 0 = first retry, >= 1 = subsequent retry</returns>
+        /// <returns>The number of retries that have already been attempted, 0 = first time or first retry, >= 1 = subsequent retry</returns>
         public static int GetRetryCount(this ConsumeContext context)
         {
             return context.TryGetPayload(out ConsumeRetryContext retryContext) ? retryContext.RetryCount : 0;


### PR DESCRIPTION
Improve the documentation:
 - RetryContextExtensions.GetRetryAttempt - made it clear that it returns the number of the current attempt
 - RetryContextExtensions.GetRetryCount - corrected the incorrect description of when it returns zero