### PR TITLE
propagate isDefault patrameter id AddDeserializer

### DIFF
--- a/src/MassTransit/Configuration/Configuration/BusFactoryConfigurator.cs
+++ b/src/MassTransit/Configuration/Configuration/BusFactoryConfigurator.cs
@@ -248,7 +248,7 @@ namespace MassTransit.Configuration
 
         public void AddDeserializer(ISerializerFactory factory, bool isDefault = false)
         {
-            _busConfiguration.Serialization.AddDeserializer(factory);
+            _busConfiguration.Serialization.AddDeserializer(factory, isDefault);
         }
 
         public void ClearSerialization()


### PR DESCRIPTION
Hello,

When I implemented my own deserializer I found out that the isDefault parametr is not propagated in the whole call chain. As a workaround I can set DefaultContentType property manually. I think better way is to propagate the parameter in the whole call chain.

Thank you 