### PR TITLE
Cosmos: Support AAD RBAC via TokenCredential

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,8 +228,8 @@ jobs:
 
       - name: Test CosmosDB
         env:
-          MT_COSMOS_ENDPOINT: ${{ secrets.AZURE_COSMOSENDPOINT }}
-          MT_COSMOS_KEY: ${{ secrets.AZURE_COSMOSKEY }}
+          MT_COSMOS_ACCOUNT_ENDPOINT: ${{ secrets.AZURE_COSMOSENDPOINT }}
+          MT_COSMOS_ACCOUNT_KEY: ${{ secrets.AZURE_COSMOSKEY }}
         run: dotnet test -c Release --logger:"console;verbosity=normal" --filter "Category!=Flaky&Category!=Integration"
         working-directory: tests/MassTransit.Azure.Cosmos.Tests
   test-dapper:

--- a/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/CosmosAuthSettings.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/CosmosAuthSettings.cs
@@ -1,0 +1,53 @@
+﻿using Azure.Core;
+
+namespace MassTransit.AzureCosmos
+{
+    public class CosmosAuthSettings
+    {
+        public CosmosAuthSettings() { }
+
+        public CosmosAuthSettings(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }
+
+        public CosmosAuthSettings(string accountEndpoint, string authKeyOrResourceToken)
+        {
+            AccountEndpoint = accountEndpoint;
+            AuthKeyOrResourceToken = authKeyOrResourceToken;
+        }
+
+        public CosmosAuthSettings(string accountEndpoint, TokenCredential tokenCredential)
+        {
+            AccountEndpoint = accountEndpoint;
+            TokenCredential = tokenCredential;
+        }
+
+        /// <summary>
+        /// The account endpoint to connect to Cosmos DB
+        /// </summary>
+        public string AccountEndpoint { get; set; }
+
+        /// <summary>
+        /// The cosmos account key or resource token to use to connect to Cosmos DB
+        /// </summary>
+        /// <remarks>
+        /// This property cannot be used if <see cref="TokenCredential" /> is being used.
+        /// </remarks>
+        public string AuthKeyOrResourceToken { get; set; }
+
+        /// <summary>
+        /// The connection string to use to connect to Cosmos DB
+        /// </summary>
+        /// <remarks>
+        /// This property cannot be used if <see cref="TokenCredential" /> or
+        /// <see cref="AuthKeyOrResourceToken" /> is being used.
+        /// </remarks>
+        public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// The token credential to use to connect to Cosmos DB
+        /// </summary>
+        public TokenCredential TokenCredential { get; set; }
+    }
+}

--- a/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/CosmosClientFactory.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/CosmosClientFactory.cs
@@ -1,0 +1,28 @@
+﻿using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+
+namespace MassTransit.AzureCosmos
+{
+    internal static class CosmosClientFactory
+    {
+        public static CosmosClient CreateClient(CosmosAuthSettings authSettings, CosmosClientOptions clientOptions)
+        {
+            if (authSettings.TokenCredential != null)
+            {
+                return new CosmosClient(authSettings.AccountEndpoint, authSettings.TokenCredential, clientOptions);
+            }
+            else if (authSettings.ConnectionString != null)
+            {
+                return new CosmosClient(authSettings.ConnectionString, clientOptions);
+            }
+            else if (authSettings.AuthKeyOrResourceToken != null)
+            {
+                return new CosmosClient(authSettings.AccountEndpoint, authSettings.AuthKeyOrResourceToken, clientOptions);
+            }
+            else
+            {
+                return new CosmosClient(authSettings.AccountEndpoint, new DefaultAzureCredential(), clientOptions);
+            }
+        }
+    }
+}

