### PR TITLE
Add Dependent when dependency added

### DIFF
--- a/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointConfigurator.cs
+++ b/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointConfigurator.cs
@@ -10,7 +10,8 @@ namespace MassTransit
     /// </summary>
     public interface IReceiveEndpointConfigurator :
         IEndpointConfigurator,
-        IReceiveEndpointObserverConnector
+        IReceiveEndpointDependencyConnector,
+        IReceiveEndpointDependentConnector
     {
         /// <summary>
         /// Returns the input address of the receive endpoint
@@ -79,11 +80,5 @@ namespace MassTransit
         /// Clears all message serialization configuration
         /// </summary>
         void ClearSerialization();
-
-        /// <summary>
-        /// Add the observable receive endpoint as a dependency
-        /// </summary>
-        /// <param name="connector"></param>
-        void AddDependency(IReceiveEndpointObserverConnector connector);
     }
 }

--- a/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependencyConnector.cs
+++ b/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependencyConnector.cs
@@ -1,0 +1,11 @@
+namespace MassTransit
+{
+    public interface IReceiveEndpointDependencyConnector
+    {
+        /// <summary>
+        /// Add the observable receive endpoint as a dependent
+        /// </summary>
+        /// <param name="dependent"></param>
+        void AddDependency(IReceiveEndpointDependentConnector dependent);
+    }
+}

--- a/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependentConnector.cs
+++ b/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependentConnector.cs
@@ -1,0 +1,12 @@
+namespace MassTransit
+{
+    public interface IReceiveEndpointDependentConnector :
+        IReceiveEndpointObserverConnector
+    {
+        /// <summary>
+        /// Add the observable receive endpoint as a dependency
+        /// </summary>
+        /// <param name="dependency"></param>
+        void AddDependent(IReceiveEndpointObserverConnector dependency);
+    }
+}

--- a/src/MassTransit.Abstractions/Transports/IReceiveEndpointDependent.cs
+++ b/src/MassTransit.Abstractions/Transports/IReceiveEndpointDependent.cs
@@ -1,0 +1,13 @@
+namespace MassTransit.Transports
+{
+    using System.Threading.Tasks;
+
+
+    public interface IReceiveEndpointDependent
+    {
+        /// <summary>
+        /// The task which is completed once the receive endpoint is completed
+        /// </summary>
+        Task Completed { get; }
+    }
+}

--- a/src/MassTransit/Configuration/Configuration/IReceiveEndpointConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/IReceiveEndpointConfiguration.cs
@@ -8,7 +8,7 @@
 
     public interface IReceiveEndpointConfiguration :
         IEndpointConfiguration,
-        IReceiveEndpointObserverConnector
+        IReceiveEndpointDependentConnector
     {
         IConsumePipe ConsumePipe { get; }
 
@@ -32,7 +32,12 @@
         /// <summary>
         /// Completed once the receive endpoint dependencies are ready
         /// </summary>
-        Task Dependencies { get; }
+        Task DependenciesReady { get; }
+
+        /// <summary>
+        /// Completed once the receive endpoint dependents are completed
+        /// </summary>
+        Task DependentsCompleted { get; }
 
         /// <summary>
         /// Create the receive pipe, using the endpoint configuration

--- a/src/MassTransit/Configuration/Configuration/ReceiverConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/ReceiverConfiguration.cs
@@ -35,13 +35,17 @@ namespace MassTransit.Configuration
             set { }
         }
 
-        public void AddDependency(IReceiveEndpointObserverConnector connector)
+        public void AddDependency(IReceiveEndpointDependentConnector dependent)
         {
         }
 
         ConnectHandle IReceiveEndpointObserverConnector.ConnectReceiveEndpointObserver(IReceiveEndpointObserver observer)
         {
             return _configuration.ConnectReceiveEndpointObserver(observer);
+        }
+
+        public void AddDependent(IReceiveEndpointObserverConnector dependency)
+        {
         }
 
         public void ConfigureMessageTopology<T>(bool enabled = true)

--- a/src/MassTransit/InMemoryTransport/InMemoryTransport/InMemoryReceiveTransport.cs
+++ b/src/MassTransit/InMemoryTransport/InMemoryTransport/InMemoryReceiveTransport.cs
@@ -131,16 +131,16 @@ namespace MassTransit.InMemoryTransport
                 context.CreateScope("inMemory");
             }
 
