### PR TITLE
fix creation of ActiveMq temporary queues

### DIFF
--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqConnectionContext.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqConnectionContext.cs
@@ -63,14 +63,14 @@ namespace MassTransit.ActiveMqTransport
             return _virtualTopicConsumerPattern.IsMatch(name);
         }
 
-        public IQueue GetTemporaryQueue(ISession session, string topicName)
+        public IQueue GetTemporaryQueue(ISession session, string queueName)
         {
-            return (IQueue)_temporaryEntities.GetOrAdd(topicName, x => (IQueue)SessionUtil.GetDestination(session, topicName, DestinationType.TemporaryQueue));
+            return (IQueue)_temporaryEntities.GetOrAdd(queueName, x => new CustomTempQueue(queueName));
         }
 
         public ITopic GetTemporaryTopic(ISession session, string topicName)
         {
-            return (ITopic)_temporaryEntities.GetOrAdd(topicName, x => (ITopic)SessionUtil.GetDestination(session, topicName, DestinationType.TemporaryTopic));
+            return (ITopic)_temporaryEntities.GetOrAdd(topicName, x => SessionUtil.GetDestination(session, topicName, DestinationType.TemporaryTopic));
         }
 
         public bool TryGetTemporaryEntity(string name, out IDestination destination)

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqSessionContext.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqSessionContext.cs
@@ -75,7 +75,7 @@
         {
             return _executor.Run(() =>
             {
-                if (!queue.Durable && queue.AutoDelete && !ConnectionContext.IsVirtualTopicConsumer(queue.EntityName))
+                if (!queue.Durable && queue.AutoDelete)
                     return ConnectionContext.GetTemporaryQueue(_session, queue.EntityName);
 
                 return SessionUtil.GetQueue(_session, queue.EntityName);

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ConnectionContext.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ConnectionContext.cs
@@ -35,7 +35,7 @@
 
         bool IsVirtualTopicConsumer(string name);
 
-        IQueue GetTemporaryQueue(ISession session, string topicName);
+        IQueue GetTemporaryQueue(ISession session, string queueName);
 
         ITopic GetTemporaryTopic(ISession session, string topicName);
 

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/CustomTempQueue.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/CustomTempQueue.cs
@@ -1,0 +1,16 @@
+﻿using Apache.NMS.ActiveMQ.Commands;
+
+namespace MassTransit.ActiveMqTransport
+{
+    public class CustomTempQueue : ActiveMQTempQueue
+    {
+        public CustomTempQueue(string name)
+            : base(name)
+        {
+        }
+
+        public override int GetDestinationType() => ACTIVEMQ_QUEUE;
+
+        public override ActiveMQDestination CreateDestination(string name) => new CustomTempQueue(name);
+    }
+}

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/SharedConnectionContext.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/SharedConnectionContext.cs
@@ -37,9 +37,9 @@
             return _context.IsVirtualTopicConsumer(name);
         }
 
-        public IQueue GetTemporaryQueue(ISession session, string topicName)
+        public IQueue GetTemporaryQueue(ISession session, string queueName)
         {
-            return _context.GetTemporaryQueue(session, topicName);
+            return _context.GetTemporaryQueue(session, queueName);
         }
 
         public ITopic GetTemporaryTopic(ISession session, string topicName)


### PR DESCRIPTION
I fixed the creation of temporary queues for the issue #3935. Now a temporary queues have the correct names and a virtual topics and queues are created as temporary and get deleted.
Screenshot after running the web application with MassTransit.SignalR:

![signalr](https://user-images.githubusercontent.com/24292953/208089711-98659fd1-53c8-40d7-b193-fcde184a3696.png)

All the created topics and queues are deleted after the application is closed.

