### PR TITLE
Fix a name of saga repository registration method.

### DIFF
--- a/docs/usage/sagas/automatonymous.md
+++ b/docs/usage/sagas/automatonymous.md
@@ -240,7 +240,7 @@ To configure a saga state machine:
 services.AddMassTransit(x =>
 {
     x.AddSagaStateMachine<OrderStateMachine, OrderState>()
-        .InMemorySagaRepository();
+        .InMemoryRepository();
 });
 ```
 


### PR DESCRIPTION
The InMemorySagaRepository extension method has been renamed to InMemoryRepository. Update the docs to reflect the new name of the registration method.