### PR TITLE
add a couple more AWS-y ways to allow the host to be configured

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsBusFactoryConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsBusFactoryConfiguratorExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace MassTransit
 {
     using System;
+    using Amazon.Runtime;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using AmazonSqsTransport.Configuration;
@@ -36,6 +37,19 @@
 
                 h.Config(new AmazonSQSConfig { ServiceURL = "http://localhost:4566" });
                 h.Config(new AmazonSimpleNotificationServiceConfig { ServiceURL = "http://localhost:4566" });
+            });
+        }
+
+        public static void UseDefaultHost(this IAmazonSqsBusFactoryConfigurator configurator)
+        {
+           configurator.UseDefaultHost(FallbackRegionFactory.GetRegionEndpoint());
+        }
+
+        public static void UseDefaultHost(this IAmazonSqsBusFactoryConfigurator configurator, Amazon.RegionEndpoint endpoint)
+        {
+            configurator.Host(endpoint.SystemName, h =>
+            {
+                h.Credentials(FallbackCredentialsFactory.GetCredentials());
             });
         }
     }


### PR DESCRIPTION
Constructs the Host with the credentials loaded from the application's default configuration, and if unsuccessful from the Instance Profile service on an EC2 instance

example usage:
```  	
x.UsingAmazonSqs((context, cfg) => {
	cfg.UseDefaultHost();
	//or
	//cfg.UseDefaultHost(Amazon.RegionEndpoint.APSoutheast2);
});
```


