### PR TITLE
Add ability to exclude components from ConfigureEndpoints

### DIFF
--- a/src/MassTransit.Abstractions/Attributes/ExcludeFromConfigureEndpointsAttribute.cs
+++ b/src/MassTransit.Abstractions/Attributes/ExcludeFromConfigureEndpointsAttribute.cs
@@ -1,0 +1,15 @@
+namespace MassTransit
+{
+    using System;
+
+
+    /// <summary>
+    /// When added to a consuming type (consumer, saga, activity, etc), prevents
+    /// MassTransit from configuring endpoint for it when ConfigureEndpoints called
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+    public class ExcludeFromConfigureEndpointsAttribute :
+        Attribute
+    {
+    }
+}

--- a/src/MassTransit.Abstractions/Configuration/DependencyInjection/IActivityRegistrationConfigurator.cs
+++ b/src/MassTransit.Abstractions/Configuration/DependencyInjection/IActivityRegistrationConfigurator.cs
@@ -33,5 +33,7 @@ namespace MassTransit
         /// </summary>
         /// <param name="configureCompensate"></param>
         IActivityRegistrationConfigurator CompensateEndpoint(Action<IEndpointRegistrationConfigurator> configureCompensate);
+
+        void ExcludeFromConfigureEndpoints();
     }
 }

--- a/src/MassTransit.Abstractions/Configuration/DependencyInjection/IConsumerRegistrationConfigurator.cs
+++ b/src/MassTransit.Abstractions/Configuration/DependencyInjection/IConsumerRegistrationConfigurator.cs
@@ -13,5 +13,6 @@ namespace MassTransit
     public interface IConsumerRegistrationConfigurator
     {
         void Endpoint(Action<IEndpointRegistrationConfigurator> configure);
+        void ExcludeFromConfigureEndpoints();
     }
 }

--- a/src/MassTransit.Abstractions/Configuration/DependencyInjection/IExecuteActivityRegistrationConfigurator.cs
+++ b/src/MassTransit.Abstractions/Configuration/DependencyInjection/IExecuteActivityRegistrationConfigurator.cs
@@ -14,5 +14,6 @@ namespace MassTransit
     public interface IExecuteActivityRegistrationConfigurator
     {
         void Endpoint(Action<IEndpointRegistrationConfigurator> configure);
+        void ExcludeFromConfigureEndpoints();
     }
 }

--- a/src/MassTransit/Configuration/DependencyInjection/IFutureRegistrationConfigurator.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/IFutureRegistrationConfigurator.cs
@@ -15,5 +15,6 @@ namespace MassTransit
     public interface IFutureRegistrationConfigurator
     {
         IFutureRegistrationConfigurator Endpoint(Action<IEndpointRegistrationConfigurator> configure);
+        void ExcludeFromConfigureEndpoints();
     }
 }

--- a/src/MassTransit/Configuration/DependencyInjection/ISagaRegistrationConfigurator.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/ISagaRegistrationConfigurator.cs
@@ -15,5 +15,6 @@ namespace MassTransit
     public interface ISagaRegistrationConfigurator
     {
         ISagaRegistrationConfigurator Endpoint(Action<IEndpointRegistrationConfigurator> configure);
+        void ExcludeFromConfigureEndpoints();
     }
 }

--- a/src/MassTransit/Configuration/DependencyInjection/RegistrationConfiguratorExtensions.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/RegistrationConfiguratorExtensions.cs
@@ -1,8 +1,6 @@
 namespace MassTransit
 {
     using System;
-    using Configuration;
-    using DependencyInjection.Registration;
     using Internals;
 
 
@@ -206,25 +204,6 @@ namespace MassTransit
             public IFutureRegistrationConfigurator Register(IRegistrationConfigurator configurator, Type futureDefinitionType)
             {
                 return configurator.AddFuture<TFuture>(futureDefinitionType);
-            }
-        }
-
-
-        interface IConfigureSagaRepository
-        {
-            void Configure(IRegistrationConfigurator configurator, ISagaRepositoryRegistrationProvider provider);
-        }
-
-
-        class ConfigureSagaRepository<TSaga> :
-            IConfigureSagaRepository
-            where TSaga : class, ISaga
-        {
-            public void Configure(IRegistrationConfigurator configurator, ISagaRepositoryRegistrationProvider provider)
-            {
-                var registrationConfigurator = new SagaRegistrationConfigurator<TSaga>(configurator);
-
-                provider.Configure(registrationConfigurator);
             }
         }
     }