--- a/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/NewtonsoftJsonCosmosClientFactory.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/NewtonsoftJsonCosmosClientFactory.cs
@@ -19,18 +19,14 @@ namespace MassTransit.AzureCosmos
         IDisposable
     {
         readonly ConcurrentDictionary<Type, Lazy<CosmosClient>> _clients;
-        readonly string _endpoint;
-        readonly string _key;
+        readonly CosmosAuthSettings _authSettings;
 
-        public NewtonsoftJsonCosmosClientFactory(string endpoint, string key)
+        public NewtonsoftJsonCosmosClientFactory(CosmosAuthSettings authSettings)
         {
-            if (string.IsNullOrWhiteSpace(endpoint))
-                throw new ArgumentNullException(nameof(endpoint));
-            if (string.IsNullOrWhiteSpace(key))
-                throw new ArgumentNullException(nameof(key));
+            if (authSettings == null)
+                throw new ArgumentNullException(nameof(authSettings));
 
-            _endpoint = endpoint;
-            _key = key;
+            _authSettings = authSettings;
 
             _clients = new ConcurrentDictionary<Type, Lazy<CosmosClient>>();
         }
@@ -61,7 +57,7 @@ namespace MassTransit.AzureCosmos
                 if (serializerSettings != null)
                     clientOptions.Serializer = new NewtonsoftJsonCosmosSerializer(serializerSettings);
 
-                return new CosmosClient(_endpoint, _key, clientOptions);
+                return CosmosClientFactory.CreateClient(_authSettings, clientOptions);
             });
         }
 

--- a/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/SystemTextJsonCosmosClientFactory.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/AzureCosmos/SystemTextJsonCosmosClientFactory.cs
@@ -4,6 +4,7 @@ namespace MassTransit.AzureCosmos
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Text.Json;
+    using System.Windows.Input;
     using Microsoft.Azure.Cosmos;
     using Saga;
     using Serialization;
@@ -18,19 +19,15 @@ namespace MassTransit.AzureCosmos
         IDisposable
     {
         readonly ConcurrentDictionary<Type, Lazy<CosmosClient>> _clients;
-        readonly string _endpoint;
-        readonly string _key;
+        readonly CosmosAuthSettings _authSettings; 
         readonly JsonNamingPolicy _namingPolicy;
 
-        public SystemTextJsonCosmosClientFactory(string endpoint, string key, JsonNamingPolicy namingPolicy)
+        public SystemTextJsonCosmosClientFactory(CosmosAuthSettings authSettings, JsonNamingPolicy namingPolicy)
         {
-            if (string.IsNullOrWhiteSpace(endpoint))
-                throw new ArgumentNullException(nameof(endpoint));
-            if (string.IsNullOrWhiteSpace(key))
-                throw new ArgumentNullException(nameof(key));
+            if (authSettings == null)
+                throw new ArgumentNullException(nameof(authSettings));
 
-            _endpoint = endpoint;
-            _key = key;
+            _authSettings = authSettings;
             _namingPolicy = namingPolicy;
 
             _clients = new ConcurrentDictionary<Type, Lazy<CosmosClient>>();
@@ -62,7 +59,7 @@ namespace MassTransit.AzureCosmos
                 if (options != null)
                     clientOptions.Serializer = new SystemTextJsonCosmosSerializer(options);
 
-                return new CosmosClient(_endpoint, _key, clientOptions);
+                return CosmosClientFactory.CreateClient(_authSettings, clientOptions);
             });
         }
 

--- a/src/Persistence/MassTransit.Azure.Cosmos/Configuration/AzureCosmosEmulatorConstants.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/Configuration/AzureCosmosEmulatorConstants.cs
@@ -2,7 +2,7 @@ namespace MassTransit
 {
     public static class AzureCosmosEmulatorConstants
     {
-        public const string EndpointUri = "https://localhost:8081/";
-        public const string Key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        public const string AccountEndpoint = "https://localhost:8081/";
+        public const string AccountKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="; 
     }
 }

