### PR TITLE
Wait until batch channel get fully cleared

### DIFF
--- a/src/MassTransit/DependencyInjection/Configuration/ServiceCollectionRiderConfigurator.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/ServiceCollectionRiderConfigurator.cs
@@ -30,7 +30,7 @@ namespace MassTransit.Configuration
             if (riderFactory == null)
                 throw new ArgumentNullException(nameof(riderFactory));
 
-            ThrowIfAlreadyConfigured<TRider>();
+            ThrowIfAlreadyConfigured(typeof(TRider));
 
             IRiderRegistrationContext CreateRegistrationContext(IServiceProvider provider)
             {
@@ -45,14 +45,11 @@ namespace MassTransit.Configuration
             this.AddSingleton(provider => provider.GetRequiredService<Bind<IBus, TRider>>().Value);
         }
 
-        protected void ThrowIfAlreadyConfigured<TRider>()
-            where TRider : class, IRider
+        protected void ThrowIfAlreadyConfigured(Type serviceType)
         {
             ThrowIfAlreadyConfigured(nameof(SetRiderFactory));
-            var riderType = typeof(TRider);
-
-            if (this.Any(d => d.ServiceType == riderType))
-                throw new ConfigurationException($"'{riderType.Name}' has been already registered.");
+            if (this.Any(d => d.ServiceType == serviceType))
+                throw new ConfigurationException($"'{serviceType.Name}' has been already registered.");
         }
     }
 
@@ -77,7 +74,7 @@ namespace MassTransit.Configuration
             if (riderFactory == null)
                 throw new ArgumentNullException(nameof(riderFactory));
 
-            ThrowIfAlreadyConfigured<TRider>();
+            ThrowIfAlreadyConfigured(typeof(Bind<TBus, TRider>));
 
             IRiderRegistrationContext CreateRegistrationContext(IServiceProvider provider)
             {


### PR DESCRIPTION
We need to wait until we checkpoint everything in channel fully. 
We can not cancel ReadBatch as long as there are some items, otherwise `WaitForBatch` will be inside infinite loop:
https://github.com/MassTransit/MassTransit/blob/ff8a86c599b683f5188d3e1ed8cb93e8d7f722ac/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Checkpoints/BatchCheckpointer.cs#L54

We can not also provide cancellation token for `WaitForBatch` as we are going to lose all the progress we have done.

EventHub is different, we need to cancel reading when we get event for not shutdown, as it means partition is already re-assigned to other instance and started from previous checkpoint. And we are going to fully wait when it is `Shutdown`