### PR TITLE
edit CreateUsingRabbitMq statements in docs so they end with lower case q

### DIFF
--- a/docs/advanced/topology/conventions.md
+++ b/docs/advanced/topology/conventions.md
@@ -26,7 +26,7 @@ public interface OrderSubmitted
     Guid CustomerId { get; }
 }
 
-Bus.Factory.CreateUsingRabbitMQ(..., cfg =>
+Bus.Factory.CreateUsingRabbitMq(..., cfg =>
 {
     cfg.Send<OrderSubmitted>(x =>
     {

--- a/docs/advanced/topology/message.md
+++ b/docs/advanced/topology/message.md
@@ -9,7 +9,7 @@ Message types are extensively leveraged in MassTransit, so making it easy to con
 MassTransit has built-in defaults for naming messaging entities (these are things like exchanges, topics, etc.). The defaults can be overridden as well. For instance, to change the topic name used by a message, just do it!
 
 ```csharp
-Bus.Factory.CreateUsingRabbitMQ(cfg =>
+Bus.Factory.CreateUsingRabbitMq(cfg =>
 {
     cfg.Message<OrderSubmitted>(x =>
     {
@@ -31,7 +31,7 @@ class FancyNameFormatter<T> :
     }
 }
 
-Bus.Factory.CreateUsingRabbitMQ(cfg =>
+Bus.Factory.CreateUsingRabbitMq(cfg =>
 {
     cfg.Message<OrderSubmitted>(x =>
     {
@@ -70,7 +70,7 @@ class FancyNameFormatter :
     }
 }
 
-Bus.Factory.CreateUsingRabbitMQ(cfg =>
+Bus.Factory.CreateUsingRabbitMq(cfg =>
 {
     cfg.Message<OrderSubmitted>(x =>
     {

--- a/docs/advanced/topology/rabbitmq.md
+++ b/docs/advanced/topology/rabbitmq.md
@@ -66,7 +66,7 @@ public interface SubmitOrder
     // ...
 }
 
-Bus.Factory.CreateUsingRabbitMQ(cfg =>
+Bus.Factory.CreateUsingRabbitMq(cfg =>
 {
     cfg.Send<SubmitOrder>(x =>
     {
@@ -102,7 +102,7 @@ public class OrderConsumer :
 And then connected to a receive endpoint:
 
 ```csharp
-Bus.Factory.CreateUsingRabbitMQ(cfg =>
+Bus.Factory.CreateUsingRabbitMq(cfg =>
 {
     cfg.ReceiveEndpoint("priority-orders", x =>
     {

--- a/docs/advanced/topology/rabbitmq.md
+++ b/docs/advanced/topology/rabbitmq.md
@@ -15,7 +15,7 @@ To configure the properties used when an exchange is created, the publish topolo
 In versions of MassTransit prior to 4.x, every implemented type was connected directly to the top-level exchange for the published message type. Starting with v4.0, the broker topology for inherited types can be configured to maintain the type hierarchy, which can significantly reduce the number of exchange bindings in some cases. To configure this new behavior, the publish topology is used to specify the broker topology option.
 
 ```csharp
-Bus.Factory.CreateUsingRabbitMQ(cfg =>
+Bus.Factory.CreateUsingRabbitMq(cfg =>
 {
     cfg.PublishTopology.BrokerTopologyOptions = PublishBrokerTopologyOptions.MaintainHierarchy;
 });


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
no code has been changed. i was using these docs and noticed, that there were no code hints from intellisense. then i found out that `CreateUsingRabbitMq` should end with lower case `q`