### PR TITLE
Timeout pipe filter

### DIFF
--- a/src/MassTransit/Configuration/ITimeoutConfigurator.cs
+++ b/src/MassTransit/Configuration/ITimeoutConfigurator.cs
@@ -1,0 +1,10 @@
+namespace MassTransit
+{
+    using System;
+
+
+    public interface ITimeoutConfigurator
+    {
+        TimeSpan Timeout { set; }
+    }
+}

--- a/src/MassTransit/Configuration/PipeConfigurators/CompensateContextTimeoutSpecification.cs
+++ b/src/MassTransit/Configuration/PipeConfigurators/CompensateContextTimeoutSpecification.cs
@@ -1,0 +1,35 @@
+namespace MassTransit.PipeConfigurators
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Courier;
+    using Courier.Contexts;
+    using GreenPipes;
+    using Pipeline.Filters;
+
+
+    public class CompensateContextTimeoutSpecification<TArguments> :
+        IPipeSpecification<CompensateContext<TArguments>>,
+        ITimeoutConfigurator
+        where TArguments : class
+    {
+        public TimeSpan Timeout { get; set; }
+
+        public void Apply(IPipeBuilder<CompensateContext<TArguments>> builder)
+        {
+            builder.AddFilter(
+                new TimeoutFilter<CompensateContext<TArguments>, TimeoutCompensateContext<TArguments>>(Factory, Timeout));
+        }
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            yield break;
+        }
+
+        static TimeoutCompensateContext<TArguments> Factory(CompensateContext<TArguments> context, CancellationToken cancellationToken)
+        {
+            return new TimeoutCompensateContext<TArguments>(context, cancellationToken);
+        }
+    }
+}

--- a/src/MassTransit/Configuration/PipeConfigurators/ExecuteContextTimeoutSpecification.cs
+++ b/src/MassTransit/Configuration/PipeConfigurators/ExecuteContextTimeoutSpecification.cs
@@ -1,0 +1,35 @@
+namespace MassTransit.PipeConfigurators
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Courier;
+    using Courier.Contexts;
+    using GreenPipes;
+    using Pipeline.Filters;
+
+
+    public class ExecuteContextTimeoutSpecification<TArguments> :
+        IPipeSpecification<ExecuteContext<TArguments>>,
+        ITimeoutConfigurator
+        where TArguments : class
+    {
+        public TimeSpan Timeout { get; set; }
+
+        public void Apply(IPipeBuilder<ExecuteContext<TArguments>> builder)
+        {
+            builder.AddFilter(
+                new TimeoutFilter<ExecuteContext<TArguments>, TimeoutExecuteContext<TArguments>>(Factory, Timeout));
+        }
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            yield break;
+        }
+
+        static TimeoutExecuteContext<TArguments> Factory(ExecuteContext<TArguments> context, CancellationToken cancellationToken)
+        {
+            return new TimeoutExecuteContext<TArguments>(context, cancellationToken);
+        }
+    }
+}

--- a/src/MassTransit/Configuration/PipeConfigurators/TimeoutConfigurationObserver.cs
+++ b/src/MassTransit/Configuration/PipeConfigurators/TimeoutConfigurationObserver.cs
@@ -1,0 +1,67 @@
+﻿namespace MassTransit.PipeConfigurators
+{
+    using System;
+    using ConsumeConfigurators;
+
+
+    public class TimeoutConfigurationObserver :
+        ConfigurationObserver,
+        IMessageConfigurationObserver
+    {
+        readonly Action<ITimeoutConfigurator> _configure;
+
+        public TimeoutConfigurationObserver(IConsumePipeConfigurator configurator, Action<ITimeoutConfigurator> configure)
+            : base(configurator)
+        {
+            _configure = configure;
+
+            Connect(this);
+        }
+
+        public void MessageConfigured<TMessage>(IConsumePipeConfigurator configurator)
+            where TMessage : class
+        {
+            var specification = new TimeoutSpecification<TMessage>();
+
+            _configure?.Invoke(specification);
+
+            configurator.AddPipeSpecification(specification);
+        }
+
+        public override void BatchConsumerConfigured<TConsumer, TMessage>(IConsumerMessageConfigurator<TConsumer, Batch<TMessage>> configurator)
+        {
+            var specification = new TimeoutSpecification<Batch<TMessage>>();
+
+            _configure?.Invoke(specification);
+
+            configurator.Message(m => m.AddPipeSpecification(specification));
+        }
+
+        public override void ActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator, Uri compensateAddress)
+        {
+            var specification = new ExecuteContextTimeoutSpecification<TArguments>();
+
+            _configure?.Invoke(specification);
+
+            configurator.Arguments(x => x.AddPipeSpecification(specification));
+        }
+
+        public override void ExecuteActivityConfigured<TActivity, TArguments>(IExecuteActivityConfigurator<TActivity, TArguments> configurator)
+        {
+            var specification = new ExecuteContextTimeoutSpecification<TArguments>();
+
+            _configure?.Invoke(specification);
+
+            configurator.Arguments(x => x.AddPipeSpecification(specification));
+        }
+
+        public override void CompensateActivityConfigured<TActivity, TLog>(ICompensateActivityConfigurator<TActivity, TLog> configurator)
+        {
+            var specification = new CompensateContextTimeoutSpecification<TLog>();
+
+            _configure?.Invoke(specification);
+
+            configurator.Log(x => x.AddPipeSpecification(specification));
+        }
+    }
+}

