### PR TITLE
Fix ArgumentNullException when using SetOffsetsCommittedHandler

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaTopicReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaTopicReceiveEndpointConfiguration.cs
@@ -151,7 +151,7 @@ namespace MassTransit.KafkaIntegration.Configuration
 
         public void SetOffsetsCommittedHandler(Action<CommittedOffsets> offsetsCommittedHandler)
         {
-            _offsetsCommittedHandler = _offsetsCommittedHandler ?? throw new ArgumentNullException(nameof(offsetsCommittedHandler));
+            _offsetsCommittedHandler = offsetsCommittedHandler ?? throw new ArgumentNullException(nameof(offsetsCommittedHandler));
         }
 
         public void SetStatisticsHandler(Action<string> statisticsHandler)


### PR DESCRIPTION
### Changes 
- set the _offsetsCommittedHandler property with the parameter value instead of itself.

### Before
Calling the SetOffsetsCommittedHandler on (IKafkaFactoryConfigurator.)TopicEndpoint with any handler results to an ArgumentNullException.

### After
Same call doesn't trigger the exception anymore.