-            async Task ReceiveTransportHandle.Stop(CancellationToken cancellationToken)
+            Task ReceiveTransportHandle.Stop(CancellationToken cancellationToken)
             {
-                await this.Stop("Stop Receive Transport", cancellationToken).ConfigureAwait(false);
+                return this.Stop("Stop Receive Transport", cancellationToken);
             }
 
             async Task Startup()
             {
                 try
                 {
-                    await _context.Dependencies.OrCanceled(Stopping).ConfigureAwait(false);
+                    await _context.DependenciesReady.OrCanceled(Stopping).ConfigureAwait(false);
 
                     _topologyHandle = _queue.ConnectMessageReceiver(_context.TransportContext, this);
 

--- a/src/MassTransit/Transports/BaseReceiveEndpointContext.cs
+++ b/src/MassTransit/Transports/BaseReceiveEndpointContext.cs
@@ -50,7 +50,8 @@ namespace MassTransit.Transports
             _receiveObservers = configuration.ReceiveObservers;
             _transportObservers = configuration.TransportObservers;
 
-            Dependencies = configuration.Dependencies;
+            DependenciesReady = configuration.DependenciesReady;
+            DependentsCompleted = configuration.DependentsCompleted;
 
             Serialization = configuration.Serialization.CreateSerializerCollection();
 
@@ -104,7 +105,8 @@ namespace MassTransit.Transports
 
         public Uri InputAddress { get; }
 
-        public Task Dependencies { get; }
+        public Task DependenciesReady { get; }
+        public Task DependentsCompleted { get; }
 
         public bool PublishFaults { get; }
 

--- a/src/MassTransit/Transports/Contexts/ReceiveEndpointContext.cs
+++ b/src/MassTransit/Transports/Contexts/ReceiveEndpointContext.cs
@@ -41,7 +41,12 @@ namespace MassTransit.Transports
         /// <summary>
         /// Task completed when dependencies are ready
         /// </summary>
-        Task Dependencies { get; }
+        Task DependenciesReady { get; }
+
+        /// <summary>
+        /// Task completed when dependants are completed
+        /// </summary>
+        Task DependentsCompleted { get; }
 
         /// <summary>
         /// If true (the default), faults should be published when no ResponseAddress or FaultAddress are present.

--- a/src/MassTransit/Transports/ReceiveEndpoint.cs
+++ b/src/MassTransit/Transports/ReceiveEndpoint.cs
@@ -4,6 +4,7 @@ namespace MassTransit.Transports
     using System.Threading;
     using System.Threading.Tasks;
     using Events;
+    using Internals;
     using Util;
 
 
@@ -167,6 +168,8 @@ namespace MassTransit.Transports
 
             if (_handle != null)
             {
+                await _context.DependentsCompleted.OrCanceled(cancellationToken).ConfigureAwait(false);
+
                 await _context.EndpointObservers.Stopping(new ReceiveEndpointStoppingEvent(_context.InputAddress, this, removed)).ConfigureAwait(false);
 
                 await _handle.TransportHandle.Stop(cancellationToken).ConfigureAwait(false);

--- a/src/MassTransit/Transports/TransportStartExtensions.cs
+++ b/src/MassTransit/Transports/TransportStartExtensions.cs
@@ -22,7 +22,7 @@ namespace MassTransit.Transports
                 await supervisor.Send(pipe, cancellationToken).ConfigureAwait(false);
             }
 
-            await context.Dependencies.OrCanceled(cancellationToken).ConfigureAwait(false);
+            await context.DependenciesReady.OrCanceled(cancellationToken).ConfigureAwait(false);
         }
 
 

--- a/src/Transports/MassTransit.GrpcTransport/GrpcTransport/GrpcReceiveTransport.cs
+++ b/src/Transports/MassTransit.GrpcTransport/GrpcTransport/GrpcReceiveTransport.cs
@@ -118,9 +118,9 @@ namespace MassTransit.GrpcTransport
                 scope.Add("nodeAddress", _context.TransportProvider.HostNodeContext.NodeAddress);
             }
 
-            async Task ReceiveTransportHandle.Stop(CancellationToken cancellationToken)
+            Task ReceiveTransportHandle.Stop(CancellationToken cancellationToken)
             {
-                await this.Stop("Stop Receive Transport", cancellationToken).ConfigureAwait(false);
+                return this.Stop("Stop Receive Transport", cancellationToken);
             }
 
             async Task StartDispatcher()