--- a/src/MassTransit/Configuration/PipeConfigurators/TimeoutConsumerConfigurationObserver.cs
+++ b/src/MassTransit/Configuration/PipeConfigurators/TimeoutConsumerConfigurationObserver.cs
@@ -1,0 +1,33 @@
+namespace MassTransit.PipeConfigurators
+{
+    using System;
+    using ConsumeConfigurators;
+
+
+    public class TimeoutConsumerConfigurationObserver<TConsumer> :
+        IConsumerConfigurationObserver
+        where TConsumer : class
+    {
+        readonly IConsumerConfigurator<TConsumer> _configurator;
+        readonly Action<ITimeoutConfigurator> _configure;
+
+        public TimeoutConsumerConfigurationObserver(IConsumerConfigurator<TConsumer> configurator, Action<ITimeoutConfigurator> configure)
+        {
+            _configurator = configurator;
+            _configure = configure;
+        }
+
+        void IConsumerConfigurationObserver.ConsumerConfigured<T>(IConsumerConfigurator<T> configurator)
+        {
+        }
+
+        void IConsumerConfigurationObserver.ConsumerMessageConfigured<T, TMessage>(IConsumerMessageConfigurator<T, TMessage> configurator)
+        {
+            var specification = new TimeoutSpecification<TMessage>();
+
+            _configure?.Invoke(specification);
+
+            _configurator.Message<TMessage>(x => x.AddPipeSpecification(specification));
+        }
+    }
+}

--- a/src/MassTransit/Configuration/PipeConfigurators/TimeoutHandlerConfigurationObserver.cs
+++ b/src/MassTransit/Configuration/PipeConfigurators/TimeoutHandlerConfigurationObserver.cs
@@ -1,0 +1,26 @@
+namespace MassTransit.PipeConfigurators
+{
+    using System;
+    using ConsumeConfigurators;
+
+
+    public class TimeoutHandlerConfigurationObserver :
+        IHandlerConfigurationObserver
+    {
+        readonly Action<ITimeoutConfigurator> _configure;
+
+        public TimeoutHandlerConfigurationObserver(Action<ITimeoutConfigurator> configure)
+        {
+            _configure = configure;
+        }
+
+        void IHandlerConfigurationObserver.HandlerConfigured<T>(IHandlerConfigurator<T> configurator)
+        {
+            var specification = new TimeoutSpecification<T>();
+
+            _configure?.Invoke(specification);
+
+            configurator.AddPipeSpecification(specification);
+        }
+    }
+}

