### PR TITLE
Update guidance.md with saga definition example

### DIFF
--- a/docs/usage/sagas/guidance.md
+++ b/docs/usage/sagas/guidance.md
@@ -48,6 +48,38 @@ services.AddMassTransit(x =>
 });
 ```
 
+Alternatively if using a [saga definition](/docs/usage/containers/definitions):
+
+```cs
+public sealed class OrderStateSagaDefinition : SagaDefinition<OrderState>
+{
+    private const int ConcurrencyLimit = 20; // this can go up, depending upon the database capacity
+
+    public OrderStateSagaDefinition()
+    {
+        // specify the message limit at the endpoint level, which influences
+        // the endpoint prefetch count, if supported.
+        Endpoint(e =>
+        {
+            e.Name = "saga-queue";
+            e.PrefetchCount = ConcurrencyLimit;
+        });
+    }
+
+    protected override void ConfigureSaga(IReceiveEndpointConfigurator endpointConfigurator, ISagaConfigurator<OrderState> sagaConfigurator)
+    {
+        endpointConfigurator.UseMessageRetry(r => r.Interval(5, 1000));
+        endpointConfigurator.UseInMemoryOutbox();
+
+        var partition = endpointConfigurator.CreatePartitioner(ConcurrencyLimit);
+
+        sagaConfigurator.Message<SubmitOrder>(x => x.UsePartitioner(partition, m => m.Message.OrderId));
+        sagaConfigurator.Message<OrderAccepted>(x => x.UsePartitioner(partition, m => m.Message.OrderId));
+        sagaConfigurator.Message<OrderCanceled>(x => x.UsePartitioner(partition, m => m.Message.OrderId));
+    }
+}
+```
+
 This example uses message retry (because concurrency issues throw exceptions), the _InMemoryOutbox_ (to avoid duplicate messages in the event of a concurrency failure), and uses a partitioner to limit the receive endpoint to only one concurrent message for each OrderId (the partitioner uses hashing to meet the partition count). 
 
 > The partitioner in this case is only for this specific receive endpoint, multiple service instances (competing consumer) may still consume events for the same saga instance.


### PR DESCRIPTION
This PR attempts to update the Saga Guidance section with an alternative example which shows how to configure the recommended settings with a SagaDefinition instead of configuring the receive endpoint directly. I thought this could be useful since a lot of folks use SagaDefinition.