--- a/src/MassTransit/DependencyInjection/Configuration/BusRegistrationContext.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/BusRegistrationContext.cs
@@ -41,19 +41,19 @@ namespace MassTransit.Configuration
             var registrationFilter = builder.Filter;
 
             List<IGrouping<string, IConsumerDefinition>> consumersByEndpoint = Selector.GetRegistrations<IConsumerRegistration>(this)
-                .Where(x => registrationFilter.Matches(x) && !WasConfigured(x.Type))
+                .Where(x => x.IncludeInConfigureEndpoints && registrationFilter.Matches(x))
                 .Select(x => x.GetDefinition(this))
                 .GroupBy(x => x.GetEndpointName(endpointNameFormatter))
                 .ToList();
 
             List<IGrouping<string, ISagaDefinition>> sagasByEndpoint = Selector.GetRegistrations<ISagaRegistration>(this)
-                .Where(x => registrationFilter.Matches(x) && !WasConfigured(x.Type))
+                .Where(x => x.IncludeInConfigureEndpoints && registrationFilter.Matches(x))
                 .Select(x => x.GetDefinition(this))
                 .GroupBy(x => x.GetEndpointName(endpointNameFormatter))
                 .ToList();
 
             List<IActivityDefinition> activities = Selector.GetRegistrations<IActivityRegistration>(this)
-                .Where(x => registrationFilter.Matches(x) && !WasConfigured(x.Type))
+                .Where(x => x.IncludeInConfigureEndpoints && registrationFilter.Matches(x))
                 .Select(x => x.GetDefinition(this))
                 .ToList();
 
@@ -66,19 +66,19 @@ namespace MassTransit.Configuration
                 .ToList();
 
             List<IGrouping<string, IExecuteActivityDefinition>> executeActivitiesByEndpoint = Selector.GetRegistrations<IExecuteActivityRegistration>(this)
-                .Where(x => registrationFilter.Matches(x) && !WasConfigured(x.Type))
+                .Where(x => x.IncludeInConfigureEndpoints && registrationFilter.Matches(x))
                 .Select(x => x.GetDefinition(this))
                 .GroupBy(x => x.GetExecuteEndpointName(endpointNameFormatter))
                 .ToList();
 
             List<IGrouping<string, IFutureDefinition>> futuresByEndpoint = Selector.GetRegistrations<IFutureRegistration>(this)
-                .Where(x => registrationFilter.Matches(x) && !WasConfigured(x.Type))
+                .Where(x => x.IncludeInConfigureEndpoints && registrationFilter.Matches(x))
                 .Select(x => x.GetDefinition(this))
                 .GroupBy(x => x.GetEndpointName(endpointNameFormatter))
                 .ToList();
 
             var endpointsWithName = Selector.GetRegistrations<IEndpointRegistration>(this)
-                .Where(x => registrationFilter.Matches(x) && !WasConfigured(x.Type))
+                .Where(x => x.IncludeInConfigureEndpoints && registrationFilter.Matches(x))
                 .Select(x => x.GetDefinition(this))
                 .Select(x => new
                 {

--- a/src/MassTransit/DependencyInjection/Configuration/IRegistration.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/IRegistration.cs
@@ -6,5 +6,7 @@ namespace MassTransit.Configuration
     public interface IRegistration
     {
         Type Type { get; }
+
+        bool IncludeInConfigureEndpoints { get; set; }
     }
 }

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Activites/ActivityRegistration.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Activites/ActivityRegistration.cs
@@ -3,6 +3,7 @@ namespace MassTransit.DependencyInjection.Registration
     using System;
     using System.Collections.Generic;
     using Configuration;
+    using Internals;
     using Microsoft.Extensions.DependencyInjection;
     using Transports;
 
@@ -21,9 +22,12 @@ namespace MassTransit.DependencyInjection.Registration
         {
             _executeActions = new List<Action<IExecuteActivityConfigurator<TActivity, TArguments>>>();
             _compensateActions = new List<Action<ICompensateActivityConfigurator<TActivity, TLog>>>();
+            IncludeInConfigureEndpoints = !Type.HasAttribute<ExcludeFromConfigureEndpointsAttribute>();
         }
 
         public Type Type => typeof(TActivity);
+
+        public bool IncludeInConfigureEndpoints { get; set; }
 
         public void AddConfigureAction<T, TA>(Action<IExecuteActivityConfigurator<T, TA>> configure)
             where T : class, IExecuteActivity<TA>
@@ -74,6 +78,8 @@ namespace MassTransit.DependencyInjection.Registration
                 TypeCache<TActivity>.ShortName);
 
             configurator.AddEndpointSpecification(specification);