--- a/src/MassTransit/Configuration/PipeConfigurators/TimeoutSagaConfigurationObserver.cs
+++ b/src/MassTransit/Configuration/PipeConfigurators/TimeoutSagaConfigurationObserver.cs
@@ -1,0 +1,40 @@
+namespace MassTransit.PipeConfigurators
+{
+    using System;
+    using Automatonymous;
+    using Saga;
+    using SagaConfigurators;
+
+
+    public class TimeoutSagaConfigurationObserver<TSaga> :
+        ISagaConfigurationObserver
+        where TSaga : class, ISaga
+    {
+        readonly ISagaConfigurator<TSaga> _configurator;
+        readonly Action<ITimeoutConfigurator> _configure;
+
+        public TimeoutSagaConfigurationObserver(ISagaConfigurator<TSaga> configurator, Action<ITimeoutConfigurator> configure)
+        {
+            _configurator = configurator;
+            _configure = configure;
+        }
+
+        void ISagaConfigurationObserver.SagaConfigured<T>(ISagaConfigurator<T> configurator)
+        {
+        }
+
+        public void StateMachineSagaConfigured<TInstance>(ISagaConfigurator<TInstance> configurator, SagaStateMachine<TInstance> stateMachine)
+            where TInstance : class, ISaga, SagaStateMachineInstance
+        {
+        }
+
+        void ISagaConfigurationObserver.SagaMessageConfigured<T, TMessage>(ISagaMessageConfigurator<T, TMessage> configurator)
+        {
+            var specification = new TimeoutSpecification<TMessage>();
+
+            _configure?.Invoke(specification);
+
+            _configurator.Message<TMessage>(x => x.AddPipeSpecification(specification));
+        }
+    }
+}

--- a/src/MassTransit/Configuration/PipeConfigurators/TimeoutSpecification.cs
+++ b/src/MassTransit/Configuration/PipeConfigurators/TimeoutSpecification.cs
@@ -1,0 +1,33 @@
+namespace MassTransit.PipeConfigurators
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Context;
+    using GreenPipes;
+    using Pipeline.Filters;
+
+
+    public class TimeoutSpecification<T> :
+        IPipeSpecification<ConsumeContext<T>>,
+        ITimeoutConfigurator
+        where T : class
+    {
+        public TimeSpan Timeout { get; set; }
+
+        public void Apply(IPipeBuilder<ConsumeContext<T>> builder)
+        {
+            builder.AddFilter(new TimeoutFilter<ConsumeContext<T>, TimeoutConsumeContext<T>>(Factory, Timeout));
+        }
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            yield break;
+        }
+
+        static TimeoutConsumeContext<T> Factory(ConsumeContext<T> context, CancellationToken cancellationToken)
+        {
+            return new TimeoutConsumeContext<T>(context, cancellationToken);
+        }
+    }
+}

--- a/src/MassTransit/Configuration/TimeoutConfiguratorExtensions.cs
+++ b/src/MassTransit/Configuration/TimeoutConfiguratorExtensions.cs
@@ -1,0 +1,88 @@
+﻿namespace MassTransit
+{
+    using System;
+    using ConsumeConfigurators;
+    using GreenPipes;
+    using PipeConfigurators;
+    using Saga;
+
+
+    public static class TimeoutConfiguratorExtensions
+    {
+        /// <summary>
+        /// Cancels context's CancellationToken once timeout is reached.
+        /// </summary>
+        /// <param name="configurator">The pipe configurator</param>
+        /// <param name="configure">Configure timeout</param>
+        public static void UseTimeout<T>(this IPipeConfigurator<ConsumeContext<T>> configurator, Action<ITimeoutConfigurator> configure = default)
+            where T : class
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+
+            var specification = new TimeoutSpecification<T>();
+
+            configure?.Invoke(specification);
+
+            configurator.AddPipeSpecification(specification);
+        }
+
+        /// <summary>
+        /// Cancels context's CancellationToken once timeout is reached.
+        /// </summary>
+        /// <param name="configurator">The pipe configurator</param>
+        /// <param name="configure">Configure timeout</param>
+        public static void UseTimeout(this IConsumePipeConfigurator configurator, Action<ITimeoutConfigurator> configure = default)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+
+            var observer = new TimeoutConfigurationObserver(configurator, configure);
+        }
+
+        /// <summary>
+        /// Cancels context's CancellationToken once timeout is reached.
+        /// </summary>
+        /// <param name="configurator">The pipe configurator</param>
+        /// <param name="configure">Configure timeout</param>
+        public static void UseTimeout<TConsumer>(this IConsumerConfigurator<TConsumer> configurator, Action<ITimeoutConfigurator> configure = default)
+            where TConsumer : class
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+
+            var observer = new TimeoutConsumerConfigurationObserver<TConsumer>(configurator, configure);
+            configurator.ConnectConsumerConfigurationObserver(observer);
+        }
+
+        /// <summary>
+        /// Cancels context's CancellationToken once timeout is reached.
+        /// </summary>
+        /// <param name="configurator">The pipe configurator</param>
+        /// <param name="configure">Configure timeout</param>
+        public static void UseTimeout<TSaga>(this ISagaConfigurator<TSaga> configurator, Action<ITimeoutConfigurator> configure = default)
+            where TSaga : class, ISaga
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+
+            var observer = new TimeoutSagaConfigurationObserver<TSaga>(configurator, configure);
+            configurator.ConnectSagaConfigurationObserver(observer);
+        }
+
+        /// <summary>
+        /// Cancels context's CancellationToken once timeout is reached.
+        /// </summary>
+        /// <param name="configurator">The pipe configurator</param>
+        /// <param name="configure">Configure timeout</param>
+        public static void UseTimeout<TMessage>(this IHandlerConfigurator<TMessage> configurator, Action<ITimeoutConfigurator> configure = default)
+            where TMessage : class
+        {
+            if (configurator == null)
+                throw new ArgumentNullException(nameof(configurator));
+
+            var observer = new TimeoutHandlerConfigurationObserver(configure);
+            configurator.ConnectHandlerConfigurationObserver(observer);
+        }
+    }
+}

