### PR TITLE
NIT fix for Bus OutBox notification

### DIFF
--- a/src/MassTransit/Middleware/Outbox/BusOutboxNotification.cs
+++ b/src/MassTransit/Middleware/Outbox/BusOutboxNotification.cs
@@ -29,6 +29,7 @@ namespace MassTransit.Middleware.Outbox
             }
             catch (OperationCanceledException e) when (e.CancellationToken == _cancellationTokenSource.Token)
             {
+                cancellationToken.ThrowIfCancellationRequested();
             }
             finally
             {


### PR DESCRIPTION
Rethrow if main token is cancelled no point to call following methods