### PR TITLE
Use Bus observers by default for Riders

### DIFF
--- a/src/MassTransit/Configuration/Configuration/IHostConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/IHostConfiguration.cs
@@ -24,6 +24,8 @@
         /// </summary>
         bool DeployTopologyOnly { get; set; }
 
+        ISendObserver SendObservers { get; }
+
         ILogContext LogContext { get; set; }
         ILogContext ReceiveLogContext { get; }
         ILogContext SendLogContext { get; }

--- a/src/MassTransit/Configuration/Configurators/BaseHostConfiguration.cs
+++ b/src/MassTransit/Configuration/Configurators/BaseHostConfiguration.cs
@@ -48,6 +48,8 @@ namespace MassTransit.Configurators
 
         public bool DeployTopologyOnly { get; set; }
 
+        public ISendObserver SendObservers => _sendObservers;
+
         public ILogContext LogContext
         {
             get => _logContext;

--- a/src/Transports/MassTransit.EventHubIntegration/Configuration/Configurators/EventHubFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/Configuration/Configurators/EventHubFactoryConfigurator.cs
@@ -163,6 +163,8 @@ namespace MassTransit.EventHubIntegration.Configurators
 
         public IEventHubRider Build(IRiderRegistrationContext context, IBusInstance busInstance)
         {
+            ConnectSendObserver(busInstance.HostConfiguration.SendObservers);
+
             var endpoints = new ReceiveEndpointCollection();
             foreach (var endpoint in _endpoints)
                 endpoints.Add(endpoint.EndpointName, endpoint.CreateReceiveEndpoint(busInstance));

--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/Configurators/KafkaFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/Configurators/KafkaFactoryConfigurator.cs
@@ -288,6 +288,8 @@ namespace MassTransit.KafkaIntegration.Configurators
 
         public IKafkaRider Build(IRiderRegistrationContext context, IBusInstance busInstance)
         {
+            ConnectSendObserver(busInstance.HostConfiguration.SendObservers);
+
             var endpoints = new ReceiveEndpointCollection();
             foreach (var topic in _topics)
                 endpoints.Add(topic.EndpointName, topic.CreateReceiveEndpoint(busInstance));

--- a/tests/MassTransit.EventHubIntegration.Tests/BatchProducer_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/BatchProducer_Specs.cs
@@ -5,6 +5,7 @@ namespace MassTransit.EventHubIntegration.Tests
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Contracts;
     using GreenPipes;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -122,12 +123,6 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 return TaskUtil.Completed;
             }
-        }
-
-
-        public interface EventHubMessage
-        {
-            string Text { get; }
         }
 
 

--- a/tests/MassTransit.EventHubIntegration.Tests/Contracts/BatchEventHubMessage.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Contracts/BatchEventHubMessage.cs
@@ -1,0 +1,7 @@
+namespace MassTransit.EventHubIntegration.Tests.Contracts
+{
+    public interface BatchEventHubMessage
+    {
+        int Index { get; }
+    }
+}

--- a/tests/MassTransit.EventHubIntegration.Tests/Contracts/EventHubMessage.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Contracts/EventHubMessage.cs
@@ -1,0 +1,7 @@
+namespace MassTransit.EventHubIntegration.Tests.Contracts
+{
+    public interface EventHubMessage
+    {
+        string Text { get; }
+    }
+}

--- a/tests/MassTransit.EventHubIntegration.Tests/EndpointConnector_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/EndpointConnector_Specs.cs
@@ -2,6 +2,7 @@ namespace MassTransit.EventHubIntegration.Tests
 {
     using System;
     using System.Threading.Tasks;
+    using Contracts;
     using GreenPipes;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -124,12 +125,6 @@ namespace MassTransit.EventHubIntegration.Tests
         {
             string Key { get; }
             string Value { get; }
-        }
-
-
-        public interface EventHubMessage
-        {
-            string Text { get; }
         }
     }
 }

--- a/tests/MassTransit.EventHubIntegration.Tests/ProducerPipe_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/ProducerPipe_Specs.cs
@@ -2,6 +2,7 @@ namespace MassTransit.EventHubIntegration.Tests
 {
     using System;
     using System.Threading.Tasks;
+    using Contracts;
     using GreenPipes;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -121,13 +122,6 @@ namespace MassTransit.EventHubIntegration.Tests
             public void Probe(ProbeContext context)
             {
             }
-        }
-
-
-        public interface EventHubMessage
-        {
-            Guid CorrelationId { get; }
-            string Text { get; }
         }
     }
 }

--- a/tests/MassTransit.EventHubIntegration.Tests/Producer_Saga_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Producer_Saga_Specs.cs
@@ -3,6 +3,7 @@ namespace MassTransit.EventHubIntegration.Tests
     using System;
     using System.Threading.Tasks;
     using Automatonymous;
+    using Contracts;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;
@@ -97,12 +98,6 @@ namespace MassTransit.EventHubIntegration.Tests
             {
                 _taskCompletionSource.TrySetResult(context);
             }
-        }
-
-
-        public interface EventHubMessage
-        {
-            string Text { get; }
         }
 
 

--- a/tests/MassTransit.EventHubIntegration.Tests/Publish_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Publish_Specs.cs
@@ -6,6 +6,7 @@ namespace MassTransit.EventHubIntegration.Tests
     using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Producer;
     using Context;
+    using Contracts;
     using GreenPipes.Util;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -129,12 +130,6 @@ namespace MassTransit.EventHubIntegration.Tests
         }
 
 
-        public interface EventHubMessage
-        {
-            string Text { get; }
-        }
-
-
         class BusPingConsumer :
             IConsumer<BusPing>
         {
@@ -154,6 +149,7 @@ namespace MassTransit.EventHubIntegration.Tests
 
 
         public interface BusPing
-        {}
+        {
+        }
     }
 }

