### PR TITLE
[OTel spec] change `messaging.destination` -> `messaging.destination.name`

### DIFF
--- a/src/MassTransit/Logging/BusLogContext.cs
+++ b/src/MassTransit/Logging/BusLogContext.cs
@@ -76,7 +76,7 @@ namespace MassTransit.Logging
                 return null;
 
             activity.SetTag(DiagnosticHeaders.Messaging.System, transportContext.ActivitySystem);
-            activity.SetTag(DiagnosticHeaders.Messaging.Destination, transportContext.ActivityDestination);
+            activity.SetTag(DiagnosticHeaders.Messaging.DestinationName, transportContext.ActivityDestination);
             activity.SetTag(DiagnosticHeaders.Messaging.Operation, "send");
 
             return PopulateSendActivity<T>(context, activity, tags);
@@ -119,7 +119,7 @@ namespace MassTransit.Logging
 
             if (activity.IsAllDataRequested)
             {
-                activity.SetTag(DiagnosticHeaders.Messaging.Destination, endpointName);
+                activity.SetTag(DiagnosticHeaders.Messaging.DestinationName, endpointName);
                 activity.SetTag(DiagnosticHeaders.Messaging.Operation, "receive");
                 activity.SetTag(DiagnosticHeaders.InputAddress, inputAddress);
 

--- a/src/MassTransit/Logging/DiagnosticHeaders.cs
+++ b/src/MassTransit/Logging/DiagnosticHeaders.cs
@@ -43,7 +43,7 @@ namespace MassTransit.Logging
         {
             public const string BodyLength = "messaging.message_payload_size_bytes";
             public const string ConversationId = "messaging.message.conversation_id";
-            public const string Destination = "messaging.destination";
+            public const string DestinationName = "messaging.destination.name";
             public const string DestinationKind = "messaging.destination.kind";
             public const string TransportMessageId = "messaging.message.id";
             public const string Operation = "messaging.operation";


### PR DESCRIPTION
`messaging.destination` should be used as a namespace. The closest attribute is `messaging.destination.name`

https://github.com/open-telemetry/opentelemetry-specification/blob/52a35899e6ae7e6f85c53aa38bfbfec091b79fac/specification/trace/semantic_conventions/messaging.md?plain=1#L254

How to test:
Enable Instrumentation for any MassTransit process.