### PR TITLE
Replace deprecated GitHub action method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -537,9 +537,9 @@ jobs:
       - id: v
         run: |
           if [ "${{ github.ref }}" = 'refs/heads/master' ]; then
-            echo "::set-output name=version::${MASSTRANSIT_VERSION}"
+            echo "version=${MASSTRANSIT_VERSION}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=version::${MASSTRANSIT_VERSION}-develop.${{ github.run_number }}"
+            echo "version=${MASSTRANSIT_VERSION}-develop.${{ github.run_number }}" >> $GITHUB_OUTPUT
           fi
 
   publish:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/