### PR TITLE
Fix batch publish default value documentation

### DIFF
--- a/docs/usage/transports/rabbitmq.md
+++ b/docs/usage/transports/rabbitmq.md
@@ -82,7 +82,7 @@ MassTransit will briefly buffer messages before sending them to RabbitMQ, to inc
 
 |  Property               | Type   | Default |Description 
 |-------|------------------------|-----|--------|---
-| Enabled        | bool | true | Enable or disable batch sends to RabbitMQ
+| Enabled        | bool | false | Enable or disable batch sends to RabbitMQ
 | MessageLimit        | int | 100 | Limit the number of messages per batch
 | SizeLimit        | int | 64K | A rough limit of the total message size
 | Timeout        | TimeSpan | 1ms | The time to wait for additional messages before sending


### PR DESCRIPTION
As mentioned in the upgrade guide to v8 batch publish is now disabled by default. But the documentation and website still said it was enabled. This caused me a bit of confusion.