### PR TITLE
SignalR documentation improvements

### DIFF
--- a/doc/content/3.documentation/5.configuration/integrations/1.signalr.md
+++ b/doc/content/3.documentation/5.configuration/integrations/1.signalr.md
@@ -58,12 +58,21 @@ The core of communication contracts between the client and server are hubs. Depe
 So this translated well into MassTransit Events:
 
 * `All<THub>` - Invokes the method (with args) for each connection on the specified hub
+  * The `ExcludedConnectionIds` property allows exclusion of specific connection ids
 * `Connection<THub>` - Invokes the method (with args) for the specific connection
+  * The `ConnectionId` indicates which connection id to send the message to. If no active connection was found for this id, no exception will be thrown and the message will be completed without further processing.
 * `Group<THub>` - Invokes the method (with args) for all connections belonging to the specified group
+  * The `GroupName` property indicates the name of the target group
+  * The `ExcludedConnectionIds` property allows exclusion of specific connection ids
 * `GroupManagement<THub>` - Adds or removes a connection to the group (on a remote server)
 * `User<THub>` - Invokes the method (with args) for all connections belonging to the specific user id
+  * The `UserId` property indicates the id of the user to be targeted. Note that although similar, this differs from `Connection<THub>` since the user id is generally a specific identifier given to a user, whereas the connection id is usually a random identifier assigned to each connection
 
-So each of these Messages has a corresponding consumer, and it will get a `HubLifetimeManager<THub>` through DI to perform the specific task.
+All event types contain a property `Messages` which transports the payload as an `IReadOnlyDictionary<string, byte[]>`.
+
+So each of these Messages has a corresponding consumer, and it will get a `HubLifetimeManager<THub>` through DI to perform the specific task. Messages sent through these endpoints will be published on your configured message broker, and once consumed, will be sent to your SignalR clients according to the configured message type.
+
+In case an exception occurs while sending a message through the SignalR connection, an exception will be logged, but the message itself will still be marked as completed.
 
 MassTransit's helper extension method will create an endpoint per consumer per hub, which follows the typical recommendation of one consumer per endpoint. Because of this, the number of endpoints can grow quickly if you have many hubs. It's best to also read some [SignalR Limitations](https://docs.microsoft.com/en-us/aspnet/signalr/overview/performance/scaleout-in-signalr#limitations), to understand what can become potential bottlenecks with SignalR and your backplane. SignalR recommends re-thinking your strategy for very high throughput, real-time applications (video games).
 
@@ -81,7 +90,29 @@ await busControl.Publish<All<ChatHub>>(new
     Messages = protocols.ToProtocolDictionary("broadcastMessage", new object[] { "backend-process", "Hello" })
 });
 ```
+
 You are done!
+
+The lifetime of the message looks like this:
+
+1. An `All<ChatHub>` message, including your payload will be published to your configured broker.
+2. All (or a select few, depending on how you configured MassTransit) consumers which registered `.AddSignalRHub<ChatHub>(...)` will receive the message.
+3. The message will be published through the SignalR connection.
+4. Your client will receive the message.
+
+A slightly more complex example of how you would send a message to a specific group, but exclude specific connection ids would look like this:
+
+```csharp
+await busControl.Publish<Group<ChatHub>>(new
+{
+	GroupName = "ServiceDeskEmployees",
+	ExcludedConnectionIds = new [] { "11b9c749-69a2-4f3e-8a8b-968122156220", "1737778b-c836-4023-a255-51c2e4898c43" },
+    Messages = protocols.ToProtocolDictionary("broadcastMessage", new object[] { "backend-process", "Hello" })
+});
+```
+
+This example would send the message to a group called "ServiceDeskEmployees", but exclude the specified connection ids from receiving the message.
+
 
 ## Complex Hubs
 
@@ -104,7 +135,9 @@ public class ProductHub : Hub
 }
 ```
 
-Your back end service might exist in a separate project and namespace, with no knowledge of the hubs or injected services. Because MassTransit routes messages by namespace+message, I recommend to create a marker hub(s) within your back end service just for use of publishing. This saves you having to have all the hub(s) injected dependencies also within your back end service.
+Your back end service might exist in a separate project and namespace, with no knowledge of the hubs or injected services. However, even if said service does not use SignalR, you might still want to publish messages which pass through the broker and end up being sent to your client.
+
+Because MassTransit routes messages by namespace+message, I recommend to create a marker hub(s) within your back end service just for use of publishing. This saves you having to have all the hub(s) injected dependencies also within your back end service and still allows your service to publish namespace-compliant messages to be picked up by your SignalR integration.
 
 ```csharp
 namespace YourNamespace.Should.Match.The.Hubs


### PR DESCRIPTION
Hey,

I added some additional documentation for the SignalR integration, especially things I wished were a bit clearer when I initially started using it:

- I added further explanation for the specific differences each SignalR message envelope has
- Added some information as to how exceptions or missing IDs are handled
- Added a rough outline of how the flow of the message looks like, from publisher to client
- Added a slightly more complex example to showcase how a Group message would look like
- Added a hint as to why it makes sense to add a marker interface