### PR TITLE
Template install command typo

### DIFF
--- a/docs/quick-starts/in-memory.md
+++ b/docs/quick-starts/in-memory.md
@@ -23,7 +23,7 @@ This example requires the following:
 MassTransit includes project and item [templates](/usage/templates) simplifying the creation of new projects. Install the templates by executing `dotnet new -i MassTransit.Templates` at the console. A video introducing the templates is available on [YouTube](https://youtu.be/nYKq61-DFBQ).
 
 ```
-dotnet new install MassTransit.Templates
+dotnet new --install MassTransit.Templates
 ```
 
 ## Initial Project Creation


### PR DESCRIPTION
Corrected the highlighted `dotnet` install command in the docs (In-Memory tutorial) which was missing dashes.  The command is correct in the preceding paragraph.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
