### PR TITLE
Tune Unique Index on OutboxMessage: Swap Order of SequenceNumber and OutboxId

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/EntityFrameworkOutboxConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/EntityFrameworkOutboxConfigurationExtensions.cs
@@ -166,8 +166,8 @@ namespace MassTransit
             outbox.Property(p => p.OutboxId);
             outbox.HasIndex(p => new
             {
-                p.SequenceNumber,
                 p.OutboxId,
+                p.SequenceNumber,
             }).IsUnique();
 
             outbox.Property(p => p.Headers);


### PR DESCRIPTION
Tweaking the index referenced in #3515 , so bus outbox delivery performance doesn't degrade as the outbox tables fill up

This swaps the order of the OutboxMessage unique index on (SequenceNumber,OutboxId) to (OutboxId,SequenceNumber), so query execution remains fast when filtering by OutboxId if OutboxMessage has many rows

Results of testing against ~1M rows in SQL Server. Query 1 old, Query 2 new:
![image](https://user-images.githubusercontent.com/33609707/178646269-1149aad7-0c41-44dd-999c-346df30b7391.png)

