### PR TITLE
Fixes MissingMethodException when using EF6 + SqlLockStatementProvider

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Extensions/ModelExtensions.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Extensions/ModelExtensions.cs
@@ -1,0 +1,45 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Extensions
+{
+    using System;
+    using System.Linq;
+    using Microsoft.EntityFrameworkCore.Metadata;
+
+
+    /// <summary>
+    /// <see cref="IModel"/> extensions
+    /// </summary>
+    public static class ModelExtensions
+    {
+        static readonly Lazy<Func<IModel, Type, IEntityType>> _findEntityType = new Lazy<Func<IModel, Type, IEntityType>>(CreateFindEntityTypeMethod);
+
+        /// <summary>
+        ///     Gets the entity that maps the given entity class. Returns <c>null</c> if no entity type with
+        ///     the given CLR type is found or the entity type has a defining navigation.
+        /// </summary>
+        /// <param name="model"> The model to find the entity type in. </param>
+        /// <param name="type"> The type to find the corresponding entity type for. </param>
+        /// <returns> The entity type, or <c>null</c> if none if found. </returns>
+        public static IEntityType SafeFindEntityType(this IModel model, Type type) => _findEntityType.Value(model, type);
+
+        // Bugfix for Github issue #2980 and #3151 - "method not found"
+        static Func<IModel, Type, IEntityType> CreateFindEntityTypeMethod()
+        {
+            var ef6FindEntityType = typeof(IModel)
+                .GetMethods()
+                .SingleOrDefault(x =>
+                    x.Name == "FindEntityType" &&
+                    x.ReturnType == typeof(IEntityType) &&
+                    x.GetParameters().Select(p => p.ParameterType).SequenceEqual(new[] { typeof(Type) }));
+            if (ef6FindEntityType != null)
+            {
+                return (Func<IModel, Type, IEntityType>)Delegate.CreateDelegate(
+                    type: typeof(Func<IModel, Type, IEntityType>), // the delegate has on more argument than the instance method
+                    firstArgument: null, // the first argument is the (hidden) instance argument of the instance method
+                    method: ef6FindEntityType);
+            }
+
+            // EF3 / EF5 fallback
+            return Microsoft.EntityFrameworkCore.ModelExtensions.FindEntityType;
+        }
+    }
+}

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SqlLockStatementProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/SqlLockStatementProvider.cs
@@ -3,6 +3,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
     using System;
     using System.Collections.Concurrent;
     using System.Linq;
+    using Extensions;
     using MassTransit.Saga;
     using Metadata;
     using Microsoft.EntityFrameworkCore;
@@ -43,7 +44,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
             if (TableNames.TryGetValue(type, out var result) && _enableSchemaCaching)
                 return result;
 
-            var entityType = context.Model.FindEntityType(type);
+            var entityType = context.Model.SafeFindEntityType(type);
 
             var schema = entityType.GetSchema();
             var tableName = entityType.GetTableName();

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Extensions/ModelExtensionsTestFixture.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Extensions/ModelExtensionsTestFixture.cs
@@ -1,0 +1,23 @@
+﻿namespace MassTransit.EntityFrameworkCoreIntegration.Tests.Extensions
+{
+    using ContainerTests;
+    using EntityFrameworkCoreIntegration.Extensions;
+    using NUnit.Framework;
+    using Shared;
+    using Shouldly;
+
+    [TestFixture(typeof(SqlServerTestDbParameters))]
+    public class Getting_an_entity_type_via_extension<T> : EntityFrameworkTestFixture<T, TestInstanceDbContext>
+        where T : ITestDbParameters, new()
+    {
+        [Test]
+        public void Should_return_the_expected_type()
+        {
+            using var db = new TestInstanceContextFactory().CreateDbContext(DbContextOptionsBuilder);
+            var entityType = db.Model.SafeFindEntityType(typeof(TestInstance));
+
+            _ = entityType.ShouldNotBeNull();
+            entityType.ClrType.ShouldBe(typeof(TestInstance));
+        }
+    }
+}


### PR DESCRIPTION
Closes #2980 and #3151 

- check the availability of EF6's new IModel.FindEntityType(Type) method
- fallback to ModelExtensions.FindEntityType(IModel, Type) when using EF Core/5

