### PR TITLE
Cancel producer flush if error occurred

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/Specifications/KafkaProducerSpecification.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/Specifications/KafkaProducerSpecification.cs
@@ -160,9 +160,6 @@ namespace MassTransit.KafkaIntegration.Specifications
             ProducerBuilder<TKey, TValue> CreateProducerBuilder()
             {
                 ProducerBuilder<TKey, TValue> producerBuilder = new ProducerBuilder<TKey, TValue>(producerConfig)
-                    .SetErrorHandler((c, error) =>
-                        busInstance.HostConfiguration.SendLogContext?.Error?.Log("Consumer error ({code}): {reason} on {topic}", error.Code, error.Reason,
-                            TopicName))
                     .SetLogHandler((c, message) => busInstance.HostConfiguration.SendLogContext?.Debug?.Log(message.Message));
 
                 if (_keySerializer != null)

--- a/src/Transports/MassTransit.KafkaIntegration/Contexts/KafkaProducerContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Contexts/KafkaProducerContext.cs
@@ -4,7 +4,9 @@ namespace MassTransit.KafkaIntegration.Contexts
     using System.Threading;
     using System.Threading.Tasks;
     using Confluent.Kafka;
+    using Context;
     using GreenPipes;
+    using Logging;
     using Serializers;
     using Transport;
 
@@ -14,12 +16,19 @@ namespace MassTransit.KafkaIntegration.Contexts
         ProducerContext<TKey, TValue>
         where TValue : class
     {
+        readonly CancellationTokenSource _cancellationTokenSource;
+        readonly ILogContext _logContext;
         readonly IProducer<TKey, TValue> _producer;
 
-        public KafkaProducerContext(ProducerBuilder<TKey, TValue> producerBuilder, IHeadersSerializer headersSerializer, CancellationToken cancellationToken)
+        public KafkaProducerContext(ProducerBuilder<TKey, TValue> producerBuilder, IHeadersSerializer headersSerializer, ILogContext logContext,
+            CancellationToken cancellationToken)
             : base(cancellationToken)
         {
-            _producer = producerBuilder.Build();
+            _logContext = logContext;
+            _producer = producerBuilder
+                .SetErrorHandler(OnError)
+                .Build();
+            _cancellationTokenSource = new CancellationTokenSource();
             HeadersSerializer = headersSerializer;
         }
 
@@ -32,10 +41,34 @@ namespace MassTransit.KafkaIntegration.Contexts
 
         public void Dispose()
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            _producer.Flush(cts.Token);
+            var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(timeoutTokenSource.Token, _cancellationTokenSource.Token);
+            try
+            {
+                _producer.Flush(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e)
+            {
+                _logContext.Error?.Log(e, "Failed to dispose producer: {producerName}", _producer.Name);
+            }
+            finally
+            {
+                timeoutTokenSource.Dispose();
+                _cancellationTokenSource.Dispose();
+                _producer.Dispose();
+            }
+        }
 
-            _producer.Dispose();
+        void OnError(IProducer<TKey, TValue> producer, Error error)
+        {
+            EnabledLogger? logger = error.IsFatal ? _logContext.Error : _logContext.Warning;
+            logger?.Log("Error ({code}): {reason} on producer: {producerName}", error.Code, error.Reason, producer.Name);
+
+            if (!_cancellationTokenSource.IsCancellationRequested && error.IsLocalError)
+                _cancellationTokenSource.Cancel();
         }
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/Contexts/ProducerContextFactory.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Contexts/ProducerContextFactory.cs
@@ -3,6 +3,7 @@ namespace MassTransit.KafkaIntegration.Contexts
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Configuration;
     using Confluent.Kafka;
     using GreenPipes;
     using GreenPipes.Agents;
@@ -18,12 +19,15 @@ namespace MassTransit.KafkaIntegration.Contexts
     {
         readonly IClientContextSupervisor _clientContextSupervisor;
         readonly IHeadersSerializer _headersSerializer;
+        readonly IHostConfiguration _hostConfiguration;
         readonly Func<ProducerBuilder<TKey, TValue>> _producerBuilderFactory;
 
-        public ProducerContextFactory(IClientContextSupervisor clientContextSupervisor, IHeadersSerializer headersSerializer,
+        public ProducerContextFactory(IClientContextSupervisor clientContextSupervisor, IHostConfiguration hostConfiguration,
+            IHeadersSerializer headersSerializer,
             Func<ProducerBuilder<TKey, TValue>> producerBuilderFactory)
         {
             _clientContextSupervisor = clientContextSupervisor;
+            _hostConfiguration = hostConfiguration;
             _headersSerializer = headersSerializer;
             _producerBuilderFactory = producerBuilderFactory;
         }
@@ -56,7 +60,8 @@ namespace MassTransit.KafkaIntegration.Contexts
             Task<ProducerContext<TKey, TValue>> Create(ClientContext clientContext, CancellationToken createCancellationToken)
             {
                 ProducerBuilder<TKey, TValue> producerBuilder = _producerBuilderFactory();
-                ProducerContext<TKey, TValue> context = new KafkaProducerContext<TKey, TValue>(producerBuilder, _headersSerializer, cancellationToken);
+                ProducerContext<TKey, TValue> context =
+                    new KafkaProducerContext<TKey, TValue>(producerBuilder, _headersSerializer, _hostConfiguration.SendLogContext, cancellationToken);
                 return Task.FromResult(context);
             }
 

--- a/src/Transports/MassTransit.KafkaIntegration/Contexts/ProducerContextSupervisor.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Contexts/ProducerContextSupervisor.cs
@@ -25,7 +25,7 @@ namespace MassTransit.KafkaIntegration.Contexts
             ISendPipe sendPipe, SendObservable sendObservers, IClientContextSupervisor clientContextSupervisor,
             IHostConfiguration hostConfiguration, IHeadersSerializer headersSerializer,
             Func<ProducerBuilder<TKey, TValue>> producerBuilderFactory)
-            : base(new ProducerContextFactory<TKey, TValue>(clientContextSupervisor, headersSerializer, producerBuilderFactory))
+            : base(new ProducerContextFactory<TKey, TValue>(clientContextSupervisor, hostConfiguration, headersSerializer, producerBuilderFactory))
         {
             _sendObservers = sendObservers;
             _hostConfiguration = hostConfiguration;


### PR DESCRIPTION
Cancel producer flush if local (it means something wrong with a client, eg: connection issue) error occurred. Same logic is used for [consumer](https://github.com/MassTransit/MassTransit/blob/92ed73841886e74d34c16a0a1e6ff6207f600449/src/Transports/MassTransit.KafkaIntegration/Transport/KafkaMessageReceiver.cs#L106)