### PR TITLE
Makes the Azure Service Bus Configuration Defaults settable

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Defaults.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Defaults.cs
@@ -8,14 +8,14 @@
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Defaults
     {
-        public static TimeSpan LockDuration = TimeSpan.FromMinutes(5);
-        public static TimeSpan DefaultMessageTimeToLive = TimeSpan.FromDays(365 + 1);
-        public static TimeSpan BasicMessageTimeToLive = TimeSpan.FromDays(14);
+        public static TimeSpan LockDuration { get; set; } = TimeSpan.FromMinutes(5);
+        public static TimeSpan DefaultMessageTimeToLive { get; set; } = TimeSpan.FromDays(365 + 1);
+        public static TimeSpan BasicMessageTimeToLive { get; set; } = TimeSpan.FromDays(14);
 
-        public static TimeSpan AutoDeleteOnIdle => TimeSpan.FromDays(427);
-        public static TimeSpan TemporaryAutoDeleteOnIdle => TimeSpan.FromMinutes(5);
-        public static TimeSpan MaxAutoRenewDuration => TimeSpan.FromMinutes(5);
-        public static TimeSpan MessageWaitTimeout => TimeSpan.FromSeconds(10);
+        public static TimeSpan AutoDeleteOnIdle { get; set; } = TimeSpan.FromDays(427);
+        public static TimeSpan TemporaryAutoDeleteOnIdle { get; set; } = TimeSpan.FromMinutes(5);
+        public static TimeSpan MaxAutoRenewDuration { get; set; } = TimeSpan.FromMinutes(5);
+        public static TimeSpan MessageWaitTimeout { get; set; } = TimeSpan.FromSeconds(10);
         public static TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
 
         public static QueueDescription CreateQueueDescription(string queueName)


### PR DESCRIPTION
Changes some read only properties to be getters and setters with an initialized value. 
