### PR TITLE
Fix worker template name in README.md

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -13,7 +13,7 @@ To create a service using MassTransit, create a worker via the Command Prompt.
 
 ```bash
 $ mkdir GettingStarted
-$ dotnet new worker -n GettingStarted
+$ dotnet new mtworker -n GettingStarted
 ```
 
 ## Using the InMemory Transport


### PR DESCRIPTION
The example that shows how to create a worker via the Command Prompt used `worker` instead of `mtworker`.

