### PR TITLE
Add `MassTransitHealthCheckOptions`

### DIFF
--- a/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
@@ -135,6 +135,7 @@ namespace MassTransit
         {
             collection.AddOptions();
             collection.AddHealthChecks();
+            collection.AddOptions<MassTransitHealthCheckOptions>();
             collection.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<HealthCheckServiceOptions>, ConfigureBusHealthCheckServiceOptions>());
 
             collection.AddOptions<MassTransitHostOptions>();

--- a/src/MassTransit/Monitoring/ConfigureBusHealthCheckServiceOptions.cs
+++ b/src/MassTransit/Monitoring/ConfigureBusHealthCheckServiceOptions.cs
@@ -21,7 +21,7 @@ namespace MassTransit.Monitoring
 
         public void Configure(HealthCheckServiceOptions options)
         {
-            string[] tags = _options.Value.Tags.ToArray() ?? new[] { "ready", "masstransit" };
+            string[] tags = _options.Value.Tags?.ToArray() ?? new[] { "ready", "masstransit" };
             foreach (var busInstance in _busInstances)
             {
                 options.Registrations.Add(new HealthCheckRegistration(

--- a/src/MassTransit/Monitoring/ConfigureBusHealthCheckServiceOptions.cs
+++ b/src/MassTransit/Monitoring/ConfigureBusHealthCheckServiceOptions.cs
@@ -1,27 +1,35 @@
 namespace MassTransit.Monitoring
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.Extensions.Diagnostics.HealthChecks;
     using Microsoft.Extensions.Options;
     using Transports;
-
 
     public class ConfigureBusHealthCheckServiceOptions :
         IConfigureOptions<HealthCheckServiceOptions>
     {
         readonly IEnumerable<IBusInstance> _busInstances;
-        readonly string[] _tags;
+        readonly IOptions<MassTransitHealthCheckOptions> _options;
 
-        public ConfigureBusHealthCheckServiceOptions(IEnumerable<IBusInstance> busInstances)
+        public ConfigureBusHealthCheckServiceOptions(IEnumerable<IBusInstance> busInstances, IOptions<MassTransitHealthCheckOptions> options)
         {
             _busInstances = busInstances;
-            _tags = new[] { "ready", "masstransit" };
+            _options = options;
         }
+
 
         public void Configure(HealthCheckServiceOptions options)
         {
+            string[] tags = _options.Value.Tags.ToArray() ?? new[] { "ready", "masstransit" };
             foreach (var busInstance in _busInstances)
-                options.Registrations.Add(new HealthCheckRegistration(busInstance.Name, new BusHealthCheck(busInstance), HealthStatus.Unhealthy, _tags));
+            {
+                options.Registrations.Add(new HealthCheckRegistration(
+                    _options.Value.Name ?? busInstance.Name,
+                    new BusHealthCheck(busInstance),
+                    _options.Value.FailureStatus ?? HealthStatus.Unhealthy,
+                    tags));
+            }
         }
     }
 }

--- a/src/MassTransit/Monitoring/MassTransitHealthCheckOptions.cs
+++ b/src/MassTransit/Monitoring/MassTransitHealthCheckOptions.cs
@@ -1,0 +1,24 @@
+﻿namespace MassTransit.Monitoring
+{
+    using System.Collections.Generic;
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+    public class MassTransitHealthCheckOptions
+    {
+        /// <summary>
+        /// The health check name. Optional. If null the type name of bus instance will be used
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The <see cref="HealthStatus"/> that should be reported when the health check fails.
+        /// If null then the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </summary>
+        public HealthStatus? FailureStatus { get; set; }
+
+        /// <summary>
+        /// A list of tags that can be used to filter sets of health checks
+        /// </summary>
+        public IEnumerable<string> Tags { get; set; }
+    }
+}

--- a/src/MassTransit/Monitoring/MassTransitHealthCheckOptions.cs
+++ b/src/MassTransit/Monitoring/MassTransitHealthCheckOptions.cs
@@ -6,7 +6,7 @@
     public class MassTransitHealthCheckOptions
     {
         /// <summary>
-        /// The health check name. Optional. If null the type name of bus instance will be used
+        /// The health check name. If null the type name of bus instance will be used
         /// </summary>
         public string Name { get; set; }
 


### PR DESCRIPTION
Added ability to configure MassTransit health check.

Example usage:
```cs
using MassTransit.Monitoring;

...

builder.Services.Configure<MassTransitHealthCheckOptions>(options =>
{
    options.Name = "MessageBroker";
    options.Tags = new[] { "ready" };
});
```

Tested locally:
![image](https://user-images.githubusercontent.com/6609929/163384782-9de174fa-74d0-4c3c-af36-f09c7564b070.png)
