### PR TITLE
Add missing http:// when defining the Uri

### DIFF
--- a/docs/code/transports/GrpcMultiConsoleListener.cs
+++ b/docs/code/transports/GrpcMultiConsoleListener.cs
@@ -21,8 +21,8 @@ public class Program
                             h.Host = "127.0.0.1";
                             h.Port = 19796;
 
-                            h.AddServer(new Uri("127.0.0.1:19797"));
-                            h.AddServer(new Uri("127.0.0.1:19798"));
+                            h.AddServer(new Uri("http://127.0.0.1:19797"));
+                            h.AddServer(new Uri("http://127.0.0.1:19798"));
                         });
 
                         cfg.ConfigureEndpoints(context);


### PR DESCRIPTION
If **http://** is missing code throw UriFormatException: Invalid URI: The format of the URI could not be determined.


