### PR TITLE
Amazon SQS: Add ability to process messages from FIFO queue in ordered way

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsHostConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsHostConfiguration.cs
@@ -92,7 +92,7 @@
         {
             var endpointConfiguration = _busConfiguration.CreateEndpointConfiguration();
 
-            var settings = new QueueReceiveSettings(endpointConfiguration, queueName, true, false);
+            var settings = new QueueReceiveSettings(endpointConfiguration, queueName, true, false, false);
 
             return CreateReceiveEndpointConfiguration(settings, endpointConfiguration, configure);
         }

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
@@ -132,6 +132,11 @@
             set => _settings.PurgeOnStartup = value;
         }
 
+        public bool OrderedMessageHandlingEnabled
+        {
+            set => _settings.OrderedMessageHandlingEnabled = value;
+        }
+
         public IDictionary<string, object> QueueAttributes => _settings.QueueAttributes;
 
         public IDictionary<string, object> QueueSubscriptionAttributes => _settings.QueueSubscriptionAttributes;

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/Configurators/AmazonSqsBusFactoryConfigurator.cs
@@ -26,7 +26,7 @@
             _hostConfiguration = busConfiguration.HostConfiguration;
 
             var queueName = _busConfiguration.Topology.Consume.CreateTemporaryQueueName("bus");
-            _settings = new QueueReceiveSettings(busConfiguration.BusEndpointConfiguration, queueName, false, true);
+            _settings = new QueueReceiveSettings(busConfiguration.BusEndpointConfiguration, queueName, false, true, false);
         }
 
         public ushort WaitTimeSeconds
@@ -47,6 +47,11 @@
         public bool PurgeOnStartup
         {
             set => _settings.PurgeOnStartup = value;
+        }
+
+        public bool OrderedMessageProcessingEnabled
+        {
+            set => _settings.OrderedMessageHandlingEnabled = value;
         }
 
         public void OverrideDefaultBusEndpointQueueName(string value)

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsReceiveEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsReceiveEndpointConfigurator.cs
@@ -12,6 +12,11 @@
         IQueueEndpointConfigurator
     {
         /// <summary>
+        /// Use only if you use FIFO queue, this setting enables grouping by MessageGroupId and process messages in ordered way by SequenceNumber
+        /// </summary>
+        bool OrderedMessageHandlingEnabled { set; }
+
+        /// <summary>
         /// Bind an existing exchange for the message type to the receive endpoint by name
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/Transports/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Topology/ReceiveSettings.cs
@@ -39,5 +39,10 @@
         /// Get the input address for the transport on the specified host
         /// </summary>
         Uri GetInputAddress(Uri hostAddress);
+
+        /// <summary>
+        /// Use only if you use FIFO queue, this setting enables grouping by MessageGroupId and process messages in ordered way by SequenceNumber
+        /// </summary>
+        bool OrderedMessageHandlingEnabled { get; }
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/Topology/Settings/QueueReceiveSettings.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Topology/Settings/QueueReceiveSettings.cs
@@ -11,10 +11,11 @@ namespace MassTransit.AmazonSqsTransport.Topology.Settings
     {
         readonly IAmazonSqsEndpointConfiguration _configuration;
 
-        public QueueReceiveSettings(IAmazonSqsEndpointConfiguration configuration, string queueName, bool durable, bool autoDelete)
+        public QueueReceiveSettings(IAmazonSqsEndpointConfiguration configuration, string queueName, bool durable, bool autoDelete, bool orderedMessageProcessingEnabled)
             : base(queueName, durable, autoDelete)
         {
             _configuration = configuration;
+            OrderedMessageHandlingEnabled = orderedMessageProcessingEnabled;
 
             WaitTimeSeconds = 3;
         }
@@ -25,6 +26,8 @@ namespace MassTransit.AmazonSqsTransport.Topology.Settings
         public int WaitTimeSeconds { get; set; }
 
         public bool PurgeOnStartup { get; set; }
+
+        public bool OrderedMessageHandlingEnabled { get; set; }
 
         public Uri GetInputAddress(Uri hostAddress)
         {


### PR DESCRIPTION
Hi guys, this change is useful for AWS SQS FIFO queue. Now, I can prefetch up to 10 messages with different MessageGroupId (it's required for FIFO queue), group them and order by SequenceNumber and process one by one message in each group. This guaranties that I will handle message in the same order as they have been sent. We really need this change for our project or please implement this ability from your side, this code can be used as a reference