### PR TITLE
Add custom schema section to Saga/EF Core docs

### DIFF
--- a/docs/usage/sagas/efcore.md
+++ b/docs/usage/sagas/efcore.md
@@ -126,7 +126,7 @@ services.AddMassTransit(cfg =>
 #### Multiple schemas
 
 In case there are multiple schemas defined for your models you need to define them in code, and there are a few different ways to do that.
-**https://learn.microsoft.com/en-us/ef/core/modeling/entity-types?tabs=data-annotations#table-schema**
+https://learn.microsoft.com/en-us/ef/core/modeling/entity-types?tabs=data-annotations#table-schema
 
 
 #### Single DbContext

--- a/docs/usage/sagas/efcore.md
+++ b/docs/usage/sagas/efcore.md
@@ -81,6 +81,54 @@ services.AddMassTransit(cfg =>
 });
 ```
 
+### Custom schemas
+
+#### Single schema
+
+In case there is a custom schema set up in your database and you are relying on the user credentials from the `ConnectionString` to access correct schema you need to define a custom implementation of `SqlLockStatementProvider` where you can define that custom schema.
+
+```cs
+public class CustomSqlLockStatementProvider : SqlLockStatementProvider
+{
+    const string DefaultSchemaName = "custom_schema";
+
+    public CSqlLockStatementProvider(bool enableSchemaCaching = true)
+        : base(DefaultSchemaName, new SqlServerLockStatementFormatter(), enableSchemaCaching)
+    {
+    }
+} 
+```
+
+And then use it in the configuration.
+
+```cs
+services.AddMassTransit(cfg =>
+{
+    cfg.AddSagaStateMachine<OrderStateMachine, OrderState>()
+        .EntityFrameworkRepository(r =>
+        {
+            r.ConcurrencyMode = ConcurrencyMode.Pessimistic; // or use Optimistic, which requires RowVersion
+            
+            r.LockStatementProvider = new CustomSqlLockStatementProvider();
+
+            r.AddDbContext<DbContext, OrderStateDbContext>((provider,builder) =>
+            {
+                builder.UseSqlServer(connectionString, m =>
+                {
+                    m.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name);
+                    m.MigrationsHistoryTable($"__{nameof(OrderStateDbContext)}");
+                });
+            });
+        });
+});
+```
+
+#### Multiple schemas
+
+In case there are multiple schemas defined for your models you need to define them in code, and there are a few different ways to do that.
+**https://learn.microsoft.com/en-us/ef/core/modeling/entity-types?tabs=data-annotations#table-schema**
+
+
 #### Single DbContext
 
 > New in 7.0.5


### PR DESCRIPTION
This section explains how a developer can use a custom schema for storing state machine states when using MT and EF Core.
