### PR TITLE
Update to Marten V4

### DIFF
--- a/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
+++ b/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Marten" Version="3.14.1" />
+    <PackageReference Include="Marten" Version="4.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>


### PR DESCRIPTION
When using MassTransit.Marten with a project using Marten V4, there are missing method exceptions when calling `IDocumentSession.Store`. This is fixed when updating MassTransit.Marten to V4.