### PR TITLE
Adding docs for the Artemis compatibility and the temporary queue name formatter feature

### DIFF
--- a/docs/usage/transports/activemq.md
+++ b/docs/usage/transports/activemq.md
@@ -60,12 +60,14 @@ Currently the only thing `cfg.EnableArtemisCompatibility()` does is setting a pr
 
 Example of setting your own ConsumerEndpointQueueNameFormatter:
 ```
-cfg.ConsumeTopology.ConsumerEndpointQueueNameFormatter= new MyCustomConsumerEndpointQueueNameFormatter();
-
+cfg.SetConsumerEndpointQueueNameFormatter(new MyCustomConsumerEndpointQueueNameFormatter());
 ```
 So it is still possible to create your own IActiveMqConsumerEndpointQueueNameFormatter if you want to tweak the queue name.
 
-The responsibility of the formatter is to create the queuename for a given endpoint name and a given topic.
+The responsibility of the formatter is to create the queuename for a given 
+
+    - a given receive/consumer endpoint name 
+    - a given topic.
 
 
 ## TemporaryQueueNameFormatter
@@ -86,6 +88,5 @@ cfg.SetTemporaryQueueNamePrefix("mycustomnamespace.");
 Behind the scenes this does something like this:
 
 ```cs
-cfg.ConsumeTopology.TemporaryQueueNameFormatter = new PrefixTemporaryQueueNameFormatter("mycustomnamespace.");
-
+cfg.SetTemporaryQueueNameFormatter( new PrefixTemporaryQueueNameFormatter("mycustomnamespace."));
 ```

--- a/docs/usage/transports/activemq.md
+++ b/docs/usage/transports/activemq.md
@@ -32,6 +32,60 @@ endpoint.ConfigureConsumeTopology = false;
 When the consume topology is not configured, the virtual consumer queues are not created.
 :::
 
-### Amazon MQ
+## Amazon MQ
 
 Amazon MQ uses ActiveMQ, so the same transport is used. Amazon MQ requires SSL, so if MassTransit detects the host name ends with `amazonaws.com`, SSL is automatically configured.
+
+## Artemis
+
+Artemis also supports the openwire protocol. However some differences exists that cause the Masstransit ActiveMQ transport provider not to function.
+One of those causes is that Artemis works internally differentl with queues compared to ActiveMq. See [Artemis:Virtual Topics](https://activemq.apache.org/components/artemis/migration)
+
+The easiest way to get the ActiveMQ transport provider working with a Artemis broker:
+
+```cs
+ var busControl = Bus.Factory.CreateUsingActiveMq(cfg =>
+			{
+				cfg.Host("localhost", 61618, cfgHost =>
+				{
+					cfgHost.Username("admin");
+					cfgHost.Password("admin");
+				});
+				cfg.EnableArtemisCompatibility();
+            });
+```
+Calling `cfg.EnableArtemisCompatibility()` will initialize the minimum necessary features so that the Masstransit ActiveMQ transport provider will work with the Artemis broker
+
+Currently the only thing `cfg.EnableArtemisCompatibility()` does is setting a predefined formatter `ArtemisConsumerEndpointQueueNameFormatter` (which implements interface IActiveMqConsumerEndpointQueueNameFormatter) on the ConsumeTopology (accessible via cfg.ConsumeTopology )
+
+Example of setting your own ConsumerEndpointQueueNameFormatter:
+```
+cfg.ConsumeTopology.ConsumerEndpointQueueNameFormatter= new MyCustomConsumerEndpointQueueNameFormatter();
+
+```
+So it is still possible to create your own IActiveMqConsumerEndpointQueueNameFormatter if you want to tweak the queue name.
+
+The responsibility of the formatter is to create the queuename for a given endpoint name and a given topic.
+
+
+## TemporaryQueueNameFormatter
+
+On the consume topology a TemporaryQueueNameFormatter can be configured. The responsibility of the formatter is to transform the 'system' generated name for a temporary queue.
+
+This could be used to e.g. add a prefix to the generated temporary queuenames.
+This helps to support namespaces in queuenames. 
+Artemis can use this to enforce security policies
+
+For adding a prefix, a handy helper is already provided.
+During the configure lambda:
+
+```cs
+cfg.SetTemporaryQueueNamePrefix("mycustomnamespace.");
+```
+
+Behind the scenes this does something like this:
+
+```cs
+cfg.ConsumeTopology.TemporaryQueueNameFormatter = new PrefixTemporaryQueueNameFormatter("mycustomnamespace.");
+
+```


### PR DESCRIPTION
Adding docs related to PR: 
https://github.com/MassTransit/MassTransit/pull/2660 Adding Artemis compatibility (district09)

In the pull request 2660 a question is still asked related to accessing some properties via the configurator (so accessible via the configure function during init), this got removed from the pull request during cleanup and rebase. I hope this was an accident :-)

In this doc it is assumed that access to the new extension properties will be adapted/granted again.

Kr,
Alex
