### PR TITLE
Fix potential NRE in subscription rules management code

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusConnectionContext.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusConnectionContext.cs
@@ -166,10 +166,10 @@
                 {
                     var ruleProperties = await GetRuleAsync(createSubscriptionOptions.TopicName, createSubscriptionOptions.SubscriptionName, rule.Name)
                         .ConfigureAwait(false);
-                    if (rule.Name == ruleProperties.Name && (!rule.Filter.Equals(ruleProperties.Filter) || !rule.Action.Equals(ruleProperties.Action)))
+                    if (rule.Name == ruleProperties.Name && (!(rule.Filter?.Equals(ruleProperties.Filter) ?? ruleProperties.Filter == null) || !(rule.Action?.Equals(ruleProperties.Action) ?? ruleProperties.Action == null)))
                     {
                         LogContext.Debug?.Log("Updating subscription Rule: {Rule} ({DescriptionFilter} -> {Filter})", rule.Name,
-                            ruleProperties.Filter.ToString(), rule.Filter.ToString());
+                            ruleProperties.Filter?.ToString(), rule.Filter?.ToString());
 
                         ruleProperties.Filter = rule.Filter;
                         ruleProperties.Action = rule.Action;
@@ -186,10 +186,10 @@
                     {
                         var existingRule = rules[0];
 
-                        if (Guid.TryParse(existingRule.Name, out _) && !existingRule.Filter.Equals(filter))
+                        if (Guid.TryParse(existingRule.Name, out _) && !(existingRule.Filter?.Equals(filter) ?? filter == null))
                         {
                             LogContext.Debug?.Log("Updating subscription filter: {Rule} ({DescriptionFilter} -> {Filter})", existingRule.Name,
-                                existingRule.Filter.ToString(), filter.ToString());
+                                existingRule.Filter?.ToString(), filter?.ToString());
 
                             existingRule.Filter = filter;
 


### PR DESCRIPTION
I just found an occurrence of an issue when debugging my code and breaking on all exceptions, when a subscription rule `Action` property was `null`.
I noticed that the checks to compare `Filter` and `Action` properties are indeed subject to a potential `NullReferenceException`.
I did not check the root cause for the situation however.

This PR should prevent the issue.