### PR TITLE
Feature/receive endpoint retry settings

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/HostSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/HostSettings.cs
@@ -15,6 +15,8 @@ namespace MassTransit.AzureServiceBusTransport.Configuration
             RetryMinBackoff = TimeSpan.FromMilliseconds(100);
             RetryMaxBackoff = TimeSpan.FromSeconds(30);
             RetryLimit = 3;
+            ReceiveTransportRetryLimit = 5;
+            ReceiveTransportRetryInterval = TimeSpan.FromSeconds(10);
 
             TransportType = ServiceBusTransportType.AmqpTcp;
 
@@ -32,5 +34,7 @@ namespace MassTransit.AzureServiceBusTransport.Configuration
         public TimeSpan RetryMaxBackoff { get; set; }
         public int RetryLimit { get; set; }
         public ServiceBusTransportType TransportType { get; set; }
+        public int ReceiveTransportRetryLimit { get; set; }
+        public TimeSpan ReceiveTransportRetryInterval { get; set; }
     }
 }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusHostConfiguration.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusHostConfiguration.cs
@@ -49,7 +49,7 @@
                     _ => false
                 });
 
-                x.Interval(5, TimeSpan.FromSeconds(10));
+                x.Interval(_hostSettings.ReceiveTransportRetryLimit, _hostSettings.ReceiveTransportRetryInterval);
             });
 
             _connectionContext = new Recycle<IConnectionContextSupervisor>(() => new ConnectionContextSupervisor(this, topologyConfiguration));

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusHostConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusHostConfigurator.cs
@@ -121,6 +121,14 @@
         {
             set => _settings.RetryLimit = value;
         }
+        public int ReceiveTransportRetryLimit
+        {
+            set => _settings.ReceiveTransportRetryLimit = value;
+        }
+        public TimeSpan ReceiveTransportRetryInterval
+        {
+            set => _settings.ReceiveTransportRetryInterval = value;
+        }
 
         static bool IsMissingCredentials(ServiceBusConnectionStringProperties properties)
         {

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusHostConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusHostConfigurator.cs
@@ -64,5 +64,15 @@
         /// Sets the messaging protocol to use with the messaging factory, defaults to AMQP TCP.
         /// </summary>
         ServiceBusTransportType TransportType { set; }
+
+        /// <summary>
+        /// Set the receive transport retry limit
+        /// </summary>
+        public int ReceiveTransportRetryLimit { set; }
+
+        /// <summary>
+        /// Set the receive transport retry interval in second
+        /// </summary>
+        public TimeSpan ReceiveTransportRetryInterval { set; }
     }
 }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/ServiceBusHostSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/ServiceBusHostSettings.cs
@@ -83,5 +83,15 @@
         /// The type of transport to use AMQP TCP or AMQP Websockets
         /// </summary>
         ServiceBusTransportType TransportType { get; }
+
+        /// <summary>
+        /// The retry limit for receive transport
+        /// </summary>
+        public int ReceiveTransportRetryLimit { get; }
+
+        /// <summary>
+        /// The retry interval for receive transport
+        /// </summary>
+        public TimeSpan ReceiveTransportRetryInterval { get; }
     }
 }

--- a/tests/MassTransit.Benchmark/ServiceBusOptionSet.cs
+++ b/tests/MassTransit.Benchmark/ServiceBusOptionSet.cs
@@ -70,6 +70,10 @@ namespace MassTransitBenchmark
 
         public ServiceBusTransportType TransportType => _hostSettings.TransportType;
 
+        public int ReceiveTransportRetryLimit => _hostSettings.ReceiveTransportRetryLimit;
+
+        public TimeSpan ReceiveTransportRetryInterval => _hostSettings.ReceiveTransportRetryInterval;
+
         public void ShowOptions()
         {
             Console.WriteLine("Service URI: {0}", ServiceUri);


### PR DESCRIPTION
Due to the poor network condition my client have, we would like some options to set retry policy for receive endpoint, which is currently hardcoded.

My testing was carried out using the following steps:

1. connect to a Azure service bus subscription with default receive endpoint retry settings (10s interval, 5 retry limit)
2. disconnect the network and wait for two minutes
3. resume the network and send a message
4. confirm that the subscription is no longer able to receive the message

I repeated the step above with longer retry settings (10s interval, 100 retry limit) and can confirm that the subscription is able to receive new messages.