+
+            IncludeInConfigureEndpoints = false;
         }
 
         public void ConfigureExecute(IReceiveEndpointConfigurator configurator, IServiceProvider configurationServiceProvider,
@@ -97,6 +103,8 @@ namespace MassTransit.DependencyInjection.Registration
                 TypeCache<TActivity>.ShortName);
 
             configurator.AddEndpointSpecification(specification);
+
+            IncludeInConfigureEndpoints = false;
         }
 
         IActivityDefinition<TActivity, TArguments, TLog> GetActivityDefinition(IServiceProvider provider)

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Activites/ExecuteActivityRegistration.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Activites/ExecuteActivityRegistration.cs
@@ -3,6 +3,7 @@ namespace MassTransit.DependencyInjection.Registration
     using System;
     using System.Collections.Generic;
     using Configuration;
+    using Internals;
     using Microsoft.Extensions.DependencyInjection;
     using Transports;
 
@@ -18,9 +19,12 @@ namespace MassTransit.DependencyInjection.Registration
         public ExecuteActivityRegistration()
         {
             _configureActions = new List<Action<IExecuteActivityConfigurator<TActivity, TArguments>>>();
+            IncludeInConfigureEndpoints = !Type.HasAttribute<ExcludeFromConfigureEndpointsAttribute>();
         }
 
         public Type Type => typeof(TActivity);
+
+        public bool IncludeInConfigureEndpoints { get; set; }
 
         void IExecuteActivityRegistration.AddConfigureAction<T, TArgs>(Action<IExecuteActivityConfigurator<T, TArgs>> configure)
         {
@@ -48,6 +52,8 @@ namespace MassTransit.DependencyInjection.Registration
                 TypeCache<TActivity>.ShortName);
 
             configurator.AddEndpointSpecification(specification);