--- a/src/Persistence/MassTransit.Azure.Cosmos/Configuration/ICosmosSagaRepositoryConfigurator.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/Configuration/ICosmosSagaRepositoryConfigurator.cs
@@ -3,17 +3,23 @@ namespace MassTransit
 {
     using System;
     using System.Text.Json;
+    using Azure.Core;
     using Microsoft.Azure.Cosmos;
 
 
     public interface ICosmosSagaRepositoryConfigurator
     {
-        string EndpointUri { set; }
-        string Key { set; }
+        string AccountEndpoint { set; }
+
+        string AuthKeyOrResourceToken { set; }
+
+        string ConnectionString { set; }
+
+        string CollectionId { set; }
 
         string DatabaseId { set; }
 
-        string CollectionId { set; }
+        TokenCredential TokenCredential { set; }
 
         /// <summary>
         /// Set the JSON naming policy, which defaults to CamelCase, to something else, or NULL to use the default PascalCase.

--- a/src/Persistence/MassTransit.Azure.Cosmos/MassTransit.Azure.Cosmos.csproj
+++ b/src/Persistence/MassTransit.Azure.Cosmos/MassTransit.Azure.Cosmos.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />

--- a/tests/MassTransit.Azure.Cosmos.Tests/Configuration.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/Configuration.cs
@@ -6,16 +6,18 @@ namespace MassTransit.Azure.Cosmos.Tests
 
     public static class Configuration
     {
-        public static string EndpointUri =>
-            TestContext.Parameters.Exists("CosmosEndpoint")
-                ? TestContext.Parameters.Get("CosmosEndpoint")
-                : Environment.GetEnvironmentVariable("MT_COSMOS_ENDPOINT")
-                ?? AzureCosmosEmulatorConstants.EndpointUri;
+        public static string AccountEndpoint =>
+            TestContext.Parameters.Exists("CosmosAccountEndpoint")
+                ? TestContext.Parameters.Get("CosmosAccountEndpoint")
+                : Environment.GetEnvironmentVariable("MT_COSMOS_ACCOUNT_ENDPOINT")
+                ?? AzureCosmosEmulatorConstants.AccountEndpoint;
 
-        public static string Key =>
-            TestContext.Parameters.Exists("CosmosKey")
-                ? TestContext.Parameters.Get("CosmosKey")
-                : Environment.GetEnvironmentVariable("MT_COSMOS_KEY")
-                ?? AzureCosmosEmulatorConstants.Key;
+        public static string AccountKey =>
+            TestContext.Parameters.Exists("CosmosAccountKey")
+                ? TestContext.Parameters.Get("CosmosAccountKey")
+                : Environment.GetEnvironmentVariable("MT_COSMOS_ACCOUNT_KEY")
+                ?? AzureCosmosEmulatorConstants.AccountKey;
+
+        public static string ConnectionString => $"AccountEndpoint={AccountEndpoint};AccountKey={AccountKey}";
     }
 }

--- a/tests/MassTransit.Azure.Cosmos.Tests/Container_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/Container_Specs.cs
@@ -1,9 +1,12 @@
+using Azure.Identity;
+
 namespace MassTransit.Azure.Cosmos.Tests
 {
     namespace ContainerTests
     {
         using System;
         using System.Threading.Tasks;
+        using global::Azure.Identity;
         using Microsoft.Extensions.DependencyInjection;
         using NUnit.Framework;
         using TestFramework;
@@ -24,8 +27,8 @@ namespace MassTransit.Azure.Cosmos.Tests
                         configurator.AddSagaStateMachine<TestStateMachineSaga, TestInstance>()
                             .CosmosRepository(r =>
                             {
-                                r.EndpointUri = Configuration.EndpointUri;
-                                r.Key = Configuration.Key;
+                                r.AccountEndpoint = Configuration.AccountEndpoint;
+                                r.AuthKeyOrResourceToken = Configuration.AccountKey;
 
                                 r.DatabaseId = "sagaTest";
                                 r.CollectionId = "TestInstance";
@@ -81,8 +84,8 @@ namespace MassTransit.Azure.Cosmos.Tests
                         x.AddSagaStateMachine<TestStateMachineSaga, TestInstance>()
                             .CosmosRepository(r =>
                             {
-                                r.EndpointUri = Configuration.EndpointUri;
-                                r.Key = Configuration.Key;
+                                r.AccountEndpoint = Configuration.AccountEndpoint;
+                                r.AuthKeyOrResourceToken = Configuration.AccountKey;
 
                                 r.DatabaseId = "sagaTest";
                                 r.CollectionId = "TestInstance";
@@ -135,7 +138,7 @@ namespace MassTransit.Azure.Cosmos.Tests
                 var clientName = Guid.NewGuid().ToString();
 
                 _provider = new ServiceCollection()
-                    .AddCosmosClientFactory(Configuration.EndpointUri, Configuration.Key)
+                    .AddCosmosClientFactory(Configuration.AccountEndpoint, Configuration.AccountKey)
                     .AddMassTransit(configurator =>
                     {
                         configurator.AddSagaStateMachine<TestStateMachineSaga, TestInstance>()

--- a/tests/MassTransit.Azure.Cosmos.Tests/Future_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/Future_Specs.cs
@@ -20,8 +20,8 @@ namespace MassTransit.Azure.Cosmos.Tests
             configurator.AddSagaRepository<FutureState>()
                 .CosmosRepository(r =>
                 {
-                    r.EndpointUri = Configuration.EndpointUri;
-                    r.Key = Configuration.Key;
+                    r.AccountEndpoint = Configuration.AccountEndpoint;
+                    r.AuthKeyOrResourceToken = Configuration.AccountKey;
 
                     r.DatabaseId = DatabaseId;
                     r.CollectionId = CollectionId;

--- a/tests/MassTransit.Azure.Cosmos.Tests/Future_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/Future_Specs.cs
@@ -15,21 +15,29 @@ namespace MassTransit.Azure.Cosmos.Tests
         void Configure(ICosmosSagaRepositoryConfigurator configurator);
     }
 
-    class AzureCosmosTestTokenCredentialConfigurator : IAzureCosmosTestAuthenticationConfigurator
-    {
-        public void Configure(ICosmosSagaRepositoryConfigurator configurator)
-        {
-            configurator.AccountEndpoint = Configuration.AccountEndpoint;
-            configurator.TokenCredential = new DefaultAzureCredential();
-        }
-    }
-
     class AzureCosmosTestAccountKeyConfigurator : IAzureCosmosTestAuthenticationConfigurator
     {
         public void Configure(ICosmosSagaRepositoryConfigurator configurator)
         {
             configurator.AccountEndpoint = Configuration.AccountEndpoint;
             configurator.AuthKeyOrResourceToken = Configuration.AccountKey;
+        }
+    }
+
+    class AzureCosmosTestConnectionStringConfigurator : IAzureCosmosTestAuthenticationConfigurator
+    {
+        public void Configure(ICosmosSagaRepositoryConfigurator configurator)
+        {
+            configurator.ConnectionString = Configuration.ConnectionString;
+        }
+    }
+
+    class AzureCosmosTestTokenCredentialConfigurator : IAzureCosmosTestAuthenticationConfigurator
+    {
+        public void Configure(ICosmosSagaRepositoryConfigurator configurator)
+        {
+            configurator.AccountEndpoint = Configuration.AccountEndpoint;
+            configurator.TokenCredential = new DefaultAzureCredential();
         }
     }
 
@@ -92,6 +100,16 @@ namespace MassTransit.Azure.Cosmos.Tests
     {
         public AzureCosmosTokenCredentialFryFutureSpecs()
             : base(new AzureCosmosFutureTestFixtureConfigurator(new AzureCosmosTestTokenCredentialConfigurator()))
+        {
+        }
+    }
+
+    [TestFixture]
+    public class AzureCosmosConnectionStringFryFutureSpecs :
+        FryFuture_Specs
+    {
+        public AzureCosmosConnectionStringFryFutureSpecs()
+            : base(new AzureCosmosFutureTestFixtureConfigurator(new AzureCosmosTestConnectionStringConfigurator()))
         {
         }
     }

--- a/tests/MassTransit.Azure.Cosmos.Tests/MissingInstance_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/MissingInstance_Specs.cs
@@ -147,8 +147,8 @@
                         x.AddSagaStateMachine<MissingInstanceStateMachine, MissingInstance>()
                             .CosmosRepository(r =>
                             {
-                                r.EndpointUri = Configuration.EndpointUri;
-                                r.Key = Configuration.Key;
+                                r.AccountEndpoint = Configuration.AccountEndpoint;
+                                r.AuthKeyOrResourceToken = Configuration.AccountKey;
 
                                 r.DatabaseId = "sagaTest";
                                 r.CollectionId = "TestInstance";
@@ -190,7 +190,7 @@
             {
                 _databaseName = "sagaTest";
                 _collectionName = "TestInstance";
-                _cosmosClient = new CosmosClient(Configuration.EndpointUri, Configuration.Key,
+                _cosmosClient = new CosmosClient(Configuration.AccountEndpoint, Configuration.AccountKey,
                     new CosmosClientOptions
                     {
                         Serializer = new SystemTextJsonCosmosSerializer(AzureCosmosSerializerExtensions.GetSerializerOptions<MissingInstance>())
@@ -270,7 +270,7 @@
             {
                 _databaseName = "masstransitunittests";
                 _collectionName = "sagas";
-                _cosmosClient = new CosmosClient(Configuration.EndpointUri, Configuration.Key,
+                _cosmosClient = new CosmosClient(Configuration.AccountEndpoint, Configuration.AccountKey,
                     new CosmosClientOptions
                     {
                         Serializer = new NewtonsoftJsonCosmosSerializer(AzureCosmosSerializerExtensions.GetSagaRenameSettings<MissingInstance>())

--- a/tests/MassTransit.Azure.Cosmos.Tests/Saga/Data/SagaRepository.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/Saga/Data/SagaRepository.cs
@@ -23,7 +23,7 @@
 
         SagaRepository()
         {
-            Client = new CosmosClient(Configuration.EndpointUri, Configuration.Key,
+            Client = new CosmosClient(Configuration.AccountEndpoint, Configuration.AccountKey,
                 new CosmosClientOptions { Serializer = new NewtonsoftJsonCosmosSerializer(AzureCosmosSerializerExtensions.GetSagaRenameSettings<TSaga>()) });
         }
 

--- a/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyNoRetry_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyNoRetry_Specs.cs
@@ -138,7 +138,7 @@
         {
             _databaseName = "choirSagas";
             _collectionName = "sagas";
-            _cosmosClient = new CosmosClient(Configuration.EndpointUri, Configuration.Key,
+            _cosmosClient = new CosmosClient(Configuration.AccountEndpoint, Configuration.AccountKey,
                 new CosmosClientOptions
                 {
                     Serializer = new SystemTextJsonCosmosSerializer(AzureCosmosSerializerExtensions.GetSerializerOptions<ChoirStateOptimistic>())

--- a/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyOptimistic_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyOptimistic_Specs.cs
@@ -146,7 +146,7 @@
         {
             _databaseName = "choirSagas";
             _collectionName = "sagas";
-            _cosmosClient = new CosmosClient(Configuration.EndpointUri, Configuration.Key,
+            _cosmosClient = new CosmosClient(Configuration.AccountEndpoint, Configuration.AccountKey,
                 new CosmosClientOptions
                 {
                     Serializer = new SystemTextJsonCosmosSerializer(AzureCosmosSerializerExtensions.GetSerializerOptions<ChoirStateOptimistic>())

--- a/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmos_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmos_Specs.cs
@@ -77,7 +77,7 @@
         {
             _databaseName = "shoppingChoreSagas";
             _collectionName = "sagas";
-            _cosmosClient = new CosmosClient(Configuration.EndpointUri, Configuration.Key,
+            _cosmosClient = new CosmosClient(Configuration.AccountEndpoint, Configuration.AccountKey,
                 new CosmosClientOptions
                 {
                     Serializer = new SystemTextJsonCosmosSerializer(AzureCosmosSerializerExtensions.GetSerializerOptions<ShoppingChore>())


### PR DESCRIPTION
Added a few more methods to authenticate to Cosmos: ConnectionString/TokenCredential.

Unfortunately RBAC doesn't support creating/deleting databases/containers, so to test that's working I had to manually create a DB, setup RBAC, create the databases/containers and finally plum through the TokenCredentials. 

I've added created/validated a test to exercise TokenCredentials, AzureCosmosTokenCredentialFryFutureSpecs, but I've marked it as ignored since it requires valid credentials and that won't work the Cosmos Emulator. I've added a description above the test fixture indicating what's necessary to get it setup.