### PR TITLE
Add BatchTimeLimitStart configuration option

### DIFF
--- a/src/MassTransit.Abstractions/Configuration/Consumers/BatchOptions.cs
+++ b/src/MassTransit.Abstractions/Configuration/Consumers/BatchOptions.cs
@@ -19,6 +19,7 @@ namespace MassTransit
             ConcurrencyLimit = 1;
             MessageLimit = 10;
             TimeLimit = TimeSpan.FromSeconds(1);
+            TimeLimitStart = BatchTimeLimitStart.FromFirst;
         }
 
         /// <summary>
@@ -35,6 +36,11 @@ namespace MassTransit
         /// The maximum time to wait before delivering a partial batch
         /// </summary>
         public TimeSpan TimeLimit { get; set; }
+
+        /// <summary>
+        /// The starting point for the <see cref="TimeLimit" />
+        /// </summary>
+        public BatchTimeLimitStart TimeLimitStart { get; set; }
 
         /// <summary>
         /// The property to group by
@@ -89,6 +95,16 @@ namespace MassTransit
         public BatchOptions SetTimeLimit(TimeSpan limit)
         {
             TimeLimit = limit;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the starting point for the <see cref="TimeLimit"/>
+        /// </summary>
+        /// <param name="timeLimitStart">The starting point</param>
+        public BatchOptions SetTimeLimitStart(BatchTimeLimitStart timeLimitStart)
+        {
+            TimeLimitStart = timeLimitStart;
             return this;
         }
 

--- a/src/MassTransit.Abstractions/Configuration/Consumers/BatchTimeLimitStart.cs
+++ b/src/MassTransit.Abstractions/Configuration/Consumers/BatchTimeLimitStart.cs
@@ -1,0 +1,8 @@
+﻿namespace MassTransit
+{
+    public enum BatchTimeLimitStart
+    {
+        FromFirst,
+        FromLast
+    }
+}

--- a/src/MassTransit.Abstractions/Configuration/Consumers/IBatchConfigurator.cs
+++ b/src/MassTransit.Abstractions/Configuration/Consumers/IBatchConfigurator.cs
@@ -17,6 +17,11 @@ namespace MassTransit
         TimeSpan TimeLimit { set; }
 
         /// <summary>
+        /// Sets the starting point for the <see cref="TimeLimit"/>
+        /// </summary>
+        BatchTimeLimitStart TimeLimitStart { set; }
+
+        /// <summary>
         /// Set the maximum number of messages which can be added to a single batch
         /// </summary>
         int MessageLimit { set; }

--- a/src/MassTransit/Consumers/Batching/BatchConsumerFactory.cs
+++ b/src/MassTransit/Consumers/Batching/BatchConsumerFactory.cs
@@ -13,12 +13,13 @@
         readonly IBatchCollector<TMessage> _collector;
         readonly int _messageLimit;
         readonly TimeSpan _timeLimit;
+        readonly BatchTimeLimitStart _timeLimitStart;
 
-        public BatchConsumerFactory(int messageLimit, TimeSpan timeLimit, IBatchCollector<TMessage> collector)
+        public BatchConsumerFactory(int messageLimit, TimeSpan timeLimit, BatchTimeLimitStart timeLimitStart, IBatchCollector<TMessage> collector)
         {
             _messageLimit = messageLimit;
             _timeLimit = timeLimit;
-
+            _timeLimitStart = timeLimitStart;
             _collector = collector;
         }
 
@@ -52,6 +53,7 @@
             var scope = context.CreateConsumerFactoryScope<IConsumer<TMessage>>("batch");
 
             scope.Add("timeLimit", _timeLimit);
+            scope.Add("timeLimitStart", _timeLimitStart);
             scope.Add("messageLimit", _messageLimit);
 
             _collector.Probe(scope);

--- a/src/MassTransit/Consumers/Configuration/BatchConfigurator.cs
+++ b/src/MassTransit/Consumers/Configuration/BatchConfigurator.cs
@@ -17,9 +17,11 @@ namespace MassTransit.Configuration
             ConcurrencyLimit = 1;
             MessageLimit = 10;
             TimeLimit = TimeSpan.FromSeconds(10);
+            TimeLimitStart = BatchTimeLimitStart.FromFirst;
         }
 
         public TimeSpan TimeLimit { private get; set; }