+
+            IncludeInConfigureEndpoints = false;
         }
 
         IExecuteActivityDefinition IExecuteActivityRegistration.GetDefinition(IServiceProvider provider)

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Activites/ExecuteActivityRegistrationConfigurator.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Activites/ExecuteActivityRegistrationConfigurator.cs
@@ -10,19 +10,29 @@ namespace MassTransit.DependencyInjection.Registration
         where TArguments : class
     {
         readonly IRegistrationConfigurator _configurator;
+        readonly IExecuteActivityRegistration _registration;
 
-        public ExecuteActivityRegistrationConfigurator(IRegistrationConfigurator configurator)
+        public ExecuteActivityRegistrationConfigurator(IRegistrationConfigurator configurator, IExecuteActivityRegistration registration)
         {
             _configurator = configurator;
+            _registration = registration;
         }
 
         public void Endpoint(Action<IEndpointRegistrationConfigurator> configure)
         {
+            if (!_registration.IncludeInConfigureEndpoints)
+                throw new ConfigurationException("ExecuteActivity is excluded from ConfigureEndpoints");
+
             var configurator = new EndpointRegistrationConfigurator<IExecuteActivity<TArguments>> { ConfigureConsumeTopology = false };
 
             configure?.Invoke(configurator);
 
             _configurator.AddEndpoint<ExecuteActivityEndpointDefinition<TActivity, TArguments>, IExecuteActivity<TArguments>>(configurator.Settings);
+        }
+
+        public void ExcludeFromConfigureEndpoints()
+        {
+            _registration.IncludeInConfigureEndpoints = false;
         }
     }
 }

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Consumers/ConsumerRegistrationConfigurator.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Consumers/ConsumerRegistrationConfigurator.cs
@@ -9,19 +9,29 @@ namespace MassTransit.DependencyInjection.Registration
         where TConsumer : class, IConsumer
     {
         readonly IRegistrationConfigurator _configurator;
+        readonly IConsumerRegistration _registration;
 
-        public ConsumerRegistrationConfigurator(IRegistrationConfigurator configurator)
+        public ConsumerRegistrationConfigurator(IRegistrationConfigurator configurator, IConsumerRegistration registration)
         {
             _configurator = configurator;
+            _registration = registration;
         }
 
         public void Endpoint(Action<IEndpointRegistrationConfigurator> configure)
         {
+            if (!_registration.IncludeInConfigureEndpoints)
+                throw new ConfigurationException("Consumer is excluded from ConfigureEndpoints");
+
             var configurator = new EndpointRegistrationConfigurator<TConsumer>();
 
             configure?.Invoke(configurator);
 
             _configurator.AddEndpoint<ConsumerEndpointDefinition<TConsumer>, TConsumer>(configurator.Settings);
+        }
+
+        public void ExcludeFromConfigureEndpoints()
+        {
+            _registration.IncludeInConfigureEndpoints = false;
         }
     }
 }

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Endpoints/EndpointRegistration.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Endpoints/EndpointRegistration.cs
@@ -11,6 +11,12 @@ namespace MassTransit.DependencyInjection.Registration
     {
         public Type Type => typeof(T);
 
+        public bool IncludeInConfigureEndpoints
+        {
+            get => true;
+            set { }
+        }
+
         public IEndpointDefinition GetDefinition(IServiceProvider provider)
         {
             return provider.GetRequiredService<IEndpointDefinition<T>>();

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Futures/FutureRegistration.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Futures/FutureRegistration.cs
@@ -2,6 +2,7 @@ namespace MassTransit.DependencyInjection.Registration
 {
     using System;
     using Configuration;
+    using Internals;
     using Microsoft.Extensions.DependencyInjection;
     using Transports;
 
@@ -12,7 +13,14 @@ namespace MassTransit.DependencyInjection.Registration
     {
         IFutureDefinition<TFuture> _definition;
 
+        public FutureRegistration()
+        {
+            IncludeInConfigureEndpoints = !Type.HasAttribute<ExcludeFromConfigureEndpointsAttribute>();
+        }
+
         public Type Type => typeof(TFuture);
+
+        public bool IncludeInConfigureEndpoints { get; set; }
 
         public void Configure(IReceiveEndpointConfigurator configurator, IServiceProvider provider)
         {
@@ -32,6 +40,8 @@ namespace MassTransit.DependencyInjection.Registration
                 configurator.InputAddress.GetEndpointName(), TypeCache<TFuture>.ShortName);
 
             configurator.AddEndpointSpecification(sagaConfigurator);
+
+            IncludeInConfigureEndpoints = false;
         }
 
         public IFutureDefinition GetDefinition(IServiceProvider provider)

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Futures/FutureRegistrationConfigurator.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Futures/FutureRegistrationConfigurator.cs
@@ -9,10 +9,12 @@ namespace MassTransit.DependencyInjection.Registration
         where TFuture : class, SagaStateMachine<FutureState>
     {
         readonly IRegistrationConfigurator _configurator;
+        readonly IFutureRegistration _registration;
 
-        public FutureRegistrationConfigurator(IRegistrationConfigurator configurator)
+        public FutureRegistrationConfigurator(IRegistrationConfigurator configurator, IFutureRegistration registration)
         {
             _configurator = configurator;
+            _registration = registration;
         }
 
         IFutureRegistrationConfigurator IFutureRegistrationConfigurator.Endpoint(Action<IEndpointRegistrationConfigurator> configure)
@@ -20,8 +22,16 @@ namespace MassTransit.DependencyInjection.Registration
             return Endpoint(configure);
         }
 
+        public void ExcludeFromConfigureEndpoints()
+        {
+            _registration.IncludeInConfigureEndpoints = false;
+        }
+
         public IFutureRegistrationConfigurator<TFuture> Endpoint(Action<IEndpointRegistrationConfigurator> configure)
         {
+            if (!_registration.IncludeInConfigureEndpoints)
+                throw new ConfigurationException("Feature is excluded from ConfigureEndpoints");
+
             var configurator = new EndpointRegistrationConfigurator<TFuture>();
 
             configure?.Invoke(configurator);

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Sagas/SagaRegistration.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Sagas/SagaRegistration.cs
@@ -3,6 +3,7 @@ namespace MassTransit.DependencyInjection.Registration
     using System;
     using System.Collections.Generic;
     using Configuration;
+    using Internals;
     using Microsoft.Extensions.DependencyInjection;
     using Transports;
 
@@ -22,9 +23,12 @@ namespace MassTransit.DependencyInjection.Registration
         public SagaRegistration()
         {
             _configureActions = new List<Action<ISagaConfigurator<TSaga>>>();
+            IncludeInConfigureEndpoints = !Type.HasAttribute<ExcludeFromConfigureEndpointsAttribute>();
         }
 
         public Type Type => typeof(TSaga);
+
+        public bool IncludeInConfigureEndpoints { get; set; }
 
         void ISagaRegistration.AddConfigureAction<T>(Action<ISagaConfigurator<T>> configure)
         {
@@ -52,6 +56,8 @@ namespace MassTransit.DependencyInjection.Registration
                 TypeCache<TSaga>.ShortName);
 
             configurator.AddEndpointSpecification(sagaConfigurator);
+
+            IncludeInConfigureEndpoints = false;
         }
 
         ISagaDefinition ISagaRegistration.GetDefinition(IServiceProvider provider)

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Sagas/SagaStateMachineRegistration.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/Sagas/SagaStateMachineRegistration.cs
@@ -3,6 +3,7 @@ namespace MassTransit.DependencyInjection.Registration
     using System;
     using System.Collections.Generic;
     using Configuration;
+    using Internals;
     using Microsoft.Extensions.DependencyInjection;
     using Transports;
 
@@ -24,9 +25,12 @@ namespace MassTransit.DependencyInjection.Registration
         public SagaStateMachineRegistration()
         {
             _configureActions = new List<Action<ISagaConfigurator<TInstance>>>();
+            IncludeInConfigureEndpoints = !Type.HasAttribute<ExcludeFromConfigureEndpointsAttribute>();
         }
 
         public Type Type => typeof(TInstance);
+
+        public bool IncludeInConfigureEndpoints { get; set; }
 
         public void AddConfigureAction<T>(Action<ISagaConfigurator<T>> configure)
             where T : class, ISaga
@@ -65,6 +69,8 @@ namespace MassTransit.DependencyInjection.Registration
                 TypeCache<TInstance>.ShortName, TypeCache.GetShortName(stateMachine.GetType()));
 
             configurator.AddEndpointSpecification(stateMachineConfigurator);
+
+            IncludeInConfigureEndpoints = false;
         }
 
         ISagaDefinition ISagaRegistration.GetDefinition(IServiceProvider provider)

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaProducerRegistration.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaProducerRegistration.cs
@@ -29,5 +29,11 @@ namespace MassTransit.KafkaIntegration.Configuration
         }
 
         public Type Type => typeof(KafkaProducerRegistration<TKey, TValue>);
