### PR TITLE
EF InboxCleanupService logger type fix

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/InboxCleanupService.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/InboxCleanupService.cs
@@ -21,11 +21,11 @@ namespace MassTransit.EntityFrameworkCoreIntegration
         BackgroundService
         where TDbContext : DbContext
     {
-        readonly ILogger<BusOutboxDeliveryService<TDbContext>> _logger;
+        readonly ILogger<InboxCleanupService<TDbContext>> _logger;
         readonly InboxCleanupServiceOptions _options;
         readonly IServiceProvider _provider;
 
-        public InboxCleanupService(IOptions<InboxCleanupServiceOptions> options, ILogger<BusOutboxDeliveryService<TDbContext>> logger,
+        public InboxCleanupService(IOptions<InboxCleanupServiceOptions> options, ILogger<InboxCleanupService<TDbContext>> logger,
             IServiceProvider provider)
         {
             _options = options.Value;


### PR DESCRIPTION
The logger definition for the InboxCleanupService was referring to BusOutboxDeliveryService