--- a/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
@@ -5,6 +5,7 @@ namespace MassTransit.EventHubIntegration.Tests
     using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Producer;
     using Context;
+    using Contracts;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;
@@ -110,12 +111,6 @@ namespace MassTransit.EventHubIntegration.Tests
                 _taskCompletionSource.TrySetResult(context);
             }
         }
-
-
-        public interface EventHubMessage
-        {
-            string Text { get; }
-        }
     }
 
 
@@ -192,11 +187,6 @@ namespace MassTransit.EventHubIntegration.Tests
             {
                 _taskCompletionSource.TrySetResult(context);
             }
-        }
-
-
-        public interface EventHubMessage
-        {
         }
     }
 }

--- a/tests/MassTransit.KafkaIntegration.Tests/Producer_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Producer_Specs.cs
@@ -11,6 +11,7 @@ namespace MassTransit.KafkaIntegration.Tests
     using NUnit.Framework;
     using TestFramework;
     using TestFramework.Sagas;
+    using Util;
 
 
     public class Producer_Specs :
@@ -94,6 +95,78 @@ namespace MassTransit.KafkaIntegration.Tests
                 Assert.That(headerType, Is.Not.Null);
                 Assert.That(headerType.Key, Is.EqualTo("Hello"));
                 Assert.That(headerType.Value, Is.EqualTo("World"));
+            }
+            finally
+            {
+                serviceScope.Dispose();
+
+                await busControl.StopAsync(TestCancellationToken);
+
+                await provider.DisposeAsync();
+            }
+        }
+
+        [Test]
+        public async Task Should_use_bus_send_observer()
+        {
+            TaskCompletionSource<ConsumeContext<KafkaMessage>> taskCompletionSource = GetTask<ConsumeContext<KafkaMessage>>();
+            TaskCompletionSource<SendContext> preSendCompletionSource = GetTask<SendContext>();
+            TaskCompletionSource<SendContext> postSendCompletionSource = GetTask<SendContext>();
+            var services = new ServiceCollection();
+            services.AddSingleton(taskCompletionSource);
+
+            services.TryAddSingleton<ILoggerFactory>(LoggerFactory);
+            services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
+
+            services.AddMassTransit(x =>
+            {
+                x.UsingInMemory((context, cfg) =>
+                {
+                    cfg.ConnectSendObserver(new TestSendObserver(preSendCompletionSource, postSendCompletionSource));
+                    cfg.ConfigureEndpoints(context);
+                });
+                x.AddRider(rider =>
+                {
+                    rider.AddConsumer<KafkaMessageConsumer>();
+
+                    rider.AddProducer<KafkaMessage>(Topic);
+
+                    rider.UsingKafka((context, k) =>
+                    {
+                        k.Host("localhost:9092");
+
+                        k.TopicEndpoint<KafkaMessage>(Topic, nameof(Producer_Specs), c =>
+                        {
+                            c.AutoOffsetReset = AutoOffsetReset.Earliest;
+                            c.ConfigureConsumer<KafkaMessageConsumer>(context);
+                        });
+                    });
+                });
+            });
+
+            var provider = services.BuildServiceProvider(true);
+
+            var busControl = provider.GetRequiredService<IBusControl>();
+
+            await busControl.StartAsync(TestCancellationToken);
+
+            var serviceScope = provider.CreateScope();
+
+            var producer = serviceScope.ServiceProvider.GetRequiredService<ITopicProducer<KafkaMessage>>();
+
+            try
+            {
+                await producer.Produce(new {Text = "text"}, TestCancellationToken);
+
+                await preSendCompletionSource.Task;
+
+                ConsumeContext<KafkaMessage> result = await taskCompletionSource.Task;
+
+                Assert.AreEqual("text", result.Message.Text);
+                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+
+                await postSendCompletionSource.Task;
             }
             finally
             {
@@ -235,6 +308,40 @@ namespace MassTransit.KafkaIntegration.Tests
             public State Active { get; private set; }
 
             public Event<StartTest> Started { get; private set; }
+        }
+
+
+        class TestSendObserver :
+            ISendObserver
+        {
+            readonly TaskCompletionSource<SendContext> _postSend;
+            readonly TaskCompletionSource<SendContext> _preSend;
+
+            public TestSendObserver(TaskCompletionSource<SendContext> preSend, TaskCompletionSource<SendContext> postSend)
+            {
+                _preSend = preSend;
+                _postSend = postSend;
+            }
+
+            public Task PreSend<T>(SendContext<T> context)
+                where T : class
+            {
+                _preSend.TrySetResult(context);
+                return TaskUtil.Completed;
+            }
+
+            public Task PostSend<T>(SendContext<T> context)
+                where T : class
+            {
+                _postSend.TrySetResult(context);
+                return TaskUtil.Completed;
+            }
+
+            public Task SendFault<T>(SendContext<T> context, Exception exception)
+                where T : class
+            {
+                return TaskUtil.Completed;
+            }
         }
     }
 }

--- a/tests/MassTransit.KafkaIntegration.Tests/docker-compose.yml
+++ b/tests/MassTransit.KafkaIntegration.Tests/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.1.1
+    image: confluentinc/cp-zookeeper:6.2.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka:6.2.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -41,7 +41,7 @@ services:
       retries: 4
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:6.1.1
+    image: confluentinc/cp-schema-registry:6.2.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:


### PR DESCRIPTION
Copy bus observers to Riders.

The only issue here, which we have for endpoints as well: during Send (Produce in case of Riders) we will `await` empty Task for Observers if they are empty. And @phatboyg you will live knowing that 🤣 