### PR TITLE
Docs: Fix example for AddGenericRequestClient

### DIFF
--- a/docs/usage/requests.md
+++ b/docs/usage/requests.md
@@ -125,9 +125,8 @@ public void ConfigureServices(IServiceCollection services)
     services.AddMassTransit(x =>
     {
         // ...
-
-        x.AddGenericRequestClient();
     });
+    services.AddGenericRequestClient();
 }
 ```
 #### Using Autofac


### PR DESCRIPTION
Fixes an incorrect usage example of AddGenericRequestClient in the docs.
This extension method needs to be called on the `IServiceCollection`, not the `IServiceCollectionBusConfigurator`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
