### PR TITLE
Implement Autofac multibus support

### DIFF
--- a/src/Containers/MassTransit.AutofacIntegration/Bind.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Bind.cs
@@ -1,0 +1,46 @@
+namespace MassTransit.AutofacIntegration
+{
+    /// <summary>
+    /// Bind is used to store types bound to their owner, such as an IBusControl to an IMyBus.
+    /// </summary>
+    /// <typeparam name="TKey">The key type</typeparam>
+    /// <typeparam name="TValue">The bound type</typeparam>
+    public class Bind<TKey, TValue>
+        where TValue : class
+    {
+        public Bind(TValue value)
+        {
+            Value = value;
+        }
+
+        public TValue Value { get; }
+
+        public static Bind<TKey, TValue, T> Create<T>(T value)
+            where T : class
+        {
+            return new Bind<TKey, TValue, T>(value);
+        }
+    }
+
+
+    public class Bind<TKey1, TKey2, TValue>
+        where TValue : class
+    {
+        public Bind(TValue value)
+        {
+            Value = value;
+        }
+
+        public TValue Value { get; }
+    }
+
+
+    public static class Bind<TKey>
+    {
+        public static Bind<TKey, TValue> Create<TValue>(TValue value)
+            where TValue : class
+        {
+            return new Bind<TKey, TValue>(value);
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Multibus/AutofacMultibusRegistrationExtensions.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Multibus/AutofacMultibusRegistrationExtensions.cs
@@ -1,0 +1,75 @@
+﻿namespace MassTransit.AutofacIntegration.Multibus
+{
+    using System;
+    using Autofac;
+    using Autofac.Core;
+    using Internals.Reflection;
+    using MassTransit.MultiBus;
+
+
+    /// <summary>
+    /// Support for multiple bus instances in a single container. This is an advanced concept. Review the documentation
+    /// for details on the constraints and known limitations of this approach.
+    /// </summary>
+    public static class AutofacMultibusRegistrationExtensions
+    {
+        static ContainerBuilder AddMassTransit<TBus, TBusInstance>(this ContainerBuilder containerBuilder,
+            Action<IContainerBuilderBusConfigurator<TBus>> configure)
+            where TBus : class, IBus
+            where TBusInstance : BusInstance<TBus>, TBus
+        {
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            if (containerBuilder.ComponentRegistryBuilder.IsRegistered(new TypedService(typeof(TBus))))
+            {
+                throw new ConfigurationException(
+                    $"AddMassTransit<{typeof(TBus).Name},{typeof(TBusInstance).Name}>() was already called and may only be called once per container. To configure additional bus instances, refer to the documentation: https://masstransit-project.com/usage/containers/multibus.html");
+            }
+
+            var configurator = new ContainerBuilderBusConfigurator<TBus, TBusInstance>(containerBuilder);
+
+            configure(configurator);
+
+            return containerBuilder;
+        }
+
+        /// <summary>
+        /// Configure a MassTransit bus instance, using the specified <typeparamref name="TBus" /> bus type, which must inherit directly from <see cref="IBus" />.
+        /// A dynamic type will be created to support the bus instance, which will be initialized when the <typeparamref name="TBus" /> type is retrieved
+        /// from the container.
+        /// </summary>
+        /// <param name="containerBuilder">The container builder</param>
+        /// <param name="configure">Bus instance configuration method</param>
+        public static ContainerBuilder AddMassTransit<TBus>(this ContainerBuilder containerBuilder, Action<IContainerBuilderBusConfigurator<TBus>> configure)
+            where TBus : class, IBus
+        {
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            var doIt = new Callback<TBus>(containerBuilder, configure);
+
+            return BusInstanceBuilder.Instance.GetBusInstanceType(doIt);
+        }
+
+        class Callback<TBus> :
+            IBusInstanceBuilderCallback<TBus, ContainerBuilder>
+            where TBus : class, IBus
+        {
+            readonly Action<IContainerBuilderBusConfigurator<TBus>> _configure;
+            readonly ContainerBuilder _services;
+
+            public Callback(ContainerBuilder services, Action<IContainerBuilderBusConfigurator<TBus>> configure)
+            {
+                _services = services;
+                _configure = configure;
+            }
+
+            public ContainerBuilder GetResult<TBusInstance>()
+                where TBusInstance : BusInstance<TBus>, TBus
+            {
+                return _services.AddMassTransit<TBus, TBusInstance>(_configure);
+            }
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Multibus/AutofacTransactionExtensions.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Multibus/AutofacTransactionExtensions.cs
@@ -1,0 +1,33 @@
+﻿namespace MassTransit.MultiBus.Transactions
+{
+    using Autofac;
+    using AutofacIntegration.Multibus;
+    using MassTransit.Transactions;
+
+    public static class AutofacTransactionExtensions
+    {
+        /// <summary>
+        /// Adds <see cref="ITransactionalBus"/> to the container with singleton lifetime, which can be used instead of <see cref="IBus"/> to enlist
+        /// published/sent messages in the current transaction. It isn't truly transactional, but delays the messages until
+        /// the transaction being to commit. This has a very limited purpose and is not meant for general use.
+        /// </summary>
+        public static void AddTransactionalEnlistmentBus<TBus>(this IContainerBuilderBusConfigurator<TBus> busConfigurator)
+            where TBus : class, IBus
+        {
+            busConfigurator.Builder.Register<ITransactionalBus>(provider => new TransactionalEnlistmentBus(provider.Resolve<TBus>()))
+                .SingleInstance();
+        }
+
+        /// <summary>
+        /// Adds <see cref="ITransactionalBus"/> to the container with scoped lifetime, which can be used to release the messages to the bus
+        /// immediately after a transaction commit. This has a very limited purpose and is not meant for general use.
+        /// It is recommended this is scoped within a unit of work (e.g. Http Request)
+        /// </summary>
+        public static void AddTransactionalBus<TBus>(this IContainerBuilderBusConfigurator<TBus> busConfigurator)
+            where TBus : class, IBus
+        {
+            busConfigurator.Builder.Register<ITransactionalBus>(provider => new TransactionalBus(provider.Resolve<TBus>()))
+                .InstancePerLifetimeScope();
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Multibus/ContainerBuilderBusConfigurator.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Multibus/ContainerBuilderBusConfigurator.cs
@@ -1,0 +1,117 @@
+﻿namespace MassTransit.AutofacIntegration.Multibus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Autofac;
+    using MassTransit.MultiBus;
+    using MassTransit.Registration;
+    using Monitoring.Health;
+    using Registration;
+    using Scoping;
+    using Transports;
+
+
+    public class ContainerBuilderBusConfigurator<TBus, TBusInstance> :
+        ContainerBuilderBusRegistrationConfigurator,
+        IContainerBuilderBusConfigurator<TBus>
+        where TBus : class, IBus
+        where TBusInstance : BusInstance<TBus>, TBus
+    {
+        public ContainerBuilderBusConfigurator(ContainerBuilder builder)
+            : base(builder, new AutofacContainerRegistrar<TBus>(builder))
+        {
+            IBusRegistrationContext CreateRegistrationContext(IComponentContext context)
+            {
+                var provider = context.Resolve<IConfigurationServiceProvider>();
+                return new BusRegistrationContext(provider, Endpoints, Consumers, Sagas, ExecuteActivities, Activities, Futures);
+            }
+
+            Builder.Register(context => Bind<TBus>.Create(GetSendEndpointProvider(context)))
+                .As<Bind<TBus, ISendEndpointProvider>>()
+                .InstancePerLifetimeScope();
+
+            Builder.Register(context => Bind<TBus>.Create(GetPublishEndpoint(context)))
+                .As<Bind<TBus, IPublishEndpoint>>()
+                .InstancePerLifetimeScope();
+
+            Builder.Register(context =>
+                {
+                    var provider = context.Resolve<IConfigurationServiceProvider>();
+                    var bus = context.Resolve<TBus>();
+                    return Bind<TBus>.Create(ClientFactoryProvider(provider, bus));
+                })
+                .As<Bind<TBus, IClientFactory>>()
+                .SingleInstance();
+
+            Builder.Register(context => Bind<TBus>.Create(CreateRegistrationContext(context)))
+                .As<Bind<TBus, IBusRegistrationContext>>()
+                .SingleInstance();
+        }
+
+        public override void AddBus(Func<IBusRegistrationContext, IBusControl> busFactory)
+        {
+            SetBusFactory(new RegistrationBusFactory(busFactory));
+        }
+
+        public override void SetBusFactory<T>(T busFactory)
+        {
+            if (busFactory == null)
+                throw new ArgumentNullException(nameof(busFactory));
+
+            ThrowIfAlreadyConfigured(nameof(SetBusFactory));
+
+            Builder.Register(context => CreateBus(busFactory, context))
+                .As<IBusInstance<TBus>>()
+                .As<IBusInstance>()
+                .SingleInstance();
+
+            Builder.Register(context => Bind<TBus>.Create(context.Resolve<IBusInstance<TBus>>()))
+                .As<Bind<TBus, IBusInstance<TBus>>>()
+                .SingleInstance();
+
+            Builder.Register(context => Bind<TBus>.Create<IReceiveEndpointConnector>(context.Resolve<IBusInstance<TBus>>()))
+                .As<Bind<TBus, IReceiveEndpointConnector>>()
+                .SingleInstance();
+
+            Builder.Register(context => context.Resolve<IBusInstance<TBus>>().BusInstance)
+                .As<TBus>()
+                .SingleInstance();
+
+
+        #pragma warning disable 618
+            Builder.Register(context => new BusHealth(context.Resolve<IBusInstance<TBus>>()))
+                .As<IBusHealth>()
+                .SingleInstance();
+        }
+
+        public override void AddRider(Action<IRiderRegistrationConfigurator> configure)
+        {
+            var configurator = new ContainerBuilderRiderConfigurator<TBus>(Builder, Registrar, RiderTypes);
+            configure?.Invoke(configurator);
+        }
+
+        static IBusInstance<TBus> CreateBus<T>(T busFactory, IComponentContext context)
+            where T : IRegistrationBusFactory
+        {
+            var specifications = context.Resolve<IEnumerable<Bind<TBus, IBusInstanceSpecification>>>().Select(x => x.Value);
+
+            var instance = busFactory.CreateBus(context.Resolve<Bind<TBus, IBusRegistrationContext>>().Value, specifications);
+
+            var busInstance = context.ResolveOptional<TBusInstance>()
+                ?? (TBusInstance)Activator.CreateInstance(typeof(TBusInstance), instance.BusControl);
+
+            return new MultiBusInstance<TBus>(busInstance, instance);
+        }
+
+        static ISendEndpointProvider GetSendEndpointProvider(IComponentContext context)
+        {
+            return new ScopedSendEndpointProvider<ILifetimeScope>(context.Resolve<TBus>(), context.Resolve<ILifetimeScope>());
+        }
+
+        static IPublishEndpoint GetPublishEndpoint(IComponentContext context)
+        {
+            return new PublishEndpoint(new ScopedPublishEndpointProvider<ILifetimeScope>(context.Resolve<TBus>(), context.Resolve<ILifetimeScope>()));
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Multibus/ContainerBuilderRiderConfigurator.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Multibus/ContainerBuilderRiderConfigurator.cs
@@ -1,0 +1,46 @@
+namespace MassTransit.AutofacIntegration.Multibus
+{
+    using System;
+    using System.Collections.Generic;
+    using Autofac;
+    using AutofacIntegration;
+    using MassTransit.Registration;
+    using MultiBus;
+    using Registration;
+
+
+    public class ContainerBuilderRiderConfigurator<TBus> :
+        ContainerBuilderRiderConfigurator,
+        IContainerBuilderRiderConfigurator<TBus>
+        where TBus : class, IBus
+    {
+        public ContainerBuilderRiderConfigurator(ContainerBuilder builder, IContainerRegistrar registrar, HashSet<Type> riderTypes)
+            : base(builder, registrar, riderTypes)
+        {
+        }
+
+        public override void SetRiderFactory<TRider>(IRegistrationRiderFactory<TRider> riderFactory)
+        {
+            if (riderFactory == null)
+                throw new ArgumentNullException(nameof(riderFactory));
+
+            ThrowIfAlreadyConfigured<TRider>();
+
+            IRiderRegistrationContext CreateRegistrationContext(IComponentContext context)
+            {
+                var registration = CreateRegistration(context.Resolve<IConfigurationServiceProvider>());
+                return new RiderRegistrationContext(registration, Registrations);
+            }
+
+            Builder.Register(provider => Bind<TBus, TRider>.Create(CreateRegistrationContext(provider)))
+                .SingleInstance();
+
+            Builder.Register(provider =>
+                Bind<TBus>.Create(riderFactory.CreateRider(provider.Resolve<Bind<TBus, TRider, IRiderRegistrationContext>>().Value)))
+                .SingleInstance();
+
+            Builder.Register(provider => Bind<TBus>.Create(provider.Resolve<IBusInstance<TBus>>().GetRider<TRider>()))
+                .SingleInstance();
+        }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Multibus/IContainerBuilderBusConfigurator.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Multibus/IContainerBuilderBusConfigurator.cs
@@ -1,0 +1,8 @@
+﻿namespace MassTransit.AutofacIntegration.Multibus
+{
+    public interface IContainerBuilderBusConfigurator<in TBus> :
+        IContainerBuilderBusConfigurator
+        where TBus : class, IBus
+    {
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Multibus/IContainerBuilderRiderConfigurator.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Multibus/IContainerBuilderRiderConfigurator.cs
@@ -1,0 +1,12 @@
+namespace MassTransit.AutofacIntegration.MultiBus
+{
+    using Autofac;
+    using MassTransit.Registration;
+
+    public interface IContainerBuilderRiderConfigurator<in TBus> :
+        IRiderRegistrationConfigurator
+        where TBus : class, IBus
+    {
+        ContainerBuilder Builder { get; }
+    }
+}

--- a/src/Containers/MassTransit.AutofacIntegration/Registration/AutofacContainerRegistrar.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Registration/AutofacContainerRegistrar.cs
@@ -233,6 +233,19 @@ namespace MassTransit.AutofacIntegration.Registration
     }
 
 
+    public class AutofacContainerRegistrar<TBus> :
+        AutofacContainerRegistrar
+    {
+        public AutofacContainerRegistrar(ContainerBuilder builder)
+            : base(builder) { }
+
+        protected override IClientFactory GetClientFactory(IComponentContext componentContext)
+        {
+            return componentContext.Resolve<Bind<TBus, IClientFactory>>().Value;
+        }
+    }
+
+
     public class AutofacContainerMediatorRegistrar :
         AutofacContainerRegistrar
     {

--- a/src/Containers/MassTransit.AutofacIntegration/Registration/ContainerBuilderRiderConfigurator.cs
+++ b/src/Containers/MassTransit.AutofacIntegration/Registration/ContainerBuilderRiderConfigurator.cs
@@ -11,7 +11,7 @@ namespace MassTransit.AutofacIntegration.Registration
         RegistrationConfigurator,
         IContainerBuilderRiderConfigurator
     {
-        readonly RegistrationCache<object> _registrations;
+        protected readonly RegistrationCache<object> Registrations;
         readonly HashSet<Type> _riderTypes;
 
         public ContainerBuilderRiderConfigurator(ContainerBuilder builder, IContainerRegistrar registrar, HashSet<Type> riderTypes)
@@ -19,7 +19,7 @@ namespace MassTransit.AutofacIntegration.Registration
         {
             Builder = builder;
             _riderTypes = riderTypes;
-            _registrations = new RegistrationCache<object>();
+            Registrations = new RegistrationCache<object>();
         }
 
         public ContainerBuilder Builder { get; }
@@ -27,10 +27,10 @@ namespace MassTransit.AutofacIntegration.Registration
         public void AddRegistration<T>(T registration)
             where T : class
         {
-            _registrations.GetOrAdd(typeof(T), _ => registration);
+            Registrations.GetOrAdd(typeof(T), _ => registration);
         }
 
-        public void SetRiderFactory<TRider>(IRegistrationRiderFactory<TRider> riderFactory)
+        public virtual void SetRiderFactory<TRider>(IRegistrationRiderFactory<TRider> riderFactory)
             where TRider : class, IRider
         {
             if (riderFactory == null)
@@ -41,7 +41,7 @@ namespace MassTransit.AutofacIntegration.Registration
             IRiderRegistrationContext CreateRegistrationContext(IComponentContext context)
             {
                 var registration = CreateRegistration(context.Resolve<IConfigurationServiceProvider>());
-                return new RiderRegistrationContext(registration, _registrations);
+                return new RiderRegistrationContext(registration, Registrations);
             }
 
             var registrationKey = typeof(TRider).Name;
@@ -57,7 +57,7 @@ namespace MassTransit.AutofacIntegration.Registration
                 .SingleInstance();
         }
 
-        void ThrowIfAlreadyConfigured<TRider>()
+        protected void ThrowIfAlreadyConfigured<TRider>()
             where TRider : IRider
         {
             ThrowIfAlreadyConfigured(nameof(SetRiderFactory));


### PR DESCRIPTION
It's an implementation of multibus support for the MassTransit Autofac integration package. It's essentially a one-to-one rewrite of the MassTransit.ExtensionsDependencyInjectionIntegration multibus support, following same convention as the rest of the package. 

There is one major difference: original ExtensionsDependencyInjection package supports custom BusInstance implementations, with the ability to inject additional parameters into them. This implementation does not support that feature. 
See:
- AutofacMultibusRegistrationExtensions AddMassTransit<TBus, TBusInstance> method - it's private instead of public
- Multibus/ContainerBuilderBusConfigurator CreateBus<T> method - it uses Activator.CreateInstance instead of ActivatorUtilities.CreateInstance from the Microsoft.Extensions.DependencyInjection package