### PR TITLE
Fix missing navigation link

### DIFF
--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -13,6 +13,7 @@
   * [Receive Pipeline](middleware/receive.md)
   * [Circuit breaker](middleware/circuit-breaker.md)
   * [Rate limiter](middleware/rate-limiter.md)
+  * [Concurrency limit](middleware/concurrency-limit.md)
   * [Latest](middleware/latest.md)
   * [Custom](middleware/custom.md)
 * [Topology](topology/README.md)


### PR DESCRIPTION
In the [Advanced] -> [Middleware] section of the documentation the link to the Concurrency Limit page is missing. Since this is only a change to the markdown source, I haven't performed any testing to validate the change.