### PR TITLE
Update InboxCleanupService.cs

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/InboxCleanupService.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/InboxCleanupService.cs
@@ -48,6 +48,11 @@ namespace MassTransit.EntityFrameworkCoreIntegration
                 catch (OperationCanceledException exception) when (exception.CancellationToken == stoppingToken)
                 {
                 }
+                catch (DbUpdateConcurrencyException exception)
+                {
+                    _logger.LogDebug(exception, "Got DbUpdateException which is expected if there are more than one InboxCleanupService");
+                    removed = 0;
+                }                
                 catch (Exception exception)
                 {
                     _logger.LogError(exception, "CleanUpInboxState faulted");


### PR DESCRIPTION
Change log level and message for DbUpdateConcurrencyExceptions when Cleaning up inbox state.

No changes outside log level, which will be Debug if the exception is `DbUpdateConcurrencyExceptions` and the log message will state that this was a `DbUpdateConcurrencyExceptions`.

Fix for issue discussed in: https://github.com/MassTransit/MassTransit/discussions/3644

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
