### PR TITLE
Add extra sqs permissions to sample iam policy

### DIFF
--- a/docs/quick-starts/sqs.md
+++ b/docs/quick-starts/sqs.md
@@ -50,7 +50,10 @@ This example requires the following:
                 "sqs:SendMessage",
                 "sqs:GetQueueUrl",
                 "sqs:GetQueueAttributes",
-                "sqs:ChangeMessageVisibility"
+                "sqs:ChangeMessageVisibility",
+                "sqs:PurgeQueue",
+                "sqs:DeleteQueue",
+                "sqs:TagQueue"
             ],
             "Resource": "arn:aws:sqs:*:YOUR_ACCOUNT_ID:*"
         },{

--- a/docs/usage/transports/amazonsqs.md
+++ b/docs/usage/transports/amazonsqs.md
@@ -57,8 +57,11 @@ Because there is only ever one "SQS/SNS" per AWS account it can be helpful to "S
                 "sqs:SendMessage",
                 "sqs:GetQueueUrl",
                 "sqs:GetQueueAttributes",
-                "sqs:ChangeMessageVisibility"
-                ],
+                "sqs:ChangeMessageVisibility",
+                "sqs:PurgeQueue",
+                "sqs:DeleteQueue",
+                "sqs:TagQueue"
+            ],
             "Resource": "arn:aws:sqs:*:YOUR_ACCOUNT_ID:*"
         },{
             "Sid": "SnsAccess",


### PR DESCRIPTION
When creating an SQS queue and specifying tags to apply, the call to CreateQueue will fail with an AccessDenied error when using the original sample iam policy. Internally, CreateQueue is calling TagQueue, but as that was missing from the sample policy, an AccessDenied error is thrown. There's no indication in any of the logging from AWS as to why this is though.

Checking the code shows that the SQS transport can also call Purge & Delete Queue as well, so have added those to avoid similar problems.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
