### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -555,6 +555,8 @@ jobs:
         working-directory: tests/MassTransit.SignalR.Tests
         
   calc-version:
+    permissions:
+      contents: none
     name: Calculate Version
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,13 @@ on:
       - 'docs/**'
       - 'package.json'
       - '**/docs.yml'
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for Git to git push
     name: Build and Deploy
     runs-on: ubuntu-latest
     if: (github.ref == 'refs/heads/develop') && github.repository == 'MassTransit/MassTransit'

--- a/.github/workflows/nightly-transports.yml
+++ b/.github/workflows/nightly-transports.yml
@@ -5,6 +5,9 @@ env:
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-transports:
     name: "Transport Validation"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
