### PR TITLE
Fix/issue 3188

### DIFF
--- a/src/MassTransit/Transactions/TransactionalBusSendEndpoint.cs
+++ b/src/MassTransit/Transactions/TransactionalBusSendEndpoint.cs
@@ -25,67 +25,57 @@
         public Task Send<T>(T message, CancellationToken cancellationToken = default)
             where T : class
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(message, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(message, cancellationToken));
         }
 
         public Task Send<T>(T message, IPipe<SendContext<T>> pipe, CancellationToken cancellationToken = default)
             where T : class
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(message, pipe, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(message, pipe, cancellationToken));
         }
 
         public Task Send<T>(T message, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
             where T : class
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(message, pipe, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(message, pipe, cancellationToken));
         }
 
         public Task Send(object message, CancellationToken cancellationToken = default)
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(message, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(message, cancellationToken));
         }
 
         public Task Send(object message, Type messageType, CancellationToken cancellationToken = default)
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(message, messageType, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(message, messageType, cancellationToken));
         }
 
         public Task Send(object message, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(message, pipe, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(message, pipe, cancellationToken));
         }
 
         public Task Send(object message, Type messageType, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(message, messageType, pipe, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(message, messageType, pipe, cancellationToken));
         }
 
         public Task Send<T>(object values, CancellationToken cancellationToken = default)
             where T : class
         {
-            _outboxBus.Add(() => _sendEndpoint.Send<T>(values, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send<T>(values, cancellationToken));
         }
 
         public Task Send<T>(object values, IPipe<SendContext<T>> pipe, CancellationToken cancellationToken = default)
             where T : class
         {
-            _outboxBus.Add(() => _sendEndpoint.Send(values, pipe, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send(values, pipe, cancellationToken));
         }
 
         public Task Send<T>(object values, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
             where T : class
         {
-            _outboxBus.Add(() => _sendEndpoint.Send<T>(values, pipe, cancellationToken));
-            return Task.CompletedTask;
+            return _outboxBus.Add(() => _sendEndpoint.Send<T>(values, pipe, cancellationToken));
         }
     }
 }

--- a/src/MassTransit/Transactions/TransactionalEnlistmentNotification.cs
+++ b/src/MassTransit/Transactions/TransactionalEnlistmentNotification.cs
@@ -37,7 +37,7 @@
                 // We can't stop any messages that might have been already published, but we can stop the rest from publishing.
                 // With a message broker, you should support idempotence, and so retry is a valid mechanism to handle this scenario
 
-                preparingEnlistment.ForceRollback();
+                preparingEnlistment.ForceRollback(e);
             }
         }
 

--- a/tests/MassTransit.Tests/Transactions/TransactionalBusSendEndpoint_Specs.cs
+++ b/tests/MassTransit.Tests/Transactions/TransactionalBusSendEndpoint_Specs.cs
@@ -1,0 +1,107 @@
+﻿namespace MassTransit.Tests.Transactions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using Internals;
+    using MassTransit.Transactions;
+    using NUnit.Framework;
+    using TestFramework;
+    using TestFramework.Messages;
+
+
+    [TestFixture]
+    public class When_using_transactional_bus_Sendendpoint
+    {
+        [Test]
+        public async Task Should_throw_exception_when_transaction_commited_and_disposed()
+        {
+            var message = new PingMessage();
+
+            var sendEndpoint = new TransactionalBusSendEndpoint(new TransactionalEnlistmentBus(null), new AlwaysThrowSendEndpointMock());
+            Assert.That(async() =>
+            {
+                using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    await sendEndpoint.Send(message);
+
+                    transaction.Complete();
+                }
+            }, Throws.TypeOf<TransactionAbortedException>().And.InnerException.TypeOf<ExceptionToBeCaught>());
+        }
+
+        [Test]
+        public async Task Should_throw_exception_immediately_outside_transaction()
+        {
+            var message = new PingMessage();
+
+            var sendEndpoint = new TransactionalBusSendEndpoint(new TransactionalEnlistmentBus(null), new AlwaysThrowSendEndpointMock());
+            Assert.That(async () => await sendEndpoint.Send(message), Throws.TypeOf<ExceptionToBeCaught>());
+        }
+
+
+        class ExceptionToBeCaught : Exception { }
+
+
+        class AlwaysThrowSendEndpointMock : ISendEndpoint
+        {
+            public ConnectHandle ConnectSendObserver(ISendObserver observer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task Send<T>(T message, CancellationToken cancellationToken = default) where T : class
+            {
+                await Task.Delay(100); //fake doing some work before throwing exception
+                throw new ExceptionToBeCaught();
+            }
+
+            public Task Send<T>(T message, IPipe<SendContext<T>> pipe, CancellationToken cancellationToken = default) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send<T>(T message, IPipe<SendContext> pipe, CancellationToken cancellationToken = default) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send(object message, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send(object message, Type messageType, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send(object message, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send(object message, Type messageType, IPipe<SendContext> pipe, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send<T>(object values, CancellationToken cancellationToken = default) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send<T>(object values, IPipe<SendContext<T>> pipe, CancellationToken cancellationToken = default) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Send<T>(object values, IPipe<SendContext> pipe, CancellationToken cancellationToken = default) where T : class
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
So, now the PR is for the develop branch.
I hope you see from the unittests that nothing fundamentally changes in the existing behavior/
The cases in TransactionalEnlistmentBus_Specs still work as expected, if there _is_ a transactionscope, the messages are send in the commit.
The fix is only for when you did not start a transactionscope but did send a message to the registered TransactionalBusSendEndpoint