### PR TITLE
Stop setting attributes in CreateTopicRequest

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
@@ -72,6 +72,7 @@ namespace MassTransit.AmazonSqsTransport
         {
             Dictionary<string, string> attributes = topic.TopicAttributes.ToDictionary(x => x.Key, x => x.Value.ToString());
 
+            // CreateTopicRequest is idempotent except for case when existing topic attributes are not matching the attributes provided in the request
             var request = new CreateTopicRequest(topic.EntityName)
             {
                 Tags = topic.TopicTags.Select(x => new Tag

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
@@ -74,7 +74,6 @@ namespace MassTransit.AmazonSqsTransport
 
             var request = new CreateTopicRequest(topic.EntityName)
             {
-                Attributes = attributes,
                 Tags = topic.TopicTags.Select(x => new Tag
                 {
                     Key = x.Key,

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicCache.cs
@@ -90,6 +90,16 @@ namespace MassTransit.AmazonSqsTransport
 
             attributesResponse.EnsureSuccessfulResponse();
 
+            foreach (var attribute in attributes)
+            {
+                if (!attributesResponse.Attributes.ContainsKey(attribute.Key) || attributesResponse.Attributes[attribute.Key] != attribute.Value)
+                {
+                    var setTopicAttributesResponse = await _client.SetTopicAttributesAsync(createResponse.TopicArn, attribute.Key, attribute.Value, _cancellationToken).ConfigureAwait(false);
+
+                    setTopicAttributesResponse.EnsureSuccessfulResponse();
+                }
+            }
+
             var missingTopic = new TopicInfo(topic.EntityName, createResponse.TopicArn);
 
             if (topic.Durable && topic.AutoDelete == false)


### PR DESCRIPTION
I propose this change to resolve #3720

Stop setting attributes in `CreateTopicRequest` because if there's a mismatch in the attribute values, the following exception will be thrown: `Amazon.SimpleNotificationService.Model.InvalidParameterException: Invalid parameter: Attributes Reason: Topic already exists with different attributes`.

The topic should be created first and any mismatched attributes should be updated after that.

- [ ] TODO: Verify that the code works
