### PR TITLE
Fix checkpointer #3360

### DIFF
--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/BatchCheckpointer.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/BatchCheckpointer.cs
@@ -91,7 +91,7 @@ namespace MassTransit.EventHubIntegration.Checkpoints
                     {
                         var confirmation = await _channel.Reader.ReadAsync(batchToken.Token).ConfigureAwait(false);
 
-                        await confirmation.Confirmed.OrCanceled(batchToken.Token).ConfigureAwait(false);
+                        await confirmation.Confirmed.OrCanceled(_shutdownTokenSource.Token).ConfigureAwait(false);
 
                         batch.Add(confirmation);
 

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Checkpoints/BatchCheckpointer.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Checkpoints/BatchCheckpointer.cs
@@ -87,7 +87,7 @@ namespace MassTransit.KafkaIntegration.Checkpoints
                     {
                         var confirmation = await _channel.Reader.ReadAsync(batchToken.Token).ConfigureAwait(false);
 
-                        await confirmation.Confirmed.OrCanceled(batchToken.Token).ConfigureAwait(false);
+                        await confirmation.Confirmed.OrCanceled(_shutdownTokenSource.Token).ConfigureAwait(false);
 
                         batch.Add(confirmation);
 

--- a/tests/MassTransit.EventHubIntegration.Tests/Long_Receive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Long_Receive_Specs.cs
@@ -1,0 +1,98 @@
+namespace MassTransit.EventHubIntegration.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Contracts;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+    using TestFramework;
+
+
+    public class Long_Receive_Specs :
+        InMemoryTestFixture
+    {
+        [Test]
+        public async Task Should_receive()
+        {
+            TaskCompletionSource<ConsumeContext<EventHubMessage>> taskCompletionSource = GetTask<ConsumeContext<EventHubMessage>>();
+            var services = new ServiceCollection();
+            services.AddSingleton(taskCompletionSource);
+
+            services.TryAddSingleton<ILoggerFactory>(LoggerFactory);
+            services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
+
+            services.AddMassTransit(x =>
+            {
+                x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+                x.AddRider(rider =>
+                {
+                    rider.AddConsumer<EventHubMessageConsumer>();
+
+                    rider.UsingEventHub((context, k) =>
+                    {
+                        k.Host(Configuration.EventHubNamespace);
+                        k.Storage(Configuration.StorageAccount);
+
+                        k.ReceiveEndpoint(Configuration.EventHubName, c =>
+                        {
+                            c.ConcurrentMessageLimit = 1;
+                            c.CheckpointMessageCount = 1;
+                            c.CheckpointInterval = TimeSpan.FromSeconds(1);
+                            c.ConfigureConsumer<EventHubMessageConsumer>(context);
+                        });
+                    });
+                });
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            var busControl = provider.GetRequiredService<IBusControl>();
+
+            var scope = provider.CreateScope();
+
+            await busControl.StartAsync(TestCancellationToken);
+
+            var producerProvider = scope.ServiceProvider.GetRequiredService<IEventHubProducerProvider>();
+            var producer = await producerProvider.GetProducer(Configuration.EventHubName);
+
+            try
+            {
+                var messageId = NewId.NextGuid();
+                await producer.Produce<EventHubMessage>(new { Text = "" }, Pipe.Execute<SendContext>(context => context.MessageId = messageId),
+                    TestCancellationToken);
+
+                ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
+
+                Assert.AreEqual(messageId, result.MessageId);
+            }
+            finally
+            {
+                scope.Dispose();
+
+                await busControl.StopAsync(TestCancellationToken);
+
+                await provider.DisposeAsync();
+            }
+        }
+
+
+        class EventHubMessageConsumer :
+            IConsumer<EventHubMessage>
+        {
+            readonly TaskCompletionSource<ConsumeContext<EventHubMessage>> _taskCompletionSource;
+
+            public EventHubMessageConsumer(TaskCompletionSource<ConsumeContext<EventHubMessage>> taskCompletionSource)
+            {
+                _taskCompletionSource = taskCompletionSource;
+            }
+
+            public async Task Consume(ConsumeContext<EventHubMessage> context)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                _taskCompletionSource.TrySetResult(context);
+            }
+        }
+    }
+}

--- a/tests/MassTransit.KafkaIntegration.Tests/Long_Receive_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Long_Receive_Specs.cs
@@ -1,0 +1,103 @@
+namespace MassTransit.KafkaIntegration.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+    using TestFramework;
+
+
+    public class Long_Receive_Specs :
+        InMemoryTestFixture
+    {
+        const string Topic = "long-receive-test";
+
+        [Test]
+        public async Task Should_receive()
+        {
+            TaskCompletionSource<ConsumeContext<KafkaMessage>> taskCompletionSource = GetTask<ConsumeContext<KafkaMessage>>();
+            var services = new ServiceCollection();
+            services.AddSingleton(taskCompletionSource);
+
+            services.TryAddSingleton<ILoggerFactory>(LoggerFactory);
+            services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
+
+            services.AddMassTransit(x =>
+            {
+                x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+                x.AddRider(rider =>
+                {
+                    rider.AddConsumer<KafkaMessageConsumer>();
+                    rider.AddProducer<KafkaMessage>(Topic);
+
+                    rider.UsingKafka((context, k) =>
+                    {
+                        k.Host("localhost:9092");
+
+                        k.TopicEndpoint<KafkaMessage>(Topic, nameof(Long_Receive_Specs), c =>
+                        {
+                            c.CreateIfMissing();
+                            c.ConcurrentMessageLimit = 1;
+                            c.CheckpointMessageCount = 1;
+                            c.CheckpointInterval = TimeSpan.FromSeconds(1);
+                            c.ConfigureConsumer<KafkaMessageConsumer>(context);
+                        });
+                    });
+                });
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            var busControl = provider.GetRequiredService<IBusControl>();
+
+            var scope = provider.CreateScope();
+
+            await busControl.StartAsync(TestCancellationToken);
+
+            var producer = scope.ServiceProvider.GetRequiredService<ITopicProducer<KafkaMessage>>();
+
+            try
+            {
+                var messageId = NewId.NextGuid();
+                await producer.Produce(new { }, Pipe.Execute<SendContext>(context => context.MessageId = messageId), TestCancellationToken);
+
+                ConsumeContext<KafkaMessage> result = await taskCompletionSource.Task;
+
+                Assert.AreEqual(messageId, result.MessageId);
+            }
+            finally
+            {
+                scope.Dispose();
+
+                await busControl.StopAsync(TestCancellationToken);
+
+                await provider.DisposeAsync();
+            }
+        }
+
+
+        class KafkaMessageConsumer :
+            IConsumer<KafkaMessage>
+        {
+            readonly TaskCompletionSource<ConsumeContext<KafkaMessage>> _taskCompletionSource;
+
+            public KafkaMessageConsumer(TaskCompletionSource<ConsumeContext<KafkaMessage>> taskCompletionSource)
+            {
+                _taskCompletionSource = taskCompletionSource;
+            }
+
+            public async Task Consume(ConsumeContext<KafkaMessage> context)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                _taskCompletionSource.TrySetResult(context);
+            }
+        }
+
+
+        public interface KafkaMessage
+        {
+        }
+    }
+}


### PR DESCRIPTION
fix for the: https://github.com/MassTransit/MassTransit/issues/3360

Use ShutdownToken to wait for confirmation in the message.

Otherwise we'll be reading messages from channel but not putting back, when Consume time greater than CheckpointInternval