### PR TITLE
Record Activity Exceptions

### DIFF
--- a/src/MassTransit/Logging/DiagnosticHeaders.cs
+++ b/src/MassTransit/Logging/DiagnosticHeaders.cs
@@ -29,6 +29,16 @@ namespace MassTransit.Logging
         public const string SagaId = "messaging.masstransit.saga_id";
 
 
+        public class Exceptions
+        {
+            public const string EventName = "exception";
+            public const string Type = "exception.type";
+            public const string Message = "exception.message";
+            public const string Escaped = "exception.escaped";
+            public const string Stacktrace = "exception.stacktrace";
+        }
+
+
         public static class Messaging
         {
             public const string BodyLength = "messaging.message_payload_size_bytes";

--- a/src/MassTransit/Logging/StartedActivity.cs
+++ b/src/MassTransit/Logging/StartedActivity.cs
@@ -1,6 +1,7 @@
 #nullable enable
 namespace MassTransit.Logging
 {
+    using System;
     using System.Diagnostics;
 
 
@@ -26,6 +27,22 @@ namespace MassTransit.Logging
         {
             if (context.BodyLength.HasValue)
                 AddTag(DiagnosticHeaders.Messaging.BodyLength, context.BodyLength.Value.ToString());
+        }
+
+        public void RecordException(Exception exception, bool escaped)
+        {
+            var tags = new ActivityTagsCollection
+            {
+                { DiagnosticHeaders.Exceptions.Escaped, escaped },
+                { DiagnosticHeaders.Exceptions.Message, exception.Message },
+                { DiagnosticHeaders.Exceptions.Type, exception.GetType().Name },
+                { DiagnosticHeaders.Exceptions.Stacktrace, exception.ToString() }
+            };
+
+            var activityEvent = new ActivityEvent(DiagnosticHeaders.Exceptions.EventName, DateTimeOffset.UtcNow, tags);
+
+            Activity.AddEvent(activityEvent);
+            Activity.SetStatus(ActivityStatusCode.Error);
         }
 
         public void Stop()

--- a/src/MassTransit/Middleware/InitiatedByOrOrchestratesSagaMessageFilter.cs
+++ b/src/MassTransit/Middleware/InitiatedByOrOrchestratesSagaMessageFilter.cs
@@ -30,6 +30,12 @@ namespace MassTransit.Middleware
 
                 await next.Send(context).ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                activity?.RecordException(ex, escaped: true);
+
+                throw;
+            }
             finally
             {
                 activity?.Stop();

--- a/src/MassTransit/Middleware/InitiatedBySagaMessageFilter.cs
+++ b/src/MassTransit/Middleware/InitiatedBySagaMessageFilter.cs
@@ -30,6 +30,12 @@ namespace MassTransit.Middleware
 
                 await next.Send(context).ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                activity?.RecordException(ex, escaped: true);
+
+                throw;
+            }
             finally
             {
                 activity?.Stop();

--- a/src/MassTransit/Middleware/InstanceMessageFilter.cs
+++ b/src/MassTransit/Middleware/InstanceMessageFilter.cs
@@ -5,6 +5,7 @@ namespace MassTransit.Middleware
     using System.Threading.Tasks;
     using Context;
     using Logging;
+    using Util;
 
 
     /// <summary>
@@ -56,17 +57,11 @@ namespace MassTransit.Middleware
             }
             catch (OperationCanceledException exception)
             {
-                await context.NotifyFaulted(timer.Elapsed, TypeCache<TConsumer>.ShortName, exception).ConfigureAwait(false);
-
-                if (exception.CancellationToken == context.CancellationToken)
-                    throw;
-
-                throw new ConsumerCanceledException($"The operation was canceled by the consumer: {TypeCache<TConsumer>.ShortName}");
+                await ThrowHelper.ConsumeFilter.ThrowOperationCancelled<TConsumer, TMessage>(context, timer.Elapsed, exception, activity).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await context.NotifyFaulted(timer.Elapsed, TypeCache<TConsumer>.ShortName, ex).ConfigureAwait(false);
-                throw;
+                await ThrowHelper.ConsumeFilter.Throw<TConsumer, TMessage>(context, timer.Elapsed, ex, activity).ConfigureAwait(false);
             }
             finally
             {

--- a/src/MassTransit/Middleware/ObservesSagaMessageFilter.cs
+++ b/src/MassTransit/Middleware/ObservesSagaMessageFilter.cs
@@ -1,5 +1,6 @@
 namespace MassTransit.Middleware
 {
+    using System;
     using System.Threading.Tasks;
     using Logging;
 
@@ -28,6 +29,12 @@ namespace MassTransit.Middleware
                 await context.Saga.Consume(context).ConfigureAwait(false);
 
                 await next.Send(context).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                activity?.RecordException(ex, escaped: true);
+
+                throw;
             }
             finally
             {

--- a/src/MassTransit/Middleware/OrchestratesSagaMessageFilter.cs
+++ b/src/MassTransit/Middleware/OrchestratesSagaMessageFilter.cs
@@ -30,6 +30,12 @@
 
                 await next.Send(context).ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                activity?.RecordException(ex, escaped: true);
+
+                throw;
+            }
             finally
             {
                 activity?.Stop();

--- a/src/MassTransit/Middleware/Outbox/OutboxSendEndpoint.cs
+++ b/src/MassTransit/Middleware/Outbox/OutboxSendEndpoint.cs
@@ -177,6 +177,11 @@ namespace MassTransit.Middleware.Outbox
                 await _outboxContext.AddSend(context).ConfigureAwait(false);
                 activity?.Update(context);
             }
+            catch (Exception ex)
+            {
+                activity?.RecordException(ex, escaped: true);
+                throw;
+            }
             finally
             {
                 activity?.Stop();

--- a/src/MassTransit/Middleware/OutboxMessagePipe.cs
+++ b/src/MassTransit/Middleware/OutboxMessagePipe.cs
@@ -88,6 +88,12 @@ namespace MassTransit.Middleware
                     {
                         await endpoint.Send(new Outbox(), pipe, context.CancellationToken).ConfigureAwait(false);
                     }
+                    catch (Exception exception)
+                    {
+                        activity?.RecordException(exception, escaped: true);
+
+                        throw;
+                    }
                     finally
                     {
                         activity?.Stop();

--- a/src/MassTransit/Middleware/StateMachineSagaMessageFilter.cs
+++ b/src/MassTransit/Middleware/StateMachineSagaMessageFilter.cs
@@ -70,7 +70,18 @@ namespace MassTransit.Middleware
             {
                 State<TSaga> currentState = await _machine.Accessor.Get(behaviorContext).ConfigureAwait(false);
 
-                throw new NotAcceptedStateMachineException(typeof(TSaga), typeof(TMessage), context.CorrelationId ?? Guid.Empty, currentState.Name, ex);
+                NotAcceptedStateMachineException stateMachineException = new NotAcceptedStateMachineException(typeof(TSaga), typeof(TMessage),
+                    context.CorrelationId ?? Guid.Empty, currentState.Name, ex);
+
+                activity?.RecordException(stateMachineException, escaped: true);
+
+                throw stateMachineException;
+            }
+            catch (Exception exception)
+            {
+                activity?.RecordException(exception, escaped: true);
+
+                throw;
             }
             finally
             {

--- a/src/MassTransit/Transports/ReceivePipeDispatcher.cs
+++ b/src/MassTransit/Transports/ReceivePipeDispatcher.cs
@@ -79,11 +79,21 @@ namespace MassTransit.Transports
                     try
                     {
                         await receiveLock.Faulted(ex).ConfigureAwait(false);
+
+                        activity?.RecordException(ex, escaped: true);
                     }
                     catch (Exception releaseLockException)
                     {
-                        throw new AggregateException("ReceiveLock.Faulted threw an exception", releaseLockException, ex);
+                        AggregateException aggregateException = new AggregateException("ReceiveLock.Faulted threw an exception", releaseLockException, ex);
+
+                        activity?.RecordException(aggregateException, escaped: true);
+
+                        throw aggregateException;
                     }
+                }
+                else
+                {
+                    activity?.RecordException(ex, escaped: true);
                 }
 
                 throw;

--- a/src/MassTransit/Transports/SendTransport.cs
+++ b/src/MassTransit/Transports/SendTransport.cs
@@ -104,6 +104,8 @@ namespace MassTransit.Transports
                     if (_sendTransportContext.SendObservers.Count > 0)
                         await _sendTransportContext.SendObservers.SendFault(sendContext, ex).ConfigureAwait(false);
 
+                    activity?.RecordException(ex, escaped: true);
+
                     throw;
                 }
                 finally

--- a/src/MassTransit/Util/ThrowHelper.cs
+++ b/src/MassTransit/Util/ThrowHelper.cs
@@ -1,0 +1,45 @@
+namespace MassTransit.Util
+{
+    using System;
+    using System.Threading.Tasks;
+    using Logging;
+
+
+    static class ThrowHelper
+    {
+        public static class ConsumeFilter
+        {
+            public static async Task Throw<TConsumer, TMessage>(ConsumeContext<TMessage> context, TimeSpan duration, Exception exception, StartedActivity? activity)
+                where TMessage : class
+            {
+                await context.NotifyFaulted(duration, TypeCache<TConsumer>.ShortName, exception).ConfigureAwait(false);
+
+                activity?.RecordException(exception, escaped: true);
+
+                throw exception;
+            }
+
+            public static async Task ThrowOperationCancelled<TConsumer, TMessage>(ConsumeContext<TMessage> context, TimeSpan duration, OperationCanceledException exception, StartedActivity? activity)
+                where TMessage : class
+            {
+                await context.NotifyFaulted(duration, TypeCache<TConsumer>.ShortName, exception).ConfigureAwait(false);
+
+                activity?.RecordException(exception, escaped: exception.CancellationToken == context.CancellationToken);
+
+                if (exception.CancellationToken == context.CancellationToken)
+                    throw exception;
+
+                ThrowConsumerCanceled<TConsumer>(activity, escaped: true);
+            }
+
+            public static void ThrowConsumerCanceled<TConsumer>(StartedActivity? activity, bool escaped)
+            {
+                var exception = new ConsumerCanceledException($"The operation was canceled by the consumer: {TypeCache<TConsumer>.ShortName}");
+
+                activity?.RecordException(exception, escaped);
+
+                throw exception;
+            }
+        }
+    }
+}

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/BusOutboxDeliveryService.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/BusOutboxDeliveryService.cs
@@ -248,6 +248,12 @@ namespace MassTransit.MongoDbIntegration
                         {
                             await endpoint.Send(new Outbox(), pipe, token.Token).ConfigureAwait(false);
                         }
+                        catch (Exception exception)
+                        {
+                            activity?.RecordException(exception, escaped: true);
+
+                            throw;
+                        }
                         finally
                         {
                             activity?.Stop();

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubProducer.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubProducer.cs
@@ -169,6 +169,8 @@ namespace MassTransit.EventHubIntegration
                     if (_context.SendObservers.Count > 0)
                         await _context.SendObservers.SendFault(sendContext, exception).ConfigureAwait(false);
 
+                    activity?.RecordException(exception, escaped: true);
+
                     throw;
                 }
                 finally
@@ -287,6 +289,8 @@ namespace MassTransit.EventHubIntegration
 
                     if (_context.SendObservers.Count > 0)
                         await Task.WhenAll(contexts.Select(c => _context.SendObservers.SendFault(c, exception))).ConfigureAwait(false);
+
+                    activity?.RecordException(exception, escaped: true);
 
                     throw;
                 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/TopicProducer.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/TopicProducer.cs
@@ -120,6 +120,8 @@ namespace MassTransit.KafkaIntegration
                     if (_context.SendObservers.Count > 0)
                         await _context.SendObservers.SendFault(sendContext, exception).ConfigureAwait(false);
 
+                    activity?.RecordException(exception, escaped: true);
+
                     throw;
                 }
                 finally


### PR DESCRIPTION
This PR adds support for recording activity exceptions. This enables OpenTelemetry to show exception data on its traces

I hacked this in a few minutes, so I'm still figuring out how to add tests