--- a/src/MassTransit/Context/TimeoutConsumeContext.cs
+++ b/src/MassTransit/Context/TimeoutConsumeContext.cs
@@ -1,0 +1,46 @@
+namespace MassTransit.Context
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+
+    public class TimeoutConsumeContext :
+        ConsumeContextProxy
+    {
+        public TimeoutConsumeContext(ConsumeContext context, CancellationToken cancellationToken)
+            : base(context)
+        {
+            CancellationToken = cancellationToken;
+        }
+
+        public override CancellationToken CancellationToken { get; }
+    }
+
+
+    public class TimeoutConsumeContext<T> :
+        TimeoutConsumeContext,
+        ConsumeContext<T>
+        where T : class
+    {
+        readonly ConsumeContext<T> _context;
+
+        public TimeoutConsumeContext(ConsumeContext<T> context, CancellationToken cancellationToken)
+            : base(context, cancellationToken)
+        {
+            _context = context;
+        }
+
+        public T Message => _context.Message;
+
+        public virtual Task NotifyConsumed(TimeSpan duration, string consumerType)
+        {
+            return NotifyConsumed(this, duration, consumerType);
+        }
+
+        public virtual Task NotifyFaulted(TimeSpan duration, string consumerType, Exception exception)
+        {
+            return NotifyFaulted(this, duration, consumerType, exception);
+        }
+    }
+}

--- a/src/MassTransit/Courier/Contexts/TimeoutCompensateContext.cs
+++ b/src/MassTransit/Courier/Contexts/TimeoutCompensateContext.cs
@@ -1,0 +1,59 @@
+namespace MassTransit.Courier.Contexts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+
+    public class TimeoutCompensateContext<TLog> :
+        TimeoutCourierContextProxy,
+        CompensateContext<TLog>
+        where TLog : class
+    {
+        readonly CompensateContext<TLog> _context;
+
+        public TimeoutCompensateContext(CompensateContext<TLog> context, CancellationToken cancellationToken)
+            : base(context, cancellationToken)
+        {
+            _context = context;
+        }
+
+        CompensationResult CompensateContext.Compensated()
+        {
+            return _context.Compensated();
+        }
+
+        CompensationResult CompensateContext.Compensated(object values)
+        {
+            return _context.Compensated(values);
+        }
+
+        CompensationResult CompensateContext.Compensated(IDictionary<string, object> variables)
+        {
+            return _context.Compensated(variables);
+        }
+
+        CompensationResult CompensateContext.Failed()
+        {
+            return _context.Failed();
+        }
+
+        CompensationResult CompensateContext.Failed(Exception exception)
+        {
+            return _context.Failed(exception);
+        }
+
+        CompensationResult CompensateContext.Result
+        {
+            get => _context.Result;
+            set => _context.Result = value;
+        }
+
+        TLog CompensateContext<TLog>.Log => _context.Log;
+
+        CompensateActivityContext<TActivity, TLog> CompensateContext<TLog>.CreateActivityContext<TActivity>(TActivity activity)
+        {
+            return new HostCompensateActivityContext<TActivity, TLog>(activity, this);
+        }
+    }
+}

