### PR TITLE
AmazonSQS transport: trying to get the topic and if does not exists creating it.

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Contexts/TopicCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Contexts/TopicCache.cs
@@ -40,11 +40,11 @@ namespace MassTransit.AmazonSqsTransport.Contexts
             {
                 try
                 {
-                    return await CreateMissingTopic(topic).ConfigureAwait(false);
-                }
-                catch (InvalidParameterException e) when (e.Message.Contains("Topic already exists"))
-                {
                     return await GetExistingTopic(topic.EntityName).ConfigureAwait(false);
+                }
+                catch (AmazonSqsTransportException e) when (e.Message.Equals($"Topic {topic.EntityName} not found."))
+                {
+                    return await CreateMissingTopic(topic).ConfigureAwait(false);
                 }
             });
         }


### PR DESCRIPTION
AmazonSQS transport: trying to get the topic and if does not exists creating it.

With those changes we do want to prevent provisioning new topics in the application, actual environment is already created with CloudFormation before the application is deployed.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
