### PR TITLE
Use default serializer/deserializer for Kafka Key Type. Change Produc…

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/Configurators/KafkaTopicReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/Configurators/KafkaTopicReceiveEndpointConfiguration.cs
@@ -41,8 +41,9 @@ namespace MassTransit.KafkaIntegration.Configurators
             _options = new OptionsSet();
             Topic = topic;
 
+            if (!SerializationUtils.DeSerializers.IsDefaultKeyType<TKey>())
+                SetKeyDeserializer(new MassTransitJsonDeserializer<TKey>());
             SetValueDeserializer(new MassTransitJsonDeserializer<TValue>());
-            SetKeyDeserializer(new MassTransitJsonDeserializer<TKey>());
             SetHeadersDeserializer(headersDeserializer);
 
             CheckpointInterval = TimeSpan.FromMinutes(1);

--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/KafkaProducerRegistrationExtensions.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/KafkaProducerRegistrationExtensions.cs
@@ -19,7 +19,7 @@ namespace MassTransit.KafkaIntegration
         /// <param name="configure"></param>
         /// <typeparam name="T">The message type</typeparam>
         public static void AddProducer<T>(this IRiderRegistrationConfigurator configurator, string topicName,
-            Action<IRiderRegistrationContext, IKafkaProducerConfigurator<Ignore, T>> configure = null)
+            Action<IRiderRegistrationContext, IKafkaProducerConfigurator<Null, T>> configure = null)
             where T : class
         {
             configurator.AddProducer(topicName, _ => default, configure);
@@ -36,7 +36,7 @@ namespace MassTransit.KafkaIntegration
         /// <typeparam name="T">The message type</typeparam>
         public static void AddProducer<T>(this IRiderRegistrationConfigurator configurator, string topicName,
             ProducerConfig producerConfig,
-            Action<IRiderRegistrationContext, IKafkaProducerConfigurator<Ignore, T>> configure = null)
+            Action<IRiderRegistrationContext, IKafkaProducerConfigurator<Null, T>> configure = null)
             where T : class
         {
             configurator.AddProducer(topicName, producerConfig, _ => default, configure);

--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/Specifications/KafkaProducerSpecification.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/Specifications/KafkaProducerSpecification.cs
@@ -34,7 +34,8 @@ namespace MassTransit.KafkaIntegration.Specifications
             _headersSerializer = headersSerializer;
             _sendObservers = new SendObservable();
 
-            SetKeySerializer(new MassTransitJsonSerializer<TKey>());
+            if (!SerializationUtils.Serializers.IsDefaultKeyType<TKey>())
+                SetKeySerializer(new MassTransitJsonSerializer<TKey>());
             SetValueSerializer(new MassTransitJsonSerializer<TValue>());
             SetHeadersSerializer(headersSerializer);
         }

--- a/src/Transports/MassTransit.KafkaIntegration/Serializers/SerializationUtils.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Serializers/SerializationUtils.cs
@@ -1,0 +1,52 @@
+namespace MassTransit.KafkaIntegration.Serializers
+{
+    using System;
+    using System.Collections.Generic;
+    using Confluent.Kafka;
+
+
+    static class SerializationUtils
+    {
+        public static class Serializers
+        {
+            //https://github.com/confluentinc/confluent-kafka-dotnet/blob/fd4b95b420418153aa39d7c94df1e1135c09c07d/src/Confluent.Kafka/Producer.cs#L50
+            static readonly ISet<Type> DefaultKeyTypes = new HashSet<Type>
+            {
+                typeof(Null),
+                typeof(int),
+                typeof(long),
+                typeof(string),
+                typeof(float),
+                typeof(double),
+                typeof(byte[])
+            };
+
+            public static bool IsDefaultKeyType<TKey>()
+            {
+                return DefaultKeyTypes.Contains(typeof(TKey));
+            }
+        }
+
+
+        public static class DeSerializers
+        {
+            //https://github.com/confluentinc/confluent-kafka-dotnet/blob/fd4b95b420418153aa39d7c94df1e1135c09c07d/src/Confluent.Kafka/Consumer.cs#L54
+            static readonly ISet<Type> DefaultKeyTypes = new HashSet<Type>
+            {
+                typeof(Ignore),
+                typeof(Null),
+                typeof(int),
+                typeof(long),
+                typeof(string),
+                typeof(float),
+                typeof(double),
+                typeof(byte[])
+            };
+
+            public static bool IsDefaultKeyType<TKey>()
+            {
+                return DefaultKeyTypes.Contains(typeof(TKey));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Use default serializer/deserializer for Kafka Key Type
- Change Producer default key type to `Null`