### PR TITLE
Limit JobTypeSaga concurrency by 1 thread.

### DIFF
--- a/src/MassTransit/JobService/Configuration/JobServiceConfigurator.cs
+++ b/src/MassTransit/JobService/Configuration/JobServiceConfigurator.cs
@@ -215,6 +215,7 @@ namespace MassTransit.JobService.Configuration
             {
                 e.UseMessageRetry(r => r.Intervals(100, 200, 300, 500, 1000, 2000, 5000));
                 e.UseInMemoryOutbox();
+                e.UseConcurrencyLimit(1);
 
                 if (_options.SagaPartitionCount.HasValue)
                 {


### PR DESCRIPTION
Hi Chris,

I was playing with JobConsumers and got concurrency version check errors when JobConsumer has low ConcurrentJobLimit (for example 1) and several Job Commands are sent. MT is creating JobSagas for each command (in parallel) and tries to update JobTypeSaga singleton object with information about Active Jobs. In this case only the first update succeeds and all subsequent updates are failing on version check step. It is not critical, but is quite annoying and brings lots of errors in the log.
Setting ConcurrencyLimit to 1 for JobTypeSaga allows to minimize concurrency error issues. 

![image](https://user-images.githubusercontent.com/1137537/126358989-efb92af3-d174-4cf0-a85d-0f88fab98b81.png)
[mt_job_consumer_job_type_saga_errors.txt](https://github.com/MassTransit/MassTransit/files/6849875/mt_job_consumer_job_type_saga_errors.txt)