+
+        public bool IncludeInConfigureEndpoints
+        {
+            get => false;
+            set { }
+        }
     }
 }

--- a/tests/MassTransit.Containers.Tests/ExcludeFromConfigureEndpoints_Specs.cs
+++ b/tests/MassTransit.Containers.Tests/ExcludeFromConfigureEndpoints_Specs.cs
@@ -1,0 +1,240 @@
+namespace MassTransit.Containers.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Common_Tests;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+    using Testing;
+
+
+    public class ExcludeConsumerFromConfigureEndpoints_Specs
+    {
+        [Test]
+        public async Task Should_exclude_consumer_explicitly()
+        {
+            await using var provider = new ServiceCollection()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.AddConsumer<ExcludedConsumer>()
+                        .ExcludeFromConfigureEndpoints();
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+
+            await harness.Start();
+
+            await harness.Bus.Publish<Ping>(new { }, harness.CancellationToken);
+
+            Assert.That(await harness.Consumed.Any<Ping>(), Is.False);
+        }
+
+        [Test]
+        public async Task Should_exclude_consumer_by_attribute()
+        {
+            await using var provider = new ServiceCollection()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.AddConsumer<ExcludedByAttributeConsumer>()
+                        .ExcludeFromConfigureEndpoints();
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+
+            await harness.Start();
+
+            await harness.Bus.Publish<Ping>(new { }, harness.CancellationToken);
+
+            Assert.That(await harness.Consumed.Any<Ping>(), Is.False);
+        }
+
+
+        class ExcludedConsumer :
+            IConsumer<Ping>
+        {
+            public Task Consume(ConsumeContext<Ping> context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+
+        [ExcludeFromConfigureEndpoints]
+        class ExcludedByAttributeConsumer :
+            IConsumer<Ping>
+        {
+            public Task Consume(ConsumeContext<Ping> context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+
+    public class ExcludeSagaFromConfigureEndpoints_Specs
+    {
+        [Test]
+        public async Task Should_exclude_saga_explicitly()
+        {
+            await using var provider = new ServiceCollection()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.AddSaga<ExcludedSaga>()
+                        .ExcludeFromConfigureEndpoints();
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+
+            await harness.Start();
+
+            await harness.Bus.Publish(new InitiateMessage(), harness.CancellationToken);
+
+            Assert.That(await harness.Consumed.Any<InitiateMessage>(), Is.False);
+        }
+
+        [Test]
+        public async Task Should_exclude_saga_by_attribute()
+        {
+            await using var provider = new ServiceCollection()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.AddSaga<ExcludedByAttributeSaga>();
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+
+            await harness.Start();
+
+            await harness.Bus.Publish(new InitiateMessage(), harness.CancellationToken);
+
+            Assert.That(await harness.Consumed.Any<Ping>(), Is.False);
+        }
+
+        [Test]
+        public async Task Should_exclude_state_machine_explicitly()
+        {
+            await using var provider = new ServiceCollection()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.AddSagaStateMachine<ExcludedStateMachine, ExcludedSagaInstance>()
+                        .ExcludeFromConfigureEndpoints();
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+
+            await harness.Start();
+
+            await harness.Bus.Publish(new InitiateMessage(), harness.CancellationToken);
+
+            Assert.That(await harness.Consumed.Any<InitiateMessage>(), Is.False);
+        }
+
+        [Test]
+        public async Task Should_exclude_state_machine_by_instance_attribute()
+        {
+            await using var provider = new ServiceCollection()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.AddSagaStateMachine<ExcludedStateMachineWithInstanceAttribute, ExcludedStaInstanceByAttribute>();
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+
+            await harness.Start();
+
+            await harness.Bus.Publish(new InitiateMessage(), harness.CancellationToken);
+
+            Assert.That(await harness.Consumed.Any<Ping>(), Is.False);
+        }
+
+
+        class InitiateMessage :
+            CorrelatedBy<Guid>
+        {
+            public InitiateMessage()
+            {
+                CorrelationId = NewId.NextGuid();
+            }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+
+        class ExcludedSagaInstance : SagaStateMachineInstance
+        {
+            public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
+        }
+
+
+        [ExcludeFromConfigureEndpoints]
+        class ExcludedStaInstanceByAttribute : ExcludedSagaInstance
+        {
+        }
+
+
+        class ExcludedSaga :
+            ISaga,
+            InitiatedBy<InitiateMessage>
+        {
+            public Task Consume(ConsumeContext<InitiateMessage> context)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+
+        [ExcludeFromConfigureEndpoints]
+        class ExcludedByAttributeSaga :
+            ISaga,
+            InitiatedBy<InitiateMessage>
+        {
+            public Task Consume(ConsumeContext<InitiateMessage> context)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Guid CorrelationId { get; set; }
+        }
+
+
+        class ExcludedStateMachine :
+            MassTransitStateMachine<ExcludedSagaInstance>
+        {
+            public ExcludedStateMachine()
+            {
+                InstanceState(x => x.CurrentState);
+
+                Initially(When(Initiated).Finalize());
+
+                SetCompletedWhenFinalized();
+            }
+
+            public Event<InitiateMessage> Initiated { get; }
+        }
+
+
+        class ExcludedStateMachineWithInstanceAttribute :
+            MassTransitStateMachine<ExcludedStaInstanceByAttribute>
+        {
+            public ExcludedStateMachineWithInstanceAttribute()
+            {
+                InstanceState(x => x.CurrentState);
+
+                Initially(When(Initiated).Finalize());
+
+                SetCompletedWhenFinalized();
+            }
+
+            public Event<InitiateMessage> Initiated { get; }
+        }
+    }
+}


### PR DESCRIPTION
Exclude components either with `.ExcludeFromConfigureEndpoints()` or `[ExcludeFromConfigureEndpoints]` attribute