### PR TITLE
Fix a typo in version 8.0.0 docs

### DIFF
--- a/docs/releases/v8.0.0.md
+++ b/docs/releases/v8.0.0.md
@@ -40,7 +40,7 @@ Previous versions of MassTransit required the use of the `MassTransit.AspNetCore
 The host can be configured using `IOptions` configuration support, such as shown below:
 
 ```cs
-services.ConfigureOptions<MassTransitHostOptions>(options =>
+services.Configure<MassTransitHostOptions>(options =>
 {
     options.WaitUntilStarted = true;
     options.StartTimeout = TimeSpan.FromSeconds(30);


### PR DESCRIPTION
Hello there Chris.
I have fixed a typo in the version 8.0.0 documents, Thank you.
![image](https://user-images.githubusercontent.com/68565441/158665627-8ddd5e9b-3740-4046-93be-5d2bd5391b1e.png)


