### PR TITLE
Fixed EF Saga Persistence example

### DIFF
--- a/docs/usage/sagas/ef.md
+++ b/docs/usage/sagas/ef.md
@@ -77,7 +77,7 @@ services.AddMassTransit(x =>
         {
             r.ConcurrencyMode = ConcurrencyMode.Pessimistic; // or use Optimistic, which requires RowVersion
 
-            r.AddDbContext<DbContext, OrderStateDbContext>(connectionString)
+            r.DatabaseFactory(() => new OrderStateDbContext(connectionString));
         });
 });
 ```


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Docs are wrong: r.AddDbContext<DbContext, OrderStateDbContext>(connectionString) does not exists for EF, only in EF Core.

Similar fix was done in: https://github.com/MassTransit/MassTransit/pull/1722