@@ -172,7 +172,7 @@ namespace MassTransit.GrpcTransport
                 {
                     await _context.TransportProvider.StartupTask.OrCanceled(Stopping).ConfigureAwait(false);
 
-                    await _context.Dependencies.OrCanceled(Stopping).ConfigureAwait(false);
+                    await _context.DependenciesReady.OrCanceled(Stopping).ConfigureAwait(false);
 
                     var hostNodeContext = _context.TransportProvider.HostNodeContext;
 


### PR DESCRIPTION
Adding Dependents when Dependency added.
Eg:
1. A is dependency of B
2. B is started only after A
3. A is stopped only after B

Added 2 sec delay for start/stop:
```
15:26:04.474-I Configured endpoint odd-job, Consumer: MassTransit.Tests.JobConsumerTests.OddJobConsumer
15:26:04.479-I Configured endpoint odd-job-completed, Consumer: MassTransit.Tests.JobConsumerTests.OddJobCompletedConsumer
15:26:04.549-D Starting bus instances: IBus
15:26:04.551-D Starting bus: loopback://localhost/
15:26:04.569-D Endpoint Ready: loopback://localhost/job-attempt
15:26:04.569-D Endpoint Ready: loopback://localhost/job-type
15:26:04.569-D Endpoint Ready: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:04.569-D Endpoint Ready: loopback://localhost/job
15:26:04.569-D Endpoint Ready: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_rrtoyyg6ww5pd3i1bdpofi1pb3
15:26:04.569-D Endpoint Ready: loopback://localhost/odd-job-completed
15:26:06.573-D Endpoint Ready: loopback://localhost/odd-job
15:26:06.577-D Job Service starting: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:06.579-D Job Service type: MassTransit.Tests.JobConsumerTests.OddJob
15:26:06.597-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:SetConcurrentJobLimit
15:26:06.666-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:SetConcurrentJobLimit 21230000-dea5-36d1-3f94-08db02d64e80 MassTransit.Contracts.JobService.SetConcurrentJobLimit
15:26:06.667-I Job Service started: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:06.667-I Bus started: loopback://localhost/
15:26:06.675-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:SubmitJob[[MassTransit.Tests.JobConsumerTests:OddJob]]
15:26:06.694-D SAGA:MassTransit.JobTypeSaga:d7ed4f43-23e2-eac7-9da0-9bfe73f3dcd9 Created MassTransit.Contracts.JobService.SetConcurrentJobLimit
15:26:06.698-D SAGA:MassTransit.JobTypeSaga:d7ed4f43-23e2-eac7-9da0-9bfe73f3dcd9 Added MassTransit.Contracts.JobService.SetConcurrentJobLimit
15:26:06.698-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:SubmitJob[[MassTransit.Tests.JobConsumerTests:OddJob]] 21230000-dea5-36d1-9748-08db02d64e88 MassTransit.Contracts.JobService.SubmitJob<MassTransit.Tests.JobConsumerTests.OddJob>
15:26:06.704-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobSubmitted
15:26:06.710-D Job Service Instance Started: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:06.710-D Concurrent Job Limit: 1
15:26:06.714-D RECEIVE loopback://localhost/job-type 21230000-dea5-36d1-3f94-08db02d64e80 MassTransit.Contracts.JobService.SetConcurrentJobLimit MassTransit.JobTypeSaga(00:00:00.0250320)
15:26:06.717-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobSubmitted 21230000-dea5-36d1-2e30-08db02d64e8c MassTransit.Contracts.JobService.JobSubmitted
15:26:06.718-D Create send transport: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_rrtoyyg6ww5pd3i1bdpofi1pb3
15:26:06.719-D SAGA:MassTransit.JobSaga:21230000-dea5-36d1-513c-08db02d64e85 Created MassTransit.Contracts.JobService.JobSubmitted
15:26:06.719-D SAGA:MassTransit.JobSaga:21230000-dea5-36d1-513c-08db02d64e85 Added MassTransit.Contracts.JobService.JobSubmitted
15:26:06.722-D Create send transport: loopback://localhost/job-type
15:26:06.724-D SEND loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_rrtoyyg6ww5pd3i1bdpofi1pb3 21230000-dea5-36d1-6d72-08db02d64e8d MassTransit.Contracts.JobService.JobSubmissionAccepted
15:26:06.724-D RECEIVE loopback://localhost/odd-job 21230000-dea5-36d1-9748-08db02d64e88 MassTransit.Contracts.JobService.SubmitJob<MassTransit.Tests.JobConsumerTests.OddJob> MassTransit.JobService.SubmitJobConsumer<MassTransit.Tests.JobConsumerTests.OddJob>(00:00:00.0235817)
15:26:06.726-D RECEIVE loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_rrtoyyg6ww5pd3i1bdpofi1pb3 21230000-dea5-36d1-6d72-08db02d64e8d MassTransit.Contracts.JobService.JobSubmissionAccepted MassTransit.MessageHandler<MassTransit.Contracts.JobService.JobSubmissionAccepted>(00:00:00.0000538)
15:26:06.731-D RECEIVE loopback://localhost/job 21230000-dea5-36d1-2e30-08db02d64e8c MassTransit.Contracts.JobService.JobSubmitted MassTransit.JobSaga(00:00:00.0124880)
15:26:06.732-D SEND loopback://localhost/job-type 21230000-dea5-36d1-14ce-08db02d64e8f MassTransit.Contracts.JobService.AllocateJobSlot
15:26:06.737-D SAGA:MassTransit.JobTypeSaga:d7ed4f43-23e2-eac7-9da0-9bfe73f3dcd9 Used MassTransit.Contracts.JobService.AllocateJobSlot
15:26:06.742-D Allocated Job Slot: 21230000-dea5-36d1-513c-08db02d64e85 (1): loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd (1)
15:26:06.742-D Create send transport: loopback://localhost/job
15:26:06.744-D RECEIVE loopback://localhost/job-type 21230000-dea5-36d1-14ce-08db02d64e8f MassTransit.Contracts.JobService.AllocateJobSlot MassTransit.JobTypeSaga(00:00:00.0074086)
15:26:06.745-D SEND loopback://localhost/job 21230000-dea5-36d1-199a-08db02d64e91 MassTransit.Contracts.JobService.JobSlotAllocated
15:26:06.746-D SAGA:MassTransit.JobSaga:21230000-dea5-36d1-513c-08db02d64e85 Used MassTransit.Contracts.JobService.JobSlotAllocated
15:26:06.747-D Create send transport: loopback://localhost/job-attempt
15:26:06.750-D RECEIVE loopback://localhost/job 21230000-dea5-36d1-199a-08db02d64e91 MassTransit.Contracts.JobService.JobSlotAllocated MassTransit.JobSaga(00:00:00.0035310)
15:26:06.751-D SEND loopback://localhost/job-attempt 21230000-dea5-36d1-f7e8-08db02d64e91 MassTransit.Contracts.JobService.StartJobAttempt
15:26:06.753-D SAGA:MassTransit.JobAttemptSaga:21230000-dea5-36d1-829e-08db02d64e8d Created MassTransit.Contracts.JobService.StartJobAttempt
15:26:06.754-D SAGA:MassTransit.JobAttemptSaga:21230000-dea5-36d1-829e-08db02d64e8d Added MassTransit.Contracts.JobService.StartJobAttempt
15:26:06.755-D Create send transport: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:06.763-D Create send transport: loopback://localhost/job-attempt
15:26:06.765-D SEND loopback://localhost/job-attempt 21230000-dea5-36d1-0c04-08db02d64e94 MassTransit.Contracts.JobService.JobStatusCheckRequested
15:26:06.766-D RECEIVE loopback://localhost/job-attempt 21230000-dea5-36d1-f7e8-08db02d64e91 MassTransit.Contracts.JobService.StartJobAttempt MassTransit.JobAttemptSaga(00:00:00.0133858)
15:26:06.768-D SEND loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd 21230000-dea5-36d1-84ea-08db02d64e94 MassTransit.Contracts.JobService.StartJob
15:26:06.771-D Executing job: MassTransit.Tests.JobConsumerTests.OddJob 21230000-dea5-36d1-513c-08db02d64e85 (0)
15:26:06.775-D Job Started: 21230000-dea5-36d1-513c-08db02d64e85 21230000-dea5-36d1-829e-08db02d64e8d (0)
15:26:06.776-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobAttemptStarted
15:26:06.782-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobAttemptStarted 21230000-dea5-36d1-b6ac-08db02d64e96 MassTransit.Contracts.JobService.JobAttemptStarted
15:26:06.783-D RECEIVE loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd 21230000-dea5-36d1-84ea-08db02d64e94 MassTransit.Contracts.JobService.StartJob MassTransit.JobService.StartJobConsumer<MassTransit.Tests.JobConsumerTests.OddJob>(00:00:00.0140674)
15:26:06.783-D SAGA:MassTransit.JobAttemptSaga:21230000-dea5-36d1-829e-08db02d64e8d Used MassTransit.Contracts.JobService.JobAttemptStarted
15:26:06.784-D SAGA:MassTransit.JobSaga:21230000-dea5-36d1-513c-08db02d64e85 Used MassTransit.Contracts.JobService.JobAttemptStarted
15:26:06.784-D RECEIVE loopback://localhost/job-attempt 21230000-dea5-36d1-b6ac-08db02d64e96 MassTransit.Contracts.JobService.JobAttemptStarted MassTransit.JobAttemptSaga(00:00:00.0010296)
15:26:06.789-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobStarted
15:26:06.789-D RECEIVE loopback://localhost/job 21230000-dea5-36d1-b6ac-08db02d64e96 MassTransit.Contracts.JobService.JobAttemptStarted MassTransit.JobSaga(00:00:00.0051844)
15:26:06.790-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobStarted 21230000-dea5-36d1-f436-08db02d64e97 MassTransit.Contracts.JobService.JobStarted
15:26:07.790-D Job Completed: 21230000-dea5-36d1-513c-08db02d64e85 21230000-dea5-36d1-829e-08db02d64e8d (0)
15:26:07.791-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobAttemptCompleted
15:26:07.801-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobAttemptCompleted 21230000-dea5-36d1-eeb0-08db02d64f31 MassTransit.Contracts.JobService.JobAttemptCompleted
15:26:07.804-D RECEIVE loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd 21230000-dea5-36d1-84ea-08db02d64e94 MassTransit.Contracts.JobService.StartJob MassTransit.Tests.JobConsumerTests.OddJobConsumer(00:00:01.0324915)
15:26:07.804-D Removed job: 21230000-dea5-36d1-513c-08db02d64e85 (RanToCompletion)
15:26:07.804-D SAGA:MassTransit.JobSaga:21230000-dea5-36d1-513c-08db02d64e85 Used MassTransit.Contracts.JobService.JobAttemptCompleted
15:26:07.804-D SAGA:MassTransit.JobAttemptSaga:21230000-dea5-36d1-829e-08db02d64e8d Used MassTransit.Contracts.JobService.JobAttemptCompleted
15:26:07.806-D Create send transport: loopback://localhost/odd-job
15:26:07.816-D SAGA:MassTransit.JobAttemptSaga:21230000-dea5-36d1-829e-08db02d64e8d Removed MassTransit.Contracts.JobService.JobAttemptCompleted
15:26:07.816-D RECEIVE loopback://localhost/job-attempt 21230000-dea5-36d1-eeb0-08db02d64f31 MassTransit.Contracts.JobService.JobAttemptCompleted MassTransit.JobAttemptSaga(00:00:00.0118452)
15:26:07.826-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobCompleted
15:26:07.834-D RECEIVE loopback://localhost/job 21230000-dea5-36d1-eeb0-08db02d64f31 MassTransit.Contracts.JobService.JobAttemptCompleted MassTransit.JobSaga(00:00:00.0299428)
15:26:07.836-D SEND loopback://localhost/odd-job 21230000-dea5-36d1-60ac-08db02d64f37 MassTransit.Contracts.JobService.CompleteJob
15:26:07.837-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobCompleted 21230000-dea5-36d1-afe4-08db02d64f37 MassTransit.Contracts.JobService.JobCompleted
15:26:07.837-D Create send transport: loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobCompleted[[MassTransit.Tests.JobConsumerTests:OddJob]]
15:26:07.842-D SEND loopback://localhost/job-type 21230000-dea5-36d1-f134-08db02d64f37 MassTransit.Contracts.JobService.JobSlotReleased
15:26:07.842-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:JobCompleted[[MassTransit.Tests.JobConsumerTests:OddJob]] 21230000-dea5-36d1-6592-08db02d64f38 MassTransit.Contracts.JobService.JobCompleted<MassTransit.Tests.JobConsumerTests.OddJob>
15:26:07.842-D RECEIVE loopback://localhost/odd-job 21230000-dea5-36d1-60ac-08db02d64f37 MassTransit.Contracts.JobService.CompleteJob MassTransit.JobService.FinalizeJobConsumer<MassTransit.Tests.JobConsumerTests.OddJob>(00:00:00.0055437)
15:26:07.843-D SAGA:MassTransit.JobSaga:21230000-dea5-36d1-513c-08db02d64e85 Used MassTransit.Contracts.JobService.JobCompleted
15:26:07.843-D Stopping bus instances: IBus
15:26:07.843-D RECEIVE loopback://localhost/odd-job-completed 21230000-dea5-36d1-6592-08db02d64f38 MassTransit.Contracts.JobService.JobCompleted<MassTransit.Tests.JobConsumerTests.OddJob> MassTransit.Tests.JobConsumerTests.OddJobCompletedConsumer(00:00:00.0007450)
15:26:07.844-D RECEIVE loopback://localhost/job 21230000-dea5-36d1-afe4-08db02d64f37 MassTransit.Contracts.JobService.JobCompleted MassTransit.JobSaga(00:00:00.0008709)
15:26:07.844-D SAGA:MassTransit.JobTypeSaga:d7ed4f43-23e2-eac7-9da0-9bfe73f3dcd9 Used MassTransit.Contracts.JobService.JobSlotReleased
15:26:07.845-D Job Service shutting down: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:07.845-D Released Job Slot: 21230000-dea5-36d1-513c-08db02d64e85 (0): loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:07.845-D RECEIVE loopback://localhost/job-type 21230000-dea5-36d1-f134-08db02d64f37 MassTransit.Contracts.JobService.JobSlotReleased MassTransit.JobTypeSaga(00:00:00.0017605)
15:26:07.847-D SEND loopback://localhost/urn:message:MassTransit.Contracts.JobService:SetConcurrentJobLimit 21230000-dea5-36d1-673a-08db02d64f39 MassTransit.Contracts.JobService.SetConcurrentJobLimit
15:26:07.847-I Job Service shut down: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:07.848-D SAGA:MassTransit.JobTypeSaga:d7ed4f43-23e2-eac7-9da0-9bfe73f3dcd9 Used MassTransit.Contracts.JobService.SetConcurrentJobLimit
15:26:07.848-D Stopping bus: loopback://localhost/
15:26:07.848-D Job Service Instance Stopped: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:07.848-D RECEIVE loopback://localhost/job-type 21230000-dea5-36d1-673a-08db02d64f39 MassTransit.Contracts.JobService.SetConcurrentJobLimit MassTransit.JobTypeSaga(00:00:00.0003331)
15:26:07.851-D Endpoint Stopping: loopback://localhost/odd-job
15:26:07.852-D Endpoint Completed: loopback://localhost/odd-job
15:26:07.853-D Consumer Completed: loopback://localhost/odd-job: 2 received, 1 concurrent
15:26:07.853-D Endpoint Stopping: loopback://localhost/odd-job-completed
15:26:07.854-D Endpoint Completed: loopback://localhost/odd-job-completed
15:26:07.854-D Consumer Completed: loopback://localhost/odd-job-completed: 1 received, 1 concurrent
15:26:09.856-D Endpoint Stopping: loopback://localhost/job-attempt
15:26:09.856-D Endpoint Stopping: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:09.856-D Endpoint Stopping: loopback://localhost/job-type
15:26:09.856-D Endpoint Stopping: loopback://localhost/job
15:26:09.856-D Endpoint Completed: loopback://localhost/job-type
15:26:09.856-D Endpoint Completed: loopback://localhost/job
15:26:09.856-D Endpoint Completed: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd
15:26:09.856-D Consumer Completed: loopback://localhost/job: 5 received, 2 concurrent
15:26:09.856-D Consumer Completed: loopback://localhost/job-type: 4 received, 1 concurrent
15:26:09.856-D Endpoint Completed: loopback://localhost/job-attempt
15:26:09.856-D Consumer Completed: loopback://localhost/instance-rrtoyyg6ww5pdopcbdpofi1pbd: 1 received, 1 concurrent
15:26:09.856-D Consumer Completed: loopback://localhost/job-attempt: 3 received, 1 concurrent
15:26:09.856-D Endpoint Stopping: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_rrtoyyg6ww5pd3i1bdpofi1pb3
15:26:09.856-D Endpoint Completed: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_rrtoyyg6ww5pd3i1bdpofi1pb3
15:26:09.856-D Consumer Completed: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_rrtoyyg6ww5pd3i1bdpofi1pb3: 1 received, 1 concurrent
15:26:09.863-I Bus stopped: loopback://localhost/
```