### PR TITLE
Add IObserver class impl for subscribing to DiagnosticListener

### DIFF
--- a/docs/advanced/monitoring/diagnostic-source.md
+++ b/docs/advanced/monitoring/diagnostic-source.md
@@ -7,17 +7,26 @@ To connect, set the current log context prior to bus configuration using:
 ```csharp
 public static async Task Main(string[] args)
 {
-    var subscription = DiagnosticListener.AllListeners.Subscribe(delegate (DiagnosticListener listener)
-    {
-        if (listener.Name == "MassTransit")
-        {
-            // subscribe to the listener with your monitoring tool, etc.
-        }
-    });
+    var subscription = DiagnosticListener.AllListeners.Subscribe(new DiagnosticObserver());
 
     var busControl = Bus.Factory.CreateUsingInMemory(cfg =>
     {
     });
+}
+
+public class DiagnosticObserver : IObserver<DiagnosticListener>
+{
+    public void OnCompleted() { }
+
+    public void OnError(Exception error) { }
+
+    public void OnNext(DiagnosticListener value)
+    {
+        if (value.Name == "MassTransit")
+        {
+            // subscribe to the listener with your monitoring tool, etc.
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
From NET5 (which about docs also are stating) there is no `delegate` parameter, but instance of IObserver.

Therefor this PR is for making compiler happy.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