+        public BatchTimeLimitStart TimeLimitStart { private get; set; }
         public int MessageLimit { private get; set; }
         public int ConcurrencyLimit { private get; set; }
 
@@ -30,7 +32,8 @@ namespace MassTransit.Configuration
             var configurator = new ConsumerConfigurator<TConsumer>(consumerFactory, _configurator);
             configurator.ConnectConsumerConfigurationObserver(_configurator);
 
-            configurator.Options<BatchOptions>(options => options.SetMessageLimit(MessageLimit).SetTimeLimit(TimeLimit).SetConcurrencyLimit(ConcurrencyLimit));
+            configurator.Options<BatchOptions>(options => options.SetMessageLimit(MessageLimit).SetTimeLimit(TimeLimit).SetTimeLimitStart(TimeLimitStart)
+                .SetConcurrencyLimit(ConcurrencyLimit));
 
             configurator.ConsumerMessage(configure);
 

--- a/src/MassTransit/Consumers/Configuration/BatchConsumerMessageConnector.cs
+++ b/src/MassTransit/Consumers/Configuration/BatchConsumerMessageConnector.cs
@@ -26,6 +26,7 @@ namespace MassTransit.Configuration
 
             var messageLimit = options.MessageLimit;
             var timeLimit = options.TimeLimit;
+            var timeLimitStart = options.TimeLimitStart;
             var concurrencyLimit = options.ConcurrencyLimit;
 
             IConsumerMessageSpecification<TConsumer, Batch<TMessage>> batchMessageSpecification = specification.GetMessageSpecification<Batch<TMessage>>();
@@ -43,7 +44,7 @@ namespace MassTransit.Configuration
 
             IBatchCollector<TMessage> collector = null;
             if (options.GroupKeyProvider == null)
-                collector = new BatchCollector<TMessage>(messageLimit, timeLimit, concurrencyLimit, batchMessagePipe);
+                collector = new BatchCollector<TMessage>(messageLimit, timeLimit, timeLimitStart, concurrencyLimit, batchMessagePipe);
             else
             {
                 if (options.GroupKeyProvider.GetType().ClosesType(typeof(IGroupKeyProvider<,>), out Type[] types))
@@ -56,7 +57,7 @@ namespace MassTransit.Configuration
                     throw new ConfigurationException("The GroupKeyProvider does not implement IGroupKeyProvider<TMessage,TKey>");
             }
 
-            var factory = new BatchConsumerFactory<TMessage>(messageLimit, timeLimit, collector);
+            var factory = new BatchConsumerFactory<TMessage>(messageLimit, timeLimit, timeLimitStart, collector);
 
             IConsumerSpecification<BatchConsumer<TMessage>> messageConsumerSpecification =
                 ConsumerConnectorCache<BatchConsumer<TMessage>>.Connector.CreateConsumerSpecification<BatchConsumer<TMessage>>();


### PR DESCRIPTION
I'm proposing this change to resolve a scenario, where I have events that trigger some long-running or resource intensive jobs, which do not rely on any data from the actual events. This means that the more the execution is postponed, the better for the app. 

This would allow more dynamical waits until all the events come, before the aforementioned job is triggered. TimeLimit on its own is unfortunately too "constant" in its nature.

For example, there are events which could come in rapid succession, (let's suppose 2-5 seconds apart, in total about 10-20 events). If I wanted to wait until all of them come, I would need to set the TimeLimit to ~2 minutes. This would however mean, that any event that comes even a second after those two minutes would trigger another job, which is not desirable. 
Another solution would be to set the TimeLimit to something higher like 5 minutes, but in case there is only one event, it would still need to wait 5 minutes before the job would be triggered, which is also undesirable. In my solution, you could set the TimeLimit to let's say 15 seconds and TimeLimitStart to FromLast, which would make sure that no event is missed and that execution is not unnecessarily postponed. 