### PR TITLE
Added support for defining x-single-active-consumer through query params

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Topology/RabbitMqSendSettings.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Topology/RabbitMqSendSettings.cs
@@ -4,6 +4,7 @@ namespace MassTransit.RabbitMqTransport.Topology
     using System.Collections.Generic;
     using System.Linq;
     using Configuration;
+    using RabbitMQ.Client;
 
 
     public class RabbitMqSendSettings :
@@ -35,6 +36,9 @@ namespace MassTransit.RabbitMqTransport.Topology
 
             if (!string.IsNullOrWhiteSpace(address.AlternateExchange))
                 SetExchangeArgument("alternate-exchange", address.AlternateExchange);
+
+            if (address.SingleActiveConsumer)
+                SetQueueArgument(Headers.XSingleActiveConsumer, true);
         }
 
         public IDictionary<string, object> QueueArguments { get; }


### PR DESCRIPTION
I've added the ability to pass `x-single-active-consumer` header through queue URI string. Here is why I did it.

I have a use case when I need to send messages to queues which are created dynamically long after the bus is started. Message producer initiates queue creation, sends some messages and then notifies consumers they should start reading from the new queue. The queue auto-create behavior of MassTransit is exactly what I need, but unfortunately there was no way to pass the `x-single-active-consumer` header from producer's side. It can be configured from consumer side, but as I mentioned, consumers don't initiate queue creation.

Provided that `RabbitMqEndpointAddress` already contains quite a lot of possible options for queues and exchanges, I thought it would be appropriate to add an ability to pass the `x-single-active-consumer` header as well.

Here is the example code that uses this feature:

```csharp
var endpoint = await _busControl.GetSendEndpoint(new("queue:event-listener?singleactiveconsumer=true"));
await endpoint.Send(new TestMessage());
```

If the queue doesn't exist, it gets created with `x-single-active-consumer` defined:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/2397857/202757289-2e61fc20-26c1-46f0-8c41-361e42fe4e0d.png">

There is a related question on SA about this: https://stackoverflow.com/questions/69633857/sending-message-to-queue-in-singleactiveconsumer-mode-in-masstransit. It seems that in that case a queue was guaranteed to exist before messages were sent, so using exchange URI was an acceptable solution. My use case is different, since I can't guarantee that queue exists beforehand (in most cases, it won't), and I need to be sure that producer creates the queue with correct attributes.