### PR TITLE
fix: ExceptionInfo Data should not be in Key

### DIFF
--- a/src/MassTransit.Abstractions/Exceptions/ExceptionInfoException.cs
+++ b/src/MassTransit.Abstractions/Exceptions/ExceptionInfoException.cs
@@ -16,7 +16,7 @@ namespace MassTransit
         {
             ExceptionInfo = exceptionInfo;
             if (ExceptionInfo.Data != null)
-                _data = ExceptionInfo.Data.ToDictionary(x => x.Key);
+                _data = (IDictionary)ExceptionInfo.Data;
         }
 
         public ExceptionInfo ExceptionInfo { get; }


### PR DESCRIPTION
Following my message on Discord : https://discord.com/channels/682238261753675864/682238261753675868/986725785299734668
The behavior is different between Consumer/JobConsumer about Data in ExceptionInfo

From a Consumer : 
![FromConsumer](https://user-images.githubusercontent.com/10074648/175109904-d17e4789-95de-4406-8c10-f4a9d93ca999.png)
 
From a JobConsumer : 
![FromJobConsumer](https://user-images.githubusercontent.com/10074648/175109906-6d2f39c9-2b0f-454f-bf68-a9c5aa85559e.png)

With a JobConsumer the Value contain the KeyValuePair when he should contains only the value
 
I applied the following fix that I propose to you