### PR TITLE
Break out of EF Core bus outbox delivery service loop when no outbox …

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/BusOutboxDeliveryService.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/BusOutboxDeliveryService.cs
@@ -85,7 +85,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
                 if (messageCount > 0)
                     resultCount++;
 
-                if (messageCount == -1)
+                if (messageCount == 0)
                     break;
             }
 


### PR DESCRIPTION
…state found, message count is 0

After some more testing with the latest develop build and looking deeper into the logic, it looks like `messageCount` returns as `0` when the underlying `outboxState` comes back with `-1`, when there's none found.

Tried a few scenarios, and breaking on 0 seems to work OK on my testing app:
![image](https://user-images.githubusercontent.com/33609707/218349973-67c2f477-1e2d-4d9b-8561-4c99443202d2.png)

