### PR TITLE
Fix SQS queues with SNS subscriptions not being deleted

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
@@ -225,7 +225,7 @@ namespace MassTransit.AmazonSqsTransport
         {
             var unsubscribeRequest = new UnsubscribeRequest { SubscriptionArn = subscriptionArn };
 
-            var response = await _snsClient.UnsubscribeAsync(unsubscribeRequest, _cancellationToken).ConfigureAwait(false);
+            var response = await _snsClient.UnsubscribeAsync(unsubscribeRequest, CancellationToken.None).ConfigureAwait(false);
 
             response.EnsureSuccessfulResponse();
         }


### PR DESCRIPTION
`CancellationToken.None` is used when deleting SNS topics and the SQS queue, but not the subscription. It seems as though the CancellationToken being used is already canceled when the bus is stopping.

https://github.com/MassTransit/MassTransit/issues/3191

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
