### PR TITLE
Update templates.md

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -38,7 +38,7 @@ Creates a dotnet project that is configured as a MassTransit Worker. Includes pr
 ### MassTransit Docker
 
 ```
-dotnet new docker
+dotnet new mtdocker
 ```
 
 Creates a `Dockerfile` and a `docker-compose.yml` in the project, configured for RabbitMQ.


### PR DESCRIPTION
All the MassTransit templates start with "mt", this prefix was missing for docker