### PR TITLE
Azure Service Bus Default Credentials when only Endpoint is specified

### DIFF
--- a/docs/code/transports/ServiceBusManagedIdentityConsoleListener.cs
+++ b/docs/code/transports/ServiceBusManagedIdentityConsoleListener.cs
@@ -18,11 +18,7 @@ public class Program
                 {
                     x.UsingAzureServiceBus((context, cfg) =>
                     {
-                        var settings = new HostSettings
-                        {
-                            ServiceUri = new Uri("sb://your-service-bus-namespace.servicebus.windows.net")
-                        };
-                        cfg.Host(settings);
+                        cfg.Host(new Uri("sb://your-service-bus-namespace.servicebus.windows.net"));
                     });
                 });
             })

--- a/docs/code/transports/ServiceBusManagedIdentityConsoleListener.cs
+++ b/docs/code/transports/ServiceBusManagedIdentityConsoleListener.cs
@@ -20,8 +20,7 @@ public class Program
                     {
                         var settings = new HostSettings
                         {
-                            ServiceUri = new Uri("sb://your-service-bus-namespace.servicebus.windows.net"),
-                            TokenCredential = new DefaultAzureCredential() // From Azure.Identity.dll
+                            ServiceUri = new Uri("sb://your-service-bus-namespace.servicebus.windows.net")
                         };
                         cfg.Host(settings);
                     });

--- a/docs/usage/transports/azure-sb.md
+++ b/docs/usage/transports/azure-sb.md
@@ -46,6 +46,12 @@ The following example shows how to configure Azure Service Bus using an Azure Ma
 
 During local development, in the case of Visual Studio, you can configure the account to use under Options -> Azure Service Authentication. Note that your Azure Active Directory user needs explicit access to the resource and have the 'Azure Service Bus Data Owner' role assigned.
 
+::: warning WARNING
+To ensure that Mass Transit has sufficient permissions to perform queue management as well as messaging operations. Your identity & managed identity will need to have the correct role assignments within Azure.
+
+Assigning the role **Azure Service Bus Data Owner** will provide sufficient permissions for Mass Transit to function on the namespace.
+:::
+
 ## Performance
 
 We **really** recommend that you use the Premium subscription levels for production workloads. We have performed our own testing using [MassTransit Benchmark](https://github.com/MassTransit/MassTransit-Benchmark) on a P4 instance. It is also critical that your application is in the same DC as the ASB instance. From a home test using a 1Gb fiber connection we could not get over 600/second. When running in the same DC as the ASB we were able to acheive 6k/second. This test was done with one instance writing to ASB and another instance reading from ASB, as adding consumption over the same AMQP connection killed throughput.

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ConnectionContextFactory.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ConnectionContextFactory.cs
@@ -84,7 +84,7 @@ namespace MassTransit.AzureServiceBusTransport
             }
             else
             {
-                if (HasSharedAccess(settings.ConnectionString))
+                if (settings.ConnectionString != null && HasSharedAccess(settings.ConnectionString))
                 {
                     client ??= new ServiceBusClient(settings.ConnectionString, clientOptions);
                     managementClient ??= new ServiceBusAdministrationClient(settings.ConnectionString);

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/MassTransit.Azure.ServiceBus.Core.csproj
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/MassTransit.Azure.ServiceBus.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.6.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />

--- a/src/Transports/MassTransit.WebJobs.ServiceBusIntegration/MassTransit.WebJobs.ServiceBusIntegration.csproj
+++ b/src/Transports/MassTransit.WebJobs.ServiceBusIntegration/MassTransit.WebJobs.ServiceBusIntegration.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.5.0" />
+      <PackageReference Include="Azure.Identity" Version="1.6.0" />
       <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
       <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.3.0" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

From discord chat - i feel TokenCredentials is valid to be separate as it may allow for you to have more fine grained control over the priority ordering which _may_ be occurring under default credentials.

The current code did not deal well with the connection string being null when checking for presence of the access token. 

I wanted to add a test for this - but i wasn't sure what credentials might be available to allow DefaultAzureCredentials to function on the build server. Is there any suggestions there?
