### PR TITLE
Store, check and cleanup StackTrace

### DIFF
--- a/src/MassTransit.Abstractions/Util/ExceptionUtil.cs
+++ b/src/MassTransit.Abstractions/Util/ExceptionUtil.cs
@@ -32,10 +32,11 @@ namespace MassTransit.Util
 
         public static string GetStackTrace(Exception? exception)
         {
-            if (string.IsNullOrWhiteSpace(exception?.StackTrace))
+            var stackTrace = exception?.StackTrace;
+            if (string.IsNullOrWhiteSpace(stackTrace))
                 return "";
 
-            return _cleanup.Replace(exception!.StackTrace, "");
+            return _cleanup.Replace(stackTrace, "");
         }
 
         public static IDictionary<string, object> GetExceptionHeaderDictionary(Exception exception)


### PR DESCRIPTION
Fixes weird exceptions (changing their StackTrace) leading to `ExceptionUtil` trying to '_cleanup' `null` `StackTrace`s.

We've got the following situation, that I can only explain by the above reason...

```
at System.Text.RegularExpressions.ThrowHelper.ThrowArgumentNullException(ExceptionArgument arg)
at System.Text.RegularExpressions.Regex.Replace(String input, String replacement)
at MassTransit.Util.ExceptionUtil.GetStackTrace(Exception exception) in /_/src/MassTransit.Abstractions/Util/ExceptionUtil.cs:line 38
at MassTransit.Events.FaultExceptionInfo..ctor(Exception exception) in /_/src/MassTransit/Events/FaultExceptionInfo.cs:line 44
at MassTransit.Events.FaultEvent`1.GetExceptions(Exception exception) in /_/src/MassTransit/Events/FaultEvent.cs:line 46
at MassTransit.Events.FaultEvent`1..ctor(T message, Nullable`1 faultedMessageId, HostInfo host, Exception exception, String[] faultMessageTypes) in /_/src/MassTransit/Events/FaultEvent.cs:line 17
at MassTransit.Context.BaseConsumeContext.GenerateFault[T](ConsumeContext`1 context, Exception exception)
at MassTransit.Context.BaseConsumeContext.NotifyFaulted[T](ConsumeContext`1 context, TimeSpan duration, String consumerType, Exception exception) in /_/src/MassTransit/Contexts/Context/BaseConsumeContext.cs:line 187
at MassTransit.Middleware.ConsumerMessageFilter`2.MassTransit.IFilter<MassTransit.ConsumeContext<TMessage>>.Send(ConsumeContext`1 context, IPipe`1 next) in /_/src/MassTransit/Middleware/ConsumerMessageFilter.cs:line 73
at AFV.Common.Messaging.CredentialsFilter`1.Send(ConsumeContext`1 context, IPipe`1 next) in H:\_work\4559\s\src\Common\Common.Messaging\CredentialsFilter.cs:line 33
at MassTransit.Middleware.ScopedConsumeFilter`2.Send(ConsumeContext`1 context, IPipe`1 next) in /_/src/MassTransit/Middleware/ScopedConsumeFilter.cs:line 26
at MassTransit.Middleware.ScopedConsumeFilter`2.Send(ConsumeContext`1 context, IPipe`1 next) in /_/src/MassTransit/Middleware/ScopedConsumeFilter.cs:line 26
at MassTransit.Middleware.TeeFilter`1.<>c__DisplayClass5_0.<<Send>g__SendAsync|1>d.MoveNext() in /_/src/MassTransit/Middleware/TeeFilter.cs:line 43
--- End of stack trace from previous location ---
at MassTransit.Middleware.OutputPipeFilter`2.SendToOutput(IPipe`1 next, TOutput pipeContext) in /_/src/MassTransit/Middleware/OutputPipeFilter.cs:line 110
at MassTransit.Middleware.OutputPipeFilter`2.SendToOutput(IPipe`1 next, TOutput pipeContext) in /_/src/MassTransit/Middleware/OutputPipeFilter.cs:line 110
at MassTransit.Middleware.DeserializeFilter.Send(ReceiveContext context, IPipe`1 next) in /_/src/MassTransit/Middleware/DeserializeFilter.cs:line 45
at MassTransit.Middleware.RescueFilter`2.MassTransit.IFilter<TContext>.Send(TContext context, IPipe`1 next) in /_/src/MassTransit/Middleware/RescueFilter.cs:line 63
```