### PR TITLE
Upgrade Newtonsoft.Json.Bson library to version 1.0.2

### DIFF
--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="NewId" Version="3.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="NewId" Version="3.0.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />


### PR DESCRIPTION
Upgrade `Newtonsoft.Json.Bson` library to version 1.0.2 (and `Newtonsoft.Json` 12.0.1 as required) 
Versions are from 2018 year, but currently used version `BSON` library 1.0.1 is built for .net standard 1.3 which has vulnurabilites https://nvd.nist.gov/vuln/detail/CVE-2018-8292 and https://nvd.nist.gov/vuln/detail/CVE-2019-0820. Version 1.0.2 is for .net standard 2.0 (the same as MassTransit)

Verified by running all unit tests:
![image](https://user-images.githubusercontent.com/36194577/142071261-08251a7d-5c75-44c7-8c56-e640aebbc4c5.png)

