### PR TITLE
SignalR ExcludedConnection Casing

### DIFF
--- a/src/MassTransit.SignalR/Consumers/AllConsumer.cs
+++ b/src/MassTransit.SignalR/Consumers/AllConsumer.cs
@@ -33,7 +33,7 @@
 
             foreach (var connection in _hubLifetimeManager.Connections)
             {
-                if (excludedConnectionIds == null || !excludedConnectionIds.Contains(connection.ConnectionId, StringComparer.OrdinalIgnoreCase))
+                if (excludedConnectionIds == null || !excludedConnectionIds.Contains(connection.ConnectionId, StringComparer.Ordinal))
                     tasks.Add(connection.WriteAsync(message.Value).AsTask());
             }
 

--- a/src/MassTransit.SignalR/Consumers/GroupConsumer.cs
+++ b/src/MassTransit.SignalR/Consumers/GroupConsumer.cs
@@ -37,7 +37,7 @@
             var tasks = new List<Task>();
             foreach (var connection in groupStore)
             {
-                if (excludedConnectionIds == null || !excludedConnectionIds.Contains(connection.ConnectionId, StringComparer.OrdinalIgnoreCase))
+                if (excludedConnectionIds == null || !excludedConnectionIds.Contains(connection.ConnectionId, StringComparer.Ordinal))
                     tasks.Add(connection.WriteAsync(message.Value).AsTask());
             }
 


### PR DESCRIPTION
- Changed excluded connection id comparisons in AllConsumer and GroupConsumer to Ordinal in order to be in line with the behaviour of a direct connection Consumer
- Added tests to verify that the casing behaves as expected
