### PR TITLE
Set a default timeout for `IBusControl` `Start` and `Stop` extension methods

### DIFF
--- a/src/MassTransit/BusControlExtensions.cs
+++ b/src/MassTransit/BusControlExtensions.cs
@@ -13,20 +13,14 @@
         /// It is a wrapper of the async method `StopAsync`
         /// </summary>
         /// <param name="busControl">The bus handle</param>
-        public static void Stop(this IBusControl busControl)
-        {
-            TaskUtil.Await(() => busControl.StopAsync());
-        }
+        public static void Stop(this IBusControl busControl) => Stop(busControl, TimeSpan.FromSeconds(60));
 
         /// <summary>
         /// Starts a bus, throwing an exception if the bus does not start
         /// It is a wrapper of the async method `StartAsync`
         /// </summary>
         /// <param name="busControl">The bus handle</param>
-        public static void Start(this IBusControl busControl)
-        {
-            TaskUtil.Await(() => busControl.StartAsync());
-        }
+        public static void Start(this IBusControl busControl) => Start(busControl, TimeSpan.FromSeconds(60));
 
         /// <summary>
         /// Stop a bus, throwing an exception if the bus does not stop in the specified timeout


### PR DESCRIPTION
If not set, the underlying async method will set one but the exception is not propagated on timeout. 

This was verified with the MassTransit v6. When RabbitMQ is not started, and `IBusControl.Start` is called, it will never time out.