### PR TITLE
exhange to exchange binding

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqExchangeBindingConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqExchangeBindingConfigurator.cs
@@ -1,4 +1,6 @@
-﻿namespace MassTransit
+﻿using System;
+
+namespace MassTransit
 {
     /// <summary>
     /// Used to configure the binding of an exchange (to either a queue or another exchange)
@@ -17,5 +19,12 @@
         /// <param name="key"></param>
         /// <param name="value"></param>
         void SetBindingArgument(string key, object value);
+
+        /// <summary>
+        /// Creates a binding with another exchange
+        /// </summary>
+        /// <param name="exchangeName">Exchange name of the new exchange</param>
+        /// <param name="configure">Configuration for new exchange and how to bind to it</param>
+        void Bind(string exchangeName, Action<IRabbitMqExchangeBindingConfigurator> configure);
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/QueueBindingConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/QueueBindingConfigurator.cs
@@ -35,5 +35,10 @@ namespace MassTransit.RabbitMqTransport.Configuration
             AutoDelete = true;
             QueueExpiration = duration;
         }
+
+        public void Bind(string exchangeName, Action<IRabbitMqExchangeBindingConfigurator> configure)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqExchangeBindingConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqExchangeBindingConfigurator.cs
@@ -39,5 +39,14 @@ namespace MassTransit.RabbitMqTransport.Configuration
         }
 
         public string RoutingKey { get; set; }
+
+        public IRabbitMqExchangeBindingConfigurator ExchangeBindingConfigurator { get; set; }
+
+        public void Bind(string exchangeName, Action<IRabbitMqExchangeBindingConfigurator> configure)
+        {
+            ExchangeBindingConfigurator = new RabbitMqExchangeBindingConfigurator(exchangeName, ExchangeType);
+
+            configure?.Invoke(ExchangeBindingConfigurator);
+        }
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/Topology/ExchangeBindingConsumeTopologySpecification.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/Topology/ExchangeBindingConsumeTopologySpecification.cs
@@ -28,9 +28,19 @@ namespace MassTransit.RabbitMqTransport.Configuration
 
         public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
         {
-            var exchangeHandle = builder.ExchangeDeclare(ExchangeName, ExchangeType, Durable, AutoDelete, ExchangeArguments);
+            RabbitMqExchangeBindingConfigurator exchangeBindingConfigurator = this;
+            ExchangeHandle destination = builder.Exchange;
+            do
+            {
+                var source = builder.ExchangeDeclare(exchangeBindingConfigurator.ExchangeName, exchangeBindingConfigurator.ExchangeType, exchangeBindingConfigurator.Durable, exchangeBindingConfigurator.AutoDelete, exchangeBindingConfigurator.ExchangeArguments);
 
-            var bindingHandle = builder.ExchangeBind(exchangeHandle, builder.Exchange, RoutingKey, BindingArguments);
+                var bindingHandle = builder.ExchangeBind(source, destination, exchangeBindingConfigurator.RoutingKey, exchangeBindingConfigurator.BindingArguments);
+
+                destination = source;
+
+                exchangeBindingConfigurator = exchangeBindingConfigurator.ExchangeBindingConfigurator as RabbitMqExchangeBindingConfigurator;
+            }
+            while (exchangeBindingConfigurator != null);
         }
     }
 }


### PR DESCRIPTION
The PR enables this usage of [this discussion](https://github.com/MassTransit/MassTransit/discussions/3919)
```
cfg.ReceiveEndpoint(
    "queue", endCfg =>
    {
        endCfg.Bind("exchange1", bind1Cfg =>
        {
            bind1Cfg.Bind("exchange2", bind2Cfg =>
            {
                bind2Cfg.Bind("exchange3", bind3Cfg =>
                {

                });
            });
        });
    }
);
```

The topology will be the following
![image](https://user-images.githubusercontent.com/11612804/206906852-79785183-5087-4e69-a41e-6faecb414e98.png)

There is one issue though, I had to implement `Bind` function for `QueueBindingConfigurator` as well. Please check the changes on the file. There should be a better way but I could not figure it out. Need your guidance and feedback

