### PR TITLE
Use equal intervals to extend SQS message visibility timeout

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsReceiveContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Contexts/AmazonSqsReceiveContext.cs
@@ -112,9 +112,10 @@
 
         async Task RenewMessageVisibility()
         {
-            TimeSpan CalculateDelay(int timeout) => TimeSpan.FromSeconds((timeout - ElapsedTime.TotalSeconds) * 0.6);
+            TimeSpan CalculateDelay(int timeout) => TimeSpan.FromSeconds(timeout * 0.7);
 
             var visibilityTimeout = _receiveSettings.VisibilityTimeout;
+            var totalTimeout = _receiveSettings.VisibilityTimeout;
 
             var delay = CalculateDelay(visibilityTimeout);
 
@@ -128,15 +129,12 @@
                     if (_activeTokenSource.Token.IsCancellationRequested)
                         break;
 
-                    visibilityTimeout = Math.Min(MaxVisibilityTimeout, visibilityTimeout * 2);
-
                     await _clientContext.ChangeMessageVisibility(_receiveSettings.QueueUrl, TransportMessage.ReceiptHandle, visibilityTimeout)
                         .ConfigureAwait(false);
 
-                    // LogContext.Debug?.Log("Extended message {ReceiptHandle} visibility to {VisibilityTimeout} ({ElapsedTime})", TransportMessage.ReceiptHandle,
-                    //     TimeSpan.FromSeconds(visibilityTimeout).ToFriendlyString(), ElapsedTime);
+                    totalTimeout += visibilityTimeout;
 
-                    if (visibilityTimeout >= MaxVisibilityTimeout)
+                    if (totalTimeout >= MaxVisibilityTimeout)
                         break;
 
                     delay = CalculateDelay(visibilityTimeout);


### PR DESCRIPTION
In the initial implementation the timeout growth exponentially, e.g. 1 hour, 2 hours, 4 hours...
So if the service crashes after 1 hour we would wait for another hour to process the message.

In proposed fix we always set visibility timeout to the same value.
So if the service crashes after 1 hour we don't need to wait for another hour but we can process the message in 30 seconds after the crash.

Also there was an issue that timeout set is absolute but should be relative, see comment below.