### PR TITLE
Typo

### DIFF
--- a/docs/.vuepress/components/Wow.vue
+++ b/docs/.vuepress/components/Wow.vue
@@ -102,7 +102,7 @@ export default {
   margin 0px auto
   display block
   .hero
-    text-alight: left
+    text-align: left
     display: flex
     img
       max-width: 100%


### PR DESCRIPTION
A typo on `text-align` was preventing the correct behavior.