### PR TITLE
Do not create batch when no more messages. Short loop for kafka producer instead of timeout

### DIFF
--- a/src/Transports/MassTransit.EventHubIntegration/Transport/EventHubProducer.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/Transport/EventHubProducer.cs
@@ -268,7 +268,9 @@ namespace MassTransit.EventHubIntegration
                         while (!eventDataBatch.TryAdd(eventData) && eventDataBatch.Count > 0)
                         {
                             await FlushAsync(eventDataBatch);
-                            eventDataBatch = await context.CreateBatch(options, _cancellationToken).ConfigureAwait(false);
+
+                            if (contexts.Length - i > 1)
+                                eventDataBatch = await context.CreateBatch(options, _cancellationToken).ConfigureAwait(false);
                         }
                     }
 

--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/KafkaTopicOptions.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/KafkaTopicOptions.cs
@@ -1,5 +1,6 @@
 namespace MassTransit.KafkaIntegration
 {
+    using System;
     using System.Collections.Generic;
     using Configuration;
     using Confluent.Kafka.Admin;
@@ -19,6 +20,7 @@ namespace MassTransit.KafkaIntegration
             _topic = topic;
             _numPartitions = 1;
             _replicaFactor = 1;
+            RequestTimeout = TimeSpan.FromSeconds(5);
         }
 
         /// <summary>
@@ -37,6 +39,8 @@ namespace MassTransit.KafkaIntegration
             set => _replicaFactor = value;
         }
 
+        public TimeSpan RequestTimeout { set; internal get; }
+
         public IEnumerable<ValidationResult> Validate()
         {
             if (_numPartitions == 0)
@@ -44,6 +48,9 @@ namespace MassTransit.KafkaIntegration
 
             if (_replicaFactor <= 0)
                 yield return this.Failure(nameof(ReplicationFactor), "should be greater than 0");
+
+            if (RequestTimeout <= TimeSpan.Zero)
+                yield return this.Failure(nameof(RequestTimeout), "should be greater than 0");
         }
 
         internal TopicSpecification ToSpecification()

--- a/src/Transports/MassTransit.KafkaIntegration/Contexts/KafkaProducerContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Contexts/KafkaProducerContext.cs
@@ -32,8 +32,9 @@ namespace MassTransit.KafkaIntegration.Contexts
 
         public void Dispose()
         {
-            var timeout = TimeSpan.FromSeconds(30);
-            _producer.Flush(timeout);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            _producer.Flush(cts.Token);
+
             _producer.Dispose();
         }
     }

--- a/src/Transports/MassTransit.KafkaIntegration/Pipeline/ConfigureTopologyFilter.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Pipeline/ConfigureTopologyFilter.cs
@@ -1,6 +1,5 @@
 namespace MassTransit.KafkaIntegration.Pipeline
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -46,13 +45,13 @@ namespace MassTransit.KafkaIntegration.Pipeline
             var client = new AdminClientBuilder(_config).Build();
             try
             {
-                var options = new CreateTopicsOptions {RequestTimeout = TimeSpan.FromSeconds(30)};
+                var options = new CreateTopicsOptions {RequestTimeout = _options.RequestTimeout};
                 LogContext.Debug?.Log("Creating topic: {Topic}", _specification.Name);
                 await client.CreateTopicsAsync(new[] {_specification}, options).ConfigureAwait(false);
             }
             catch (CreateTopicsException e)
             {
-                EnabledLogger? logger = e.Error.IsFatal ? LogContext.Critical : LogContext.Error;
+                EnabledLogger? logger = e.Error.IsFatal ? LogContext.Error : LogContext.Debug;
                 logger?.Log("An error occured creating topics. {Errors}", string.Join(", ", e.Results.Select(x => $"{x.Topic}:{x.Error.Reason}")));
             }
             finally


### PR DESCRIPTION
- Do not create batch if there is no message for EventHub Producer
- Use `Debug` level for NonCritical errors for ConfigureTopology in Kafka 
- Make a short loop for kafka producer flush instead of constant timeout