--- a/src/MassTransit/Courier/Contexts/TimeoutCourierContextProxy.cs
+++ b/src/MassTransit/Courier/Contexts/TimeoutCourierContextProxy.cs
@@ -1,0 +1,27 @@
+namespace MassTransit.Courier.Contexts
+{
+    using System;
+    using System.Threading;
+    using Context;
+    using Contracts;
+
+
+    public abstract class TimeoutCourierContextProxy :
+        TimeoutConsumeContext<RoutingSlip>,
+        CourierContext
+    {
+        readonly CourierContext _courierContext;
+
+        protected TimeoutCourierContextProxy(CourierContext courierContext, CancellationToken cancellationToken)
+            : base(courierContext, cancellationToken)
+        {
+            _courierContext = courierContext;
+        }
+
+        DateTime CourierContext.Timestamp => _courierContext.Timestamp;
+        TimeSpan CourierContext.Elapsed => _courierContext.Elapsed;
+        Guid CourierContext.TrackingNumber => _courierContext.TrackingNumber;
+        Guid CourierContext.ExecutionId => _courierContext.ExecutionId;
+        string CourierContext.ActivityName => _courierContext.ActivityName;
+    }
+}

--- a/src/MassTransit/Courier/Contexts/TimeoutExecuteContext.cs
+++ b/src/MassTransit/Courier/Contexts/TimeoutExecuteContext.cs
@@ -1,0 +1,130 @@
+namespace MassTransit.Courier.Contexts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+
+    public class TimeoutExecuteContext<TArguments> :
+        TimeoutCourierContextProxy,
+        ExecuteContext<TArguments>
+        where TArguments : class
+    {
+        readonly ExecuteContext<TArguments> _context;
+
+        public TimeoutExecuteContext(ExecuteContext<TArguments> context, CancellationToken cancellationToken)
+            : base(context, cancellationToken)
+        {
+            _context = context;
+        }
+
+        ExecutionResult ExecuteContext.Completed()
+        {
+            return _context.Completed();
+        }
+
+        ExecutionResult ExecuteContext.CompletedWithVariables(IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            return _context.CompletedWithVariables(variables);
+        }
+
+        ExecutionResult ExecuteContext.CompletedWithVariables(object variables)
+        {
+            return _context.CompletedWithVariables(variables);
+        }
+
+        ExecutionResult ExecuteContext.Completed<TLog>(TLog log)
+        {
+            return _context.Completed(log);
+        }
+
+        ExecutionResult ExecuteContext.Completed<TLog>(object logValues)
+        {
+            return _context.Completed<TLog>(logValues);
+        }
+
+        ExecutionResult ExecuteContext.CompletedWithVariables<TLog>(TLog log, object variables)
+        {
+            return _context.CompletedWithVariables(log, variables);
+        }
+
+        ExecutionResult ExecuteContext.CompletedWithVariables<TLog>(object logValues, object variables)
+        {
+            return _context.CompletedWithVariables<TLog>(logValues, variables);
+        }
+
+        ExecutionResult ExecuteContext.CompletedWithVariables<TLog>(TLog log, IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            return _context.CompletedWithVariables(log, variables);
+        }
+
+        ExecutionResult ExecuteContext.ReviseItinerary(Action<ItineraryBuilder> buildItinerary)
+        {
+            return _context.ReviseItinerary(buildItinerary);
+        }
+
+        ExecutionResult ExecuteContext.ReviseItinerary<TLog>(TLog log, Action<ItineraryBuilder> buildItinerary)
+        {
+            return _context.ReviseItinerary(log, buildItinerary);
+        }
+
+        ExecutionResult ExecuteContext.ReviseItinerary<TLog>(TLog log, object variables, Action<ItineraryBuilder> buildItinerary)
+        {
+            return _context.ReviseItinerary(log, variables, buildItinerary);
+        }
+
+        ExecutionResult ExecuteContext.ReviseItinerary<TLog>(TLog log, IEnumerable<KeyValuePair<string, object>> variables,
+            Action<ItineraryBuilder> buildItinerary)
+        {
+            return _context.ReviseItinerary(log, variables, buildItinerary);
+        }
+
+        ExecutionResult ExecuteContext.Terminate()
+        {
+            return _context.Terminate();
+        }
+
+        ExecutionResult ExecuteContext.Terminate(object variables)
+        {
+            return _context.Terminate(variables);
+        }
+
+        ExecutionResult ExecuteContext.Terminate(IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            return _context.Terminate(variables);
+        }
+
+        ExecutionResult ExecuteContext.Faulted()
+        {
+            return _context.Faulted();
+        }
+
+        ExecutionResult ExecuteContext.Faulted(Exception exception)
+        {
+            return _context.Faulted(exception);
+        }
+
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, object variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
+
+        ExecutionResult ExecuteContext.FaultedWithVariables(Exception exception, IEnumerable<KeyValuePair<string, object>> variables)
+        {
+            return _context.FaultedWithVariables(exception, variables);
+        }
+
+        ExecutionResult ExecuteContext.Result
+        {
+            get => _context.Result;
+            set => _context.Result = value;
+        }
+
+        TArguments ExecuteContext<TArguments>.Arguments => _context.Arguments;
+
+        ExecuteActivityContext<TActivity, TArguments> ExecuteContext<TArguments>.CreateActivityContext<TActivity>(TActivity activity)
+        {
+            return new HostExecuteActivityContext<TActivity, TArguments>(activity, this);
+        }
+    }
+}

