### PR TITLE
BusActivityMonitor hardened and simplified

### DIFF
--- a/src/MassTransit/Testing/ExtensionMethodsForBuses.cs
+++ b/src/MassTransit/Testing/ExtensionMethodsForBuses.cs
@@ -41,9 +41,12 @@ namespace MassTransit.Testing
             BusActivityConsumeIndicator consumeIndicator,
             BusActivitySendIndicator sendIndicator, BusActivityPublishIndicator publishIndicator)
         {
-            var activityMonitor = new BusActivityMonitor();
+            var predicateHelper = new BusInactivePredicateHelper();
+            var activityMonitor = new BusActivityMonitor(predicateHelper.BusInactive);
+
             var conditionExpression = new ConditionExpression(activityMonitor);
             conditionExpression.AddConditionBlock(receiveIndicator, consumeIndicator, sendIndicator, publishIndicator);
+            predicateHelper.BusInactivePredicate = conditionExpression.CheckCondition;
 
             bus.ConnectReceiveObserver(receiveIndicator);
             bus.ConnectConsumeObserver(consumeIndicator);

--- a/src/MassTransit/Testing/Implementations/BusInactivePredicateHelper.cs
+++ b/src/MassTransit/Testing/Implementations/BusInactivePredicateHelper.cs
@@ -1,0 +1,14 @@
+﻿namespace MassTransit.Testing.Implementations
+{
+    using System;
+
+    class BusInactivePredicateHelper
+    {
+        public Func<bool> BusInactivePredicate { get; set; }
+
+        public bool BusInactive()
+        {
+            return BusInactivePredicate?.Invoke() ?? false;
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I use the BusActivityMonitor to ensure that all events are processed after my integrationtest finished, so I'm able to safely reset my database after each integrationtest without events that are still being processed.

The current implementation of the BusActivityMonitor is not that friendly to use in my case => I need to use a long inactivitytimeout and I also get issues, if I call the AwaitBusInactivity function twice. (semaphore is only released once, so the second call waits forever)

I builded a workaround for myself, but I think it could help other people too, so I integrated my workaround directly into the busactivitymonitor.

With these changes you are now able to use a very short inactivity timeout (I currently using 20ms) and you are also able to call the monitor as often as you like without any issues.


As a side note: I'm not that happy with the way I integrated my changes to the monitor, but I didn't want to break the Class api surface for people who use the classes directly in there own code. 
If I'm allowed to "break" the class api surface of the "TestFramework Implemations" namespace by removing the empty constructor from the BusActivityMonitor, I would rename the old BusActivityMonitor to InternalBusActivityMonitor and then implement a new BusActivityMonitor that just wraps the InternalMonitor and get's the BusInactive Predicate as second parameter?  