### PR TITLE
AmazonSQS transport: trying to get the queue url when queue already exists and when application does not have create permissions.

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Contexts/QueueCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Contexts/QueueCache.cs
@@ -62,17 +62,11 @@ namespace MassTransit.AmazonSqsTransport.Contexts
             {
                 try
                 {
+                    return await GetExistingQueue(queue.EntityName).ConfigureAwait(false);
+                }
+                catch (QueueDoesNotExistException)
+                {
                     return await CreateMissingQueue(queue).ConfigureAwait(false);
-                }
-                catch (QueueNameExistsException queueNameExistsException)
-                {
-                    Console.WriteLine($"QueueNameExistsException: {queueNameExistsException.Message}, {queueNameExistsException.StatusCode}, {queueNameExistsException.ErrorType}, {queueNameExistsException.ErrorCode}, {queueNameExistsException.GetType().FullName}, {queueNameExistsException.StackTrace}");
-                    return await GetExistingQueue(queue.EntityName).ConfigureAwait(false);
-                }
-                catch (Exception exception)
-                {
-                    Console.WriteLine($"Exception: {exception.Message}, {exception.GetType().FullName}, {exception.StackTrace}");
-                    return await GetExistingQueue(queue.EntityName).ConfigureAwait(false);
                 }
             });
         }

--- a/src/Transports/MassTransit.AmazonSqsTransport/Contexts/QueueCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Contexts/QueueCache.cs
@@ -64,8 +64,14 @@ namespace MassTransit.AmazonSqsTransport.Contexts
                 {
                     return await CreateMissingQueue(queue).ConfigureAwait(false);
                 }
-                catch (QueueNameExistsException)
+                catch (QueueNameExistsException queueNameExistsException)
                 {
+                    Console.WriteLine($"QueueNameExistsException: {queueNameExistsException.Message}, {queueNameExistsException.StatusCode}, {queueNameExistsException.ErrorType}, {queueNameExistsException.ErrorCode}, {queueNameExistsException.GetType().FullName}, {queueNameExistsException.StackTrace}");
+                    return await GetExistingQueue(queue.EntityName).ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    Console.WriteLine($"Exception: {exception.Message}, {exception.GetType().FullName}, {exception.StackTrace}");
                     return await GetExistingQueue(queue.EntityName).ConfigureAwait(false);
                 }
             });


### PR DESCRIPTION

With those changes, we do want to prevent application to provision new queues, as the queues are already created with CloudFormation before the application is deployed.

With the previous implementation, when the application was not having CreateQueue permissions, it was never checking if the queue exists, as it was getting "AmazonSQSException: Access to the resource https://sqs.eu-west-1.amazonaws.com/ is denied." which was not handled in this code.

Instructions for verification:
- Application should not have permissions for creating queue `sqs:CreateQueue `
- When the queue does exist, you should still see the error: `[Debug] MassTransit: Endpoint Faulted: amazonsqs://eu-west-1/dev-sample-queue-name`
- When the queue exists it should be able to consume messages from the queue.


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
