### PR TITLE
Update template installation snippet

### DIFF
--- a/docs/quick-starts/in-memory.md
+++ b/docs/quick-starts/in-memory.md
@@ -23,7 +23,7 @@ This example requires the following:
 MassTransit includes project and item [templates](/usage/templates) simplifying the creation of new projects. Install the templates by executing `dotnet new -i MassTransit.Templates` at the console. A video introducing the templates is available on [YouTube](https://youtu.be/nYKq61-DFBQ).
 
 ```
-dotnet new -i MassTransit.Templates
+dotnet new install MassTransit.Templates
 ```
 
 ## Initial Project Creation


### PR DESCRIPTION
Update template installation snippet

Fixes:
Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.

![image](https://user-images.githubusercontent.com/5972917/195020169-3d42e1c4-06f0-44ba-9e69-bd71e4514376.png)