### PR TITLE
Expose the underlying outbox transaction

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/DbContextOutboxConsumeContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/DbContextOutboxConsumeContext.cs
@@ -40,6 +40,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
         public override long? LastSequenceNumber => _inboxState.LastSequenceNumber;
 
         public Guid TransactionId => _transaction.TransactionId;
+        public IDbContextTransaction Transaction => _transaction;
 
         public override async Task SetConsumed()
         {

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/DbTransactionContext.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/DbTransactionContext.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.EntityFrameworkCoreIntegration
 {
     using System;
+    using Microsoft.EntityFrameworkCore.Storage;
 
 
     /// <summary>
@@ -9,5 +10,6 @@ namespace MassTransit.EntityFrameworkCoreIntegration
     public interface DbTransactionContext
     {
         Guid TransactionId { get; }
+        IDbContextTransaction Transaction { get; }
     }
 }


### PR DESCRIPTION
This would allow a solution to have separate DbContexts participate in the Outbox Db Transaction.

### First
You would have to have a db context that is dedicated to just having the Mass Transit Outbox Entities

`MassTransitOutboxDbContext`

This DbContext would only have these entity configurations:

```csharp
modelBuilder.AddInboxStateEntity();
modelBuilder.AddOutboxMessageEntity();
modelBuilder.AddOutboxStateEntity();
```
Thats it.

Then make sure that you use that db context in the configuration
`x.AddEntityFrameworkOutbox<MassTransitOutboxDbContext>(o =>`

### Then
You could make any additional number of db contexts.

SalesDbContext
WarehouseDbContext

And these db contexts, within a consumer, MUST use the same transaction

```csharp
public class OrderCreatedConsumer :
    IConsumer<OrderCreated>
{
    readonly SalesDbContext _dbContext;

    public AddEventAttendeeConsumer(SalesDbContext dbContext)
    {
        _dbContext = dbContext;
    }

    public async Task Consume(ConsumeContext<OrderCreated> context)
    {
		// enlist in the outbox transaction if it exists
		if(context.TryGetPayload(out DbTransactionContext transaction))
		{
			_dbContext.Database.UseTransaction(transaction.GetDbTransaction());
		}
		
        _dbContext.SomeEntity.Add(...);
		
		await _dbContext.SaveChangesAsync();
    }
}
```

The only Caveat is, these dbContexts, MUST be using the same underying db connection, as mentioned here https://learn.microsoft.com/en-us/ef/core/saving/transactions#allow-connection-to-be-externally-provided