### PR TITLE
Fixed #3048 - Removed UTF BOM emission in EnvelopeMessageSerializer

### DIFF
--- a/src/MassTransit/Courier/Serialization/EnvelopeMessageSerializer.cs
+++ b/src/MassTransit/Courier/Serialization/EnvelopeMessageSerializer.cs
@@ -97,7 +97,7 @@
 
                 if (_useEncryption == false)
                 {
-                    using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
+                    using (var writer = new StreamWriter(stream, new UTF8Encoding(false, true), 1024, true))
                     using (var jsonWriter = new JsonTextWriter(writer))
                     {
                         jsonWriter.Formatting = Formatting.Indented;


### PR DESCRIPTION
Fixes #3048: 
Emitted Unicode BOM breaks redelivery, because `ForwardJsonMessageSerializer` converts to Json by doing `JObject.Parse(encoding.GetString(receiveContext.GetBody()))`


Tested using these tests:
https://gist.github.com/FroHenK/7fab89310405a96d482ae4b492c44833

Should a test like `Send_an_event_at_the_end_of_the_routing_slip_and_redeliver` be added to the repo?