### PR TITLE
FIX #3352 FutureState deserialization

### DIFF
--- a/src/MassTransit.Abstractions/Futures/FutureState.cs
+++ b/src/MassTransit.Abstractions/Futures/FutureState.cs
@@ -37,7 +37,7 @@ namespace MassTransit
 
                 return _pending;
             }
-            private set => _pending = value;
+            set => _pending = value;
         }
 
         public HashSet<FutureSubscription> Subscriptions
@@ -52,7 +52,7 @@ namespace MassTransit
 
                 return _subscriptions;
             }
-            private set => _subscriptions = value;
+            set => _subscriptions = value;
         }
 
         public Dictionary<string, object> Variables
@@ -67,7 +67,7 @@ namespace MassTransit
 
                 return _variables;
             }
-            private set => _variables = value != null ? new Dictionary<string, object>(value, StringComparer.OrdinalIgnoreCase) : null;
+            set => _variables = value != null ? new Dictionary<string, object>(value, StringComparer.OrdinalIgnoreCase) : null;
         }
 
         public Dictionary<Guid, FutureMessage> Results
@@ -82,7 +82,7 @@ namespace MassTransit
 
                 return _results;
             }
-            private set => _results = value;
+            set => _results = value;
         }
 
         public Dictionary<Guid, FutureMessage> Faults
@@ -97,7 +97,7 @@ namespace MassTransit
 
                 return _faults;
             }
-            private set => _faults = value;
+            set => _faults = value;
         }
 
         public byte[] RowVersion { get; set; }

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Future_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Future_Specs.cs
@@ -1,0 +1,96 @@
+namespace MassTransit.Azure.ServiceBus.Core.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using DependencyInjection.Registration;
+    using MassTransit.TestFramework;
+    using MassTransit.TestFramework.ForkJoint.Tests;
+    using MassTransit.TestFramework.Futures.Tests;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+    using TestFramework.ForkJoint.Consumers;
+    using TestFramework.ForkJoint.Contracts;
+    using TestFramework.ForkJoint.Futures;
+
+
+    class AzureServiceBusFutureTestFixtureConfigurator :
+        IFutureTestFixtureConfigurator
+    {
+
+        public void ConfigureFutureSagaRepository(IBusRegistrationConfigurator configurator)
+        {
+            configurator.AddSagaRepository<FutureState>()
+                .MessageSessionRepository();
+        }
+
+        public void ConfigureServices(IServiceCollection collection)
+        {
+            
+        }
+
+        public async Task OneTimeSetup(IServiceProvider provider)
+        {
+            
+        }
+
+        public Task OneTimeTearDown(IServiceProvider provider)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public class AzureServiceBusFutureDefinition<TFuture> : DefaultFutureDefinition<TFuture>
+        where TFuture : class, SagaStateMachine<FutureState>
+    {
+        protected override void ConfigureSaga(IReceiveEndpointConfigurator endpointConfigurator, ISagaConfigurator<FutureState> sagaConfigurator)
+        {
+            if (endpointConfigurator is IServiceBusEndpointConfigurator configurator)
+            {
+                configurator.RequiresSession = true;
+            }
+
+            base.ConfigureSaga(endpointConfigurator, sagaConfigurator);
+        }
+    }
+
+
+    [TestFixture]
+    public class AzureServiceBusFryFutureSpecs :
+        FryFuture_Specs
+    {
+        public AzureServiceBusFryFutureSpecs()
+            : base(new AzureServiceBusFutureTestFixtureConfigurator())
+        {
+        }
+
+        protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
+        {
+            configurator.AddConsumer<CookFryConsumer, CookFryConsumerDefinition>();
+            configurator.AddFuture<FryFuture, AzureServiceBusFutureDefinition<FryFuture>>();
+
+            var serviceUri = AzureServiceBusEndpointUriCreator.Create(Configuration.ServiceNamespace);
+            ServiceBusTokenProviderSettings settings = new TestAzureServiceBusAccountSettings();
+
+            configurator.UsingAzureServiceBus((context, cfg) =>
+            {
+                cfg.Host(serviceUri, h =>
+                {
+                    h.NamedKey(s =>
+                    {
+                        s.NamedKeyCredential = settings.NamedKeyCredential;
+                    });
+                });
+
+                cfg.Send<OrderFry>(s =>
+                {
+                    s.UseSessionIdFormatter(x => x.Message.OrderLineId.ToString("D"));
+                });
+
+                cfg.ConfigureEndpoints(context);
+            });
+        }
+    }
+
+    //have not ported the other future specs    
+}


### PR DESCRIPTION
Fix for #3352 

I had to hack on the ContainerTestHarness cancellation token property to stop the runner from being cancelled. Hoping that was just some quirk of my setup. Hacks not included in the PR.

I've ported a single future spec to run against azure service bus. It proves it works.

As for the changes I just made all the setters for the collections public on FutureState.