### PR TITLE
Expose event configurator via IStateMachineModifier

### DIFF
--- a/src/MassTransit/SagaStateMachine/Configuration/StateMachineEventActivitiesBuilder.cs
+++ b/src/MassTransit/SagaStateMachine/Configuration/StateMachineEventActivitiesBuilder.cs
@@ -165,6 +165,12 @@
             return CommitActivities().Event(name, out @event);
         }
 
+        public IStateMachineModifier<TInstance> Event<T>(string name, Action<IEventCorrelationConfigurator<TInstance, T>> configure, out Event<T> @event)
+            where T : class
+        {
+            return CommitActivities().Event(name, configure, out @event);
+        }
+
         public IStateMachineModifier<TInstance> Event<TProperty, T>(Expression<Func<TProperty>> propertyExpression,
             Expression<Func<TProperty, Event<T>>> eventPropertyExpression)
             where TProperty : class

--- a/src/MassTransit/SagaStateMachine/Configuration/StateMachineModifier.cs
+++ b/src/MassTransit/SagaStateMachine/Configuration/StateMachineModifier.cs
@@ -125,6 +125,13 @@
             return this;
         }
 
+        public IStateMachineModifier<TSaga> Event<T>(string name, Action<IEventCorrelationConfigurator<TSaga, T>> configure, out Event<T> @event)
+            where T : class
+        {
+            @event = _machine.Event<T>(name, configure);
+            return this;
+        }
+
         public IStateMachineModifier<TSaga> Event<TProperty, T>(Expression<Func<TProperty>> propertyExpression,
             Expression<Func<TProperty, Event<T>>> eventPropertyExpression)
             where TProperty : class

--- a/src/MassTransit/SagaStateMachine/IStateMachineModifier.cs
+++ b/src/MassTransit/SagaStateMachine/IStateMachineModifier.cs
@@ -18,6 +18,8 @@
 
         IStateMachineModifier<TSaga> Event<T>(string name, out Event<T> @event)
             where T : class;
+        IStateMachineModifier<TSaga> Event<T>(string name, Action<IEventCorrelationConfigurator<TSaga, T>> configure, out Event<T> @event)
+            where T : class;
 
         IStateMachineModifier<TSaga> Event<TProperty, T>(Expression<Func<TProperty>> propertyExpression,
             Expression<Func<TProperty, Event<T>>> eventPropertyExpression)

--- a/src/MassTransit/SagaStateMachine/MassTransitStateMachine.cs
+++ b/src/MassTransit/SagaStateMachine/MassTransitStateMachine.cs
@@ -471,7 +471,7 @@
         /// <typeparam name="T">The event data type</typeparam>
         /// <param name="name">The event name (must be unique)</param>
         /// <param name="configure">Configuration callback method</param>
-        protected Event<T> Event<T>(string name, Action<IEventCorrelationConfigurator<TInstance, T>> configure)
+        protected internal Event<T> Event<T>(string name, Action<IEventCorrelationConfigurator<TInstance, T>> configure)
             where T : class
         {
             Event<T> @event = Event<T>(name);

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Event_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Event_Specs.cs
@@ -32,8 +32,15 @@
             Assert.IsInstanceOf<TriggerEvent>(Hello);
         }
 
+        [Test]
+        public void It_should_create_configured_events()
+        {
+            Assert.IsInstanceOf<TriggerEvent>(EventB);
+        }
+
         Event Hello;
         Event<A> EventA;
+        Event<B> EventB;
         StateMachine<Instance> _machine;
 
 
@@ -52,6 +59,7 @@
                 .New(builder => builder
                     .Event("Hello", out Hello)
                     .Event("EventA", out EventA)
+                    .Event("EventB", x => x.CorrelateById(ctx => ctx.Message.Id), out EventB)
                 );
         }
 
@@ -59,13 +67,9 @@
         class A
         {
         }
-
-
-        class TestStateMachine :
-            MassTransitStateMachine<Instance>
+        class B
         {
-            public Event Hello { get; private set; }
-            public Event<A> EventA { get; private set; }
+            public Guid Id { get; set; }
         }
     }
 }


### PR DESCRIPTION
Adds `Event` overload to bring state machine builder API to parity with inheritance-based interface and allow for configuration of correlation. 

Closes #3702 
