### PR TITLE
fire serializer before copying headers to transport

### DIFF
--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqSendTransportContext.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqSendTransportContext.cs
@@ -78,13 +78,13 @@ namespace MassTransit.ActiveMqTransport
 
             var transportMessage = sessionContext.CreateBytesMessage();
 
+            transportMessage.Content = context.Body.GetBytes();
+
             transportMessage.Properties.SetHeaders(context.Headers);
 
             transportMessage.Properties[MessageHeaders.ContentType] = context.ContentType.ToString();
 
             transportMessage.NMSDeliveryMode = context.Durable ? MsgDeliveryMode.Persistent : MsgDeliveryMode.NonPersistent;
-
-            transportMessage.Content = context.Body.GetBytes();
 
             if (context.MessageId.HasValue)
                 transportMessage.NMSMessageId = context.MessageId.ToString();


### PR DESCRIPTION
Hello

this is a proposal to change flow in ActiveMQ send context to fire a message body serialization before copying headers to transport. It allows propagation of headers set during a serialization process.

It relates to discussion #3635