### PR TITLE
Concurrency Improvements for Riders

### DIFF
--- a/src/MassTransit/Transports/BaseReceiveContext.cs
+++ b/src/MassTransit/Transports/BaseReceiveContext.cs
@@ -103,7 +103,7 @@ namespace MassTransit.Transports
         }
 
         public TimeSpan ElapsedTime => _receiveTimer.Elapsed;
-        public Uri InputAddress { get; }
+        public Uri InputAddress { get; protected set; }
         public ContentType ContentType => _contentType.Value;
 
         protected virtual ISendEndpointProvider GetSendEndpointProvider()

--- a/src/MassTransit/Util/IChannelExecutorPool.cs
+++ b/src/MassTransit/Util/IChannelExecutorPool.cs
@@ -1,0 +1,14 @@
+namespace MassTransit.Util
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+
+    public interface IChannelExecutorPool<in TPartition> :
+        IAsyncDisposable
+    {
+        Task Push(TPartition partition, Func<Task> method, CancellationToken cancellationToken = default);
+        Task Run(TPartition partition, Func<Task> method, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/MassTransit/Util/PartitionChannelExecutorPool.cs
+++ b/src/MassTransit/Util/PartitionChannelExecutorPool.cs
@@ -1,0 +1,53 @@
+namespace MassTransit.Util
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Middleware;
+
+
+    public class PartitionChannelExecutorPool<T> :
+        IChannelExecutorPool<T>
+    {
+        readonly PartitionKeyProvider<T> _partitionKeyProvider;
+        readonly IHashGenerator _hashGenerator;
+        readonly ChannelExecutor[] _partitions;
+
+        public PartitionChannelExecutorPool(PartitionKeyProvider<T> partitionKeyProvider, IHashGenerator hashGenerator, int concurrencyLimit,
+            int concurrentDeliveryLimit = 1)
+        {
+            _partitionKeyProvider = partitionKeyProvider;
+            _hashGenerator = hashGenerator;
+            _partitions = Enumerable.Range(0, concurrencyLimit)
+                .Select(x => new ChannelExecutor(concurrentDeliveryLimit))
+                .ToArray();
+        }
+
+        public Task Push(T partition, Func<Task> handle, CancellationToken cancellationToken)
+        {
+            var executor = GetExecutor(partition);
+            return executor.Push(handle, cancellationToken);
+        }
+
+        public Task Run(T partition, Func<Task> method, CancellationToken cancellationToken = default)
+        {
+            var executor = GetExecutor(partition);
+            return executor.Run(method, cancellationToken);
+        }
+
+        ChannelExecutor GetExecutor(T partition)
+        {
+            var partitionKey = _partitionKeyProvider(partition);
+            var hash = partitionKey?.Length > 0 ? _hashGenerator.Hash(partitionKey) : 0;
+            var index = hash % _partitions.Length;
+            return _partitions[index];
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            foreach (var partition in _partitions)
+                await partition.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Transports/MassTransit.EventHubIntegration/Configuration/IEventHubReceiveEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/Configuration/IEventHubReceiveEndpointConfigurator.cs
@@ -30,6 +30,11 @@ namespace MassTransit
         ushort CheckpointMessageLimit { set; }
 
         /// <summary>
+        /// Set number of concurrent messages per single Key-partition, higher value will increase throughput but will break delivery order (default: 1)
+        /// </summary>
+        int ConcurrentDeliveryLimit { set; }
+
+        /// <summary>
         /// Configure <see cref="EventProcessorClientOptions" />
         /// </summary>
         Action<EventProcessorClientOptions> ConfigureOptions { set; }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/ICheckpointer.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/ICheckpointer.cs
@@ -1,12 +1,12 @@
 namespace MassTransit.EventHubIntegration.Checkpoints
 {
+    using System;
     using System.Threading.Tasks;
-    using Azure.Messaging.EventHubs.Processor;
 
 
-    public interface ICheckpointer
+    public interface ICheckpointer :
+        IAsyncDisposable
     {
         Task Pending(IPendingConfirmation confirmation);
-        Task Close(ProcessingStoppedReason stoppedReason);
     }
 }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointBuilder.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointBuilder.cs
@@ -4,7 +4,6 @@ namespace MassTransit.EventHubIntegration.Configuration
     using System.Threading.Tasks;
     using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Processor;
-    using Azure.Storage.Blobs;
     using MassTransit.Configuration;
     using Transports;
 
@@ -12,9 +11,8 @@ namespace MassTransit.EventHubIntegration.Configuration
     public class EventHubReceiveEndpointBuilder :
         ReceiveEndpointBuilder
     {
-        readonly Func<IStorageSettings, BlobContainerClient> _blobContainerClientFactory;
         readonly IBusInstance _busInstance;
-        readonly Func<IHostSettings, BlobContainerClient, EventProcessorClient> _clientFactory;
+        readonly Func<EventProcessorClient> _clientFactory;
         readonly IReceiveEndpointConfiguration _configuration;
         readonly IEventHubHostConfiguration _hostConfiguration;
         readonly Func<PartitionClosingEventArgs, Task> _partitionClosingHandler;
@@ -23,8 +21,7 @@ namespace MassTransit.EventHubIntegration.Configuration
 
         public EventHubReceiveEndpointBuilder(IEventHubHostConfiguration hostConfiguration, IBusInstance busInstance,
             IReceiveEndpointConfiguration configuration, ReceiveSettings receiveSettings,
-            Func<IStorageSettings, BlobContainerClient> blobContainerClientFactory,
-            Func<IHostSettings, BlobContainerClient, EventProcessorClient> clientFactory,
+            Func<EventProcessorClient> clientFactory,
             Func<PartitionClosingEventArgs, Task> partitionClosingHandler,
             Func<PartitionInitializingEventArgs, Task> partitionInitializingHandler)
             : base(configuration)
@@ -33,7 +30,6 @@ namespace MassTransit.EventHubIntegration.Configuration
             _busInstance = busInstance;
             _configuration = configuration;
             _receiveSettings = receiveSettings;
-            _blobContainerClientFactory = blobContainerClientFactory;
             _clientFactory = clientFactory;
             _partitionClosingHandler = partitionClosingHandler;
             _partitionInitializingHandler = partitionInitializingHandler;
@@ -41,7 +37,7 @@ namespace MassTransit.EventHubIntegration.Configuration
 
         public IEventHubReceiveEndpointContext CreateReceiveEndpointContext()
         {
-            var context = new EventHubReceiveEndpointContext(_hostConfiguration, _busInstance, _configuration, _receiveSettings, _blobContainerClientFactory,
+            var context = new EventHubReceiveEndpointContext(_hostConfiguration, _busInstance, _configuration, _receiveSettings,
                 _clientFactory, _partitionClosingHandler, _partitionInitializingHandler);
 
             context.GetOrAddPayload(() => _busInstance.HostConfiguration.Topology);

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointSpecification.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointSpecification.cs
@@ -62,7 +62,8 @@ namespace MassTransit.EventHubIntegration.Configuration
             var endpointConfiguration = busInstance.HostConfiguration.CreateReceiveEndpointConfiguration(EndpointName);
             endpointConfiguration.ConnectReceiveEndpointObserver(_endpointObservers);
 
-            var configurator = new EventHubReceiveEndpointConfigurator(_hostConfiguration, busInstance, endpointConfiguration, _eventHubName, _consumerGroup);
+            var configurator = new EventHubReceiveEndpointConfigurator(_hostConfiguration, busInstance, endpointConfiguration, _hostSettings,
+                _storageSettings, _eventHubName, _consumerGroup);
             _configure?.Invoke(configurator);
 
             IReadOnlyList<ValidationResult> result = Validate().Concat(configurator.Validate())

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ConfigureTopologyContext.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ConfigureTopologyContext.cs
@@ -1,0 +1,6 @@
+namespace MassTransit.EventHubIntegration
+{
+    public interface ConfigureTopologyContext
+    {
+    }
+}

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ConnectionContext.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ConnectionContext.cs
@@ -1,15 +1,11 @@
 namespace MassTransit.EventHubIntegration
 {
     using Azure.Messaging.EventHubs.Producer;
-    using Configuration;
 
 
     public interface ConnectionContext :
         PipeContext
     {
-        IHostSettings HostSettings { get; }
-        IStorageSettings StorageSettings { get; }
-
         EventHubProducerClient CreateEventHubClient(string eventHubName);
     }
 }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubDataReceiver.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubDataReceiver.cs
@@ -1,7 +1,10 @@
 ﻿namespace MassTransit.EventHubIntegration
 {
     using System;
+    using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Processor;
     using Internals;
     using MassTransit.Middleware;
@@ -16,48 +19,31 @@
         readonly ReceiveEndpointContext _context;
         readonly TaskCompletionSource<bool> _deliveryComplete;
         readonly IReceivePipeDispatcher _dispatcher;
-        readonly ChannelExecutor _executor;
         readonly ProcessorContext _processorContext;
+        readonly EventProcessorClient _client;
+        readonly IChannelExecutorPool<ProcessEventArgs> _executorPool;
 
-        public EventHubDataReceiver(ReceiveEndpointContext context, ProcessorContext processorContext)
+        public EventHubDataReceiver(ReceiveSettings receiveSettings, ReceiveEndpointContext context, ProcessorContext processorContext)
         {
             _context = context;
             _processorContext = processorContext;
+            _executorPool = new CombinedChannelExecutorPool(_processorContext, receiveSettings);
 
             _deliveryComplete = TaskUtil.GetTask<bool>();
 
             _dispatcher = context.CreateReceivePipeDispatcher();
             _dispatcher.ZeroActivity += HandleDeliveryComplete;
 
-            _executor = new ChannelExecutor(processorContext.ReceiveSettings.PrefetchCount, processorContext.ReceiveSettings.ConcurrentMessageLimit);
+            _client = processorContext.CreateClient(HandleError);
+
+            _client.ProcessEventAsync += HandleMessage;
+
+            SetReady(_client.StartProcessingAsync(Stopping));
         }
 
         public long DeliveryCount => _dispatcher.DispatchCount;
 
         public int ConcurrentDeliveryCount => _dispatcher.MaxConcurrentDispatchCount;
-
-        public async Task Start()
-        {
-            _processorContext.ProcessEvent += HandleMessage;
-            _processorContext.ProcessError += HandleError;
-
-            await _processorContext.StartProcessingAsync(Stopping).ConfigureAwait(false);
-
-            SetReady();
-        }
-
-        async Task HandleMessage(ProcessEventArgs eventArgs)
-        {
-            LogContext.SetCurrentIfNull(_context.LogContext);
-
-            try
-            {
-                await _executor.Push(() => Handle(eventArgs), Stopping).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException e) when (e.CancellationToken == Stopping)
-            {
-            }
-        }
 
         async Task HandleError(ProcessErrorEventArgs eventArgs)
         {
@@ -74,8 +60,20 @@
             }
         }
 
+        async Task HandleMessage(ProcessEventArgs eventArgs)
+        {
+            if (IsStopping || !eventArgs.HasEvent)
+                return;
+
+            await _processorContext.Pending(eventArgs).ConfigureAwait(false);
+            await _executorPool.Push(eventArgs, () => Handle(eventArgs), Stopping);
+        }
+
         async Task Handle(ProcessEventArgs eventArgs)
         {
+            if (IsStopping)
+                return;
+
             var context = new EventHubReceiveContext(eventArgs, _context, _processorContext);
 
             try
@@ -100,12 +98,9 @@
 
         protected override async Task StopAgent(StopContext context)
         {
-            await _processorContext.StopProcessingAsync().ConfigureAwait(false);
+            await _client.StopProcessingAsync().ConfigureAwait(false);
 
-            _processorContext.ProcessEvent -= HandleMessage;
-            _processorContext.ProcessError -= HandleError;
-
-            await _executor.DisposeAsync().ConfigureAwait(false);
+            _client.ProcessEventAsync -= HandleMessage;
 
             LogContext.Debug?.Log("Stopping consumer: {InputAddress}", _context.InputAddress);
 
@@ -126,6 +121,46 @@
                 {
                     LogContext.Warning?.Log("Stop canceled waiting for message consumers to complete: {InputAddress}", _context.InputAddress);
                 }
+            }
+
+            await _executorPool.DisposeAsync().ConfigureAwait(false);
+        }
+
+
+        class CombinedChannelExecutorPool :
+            IChannelExecutorPool<ProcessEventArgs>
+        {
+            readonly IChannelExecutorPool<ProcessEventArgs> _partitionExecutorPool;
+            readonly IChannelExecutorPool<ProcessEventArgs> _keyExecutorPool;
+
+            public CombinedChannelExecutorPool(IChannelExecutorPool<ProcessEventArgs> partitionExecutorPool, ReceiveSettings receiveSettings)
+            {
+                _partitionExecutorPool = partitionExecutorPool;
+                IHashGenerator hashGenerator = new Murmur3UnsafeHashGenerator();
+                _keyExecutorPool = new PartitionChannelExecutorPool<ProcessEventArgs>(GetBytes, hashGenerator,
+                    receiveSettings.ConcurrentMessageLimit,
+                    receiveSettings.ConcurrentDeliveryLimit);
+            }
+
+            public Task Push(ProcessEventArgs args, Func<Task> handle, CancellationToken cancellationToken)
+            {
+                return _partitionExecutorPool.Push(args, () => _keyExecutorPool.Run(args, handle, cancellationToken), cancellationToken);
+            }
+
+            public Task Run(ProcessEventArgs args, Func<Task> method, CancellationToken cancellationToken = default)
+            {
+                return _partitionExecutorPool.Run(args, () => _keyExecutorPool.Run(args, method, cancellationToken), cancellationToken);
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                return _keyExecutorPool.DisposeAsync();
+            }
+
+            static byte[] GetBytes(ProcessEventArgs args)
+            {
+                var partitionKey = args.Data.PartitionKey;
+                return !string.IsNullOrEmpty(partitionKey) ? Encoding.UTF8.GetBytes(partitionKey) : Array.Empty<byte>();
             }
         }
     }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubReceiveEndpointContext.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubReceiveEndpointContext.cs
@@ -4,7 +4,6 @@ namespace MassTransit.EventHubIntegration
     using System.Threading.Tasks;
     using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Processor;
-    using Azure.Storage.Blobs;
     using Configuration;
     using MassTransit.Configuration;
     using Transports;
@@ -20,16 +19,15 @@ namespace MassTransit.EventHubIntegration
 
         public EventHubReceiveEndpointContext(IEventHubHostConfiguration hostConfiguration, IBusInstance busInstance,
             IReceiveEndpointConfiguration endpointConfiguration, ReceiveSettings receiveSettings,
-            Func<IStorageSettings, BlobContainerClient> blobContainerClientFactory,
-            Func<IHostSettings, BlobContainerClient, EventProcessorClient> clientFactory,
+            Func<EventProcessorClient> clientFactory,
             Func<PartitionClosingEventArgs, Task> partitionClosingHandler,
             Func<PartitionInitializingEventArgs, Task> partitionInitializingHandler)
             : base(busInstance.HostConfiguration, endpointConfiguration)
         {
             _busInstance = busInstance;
             _contextSupervisor = new Recycle<IProcessorContextSupervisor>(() =>
-                new ProcessorContextSupervisor(hostConfiguration.ConnectionContextSupervisor, busInstance.HostConfiguration, receiveSettings,
-                    blobContainerClientFactory, clientFactory, partitionClosingHandler, partitionInitializingHandler));
+                new ProcessorContextSupervisor(hostConfiguration.ConnectionContextSupervisor, busInstance.HostConfiguration, receiveSettings, clientFactory,
+                    partitionClosingHandler, partitionInitializingHandler));
         }
 
         public override void AddSendAgent(IAgent agent)

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/IEventHubDataReceiver.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/IEventHubDataReceiver.cs
@@ -1,6 +1,5 @@
 ﻿namespace MassTransit.EventHubIntegration
 {
-    using System.Threading.Tasks;
     using Transports;
 
 
@@ -8,6 +7,5 @@
         IAgent,
         DeliveryMetrics
     {
-        Task Start();
     }
 }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/IProcessorLockContext.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/IProcessorLockContext.cs
@@ -3,9 +3,11 @@ namespace MassTransit.EventHubIntegration
     using System;
     using System.Threading.Tasks;
     using Azure.Messaging.EventHubs.Processor;
+    using Util;
 
 
-    public interface IProcessorLockContext
+    public interface IProcessorLockContext :
+        IChannelExecutorPool<ProcessEventArgs>
     {
         Task Pending(ProcessEventArgs eventArgs);
         Task Faulted(ProcessEventArgs eventArgs, Exception exception);

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Middleware/EventHubBlobContainerFactoryFilter.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Middleware/EventHubBlobContainerFactoryFilter.cs
@@ -1,22 +1,57 @@
 namespace MassTransit.EventHubIntegration.Middleware
 {
+    using System.Threading;
     using System.Threading.Tasks;
+    using Azure;
+    using Azure.Storage.Blobs;
 
 
     public class EventHubBlobContainerFactoryFilter :
         IFilter<ProcessorContext>
     {
-        bool _hasBeenCreated;
+        readonly BlobContainerClient _blockClient;
+
+        public EventHubBlobContainerFactoryFilter(BlobContainerClient blockClient)
+        {
+            _blockClient = blockClient;
+        }
 
         public async Task Send(ProcessorContext context, IPipe<ProcessorContext> next)
         {
-            if (!_hasBeenCreated)
-                _hasBeenCreated = await context.CreateBlobIfNotExistsAsync(context.CancellationToken).ConfigureAwait(false);
+            await context.OneTimeSetup<ConfigureTopologyContext>(_ => CreateBlobIfNotExistsAsync(context.CancellationToken), () => new Context())
+                .ConfigureAwait(false);
 
             await next.Send(context).ConfigureAwait(false);
         }
 
         public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateFilterScope("configureTopology");
+            scope.Add("Uri", _blockClient.Uri);
+            scope.Add("Name", _blockClient.Name);
+        }
+
+        async Task<bool> CreateBlobIfNotExistsAsync(CancellationToken cancellationToken = default)
+        {
+            Response<bool> exists = await _blockClient.ExistsAsync(cancellationToken).ConfigureAwait(false);
+            if (exists.Value)
+                return true;
+
+            try
+            {
+                await _blockClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (RequestFailedException exception)
+            {
+                LogContext.Warning?.Log(exception, "Azure Blob Container does not exist: {Address}", _blockClient.Uri);
+                return false;
+            }
+        }
+
+
+        class Context :
+            ConfigureTopologyContext
         {
         }
     }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Middleware/EventHubConsumerFilter.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Middleware/EventHubConsumerFilter.cs
@@ -16,9 +16,8 @@ namespace MassTransit.EventHubIntegration.Middleware
 
         public async Task Send(ProcessorContext context, IPipe<ProcessorContext> next)
         {
-            IEventHubDataReceiver receiver = new EventHubDataReceiver(_context, context);
-
-            await receiver.Start().ConfigureAwait(false);
+            var receiveSettings = _context.GetPayload<ReceiveSettings>();
+            IEventHubDataReceiver receiver = new EventHubDataReceiver(receiveSettings, _context, context);
 
             await receiver.Ready.ConfigureAwait(false);
 

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ProcessorContext.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ProcessorContext.cs
@@ -1,22 +1,18 @@
 namespace MassTransit.EventHubIntegration
 {
     using System;
-    using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Processor;
+    using Util;
 
 
     public interface ProcessorContext :
         PipeContext,
+        IChannelExecutorPool<ProcessEventArgs>,
         IProcessorLockContext
     {
-        ReceiveSettings ReceiveSettings { get; }
-        event Func<ProcessEventArgs, Task> ProcessEvent;
         event Func<ProcessErrorEventArgs, Task> ProcessError;
-
-        Task<bool> CreateBlobIfNotExistsAsync(CancellationToken cancellationToken = default);
-
-        Task StartProcessingAsync(CancellationToken cancellationToken = default);
-        Task StopProcessingAsync(CancellationToken cancellationToken = default);
+        EventProcessorClient CreateClient(Func<ProcessErrorEventArgs, Task> onError);
     }
 }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ProcessorContextFactory.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ProcessorContextFactory.cs
@@ -6,8 +6,6 @@ namespace MassTransit.EventHubIntegration
     using Agents;
     using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Processor;
-    using Azure.Storage.Blobs;
-    using Configuration;
     using Internals;
     using MassTransit.Configuration;
 
@@ -15,8 +13,7 @@ namespace MassTransit.EventHubIntegration
     public class ProcessorContextFactory :
         IPipeContextFactory<ProcessorContext>
     {
-        readonly Func<IStorageSettings, BlobContainerClient> _blobContainerClientFactory;
-        readonly Func<IHostSettings, BlobContainerClient, EventProcessorClient> _clientFactory;
+        readonly Func<EventProcessorClient> _clientFactory;
         readonly IConnectionContextSupervisor _contextSupervisor;
         readonly IHostConfiguration _hostConfiguration;
         readonly Func<PartitionClosingEventArgs, Task> _partitionClosingHandler;
@@ -24,15 +21,14 @@ namespace MassTransit.EventHubIntegration
         readonly ReceiveSettings _receiveSettings;
 
         public ProcessorContextFactory(IConnectionContextSupervisor contextSupervisor, IHostConfiguration hostConfiguration,
-            ReceiveSettings receiveSettings, Func<IStorageSettings, BlobContainerClient> blobContainerClientFactory,
-            Func<IHostSettings, BlobContainerClient, EventProcessorClient> clientFactory,
+            ReceiveSettings receiveSettings,
+            Func<EventProcessorClient> clientFactory,
             Func<PartitionClosingEventArgs, Task> partitionClosingHandler,
             Func<PartitionInitializingEventArgs, Task> partitionInitializingHandler)
         {
             _contextSupervisor = contextSupervisor;
             _hostConfiguration = hostConfiguration;
             _receiveSettings = receiveSettings;
-            _blobContainerClientFactory = blobContainerClientFactory;
             _clientFactory = clientFactory;
             _partitionClosingHandler = partitionClosingHandler;
             _partitionInitializingHandler = partitionInitializingHandler;
@@ -65,10 +61,8 @@ namespace MassTransit.EventHubIntegration
         {
             Task<ProcessorContext> Create(ConnectionContext connectionContext, CancellationToken createCancellationToken)
             {
-                var blobContainerClient = _blobContainerClientFactory(connectionContext.StorageSettings);
-                var client = _clientFactory(connectionContext.HostSettings, blobContainerClient);
-                ProcessorContext context = new EventHubProcessorContext(_hostConfiguration, _receiveSettings, blobContainerClient,
-                    client, _partitionInitializingHandler, _partitionClosingHandler, createCancellationToken);
+                ProcessorContext context = new EventHubProcessorContext(_hostConfiguration, _receiveSettings,
+                    _clientFactory, _partitionInitializingHandler, _partitionClosingHandler, createCancellationToken);
                 return Task.FromResult(context);
             }
 

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ProcessorContextSupervisor.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ProcessorContextSupervisor.cs
@@ -4,8 +4,6 @@ namespace MassTransit.EventHubIntegration
     using System.Threading.Tasks;
     using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Processor;
-    using Azure.Storage.Blobs;
-    using Configuration;
     using MassTransit.Configuration;
     using Transports;
 
@@ -15,10 +13,9 @@ namespace MassTransit.EventHubIntegration
         IProcessorContextSupervisor
     {
         public ProcessorContextSupervisor(IConnectionContextSupervisor supervisor, IHostConfiguration hostConfiguration, ReceiveSettings receiveSettings,
-            Func<IStorageSettings, BlobContainerClient> blobContainerClientFactory,
-            Func<IHostSettings, BlobContainerClient, EventProcessorClient> clientFactory, Func<PartitionClosingEventArgs, Task> partitionClosingHandler,
+            Func<EventProcessorClient> clientFactory, Func<PartitionClosingEventArgs, Task> partitionClosingHandler,
             Func<PartitionInitializingEventArgs, Task> partitionInitializingHandler)
-            : base(new ProcessorContextFactory(supervisor, hostConfiguration, receiveSettings, blobContainerClientFactory, clientFactory,
+            : base(new ProcessorContextFactory(supervisor, hostConfiguration, receiveSettings, clientFactory,
                 partitionClosingHandler,
                 partitionInitializingHandler))
         {

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ReceiveSettings.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/ReceiveSettings.cs
@@ -13,5 +13,6 @@ namespace MassTransit.EventHubIntegration
         int PrefetchCount { get; }
         TimeSpan CheckpointInterval { get; }
         int ConcurrentMessageLimit { get; }
+        int ConcurrentDeliveryLimit { get; }
     }
 }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/SharedConnectionContext.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/SharedConnectionContext.cs
@@ -2,7 +2,6 @@ namespace MassTransit.EventHubIntegration
 {
     using System.Threading;
     using Azure.Messaging.EventHubs.Producer;
-    using Configuration;
     using MassTransit.Middleware;
 
 
@@ -20,10 +19,6 @@ namespace MassTransit.EventHubIntegration
         }
 
         public override CancellationToken CancellationToken { get; }
-
-        public IHostSettings HostSettings => _context.HostSettings;
-
-        public IStorageSettings StorageSettings => _context.StorageSettings;
 
         public EventHubProducerClient CreateEventHubClient(string eventHubName)
         {

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/SharedProcessorContext.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/SharedProcessorContext.cs
@@ -3,6 +3,7 @@ namespace MassTransit.EventHubIntegration
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Messaging.EventHubs;
     using Azure.Messaging.EventHubs.Processor;
     using MassTransit.Middleware;
 
@@ -22,33 +23,15 @@ namespace MassTransit.EventHubIntegration
 
         public override CancellationToken CancellationToken { get; }
 
-        public event Func<ProcessEventArgs, Task> ProcessEvent
-        {
-            add => _context.ProcessEvent += value;
-            remove => _context.ProcessEvent -= value;
-        }
-
         public event Func<ProcessErrorEventArgs, Task> ProcessError
         {
             add => _context.ProcessError += value;
             remove => _context.ProcessError -= value;
         }
 
-        public ReceiveSettings ReceiveSettings => _context.ReceiveSettings;
-
-        public Task<bool> CreateBlobIfNotExistsAsync(CancellationToken cancellationToken = default)
+        public EventProcessorClient CreateClient(Func<ProcessErrorEventArgs, Task> onError)
         {
-            return _context.CreateBlobIfNotExistsAsync(cancellationToken);
-        }
-
-        public Task StartProcessingAsync(CancellationToken cancellationToken = default)
-        {
-            return _context.StartProcessingAsync(cancellationToken);
-        }
-
-        public Task StopProcessingAsync(CancellationToken cancellationToken = default)
-        {
-            return _context.StopProcessingAsync(cancellationToken);
+            return _context.CreateClient(onError);
         }
 
         public Task Pending(ProcessEventArgs eventArgs)
@@ -64,6 +47,21 @@ namespace MassTransit.EventHubIntegration
         public Task Complete(ProcessEventArgs eventArgs)
         {
             return _context.Complete(eventArgs);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return _context.DisposeAsync();
+        }
+
+        public Task Push(ProcessEventArgs partition, Func<Task> method, CancellationToken cancellationToken = default)
+        {
+            return _context.Push(partition, method, cancellationToken);
+        }
+
+        public Task Run(ProcessEventArgs partition, Func<Task> method, CancellationToken cancellationToken = default)
+        {
+            return _context.Run(partition, method, cancellationToken);
         }
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/IKafkaProducerConfigurator.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/IKafkaProducerConfigurator.cs
@@ -205,7 +205,7 @@ namespace MassTransit
         /// Local_KeyDeserialization and thrown by the initiating call to
         /// Consume.
         /// </remarks>
-        void SetKeySerializer(ISerializer<TKey> serializer);
+        void SetKeySerializer(IAsyncSerializer<TKey> serializer);
 
         /// <summary>
         /// Set the serializer to use to serialize values.
@@ -216,6 +216,6 @@ namespace MassTransit
         /// Local_ValueDeserialization and thrown by the initiating call to
         /// Consume.
         /// </remarks>
-        void SetValueSerializer(ISerializer<TValue> serializer);
+        void SetValueSerializer(IAsyncSerializer<TValue> serializer);
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/IKafkaTopicReceiveEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/IKafkaTopicReceiveEndpointConfigurator.cs
@@ -33,12 +33,6 @@
         TimeSpan CheckpointInterval { set; }
 
         /// <summary>
-        /// The number of concurrent messages to process. Could increase throughput but will not preserve an order (default: 1)
-        /// </summary>
-        [Obsolete("Use ConcurrentMessageLimit instead")]
-        int ConcurrencyLimit { set; }
-
-        /// <summary>
         /// The maximum number of messages in a single partition before checkpoint (default: 10000)
         /// </summary>
         ushort MessageLimit { set; }
@@ -47,6 +41,16 @@
         /// Set max message count for checkpoint, low message count will decrease throughput (default: 5000)
         /// </summary>
         ushort CheckpointMessageCount { set; }
+
+        /// <summary>
+        /// Set number of concurrent consumers, higher value will increase throughput based on partition but might create idle consumers (default: 1)
+        /// </summary>
+        ushort ConcurrentConsumerLimit { set; }
+
+        /// <summary>
+        /// Set number of concurrent messages per single Key-partition, higher value will increase throughput but will break delivery order (default: 1)
+        /// </summary>
+        int ConcurrentDeliveryLimit { set; }
 
         /// <summary>
         /// Name of partition assignment strategy to use when elected group leader assigns partitions to group members.
@@ -149,6 +153,18 @@
         void SetHeadersDeserializer(IHeadersDeserializer deserializer);
 
         /// <summary>
+        /// A handler that is called to report the result of (automatic) offset
+        /// commits. It is not called as a result of the use of the Commit method.
+        /// </summary>
+        /// <remarks>
+        /// Executes as a side-effect of the Consumer.Consume call (on the same thread).
+        /// Exceptions: Any exception thrown by your offsets committed handler
+        /// will be wrapped in a ConsumeException with ErrorCode
+        /// ErrorCode.Local_Application and thrown by the initiating call to Consume/Close.
+        /// </remarks>
+        void SetOffsetsCommittedHandler(Action<CommittedOffsets> offsetsCommittedHandler);
+
+        /// <summary>
         /// Create topic if not exists every time endpoint starts (admin permissions are required).
         /// </summary>
         /// <param name="configure"></param>
@@ -179,17 +195,5 @@
         /// Consume.
         /// </remarks>
         void SetValueDeserializer(IDeserializer<TValue> deserializer);
-
-        /// <summary>
-        /// A handler that is called to report the result of (automatic) offset
-        /// commits. It is not called as a result of the use of the Commit method.
-        /// </summary>
-        /// <remarks>
-        /// Executes as a side-effect of the Consumer.Consume call (on the same thread).
-        /// Exceptions: Any exception thrown by your offsets committed handler
-        /// will be wrapped in a ConsumeException with ErrorCode
-        /// ErrorCode.Local_Application and thrown by the initiating call to Consume/Close.
-        /// </remarks>
-        void SetOffsetsCommittedHandler(Action<IConsumer<TKey, TValue>, CommittedOffsets> offsetsCommittedHandler);
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/Configuration/KafkaProducerConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/Configuration/KafkaProducerConfiguratorExtensions.cs
@@ -1,0 +1,57 @@
+namespace MassTransit
+{
+    using System.Threading.Tasks;
+    using Confluent.Kafka;
+
+
+    public static class KafkaProducerConfiguratorExtensions
+    {
+        class AsyncSerializerWrapper<T> :
+            IAsyncSerializer<T>
+        {
+            readonly ISerializer<T> _serializer;
+
+            public AsyncSerializerWrapper(ISerializer<T> serializer)
+            {
+                _serializer = serializer;
+            }
+
+            public Task<byte[]> SerializeAsync(T data, SerializationContext context)
+            {
+                return Task.FromResult(_serializer.Serialize(data, context));
+            }
+        }
+
+
+        public static IAsyncSerializer<T> AsAsyncOverSync<T>(this ISerializer<T> serializer)
+        {
+            return new AsyncSerializerWrapper<T>(serializer);
+        }
+
+        /// <summary>Set the serializer to use to serialize keys.</summary>
+        /// <remarks>
+        /// If your key serializer throws an exception, this will be
+        /// wrapped in a ConsumeException with ErrorCode
+        /// Local_KeyDeserialization and thrown by the initiating call to
+        /// Consume.
+        /// </remarks>
+        public static void SetKeySerializer<TKey, TValue>(this IKafkaProducerConfigurator<TKey, TValue> configurator, ISerializer<TKey> serializer)
+        {
+            configurator.SetKeySerializer(serializer.AsAsyncOverSync());
+        }
+
+        /// <summary>
+        /// Set the serializer to use to serialize values.
+        /// </summary>
+        /// <remarks>
+        /// If your value serializer throws an exception, this will be
+        /// wrapped in a ConsumeException with ErrorCode
+        /// Local_ValueDeserialization and thrown by the initiating call to
+        /// Consume.
+        /// </remarks>
+        public static void SetValueSerializer<TKey, TValue>(this IKafkaProducerConfigurator<TKey, TValue> configurator, ISerializer<TValue> serializer)
+        {
+            configurator.SetValueSerializer(serializer.AsAsyncOverSync());
+        }
+    }
+}

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaProducerSpecification.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaProducerSpecification.cs
@@ -21,8 +21,8 @@ namespace MassTransit.KafkaIntegration.Configuration
         readonly SerializationConfiguration _serialization;
         Action<ISendPipeConfigurator> _configureSend;
         IHeadersSerializer _headersSerializer;
-        ISerializer<TKey> _keySerializer;
-        ISerializer<TValue> _valueSerializer;
+        IAsyncSerializer<TKey> _keySerializer;
+        IAsyncSerializer<TValue> _valueSerializer;
 
         public KafkaProducerSpecification(IKafkaHostConfiguration hostConfiguration, ProducerConfig producerConfig, string topicName,
             IHeadersSerializer headersSerializer, Action<IClient, string> oAuthBearerTokenRefreshHandler)
@@ -35,8 +35,8 @@ namespace MassTransit.KafkaIntegration.Configuration
             _sendObservers = new SendObservable();
 
             if (!SerializationUtils.Serializers.IsDefaultKeyType<TKey>())
-                SetKeySerializer(new MassTransitJsonSerializer<TKey>());
-            SetValueSerializer(new MassTransitJsonSerializer<TValue>());
+                SetKeySerializer(new MassTransitAsyncJsonSerializer<TKey>());
+            SetValueSerializer(new MassTransitAsyncJsonSerializer<TValue>());
             SetHeadersSerializer(headersSerializer);
 
             _serialization = new SerializationConfiguration();
@@ -137,12 +137,12 @@ namespace MassTransit.KafkaIntegration.Configuration
             set => _producerConfig.EnableBackgroundPoll = value;
         }
 
-        public void SetKeySerializer(ISerializer<TKey> serializer)
+        public void SetKeySerializer(IAsyncSerializer<TKey> serializer)
         {
             _keySerializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         }
 
-        public void SetValueSerializer(ISerializer<TValue> serializer)
+        public void SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
             _valueSerializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerBuilderFactory.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerBuilderFactory.cs
@@ -1,0 +1,7 @@
+namespace MassTransit.KafkaIntegration
+{
+    using Confluent.Kafka;
+
+
+    public delegate ConsumerBuilder<byte[], byte[]> ConsumerBuilderFactory();
+}

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerContext.cs
@@ -1,25 +1,16 @@
 namespace MassTransit.KafkaIntegration
 {
     using System;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Confluent.Kafka;
-    using Serializers;
+    using Util;
 
 
-    public interface ConsumerContext<TKey, TValue> :
+    public interface ConsumerContext :
         PipeContext,
-        IConsumerLockContext<TKey, TValue>,
-        IAsyncDisposable
-        where TValue : class
+        IConsumerLockContext,
+        IChannelExecutorPool<ConsumeResult<byte[], byte[]>>
     {
-        ReceiveSettings ReceiveSettings { get; }
-        IHeadersDeserializer HeadersDeserializer { get; }
-        event Action<IConsumer<TKey, TValue>, Error> ErrorHandler;
-
-        Task Subscribe();
-        Task Close();
-
-        Task<ConsumeResult<TKey, TValue>> Consume(CancellationToken cancellationToken);
+        event Action<Error> ErrorHandler;
+        IConsumer<byte[], byte[]> CreateConsumer(Action<IConsumer<byte[], byte[]>, Error> onError);
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerContextFactory.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerContextFactory.cs
@@ -1,65 +1,58 @@
 namespace MassTransit.KafkaIntegration
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Agents;
-    using Confluent.Kafka;
     using Internals;
     using MassTransit.Configuration;
-    using Serializers;
 
 
-    public class ConsumerContextFactory<TKey, TValue> :
-        IPipeContextFactory<ConsumerContext<TKey, TValue>>
-        where TValue : class
+    public class ConsumerContextFactory :
+        IPipeContextFactory<ConsumerContext>
     {
-        readonly IClientContextSupervisor _clientContextSupervisor;
-        readonly Func<ConsumerBuilder<TKey, TValue>> _consumerBuilderFactory;
-        readonly IHeadersDeserializer _headersDeserializer;
         readonly IHostConfiguration _hostConfiguration;
+        readonly IClientContextSupervisor _clientContextSupervisor;
         readonly ReceiveSettings _receiveSettings;
+        readonly ConsumerBuilderFactory _consumerBuilderFactory;
 
-        public ConsumerContextFactory(IClientContextSupervisor clientContextSupervisor, ReceiveSettings receiveSettings,
-            IHostConfiguration hostConfiguration, IHeadersDeserializer headersDeserializer, Func<ConsumerBuilder<TKey, TValue>> consumerBuilderFactory)
+        public ConsumerContextFactory(IHostConfiguration hostConfiguration, IClientContextSupervisor clientContextSupervisor, ReceiveSettings receiveSettings,
+            ConsumerBuilderFactory consumerBuilderFactory)
         {
+            _hostConfiguration = hostConfiguration;
             _clientContextSupervisor = clientContextSupervisor;
             _receiveSettings = receiveSettings;
-            _headersDeserializer = headersDeserializer;
-            _hostConfiguration = hostConfiguration;
             _consumerBuilderFactory = consumerBuilderFactory;
         }
 
-        public IPipeContextAgent<ConsumerContext<TKey, TValue>> CreateContext(ISupervisor supervisor)
+        public IPipeContextAgent<ConsumerContext> CreateContext(ISupervisor supervisor)
         {
-            IAsyncPipeContextAgent<ConsumerContext<TKey, TValue>> asyncContext = supervisor.AddAsyncContext<ConsumerContext<TKey, TValue>>();
+            IAsyncPipeContextAgent<ConsumerContext> asyncContext = supervisor.AddAsyncContext<ConsumerContext>();
 
             CreateConsumer(asyncContext, supervisor.Stopped);
 
             return asyncContext;
         }
 
-        public IActivePipeContextAgent<ConsumerContext<TKey, TValue>> CreateActiveContext(ISupervisor supervisor,
-            PipeContextHandle<ConsumerContext<TKey, TValue>> context, CancellationToken cancellationToken = new CancellationToken())
+        public IActivePipeContextAgent<ConsumerContext> CreateActiveContext(ISupervisor supervisor,
+            PipeContextHandle<ConsumerContext> context, CancellationToken cancellationToken = new CancellationToken())
         {
             return supervisor.AddActiveContext(context, CreateSharedConnection(context.Context, cancellationToken));
         }
 
-        static async Task<ConsumerContext<TKey, TValue>> CreateSharedConnection(Task<ConsumerContext<TKey, TValue>> context,
+        static async Task<ConsumerContext> CreateSharedConnection(Task<ConsumerContext> context,
             CancellationToken cancellationToken)
         {
             return context.IsCompletedSuccessfully()
-                ? new SharedConsumerContext<TKey, TValue>(context.Result, cancellationToken)
-                : new SharedConsumerContext<TKey, TValue>(await context.OrCanceled(cancellationToken).ConfigureAwait(false), cancellationToken);
+                ? new SharedConsumerContext(context.Result, cancellationToken)
+                : new SharedConsumerContext(await context.OrCanceled(cancellationToken).ConfigureAwait(false), cancellationToken);
         }
 
-        void CreateConsumer(IAsyncPipeContextAgent<ConsumerContext<TKey, TValue>> asyncContext, CancellationToken cancellationToken)
+        void CreateConsumer(IAsyncPipeContextAgent<ConsumerContext> asyncContext, CancellationToken cancellationToken)
         {
-            Task<ConsumerContext<TKey, TValue>> Create(ClientContext clientContext, CancellationToken createCancellationToken)
+            Task<ConsumerContext> Create(ClientContext clientContext, CancellationToken createCancellationToken)
             {
-                ConsumerBuilder<TKey, TValue> consumerBuilder = _consumerBuilderFactory();
-                ConsumerContext<TKey, TValue> context = new KafkaConsumerContext<TKey, TValue>(_hostConfiguration, _receiveSettings,
-                    _headersDeserializer, consumerBuilder, cancellationToken);
+                ConsumerContext context =
+                    new KafkaConsumerContext(_hostConfiguration, _receiveSettings, _consumerBuilderFactory, cancellationToken);
                 return Task.FromResult(context);
             }
 

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerContextSupervisor.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerContextSupervisor.cs
@@ -1,21 +1,17 @@
 namespace MassTransit.KafkaIntegration
 {
-    using System;
-    using Confluent.Kafka;
     using MassTransit.Configuration;
-    using Serializers;
     using Transports;
 
 
-    public class ConsumerContextSupervisor<TKey, TValue> :
-        TransportPipeContextSupervisor<ConsumerContext<TKey, TValue>>,
-        IConsumerContextSupervisor<TKey, TValue>
-        where TValue : class
+    public class ConsumerContextSupervisor :
+        TransportPipeContextSupervisor<ConsumerContext>,
+        IConsumerContextSupervisor
     {
-        public ConsumerContextSupervisor(IClientContextSupervisor clientContextSupervisor, ReceiveSettings receiveSettings,
-            IHostConfiguration hostConfiguration, IHeadersDeserializer headersDeserializer, Func<ConsumerBuilder<TKey, TValue>> consumerBuilderFactory)
-            : base(new ConsumerContextFactory<TKey, TValue>(clientContextSupervisor, receiveSettings, hostConfiguration, headersDeserializer,
-                consumerBuilderFactory))
+        public ConsumerContextSupervisor(IHostConfiguration hostConfiguration,
+            IClientContextSupervisor clientContextSupervisor, ReceiveSettings receiveSettings,
+            ConsumerBuilderFactory consumerBuilderFactory)
+            : base(new ConsumerContextFactory(hostConfiguration, clientContextSupervisor, receiveSettings, consumerBuilderFactory))
         {
             clientContextSupervisor.AddConsumeAgent(this);
         }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerLockContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ConsumerLockContext.cs
@@ -3,6 +3,7 @@ namespace MassTransit.KafkaIntegration
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Checkpoints;
     using Confluent.Kafka;
@@ -10,11 +11,12 @@ namespace MassTransit.KafkaIntegration
     using Util;
 
 
-    public class ConsumerLockContext<TKey, TValue> :
-        IConsumerLockContext<TKey, TValue>
-        where TValue : class
+    public class ConsumerLockContext :
+        IConsumerLockContext
     {
-        readonly SingleThreadedDictionary<Partition, PartitionCheckpointData> _data = new SingleThreadedDictionary<Partition, PartitionCheckpointData>();
+        readonly SingleThreadedDictionary<TopicPartition, PartitionCheckpointData> _data =
+            new SingleThreadedDictionary<TopicPartition, PartitionCheckpointData>();
+
         readonly IHostConfiguration _hostConfiguration;
         readonly ReceiveSettings _receiveSettings;
 
@@ -24,65 +26,61 @@ namespace MassTransit.KafkaIntegration
             _receiveSettings = receiveSettings;
         }
 
-        public async Task Pending(ConsumeResult<TKey, TValue> result)
+        public async Task Pending(ConsumeResult<byte[], byte[]> result)
         {
             LogContext.SetCurrentIfNull(_hostConfiguration.ReceiveLogContext);
 
-            if (_data.TryGetValue(result.Partition, out var data))
+            if (_data.TryGetValue(result.TopicPartition, out var data))
                 await data.Pending(result).ConfigureAwait(false);
         }
 
-        public Task Complete(ConsumeResult<TKey, TValue> result)
+        public Task Complete(ConsumeResult<byte[], byte[]> result)
         {
             LogContext.SetCurrentIfNull(_hostConfiguration.ReceiveLogContext);
 
-            if (_data.TryGetValue(result.Partition, out var data))
+            if (_data.TryGetValue(result.TopicPartition, out var data))
                 data.Complete(result);
 
             return Task.CompletedTask;
         }
 
-        public Task Faulted(ConsumeResult<TKey, TValue> result, Exception exception)
+        public Task Faulted(ConsumeResult<byte[], byte[]> result, Exception exception)
         {
             LogContext.SetCurrentIfNull(_hostConfiguration.ReceiveLogContext);
 
-            if (_data.TryGetValue(result.Partition, out var data))
+            if (_data.TryGetValue(result.TopicPartition, out var data))
                 data.Faulted(result, exception);
 
             return Task.CompletedTask;
         }
 
-        public void OnAssigned(IConsumer<TKey, TValue> consumer, IEnumerable<TopicPartition> partitions)
+        public void OnAssigned(IConsumer<byte[], byte[]> consumer, IEnumerable<TopicPartition> partitions)
         {
             LogContext.SetCurrentIfNull(_hostConfiguration.ReceiveLogContext);
 
             foreach (var partition in partitions)
             {
-                if (_data.TryAdd(partition.Partition, p => new PartitionCheckpointData(partition, consumer, _receiveSettings)))
-                    LogContext.Info?.Log("Partition: {PartitionId} was assigned", partition);
+                if (!_data.TryAdd(partition, p => new PartitionCheckpointData(partition, consumer, _receiveSettings)))
+                    continue;
+
+                LogContext.Debug?.Log("Partition: {PartitionId} was assigned to: {MemberId}", partition, consumer.MemberId);
             }
         }
 
-        public void OnUnAssigned(IConsumer<TKey, TValue> consumer, IEnumerable<TopicPartitionOffset> partitions)
+        public void OnUnAssigned(IConsumer<byte[], byte[]> consumer, IEnumerable<TopicPartitionOffset> partitions)
         {
             LogContext.SetCurrentIfNull(_hostConfiguration.ReceiveLogContext);
 
             async Task<bool> CloseAndDelete(TopicPartitionOffset topicPartition)
             {
-                if (!_data.TryGetValue(topicPartition.Partition, out var data))
+                if (!_data.TryGetValue(topicPartition.TopicPartition, out var data))
                     return false;
 
                 await data.Close(topicPartition).ConfigureAwait(false);
-                return _data.TryRemove(topicPartition.Partition, out _);
-
+                return _data.TryRemove(topicPartition.TopicPartition, out _);
             }
 
-            async Task Close()
-            {
-                await Task.WhenAll(partitions.Select(partition => CloseAndDelete(partition))).ConfigureAwait(false);
-            }
-
-            TaskUtil.Await(Close);
+            TaskUtil.Await(Task.WhenAll(partitions.Select(partition => CloseAndDelete(partition))));
         }
 
 
@@ -91,37 +89,64 @@ namespace MassTransit.KafkaIntegration
             readonly ICheckpointer _checkpointer;
             readonly ChannelExecutor _executor;
             readonly PendingConfirmationCollection _pending;
+            readonly string _memberId;
 
-            public PartitionCheckpointData(TopicPartition partition, IConsumer<TKey, TValue> consumer, ReceiveSettings settings)
+            public PartitionCheckpointData(TopicPartition partition, IConsumer<byte[], byte[]> consumer, ReceiveSettings settings)
             {
+                _memberId = consumer.MemberId;
                 _pending = new PendingConfirmationCollection(partition);
-                _executor = new ChannelExecutor(1);
-                _checkpointer = new BatchCheckpointer<TKey, TValue>(_executor, consumer, settings);
+                _executor = new ChannelExecutor(settings.PrefetchCount, settings.ConcurrentMessageLimit);
+                _checkpointer = new BatchCheckpointer(consumer, settings);
             }
 
-            public Task Pending(ConsumeResult<TKey, TValue> result)
+            public Task Pending(ConsumeResult<byte[], byte[]> result)
             {
                 var pendingConfirmation = _pending.Add(result.Offset);
                 return _checkpointer.Pending(pendingConfirmation);
             }
 
-            public void Complete(ConsumeResult<TKey, TValue> result)
+            public void Complete(ConsumeResult<byte[], byte[]> result)
             {
                 _pending.Complete(result.Offset);
             }
 
-            public void Faulted(ConsumeResult<TKey, TValue> result, Exception exception)
+            public void Faulted(ConsumeResult<byte[], byte[]> result, Exception exception)
             {
                 _pending.Faulted(result.Offset, exception);
             }
 
             public async Task Close(TopicPartitionOffset partition)
             {
-                await _checkpointer.DisposeAsync().ConfigureAwait(false);
                 await _executor.DisposeAsync().ConfigureAwait(false);
+                await _checkpointer.DisposeAsync().ConfigureAwait(false);
 
-                LogContext.Info?.Log("Partition: {PartitionId} was closed", partition.TopicPartition);
+                LogContext.Debug?.Log("Partition: {PartitionId} was closed on {MemberId}", partition.TopicPartition, _memberId);
             }
+
+            public Task Push(Func<Task> method, CancellationToken cancellationToken = default)
+            {
+                return _executor.Push(method, cancellationToken);
+            }
+
+            public Task Run(Func<Task> method, CancellationToken cancellationToken = default)
+            {
+                return _executor.Run(method, cancellationToken);
+            }
+        }
+
+
+        public async ValueTask DisposeAsync()
+        {
+        }
+
+        public Task Push(ConsumeResult<byte[], byte[]> partition, Func<Task> method, CancellationToken cancellationToken = default)
+        {
+            return _data[partition.TopicPartition].Push(method, cancellationToken);
+        }
+
+        public Task Run(ConsumeResult<byte[], byte[]> partition, Func<Task> method, CancellationToken cancellationToken = default)
+        {
+            return _data[partition.TopicPartition].Run(method, cancellationToken);
         }
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/IConsumerContextSupervisor.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/IConsumerContextSupervisor.cs
@@ -3,9 +3,8 @@ namespace MassTransit.KafkaIntegration
     using Transports;
 
 
-    public interface IConsumerContextSupervisor<TKey, TValue> :
-        ITransportSupervisor<ConsumerContext<TKey, TValue>>
-        where TValue : class
+    public interface IConsumerContextSupervisor :
+        ITransportSupervisor<ConsumerContext>
     {
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/IConsumerLockContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/IConsumerLockContext.cs
@@ -3,13 +3,14 @@ namespace MassTransit.KafkaIntegration
     using System;
     using System.Threading.Tasks;
     using Confluent.Kafka;
+    using Util;
 
 
-    public interface IConsumerLockContext<TKey, TValue>
-        where TValue : class
+    public interface IConsumerLockContext :
+        IChannelExecutorPool<ConsumeResult<byte[], byte[]>>
     {
-        Task Pending(ConsumeResult<TKey, TValue> result);
-        Task Complete(ConsumeResult<TKey, TValue> result);
-        Task Faulted(ConsumeResult<TKey, TValue> result, Exception exception);
+        Task Pending(ConsumeResult<byte[], byte[]> result);
+        Task Complete(ConsumeResult<byte[], byte[]> result);
+        Task Faulted(ConsumeResult<byte[], byte[]> result, Exception exception);
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/IKafkaMessageConsumer.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/IKafkaMessageConsumer.cs
@@ -10,9 +10,10 @@
     }
 
 
-    public interface IKafkaMessageReceiver<TKey, TValue> :
+    public interface IKafkaMessageConsumer<TKey, TValue> :
         IKafkaMessageReceiver
         where TValue : class
     {
+
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaHeaderAdapter.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaHeaderAdapter.cs
@@ -4,11 +4,11 @@ namespace MassTransit.KafkaIntegration
     using Confluent.Kafka;
 
 
-    public class KafkaHeaderAdapter<TKey, TValue> :
+    public class KafkaHeaderAdapter :
         MessageContext
     {
         readonly ReceiveContext _receiveContext;
-        readonly ConsumeResult<TKey, TValue> _result;
+        readonly ConsumeResult<byte[], byte[]> _result;
         Guid? _conversationId;
         Guid? _correlationId;
         Guid? _initiatorId;
@@ -16,7 +16,7 @@ namespace MassTransit.KafkaIntegration
         DateTime? _sentTime;
         Uri _sourceAddress;
 
-        public KafkaHeaderAdapter(ConsumeResult<TKey, TValue> result, ReceiveContext receiveContext)
+        public KafkaHeaderAdapter(ConsumeResult<byte[], byte[]> result, ReceiveContext receiveContext)
         {
             _result = result;
             _receiveContext = receiveContext;

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaReceiveEndpointContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaReceiveEndpointContext.cs
@@ -1,5 +1,8 @@
 namespace MassTransit.KafkaIntegration
 {
+    using System;
+    using Confluent.Kafka;
+    using Serializers;
     using Transports;
 
 
@@ -7,6 +10,11 @@ namespace MassTransit.KafkaIntegration
         ReceiveEndpointContext
         where TValue : class
     {
-        IConsumerContextSupervisor<TKey, TValue> ConsumerContextSupervisor { get; }
+        IHeadersDeserializer HeadersDeserializer { get; }
+        IDeserializer<TKey> KeyDeserializer { get; }
+        IDeserializer<TValue> ValueDeserializer { get; }
+        IConsumerContextSupervisor ConsumerContextSupervisor { get; }
+
+        KafkaTopicAddress NormalizeAddress(Uri address);
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Middleware/ConfigureKafkaTopologyFilter.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Middleware/ConfigureKafkaTopologyFilter.cs
@@ -10,7 +10,7 @@ namespace MassTransit.KafkaIntegration.Middleware
 
 
     public class ConfigureKafkaTopologyFilter<TKey, TValue> :
-        IFilter<ConsumerContext<TKey, TValue>>
+        IFilter<ConsumerContext>
         where TValue : class
     {
         readonly AdminClientConfig _config;
@@ -24,7 +24,7 @@ namespace MassTransit.KafkaIntegration.Middleware
             _config = new AdminClientConfig(clientConfig.ToDictionary(x => x.Key, x => x.Value));
         }
 
-        public async Task Send(ConsumerContext<TKey, TValue> context, IPipe<ConsumerContext<TKey, TValue>> next)
+        public async Task Send(ConsumerContext context, IPipe<ConsumerContext> next)
         {
             await context.OneTimeSetup<ConfigureTopologyContext<TKey, TValue>>(_ => CreateTopic(), () => new Context()).ConfigureAwait(false);
 

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ReceiveSettings.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/ReceiveSettings.cs
@@ -9,7 +9,9 @@ namespace MassTransit.KafkaIntegration
         ushort MessageLimit { get; }
         ushort CheckpointMessageCount { get; }
         int PrefetchCount { get; }
-        int ConcurrencyLimit { get; }
+        int ConcurrentDeliveryLimit { get; }
+        int ConcurrentMessageLimit { get; }
+        ushort ConcurrentConsumerLimit { get; }
         TimeSpan CheckpointInterval { get; }
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Serializers/MassTransitJsonSerializer.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Serializers/MassTransitJsonSerializer.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.KafkaIntegration.Serializers
 {
     using System.Text.Json;
+    using System.Threading.Tasks;
     using Confluent.Kafka;
     using Serialization;
 
@@ -11,6 +12,16 @@ namespace MassTransit.KafkaIntegration.Serializers
         public byte[] Serialize(T data, SerializationContext context)
         {
             return JsonSerializer.SerializeToUtf8Bytes(data, SystemTextJsonMessageSerializer.Options);
+        }
+    }
+
+
+    public class MassTransitAsyncJsonSerializer<T> :
+        IAsyncSerializer<T>
+    {
+        public Task<byte[]> SerializeAsync(T data, SerializationContext context)
+        {
+            return Task.FromResult(JsonSerializer.SerializeToUtf8Bytes(data, SystemTextJsonMessageSerializer.Options));
         }
     }
 }

--- a/tests/MassTransit.EventHubIntegration.Tests/BatchReceive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/BatchReceive_Specs.cs
@@ -46,6 +46,7 @@ namespace MassTransit.EventHubIntegration.Tests
                         {
                             c.ConfigureConsumer<EventHubMessageConsumer>(context);
 
+                            c.ConcurrentDeliveryLimit = batchSize;
                             c.CheckpointMessageCount = batchSize;
                             c.CheckpointInterval = checkpointInterval;
                         });

--- a/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
@@ -104,7 +104,6 @@ namespace MassTransit.EventHubIntegration.Tests
         }
     }
 
-
     public class ReceiveWithPayload_Specs :
         InMemoryTestFixture
     {

--- a/tests/MassTransit.KafkaIntegration.Tests/Avro_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Avro_Specs.cs
@@ -34,9 +34,9 @@ namespace MassTransit.KafkaIntegration.Tests
             services.TryAddSingleton<ILoggerFactory>(LoggerFactory);
             services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
 
-            static ISerializer<T> GetSerializer<T>(IServiceProvider provider)
+            static IAsyncSerializer<T> GetSerializer<T>(IServiceProvider provider)
             {
-                return new AvroSerializer<T>(provider.GetService<ISchemaRegistryClient>()).AsSyncOverAsync();
+                return new AvroSerializer<T>(provider.GetService<ISchemaRegistryClient>());
             }
 
             static IDeserializer<T> GetDeserializer<T>(IServiceProvider provider)

--- a/tests/MassTransit.KafkaIntegration.Tests/Filter_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Filter_Specs.cs
@@ -12,7 +12,7 @@ namespace MassTransit.KafkaIntegration.Tests
 
     public class Using_a_consumer_filter
     {
-        const string Topic = "producer";
+        const string Topic = "filter";
 
         static int _attempts;
         static int _lastAttempt;
@@ -110,6 +110,8 @@ namespace MassTransit.KafkaIntegration.Tests
     [TestFixture]
     public class Using_a_scoped_send_filter
     {
+        const string Topic = "scoped-filter-producer";
+
         [Test]
         public async Task Should_properly_configure_the_filter()
         {
@@ -159,9 +161,6 @@ namespace MassTransit.KafkaIntegration.Tests
 
             Assert.That(result.Headers.Get<string>("Scoped-Value"), Is.EqualTo("Hello, World"));
         }
-
-        const string Topic = "producer";
-
 
         public class ScopedContext
         {

--- a/tests/MassTransit.KafkaIntegration.Tests/MultiBus_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/MultiBus_Specs.cs
@@ -296,4 +296,149 @@ namespace MassTransit.KafkaIntegration.Tests
         {
         }
     }
+
+
+    public class MultiBus_ConcurrentConsumers_ReBalance_Specs :
+        InMemoryTestFixture
+    {
+        const string Topic = "concurrent-rebalance-receive-test-multi";
+
+        public MultiBus_ConcurrentConsumers_ReBalance_Specs()
+        {
+            TestTimeout = TimeSpan.FromMinutes(2);
+        }
+
+        [Test]
+        public async Task Should_receive()
+        {
+            TaskCompletionSource<ConsumeContext<KafkaMessage>> taskCompletionSource = GetTask<ConsumeContext<KafkaMessage>>();
+
+            var config = new AdminClientConfig
+            {
+                BootstrapServers = "localhost:9092",
+            };
+
+            var adminClient = new AdminClientBuilder(config).Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton(taskCompletionSource);
+
+            services.TryAddSingleton<ILoggerFactory>(LoggerFactory);
+            services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
+
+            services.AddMassTransit(x =>
+            {
+                x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+                x.AddRider(rider =>
+                {
+                    rider.AddConsumer<KafkaMessageConsumer>();
+                    rider.AddProducer<KafkaMessage>(Topic);
+
+                    rider.UsingKafka((context, k) =>
+                    {
+                        k.Host("localhost:9092");
+
+                        k.TopicEndpoint<KafkaMessage>(Topic, nameof(MultiBus_ConcurrentConsumers_ReBalance_Specs), c =>
+                        {
+                            c.ConcurrentConsumerLimit = 3;
+                            c.CreateIfMissing(t => t.NumPartitions = 6);
+                            c.ConfigureConsumer<KafkaMessageConsumer>(context);
+                        });
+                    });
+                });
+            });
+
+            services.AddMassTransit<ISecondBus>(x =>
+            {
+                x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+                x.AddRider(rider =>
+                {
+                    rider.AddConsumer<KafkaMessageConsumer>();
+                    rider.AddProducer<KafkaMessage>(Topic);
+
+                    rider.UsingKafka((context, k) =>
+                    {
+                        k.Host("localhost:9092");
+
+                        k.TopicEndpoint<KafkaMessage>(Topic, nameof(MultiBus_ConcurrentConsumers_ReBalance_Specs), c =>
+                        {
+                            c.ConcurrentConsumerLimit = 3;
+                            c.ConfigureConsumer<KafkaMessageConsumer>(context);
+                        });
+                    });
+                });
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            var busControl = provider.GetRequiredService<IBusControl>();
+
+            var scope = provider.CreateScope();
+
+            await busControl.StartAsync(TestCancellationToken);
+
+            var producer = scope.ServiceProvider.GetRequiredService<ITopicProducer<KafkaMessage>>();
+
+            try
+            {
+                var messageId = NewId.NextGuid();
+                await producer.Produce(new { }, Pipe.Execute<SendContext>(context => context.MessageId = messageId), TestCancellationToken);
+
+                var secondBus = provider.GetRequiredService<IBusInstance<ISecondBus>>();
+                await secondBus.BusControl.StartAsync(TestCancellationToken);
+
+                ConsumeContext<KafkaMessage> result = await taskCompletionSource.Task;
+
+                var groupInfo = adminClient.ListGroup(nameof(MultiBus_ConcurrentConsumers_ReBalance_Specs), TimeSpan.FromSeconds(5));
+
+                while (groupInfo.State != "Stable")
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(10));
+                    groupInfo = adminClient.ListGroup(nameof(MultiBus_ConcurrentConsumers_ReBalance_Specs), TimeSpan.FromSeconds(5));
+                }
+
+                Assert.AreEqual(messageId, result.MessageId);
+                Assert.AreEqual(groupInfo.Members.Count, 6); // this fails, second instance consumer assigned to all partitions
+
+                await secondBus.BusControl.StopAsync(TestCancellationToken);
+            }
+            finally
+            {
+                scope.Dispose();
+
+                await busControl.StopAsync(TestCancellationToken);
+
+                await provider.DisposeAsync();
+            }
+        }
+
+
+        class KafkaMessageConsumer :
+            IConsumer<KafkaMessage>
+        {
+            readonly TaskCompletionSource<ConsumeContext<KafkaMessage>> _taskCompletionSource;
+
+            public KafkaMessageConsumer(TaskCompletionSource<ConsumeContext<KafkaMessage>> taskCompletionSource)
+            {
+                _taskCompletionSource = taskCompletionSource;
+            }
+
+            public async Task Consume(ConsumeContext<KafkaMessage> context)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(20));
+                _taskCompletionSource.TrySetResult(context);
+            }
+        }
+
+
+        public interface ISecondBus :
+            IBus
+        {
+        }
+
+
+        public interface KafkaMessage
+        {
+        }
+    }
 }

--- a/tests/MassTransit.KafkaIntegration.Tests/Publish_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Publish_Specs.cs
@@ -15,7 +15,7 @@ namespace MassTransit.KafkaIntegration.Tests
     public class Publish_Specs :
         InMemoryTestFixture
     {
-        const string Topic = "test2";
+        const string Topic = "publish";
 
         [Test]
         public async Task Should_receive()

--- a/tests/MassTransit.KafkaIntegration.Tests/TopicCreator.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/TopicCreator.cs
@@ -1,0 +1,60 @@
+namespace MassTransit.KafkaIntegration.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Confluent.Kafka;
+    using Confluent.Kafka.Admin;
+
+
+    class TopicCreator :
+        IAsyncDisposable
+    {
+        readonly IAdminClient _client;
+        readonly List<string> _topicNames;
+
+        public TopicCreator(ClientConfig clientConfig)
+        {
+            _client = new AdminClientBuilder(new AdminClientConfig(clientConfig)).Build();
+            _topicNames = new List<string>();
+        }
+
+        public async Task CreateTopics(int partitions = 1, short replicas = 1, params string[] topicNames)
+        {
+            foreach (var topicName in topicNames)
+            {
+                try
+                {
+                    await _client.CreateTopicsAsync(new[]
+                    {
+                        new TopicSpecification
+                        {
+                            Name = topicName,
+                            NumPartitions = partitions,
+                            ReplicationFactor = replicas
+                        }
+                    });
+                }
+                catch (CreateTopicsException)
+                {
+                }
+                finally
+                {
+                    _topicNames.Add(topicName);
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await _client.DeleteTopicsAsync(_topicNames).ConfigureAwait(false);
+            }
+            finally
+            {
+                _client.Dispose();
+            }
+        }
+    }
+}

--- a/tests/MassTransit.KafkaIntegration.Tests/Wildcard_Receive_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Wildcard_Receive_Specs.cs
@@ -1,0 +1,145 @@
+namespace MassTransit.KafkaIntegration.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using Confluent.Kafka;
+    using Context;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+    using Serializers;
+    using TestFramework;
+
+
+    public class Wildcard_Receive_Specs :
+        InMemoryTestFixture
+    {
+        const string Host = "localhost:9092";
+        const string TopicPrefix = "Wildcard-topic-";
+        static readonly Regex Topic = new($"^{TopicPrefix}[0-9]*", RegexOptions.Compiled);
+
+        [Test]
+        public async Task Should_receive()
+        {
+            const int numTopics = 2;
+
+            var topicNames = new string[numTopics];
+            for (var i = 0; i < numTopics; i++)
+                topicNames[i] = TopicPrefix + i;
+
+            Dictionary<string, TaskCompletionSource<ConsumeContext<KafkaMessage>>> taskCompletionSource =
+                topicNames.ToDictionary(x => x, _ => GetTask<ConsumeContext<KafkaMessage>>());
+            var clientConfig = new ClientConfig { BootstrapServers = Host };
+
+            await using var provider = new ServiceCollection()
+                .AddSingleton<ILoggerFactory>(LoggerFactory)
+                .AddSingleton(taskCompletionSource)
+                .AddSingleton(new TopicCreator(clientConfig))
+                .AddSingleton(typeof(ILogger<>), typeof(Logger<>))
+                .AddMassTransit(x =>
+                {
+                    x.AddRider(r =>
+                    {
+                        r.AddConsumer<KafkaMessageConsumer>();
+
+                        r.UsingKafka((context, k) =>
+                        {
+                            k.Host(Host);
+
+                            k.TopicEndpoint<KafkaMessage>(Topic.ToString(), nameof(Wildcard_Receive_Specs), c =>
+                            {
+                                c.AutoOffsetReset = AutoOffsetReset.Earliest;
+                                c.ConfigureConsumer<KafkaMessageConsumer>(context);
+                            });
+                        });
+                    });
+
+                    x.UsingInMemory();
+                }).BuildServiceProvider();
+
+
+            var busControl = provider.GetRequiredService<IBusControl>();
+            var topicCreator = provider.GetRequiredService<TopicCreator>();
+            await busControl.StartAsync(TestCancellationToken);
+
+            try
+            {
+                await topicCreator.CreateTopics(2, 1, topicNames);
+
+                using IProducer<Null, KafkaMessage> p = new ProducerBuilder<Null, KafkaMessage>(new ProducerConfig(clientConfig))
+                    .SetKeySerializer(Serializers.Null)
+                    .SetValueSerializer(new MassTransitJsonSerializer<KafkaMessage>())
+                    .Build();
+
+                var kafkaMessage = new KafkaMessageClass("test");
+                var sendContext = new MessageSendContext<KafkaMessage>(kafkaMessage);
+                var message = new Message<Null, KafkaMessage>
+                {
+                    Value = kafkaMessage,
+                    Headers = DictionaryHeadersSerialize.Serializer.Serialize(sendContext)
+                };
+
+                foreach (var topicName in topicNames)
+                    await p.ProduceAsync(topicName, message);
+
+                p.Flush();
+                p.Dispose();
+
+                foreach ((var topic, TaskCompletionSource<ConsumeContext<KafkaMessage>> value) in taskCompletionSource)
+                {
+                    ConsumeContext<KafkaMessage> result = await value.Task;
+
+                    Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{topic}")));
+                }
+            }
+            finally
+            {
+                await topicCreator.DisposeAsync();
+
+                await busControl.StopAsync(TestCancellationToken);
+
+                await provider.DisposeAsync();
+            }
+        }
+
+
+        class KafkaMessageClass :
+            KafkaMessage
+        {
+            public KafkaMessageClass(string text)
+            {
+                Text = text;
+            }
+
+            public string Text { get; }
+        }
+
+
+        class KafkaMessageConsumer :
+            IConsumer<KafkaMessage>
+        {
+            readonly ConcurrentDictionary<string, TaskCompletionSource<ConsumeContext<KafkaMessage>>> _taskCompletionSource;
+
+            public KafkaMessageConsumer(Dictionary<string, TaskCompletionSource<ConsumeContext<KafkaMessage>>> taskCompletionSource)
+            {
+                _taskCompletionSource = new ConcurrentDictionary<string, TaskCompletionSource<ConsumeContext<KafkaMessage>>>(taskCompletionSource);
+            }
+
+            public async Task Consume(ConsumeContext<KafkaMessage> context)
+            {
+                var payload = context.GetPayload<KafkaConsumeContext<Ignore>>();
+                if (_taskCompletionSource.TryGetValue(payload.Topic, out TaskCompletionSource<ConsumeContext<KafkaMessage>> source))
+                    source.TrySetResult(context);
+            }
+        }
+
+
+        public interface KafkaMessage
+        {
+        }
+    }
+}

--- a/tests/MassTransit.KafkaIntegration.Tests/docker-compose.yml
+++ b/tests/MassTransit.KafkaIntegration.Tests/docker-compose.yml
@@ -1,8 +1,8 @@
 ---
-version: '2'
+version: '3'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:7.0.1
+    image: confluentinc/cp-server:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -41,7 +41,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.0.1
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:


### PR DESCRIPTION
- Add ability to specify number of `ConcurrentConsumerLimit` this will create multiple consumers listening to the same topic
- Use ConcurrencyLimit per Partition instead of Consumer itself. Applies for both: EventHub and Kafka
- Replace Serializers for Producer with Async as default