--- a/src/MassTransit/Pipeline/Filters/TimeoutFilter.cs
+++ b/src/MassTransit/Pipeline/Filters/TimeoutFilter.cs
@@ -1,0 +1,49 @@
+﻿namespace MassTransit.Pipeline.Filters
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using GreenPipes;
+
+
+    public class TimeoutFilter<TContext, TResult> :
+        IFilter<TContext>
+        where TContext : class, ConsumeContext
+        where TResult : TContext
+    {
+        readonly Func<TContext, CancellationToken, TResult> _contextFactory;
+        readonly TimeSpan _timeout;
+
+        public TimeoutFilter(Func<TContext, CancellationToken, TResult> contextFactory, TimeSpan timeout)
+        {
+            _contextFactory = contextFactory;
+            _timeout = timeout;
+        }
+
+        public async Task Send(TContext context, IPipe<TContext> next)
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+
+            cts.CancelAfter(_timeout);
+
+            try
+            {
+                var timeoutContext = _contextFactory(context, cts.Token);
+
+                await next.Send(timeoutContext).ConfigureAwait(false);
+
+                await timeoutContext.ConsumeCompleted.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
+            {
+                throw new ConsumerCanceledException("The operation was canceled by the timeout filter", ex);
+            }
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateFilterScope("timeout");
+            scope.Add("timeout", _timeout);
+        }
+    }
+}

--- a/tests/MassTransit.Tests/Timeout_Specs.cs
+++ b/tests/MassTransit.Tests/Timeout_Specs.cs
@@ -1,0 +1,51 @@
+﻿namespace MassTransit.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using TestFramework;
+    using TestFramework.Messages;
+
+
+    [TestFixture]
+    public class Timeout_Specs :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_throw_on_timeout()
+        {
+            Task<ConsumeContext<Fault<PingMessage>>> faulted = await ConnectPublishHandler<Fault<PingMessage>>();
+
+            await InputQueueSendEndpoint.Send(new PingMessage());
+            await Task.WhenAny(_succeeded, faulted);
+
+            Assert.IsTrue(_firstCalled);
+            Assert.IsTrue(_firstRequested.HasValue);
+            Assert.IsFalse(_firstRequested.Value);
+            Assert.IsFalse(_secondCalled);
+            Assert.IsFalse(_secondRequested.HasValue);
+        }
+
+        Task _succeeded;
+        bool _firstCalled;
+        bool? _firstRequested;
+        bool _secondCalled;
+        bool? _secondRequested;
+
+        protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
+        {
+            configurator.UseTimeout(c => c.Timeout = TimeSpan.FromMilliseconds(100));
+
+            _succeeded = Handler<PingMessage>(configurator, async context =>
+            {
+                _firstCalled = true;
+                _firstRequested = context.CancellationToken.IsCancellationRequested;
+
+                await Task.Delay(1000, context.CancellationToken);
+
+                _secondCalled = true;
+                _secondRequested = context.CancellationToken.IsCancellationRequested;
+            });
+        }
+    }
+}


### PR DESCRIPTION
Based on https://github.com/MassTransit/MassTransit/discussions/2734

Question: Is consume context proxy implemented correctly? Have to say it looks somehow wrong considering amount of boilerplate code required for all use cases.