### PR TITLE
Fixed bug when inspecting the properties of a type with multiple this…

### DIFF
--- a/src/MassTransit.Abstractions/Internals/Extensions/TypeExtensions.cs
+++ b/src/MassTransit.Abstractions/Internals/Extensions/TypeExtensions.cs
@@ -36,10 +36,12 @@ namespace MassTransit.Internals
                     yield return prop;
             }
 
-            List<PropertyInfo> properties = typeInfo.DeclaredMethods
+            var specialGetPropertyNames = typeInfo.DeclaredMethods
                 .Where(x => x.IsSpecialName && x.Name.StartsWith("get_") && !x.IsStatic)
-                .Select(x => typeInfo.GetDeclaredProperty(x.Name.Substring("get_".Length)))
-                .Cast<PropertyInfo>()
+                .Select(x => x.Name.Substring("get_".Length)).Distinct();
+
+            List<PropertyInfo> properties = typeInfo.DeclaredProperties
+                .Where(x => specialGetPropertyNames.Contains(x.Name))
                 .ToList();
 
             if (typeInfo.IsInterface)

--- a/tests/MassTransit.Abstractions.Tests/TypeExtensions_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/TypeExtensions_Specs.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace MassTransit.Abstractions.Tests
+{
+    [TestFixture]
+    public class Using_the_TypeExtensions
+    {
+        [Test]
+        public void Should_accept_multiple_this_operators()
+        {
+            var typeInfo = typeof(TypeWithMultipleThisOperators).GetTypeInfo();
+            Assert.That(() => Internals.TypeExtensions.GetAllProperties(typeInfo).ToList(), Throws.Nothing);
+        }
+    }
+
+    internal class TypeWithMultipleThisOperators
+    {
+        public string FirstValue { get; } = "aValue";
+        public string SecondValue { get; } = "anotherValue";
+
+        public string this[int index] => index switch
+        {
+            0 => FirstValue,
+            1 => SecondValue,
+            _ => throw new ArgumentOutOfRangeException(nameof(index))
+        };
+
+        public string this[string name] => name.ToLower() switch
+        {
+            "first" => FirstValue,
+            "second" => SecondValue,
+            _ => throw new ArgumentOutOfRangeException(nameof(name))
+        };
+
+
+    }
+}


### PR DESCRIPTION
I was testing the MessageData functionality and found that my message type caused an exception:
```
info: MassTransit[0]
      Configured endpoint mass-transit-message-data-tester, Consumer: MassTransitMessageDataTester.Consumers.MassTransitMessageDataTesterConsumer
Unhandled exception. MassTransit.ConfigurationException: An exception occurred during bus creation
 ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
````
I investigated the issue and found out that the exception is generated in `TypeExtensions.GetAllProperties()` if the message includes a type with multiple `this[]` operators. I was using [Coordinate](https://github.com/NetTopologySuite/GeoAPI/blob/develop/src/GeoAPI/Geometries/Coordinate.cs) from the GeoAPI project in my own code.

I've included a test case that demonstrates the bug in the original code and shows that the fix works.

I can provide a complete project to demonstrate the bug, but I think I narrowed it down enough in the test.