### PR TITLE
Fix typo

### DIFF
--- a/docs/usage/riders/kafka.md
+++ b/docs/usage/riders/kafka.md
@@ -6,11 +6,15 @@ Kafka is supported as a [Rider](/usage/riders/), and supports consuming and prod
 
 > Uses [MassTransit.RabbitMQ](https://nuget.org/packages/MassTransit.RabbitMQ/), [MassTransit.Kafka](https://nuget.org/packages/MassTransit.Kafka/), [MassTransit.Extensions.DependencyInjection](https://www.nuget.org/packages/MassTransit.Extensions.DependencyInjection/)
 
+> Note: the following examples are using the RabbitMQ Transport. You can also use InMemory Transport to achieve the same effect when developing. With that, there is no need to install MassTransit.RabbitMQ.
+> `x.UsingInMemory((context,config) => config.ConfigureEndpoints(context));`
+
+
 To consume a Kafka topic, configure a Rider within the bus configuration as shown.
 
 <<< @/docs/code/riders/KafkaConsumer.cs
 
-A _TopicEndpoint_ connects a Kafka Consumer to a topic, using the specified topic name. The consumer group specified should be unique to the application, and shared by a cluster of service instances for load balancing. Consumers and sagas can be configured on the topic endpoint, which should be registered in the rider configuration. While they configuration for topic endpoints is the same as a receive endpoint, there is no implicit binding of consumer message types to Kafka topics. The message type is specified on the TopicEndpoint as a generic argument.
+A _TopicEndpoint_ connects a Kafka Consumer to a topic, using the specified topic name. The consumer group specified should be unique to the application, and shared by a cluster of service instances for load balancing. Consumers and sagas can be configured on the topic endpoint, which should be registered in the rider configuration. While the configuration for topic endpoints is the same as a receive endpoint, there is no implicit binding of consumer message types to Kafka topics. The message type is specified on the TopicEndpoint as a generic argument.
 
 #### Configure Topology
 
@@ -20,7 +24,7 @@ When client has *required* permissions and `CreateIfMissing` is configured, topi
 
 ### Producers
 
-Producing messages to Kafka topics requires the producer to be registered. The producer can then be used to produce messages to the specified Kafka topic. In the example below, messages are produced to the Kafka topic as they are entered.
+Producing messages to Kafka topics requires the producer to be registered. The producer can then be used to produce messages to the specified Kafka topic. In the example below, messages are produced to the Kafka topic as they are entered by the user.
 
 <<< @/docs/code/riders/KafkaProducer.cs
 
@@ -30,16 +34,16 @@ There are situations where you might want to produce / consume events of differe
 
 Confluent have some documentation about how this can be implemented on the Schema Registry side:
 
-https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#multiple-event-types-in-the-same-topic
-https://docs.confluent.io/platform/current/schema-registry/serdes-develop/serdes-avro.html#multiple-event-types-in-the-same-topic
-https://www.confluent.io/blog/multiple-event-types-in-the-same-kafka-topic/
+- [Confluent Docs - Multiple Event Types in the Same Topic](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#multiple-event-types-in-the-same-topic)
+- [Confluent Docs - Multiple Event Types in the Same Topic with Avro](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/serdes-avro.html#multiple-event-types-in-the-same-topic)
+- [Confluent Blog - Multiple Event Types in the Same Topic](https://www.confluent.io/blog/multiple-event-types-in-the-same-kafka-topic/)
 
 Unfortunately, it is [not yet widely supported in client tools and products](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#limitations) and there is limited documentation about how to support this in your own applications. 
 
-However, it is possible... The following demo uses the MassTransit Kafka rider with custom Avro serializer / deserializer implementations and the Schema Registry to support multiple event types on a single topic:
+However, it is possible... The following demo uses the MassTransit Kafka Rider with custom [Avro](https://avro.apache.org/docs/current/) serializer / deserializer implementations and the Schema Registry to support multiple event types on a single topic:
 
-https://github.com/danmalcolm/masstransit-kafka-demo
+[MassTransit-Kafka-Demo](https://github.com/danmalcolm/masstransit-kafka-demo)
 
 The custom serializers / deserializer implementations leverage the wire format used by the standard Confluent schema-based serializers, which includes the schema id in the data stored for each message. This is also good news for interoperability with non-MassTransit applications.
 
-Warning: It's a little hacky and only supports the Avro format, but there's enough there to get you started. 
+**Warning: It's a little hacky and only supports the Avro format, but there's enough there to get you started.**


### PR DESCRIPTION
Fixed some typos and text formatting with links and lists.
Also added information about using InMemory transport (if the application does not need RabbitMQ).