### PR TITLE
Fixed #2702:  use CreateContainerIfNotExistsAsync in Setup method

### DIFF
--- a/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyNoRetry_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyNoRetry_Specs.cs
@@ -156,7 +156,7 @@
             var dbResponse = await _cosmosClient.CreateDatabaseIfNotExistsAsync(_databaseName).ConfigureAwait(false);
             _database = dbResponse.Database;
             var cResponse = await _database
-                .CreateContainerAsync(_collectionName, "/id")
+                .CreateContainerIfNotExistsAsync(_collectionName, "/id")
                 .ConfigureAwait(false);
             _container = cResponse.Container;
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Fix #2702 
Use `CreateContainerIfNotExistsAsync` intead of `CreateContainerAsync` in the Setup method in `When_using_CosmosConcurrencyNoRetry`
