### PR TITLE
Mark the Analyzers assembly as a DevelopmentDependency

### DIFF
--- a/src/MassTransit.Analyzers/MassTransit.Analyzers.csproj
+++ b/src/MassTransit.Analyzers/MassTransit.Analyzers.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
By marking the MassTransit.Analyzers as a DevelopmentDependency it will not be included in the publish folder of application that uses it.

When installing the NuGet package the csproj should look like:
```xml
<PackageReference Include="MassTransit.Analyzers" Version="8.0.10">
	<PrivateAssets>all</PrivateAssets>
	<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
</PackageReference>
```

Instead of:
```xml
<PackageReference Include="MassTransit.Analyzers" Version="8.0.10" />
```

More information on https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference