### PR TITLE
Update docs/quick-start/in-memory.md

### DIFF
--- a/docs/quick-starts/in-memory.md
+++ b/docs/quick-starts/in-memory.md
@@ -40,11 +40,21 @@ $ dotnet new mtconsumer
 
 ### Overview of the code
 
-When you open the project you will see that you have 3 class files.
+When you open the project you will see that you have 1 class file.
 
 - `Program.cs` is the standard entry point and here we configure the host builder.
-- `Consumers/GettingStartedConsumer.cs` is the MassTransit [Consumer](/usage/consumers)
-- `Contracts/GettingStarted.cs` is an example message
+
+### Create a Contract
+Create a `Contracts` folder in the root of your project, and within that folder create a file named `GettingStarted.cs` with the following contents:
+
+``` cs
+namespace GettingStarted.Contracts;
+
+public record GettingStarted() 
+{
+    public string Value { get; init; }
+}
+```
 
 ### Add A BackgroundService
 
@@ -60,9 +70,9 @@ In `Program.cs` at the bottom of the `ConfigureServices` method add
 services.AddHostedService<Worker>();
 ```
 
-### Update your Consumer
+### Create a Consumer
 
-In your `Consumers` folder, edit the `GettingStartedConsumer` with a logging statement that looks like this.
+Create a `Consumers` folder in the root of your project, and within that folder create a file named `GettingStartedConsumer.cs` with the following contents:
 
 <<< @/docs/code/quickstart/GettingStartedConsumer.cs
 


### PR DESCRIPTION
It appears that the ['Overview of the code' section](https://github.com/MassTransit/MassTransit/blob/develop/docs/quick-starts/in-memory.md#overview-of-the-code) of the 'In-Memory Quickstart' docs is out of sync with the files that are currently generated by the [MassTransit Worker Template](https://masstransit-project.com/usage/templates.html#masstransit-worker). The template does not appear to generate the Consumer or the Contract that are currently mentioned in the 'Overview of the code' section.

This PR updates the aforementioned section and adds or edits other sections indicating how to manually create the consumer and contract files.

This change was tested using VS Code's Markdown Preview feature:
![image](https://user-images.githubusercontent.com/20759256/215340463-c553df2b-7b17-4e27-b13a-16576fcae70a.png)
