### PR TITLE
Add `using` to the CTS.

### DIFF
--- a/docs/code/transports/RabbitMqConsoleListener.cs
+++ b/docs/code/transports/RabbitMqConsoleListener.cs
@@ -16,7 +16,7 @@ namespace RabbitMqConsoleListener
     using OrderSystem.Events;
     using MassTransit;
 
-    public class Program
+    public static class Program
     {
         public static async Task Main()
         {
@@ -34,9 +34,10 @@ namespace RabbitMqConsoleListener
                 });
             });
 
-            var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             await busControl.StartAsync(source.Token);
+            
             try
             {
                 Console.WriteLine("Press enter to exit");
@@ -49,8 +50,7 @@ namespace RabbitMqConsoleListener
             }
         }
 
-        class OrderSubmittedEventConsumer :
-            IConsumer<OrderSubmitted>
+        private sealed class OrderSubmittedEventConsumer : IConsumer<OrderSubmitted>
         {
             public async Task Consume(ConsumeContext<OrderSubmitted> context)
             {


### PR DESCRIPTION
1. `Program` example class gets `static` attribute, because it is not instantiated.
2. `CancellationTokenSource` gets disposed after usage, as any `IDisposable` should be.
3. `OrderSubmittedEventConsumer` gets explicit attributes, because visible code is almost always better than invisible.