### PR TITLE
Allow Consume methods for RoutingSlipRequest/ResponseProxy to be virtual

### DIFF
--- a/src/MassTransit/Courier/RoutingSlipRequestProxy.cs
+++ b/src/MassTransit/Courier/RoutingSlipRequestProxy.cs
@@ -8,7 +8,7 @@ namespace MassTransit.Courier
         IConsumer<TRequest>
         where TRequest : class
     {
-        public async Task Consume(ConsumeContext<TRequest> context)
+        public virtual async Task Consume(ConsumeContext<TRequest> context)
         {
             var builder = new RoutingSlipBuilder(NewId.NextGuid());
 

--- a/src/MassTransit/Courier/RoutingSlipResponseProxy.cs
+++ b/src/MassTransit/Courier/RoutingSlipResponseProxy.cs
@@ -16,7 +16,7 @@
         where TResponse : class
         where TFaultResponse : class
     {
-        public async Task Consume(ConsumeContext<RoutingSlipCompleted> context)
+        public virtual async Task Consume(ConsumeContext<RoutingSlipCompleted> context)
         {
             var request = context.Message.GetVariable<TRequest>("Request");
             var requestId = context.Message.GetVariable<Guid>("RequestId");
@@ -35,7 +35,7 @@
             await endpoint.Send(response).ConfigureAwait(false);
         }
 
-        public async Task Consume(ConsumeContext<RoutingSlipFaulted> context)
+        public virtual async Task Consume(ConsumeContext<RoutingSlipFaulted> context)
         {
             var request = context.Message.GetVariable<TRequest>("Request");
             var requestId = context.Message.GetVariable<Guid>("RequestId");


### PR DESCRIPTION
Allow Consume methods for RoutingSlipRequest/ResponseProxy to be virtual so that they may be overridden if necessary.

Original question/answer on [Stack Overflow](https://stackoverflow.com/questions/68385160/masstransit-cannot-override-the-consume-method-from-routingslipresponseproxy/68395420#68395420)

Ensured code worked by running unit tests with `dotnet test` and ensuring all unit tests passed!