### PR TITLE
Fixed AWS SNS Throttling Exception

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
@@ -37,14 +37,7 @@ namespace MassTransit.AmazonSqsTransport
 
             return _nameIndex.Get(topic.EntityName, async key =>
             {
-                try
-                {
-                    return await GetExistingTopic(topic.EntityName).ConfigureAwait(false);
-                }
-                catch (AmazonSqsTransportException e) when (e.Message.Equals($"Topic {topic.EntityName} not found."))
-                {
-                    return await CreateMissingTopic(topic).ConfigureAwait(false);
-                }
+                return await GetTopic(topic).ConfigureAwait(false);
             });
         }
 
@@ -67,7 +60,7 @@ namespace MassTransit.AmazonSqsTransport
             _nameIndex.Remove(entityName);
         }
 
-        async Task<TopicInfo> CreateMissingTopic(Topology.Topic topic)
+        async Task<TopicInfo> GetTopic(Topology.Topic topic)
         {
             Dictionary<string, string> attributes = topic.TopicAttributes.ToDictionary(x => x.Key, x => x.Value.ToString());
 


### PR DESCRIPTION
- We were experiencing a lot of AmazonSimpleNotificationServiceException when starting our project
- We had over 30 consumers 
- On startup, MassTransit is configuring the topology and calling AWS SDK FindTopicAsync Method to find the topic - this method is using ListTopics by iterating all topics until the topic is found
- This method has a hard limit of 30 requests per second 
![image](https://user-images.githubusercontent.com/106080089/169820481-c0ca9ed5-7111-40c1-b407-38f5db748839.png)
[Amazon Simple Notification Service endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/sns.html)

- With this PR we removed the call to the FindTopicAsync AWS SDK method and instead called the CreateTopicAsync method which either returns topics (if already exist) or creates one (if it doesn't exist) 
![image](https://user-images.githubusercontent.com/106080089/169821040-93aaae91-689e-4a9e-aca5-956dba7cf069.png)
- This matches the logic that was there before 
![image](https://user-images.githubusercontent.com/106080089/169821462-729db54c-dd66-4ed9-bc47-1c5eee21aef8.png)
- There is one similar question already asked on StackOverflow with the same problem: https://stackoverflow.com/questions/70615571/am-i-missing-something-when-using-masstransit-and-amazonsqs-in-a-large-project
