### PR TITLE
Vectorize generate guid

### DIFF
--- a/src/MassTransit.Abstractions/NewId/INewIdGenerator.cs
+++ b/src/MassTransit.Abstractions/NewId/INewIdGenerator.cs
@@ -11,7 +11,7 @@ namespace MassTransit
 
         Guid NextGuid();
 
-        ArraySegment<Guid> NextGuid(Guid[] ids, int index, int count);
+        ArraySegment<Guid> NextSequentialGuid(Guid[] ids, int index, int count);
 
         Guid NextSequentialGuid();
     }

--- a/src/MassTransit.Abstractions/NewId/NewId.cs
+++ b/src/MassTransit.Abstractions/NewId/NewId.cs
@@ -500,7 +500,7 @@ namespace MassTransit
         {
             var ids = new Guid[count];
 
-            _getGenerator().NextGuid(ids, 0, count);
+            _getGenerator().NextSequentialGuid(ids, 0, count);
 
             return ids;
         }
@@ -514,7 +514,7 @@ namespace MassTransit
         /// <returns></returns>
         public static ArraySegment<Guid> NextGuid(Guid[] ids, int index, int count)
         {
-            return _getGenerator().NextGuid(ids, index, count);
+            return _getGenerator().NextSequentialGuid(ids, index, count);
         }
 
         /// <summary>

--- a/src/MassTransit.Abstractions/NewId/NewId.cs
+++ b/src/MassTransit.Abstractions/NewId/NewId.cs
@@ -371,7 +371,7 @@ namespace MassTransit
 
         public override bool Equals(object? obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
                 return false;
             if (obj.GetType() != typeof(NewId))
                 return false;

--- a/tests/MassTransit.Abstractions.Tests/NewId/Generator_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/Generator_Specs.cs
@@ -118,6 +118,40 @@
             Assert.AreEqual(nid, nid1);
         }
 
+        [Test]
+        public void Should_generate_known_sequential_guid()
+        {
+            var expected = Guid.Parse("74b719ec-7596-3cf0-7d81-bf34437f0b01");
+            var tickProvider = new MockTickProvider(8410219332513447152);
+            var networkProvider = new MockNetworkProvider(BitConverter.GetBytes(6857996259202924925));
+            var generator = new NewIdGenerator(tickProvider, networkProvider);
+
+            for (int i = 0; i < 267; i++)
+            {
+                generator.NextSequentialGuid();
+            }
+            var guid = generator.NextSequentialGuid();
+
+            Assert.AreEqual(expected, guid);
+        }
+
+        [Test]
+        public void Should_generate_known_guid()
+        {
+            var expected = Guid.Parse("437f0b01-bf34-7d81-3cf0-74b719ec7596");
+            var tickProvider = new MockTickProvider(8410219332513447152);
+            var networkProvider = new MockNetworkProvider(BitConverter.GetBytes(6857996259202924925));
+            var generator = new NewIdGenerator(tickProvider, networkProvider);
+
+            for (int i = 0; i < 267; i++)
+            {
+                generator.NextGuid();
+            }
+            var guid = generator.NextGuid();
+
+            Assert.AreEqual(expected, guid);
+        }
+
         [SetUp]
         public void Init()
         {

--- a/tests/MassTransit.Abstractions.Tests/NewId/Generator_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/Generator_Specs.cs
@@ -152,6 +152,29 @@
             Assert.AreEqual(expected, guid);
         }
 
+        [Test]
+        public void Should_generate_known_guid_batch()
+        {
+            var exp = new string[] { "74b719ec-7596-3cf0-7d81-bf34437f0b01", "74b719ec-7596-3cf0-7d81-bf34437f0c01", "74b719ec-7596-3cf0-7d81-bf34437f0d01" };
+            var tickProvider = new MockTickProvider(8410219332513447152);
+            var networkProvider = new MockNetworkProvider(BitConverter.GetBytes(6857996259202924925));
+            var generator = new NewIdGenerator(tickProvider, networkProvider);
+
+            for (int i = 0; i < 267; i++)
+            {
+                generator.NextGuid();
+            }
+
+            var batch = new Guid[3];
+            generator.NextSequentialGuid(batch, 0, batch.Length);
+
+            for (int i = 0; i < exp.Length; i++)
+            {
+                var guid = Guid.Parse(exp[i]);
+                Assert.AreEqual(guid, batch[i]);
+            }
+        }
+
         [SetUp]
         public void Init()
         {

--- a/tests/MassTransit.Abstractions.Tests/NewId/NewId_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/NewId_Specs.cs
@@ -109,7 +109,7 @@
 
             IGrouping<NewId, NewId>[] duplicates = ids.GroupBy(x => x).Where(x => x.Count() > 1).ToArray();
 
-            Console.WriteLine("Duplicates: {0}", duplicates.Count());
+            Console.WriteLine("Duplicates: {0}", duplicates.Length);
 
             foreach (IGrouping<NewId, NewId> newId in duplicates)
                 Console.WriteLine("{0} {1}", newId.Key, newId.Count());
@@ -141,7 +141,7 @@
 
             IGrouping<NewId, NewId>[] duplicates = ids.GroupBy(x => x).Where(x => x.Count() > 1).ToArray();
 
-            Console.WriteLine("Duplicates: {0}", duplicates.Count());
+            Console.WriteLine("Duplicates: {0}", duplicates.Length);
 
             foreach (IGrouping<NewId, NewId> newId in duplicates)
                 Console.WriteLine("{0} {1}", newId.Key, newId.Count());


### PR DESCRIPTION
Mirroring changes

I've made some changes to `NextGuid` and `NextSequentialGuid` to improve their performance. These changes include vectorizing the functions, which has resulted in a speed improvement of 10-15%. As NextGuid is frequently called in MassTransit, this small improvement should add up.

Also added some simple assertion tests to ensure that the changes do not break any existing functionality. Additionally, I've made some minor code improvements.

See [original pr](https://github.com/phatboyg/NewId/pull/26) for more details.