### PR TITLE
Make MassTransit.Grpc work with old .NET Framework

### DIFF
--- a/src/Transports/MassTransit.GrpcTransport/GrpcTransport/GrpcTransportProvider.cs
+++ b/src/Transports/MassTransit.GrpcTransport/GrpcTransport/GrpcTransportProvider.cs
@@ -111,11 +111,20 @@ namespace MassTransit.GrpcTransport
 
         IGrpcClient GetClient(Uri address)
         {
-            var channel = GrpcChannel.ForAddress(address.GetLeftPart(UriPartial.Authority), new GrpcChannelOptions
+            ChannelBase channel;
+            bool isOldFramework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
+            if (!isOldFramework)
             {
-                Credentials = ChannelCredentials.Insecure,
-                MaxReceiveMessageSize = MaxMessageLengthBytes
-            });
+                channel = GrpcChannel.ForAddress(address.GetLeftPart(UriPartial.Authority), new GrpcChannelOptions
+                {
+                    Credentials = ChannelCredentials.Insecure,
+                    MaxReceiveMessageSize = MaxMessageLengthBytes,
+                });
+            }
+            else
+            {
+                channel = new Channel(address.Host, address.Port, ChannelCredentials.Insecure);
+            }
 
             var client = new TransportService.TransportServiceClient(channel);
 


### PR DESCRIPTION
Existing Code throws a Runtime Exception on .NET Framework 4.8
"gRPC requires extra configuration on .NET implementations that don't support gRPC over HTTP/2. An HTTP provider must be specified using GrpcChannelOptions.HttpHandler.The configured HTTP provider must either support HTTP/2 or be configured to use gRPC-Web. See https://aka.ms/aspnet/grpc/netstandard for details."

The proposed changed solves that error