### PR TITLE
Fix default schema in SqlLockStatementProvider

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/PostgresLockStatementFormatter.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/PostgresLockStatementFormatter.cs
@@ -8,7 +8,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
     {
         public void Create(StringBuilder sb, string schema, string table)
         {
-            sb.AppendFormat("SELECT * FROM \"{0}\".\"{1}\" WHERE ", schema, table);
+            sb.AppendFormat("SELECT * FROM {0} WHERE ", GetSchemaTableName(schema, table));
         }
 
         public void AppendColumn(StringBuilder sb, int index, string columnName)
@@ -26,7 +26,12 @@ namespace MassTransit.EntityFrameworkCoreIntegration
 
         public void CreateOutboxStatement(StringBuilder sb, string schema, string table, string columnName)
         {
-            sb.AppendFormat(@"SELECT * FROM ""{0}"".""{1}"" ORDER BY ""{2}"" LIMIT 1 FOR UPDATE SKIP LOCKED", schema, table, columnName);
+            sb.AppendFormat(@"SELECT * FROM {0} ORDER BY ""{1}"" LIMIT 1 FOR UPDATE SKIP LOCKED", GetSchemaTableName(schema, table), columnName);
+        }
+
+        private static string GetSchemaTableName(string schema, string table)
+        {
+            return string.IsNullOrEmpty(schema) ? $"\"{table}\"" : $"\"{schema}\".\"{table}\"";
         }
     }
 }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/PostgresLockStatementProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/PostgresLockStatementProvider.cs
@@ -3,10 +3,8 @@ namespace MassTransit.EntityFrameworkCoreIntegration
     public class PostgresLockStatementProvider :
         SqlLockStatementProvider
     {
-        const string DefaultSchemaName = "public";
-
         public PostgresLockStatementProvider(bool enableSchemaCaching = true)
-            : base(DefaultSchemaName, new PostgresLockStatementFormatter(), enableSchemaCaching)
+            : base(null, new PostgresLockStatementFormatter(), enableSchemaCaching)
         {
         }
 

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlLockStatementProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlLockStatementProvider.cs
@@ -18,7 +18,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
 
         public SqlLockStatementProvider(string defaultSchema, ILockStatementFormatter formatter, bool enableSchemaCaching = true)
         {
-            DefaultSchema = defaultSchema ?? throw new ArgumentNullException(nameof(defaultSchema));
+            DefaultSchema = defaultSchema;
 
             _formatter = formatter;
             _enableSchemaCaching = enableSchemaCaching;

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementFormatter.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementFormatter.cs
@@ -8,7 +8,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
     {
         public void Create(StringBuilder sb, string schema, string table)
         {
-            sb.AppendFormat("SELECT * FROM [{0}].{1} WITH (UPDLOCK, ROWLOCK, SERIALIZABLE) WHERE ", schema, table);
+            sb.AppendFormat("SELECT * FROM {0} WITH (UPDLOCK, ROWLOCK, SERIALIZABLE) WHERE ", GetSchemaTableName(schema, table));
         }
 
         public void AppendColumn(StringBuilder sb, int index, string columnName)
@@ -25,7 +25,12 @@ namespace MassTransit.EntityFrameworkCoreIntegration
 
         public void CreateOutboxStatement(StringBuilder sb, string schema, string table, string columnName)
         {
-            sb.AppendFormat(@"SELECT TOP 1 * FROM [{0}].{1} WITH (UPDLOCK, ROWLOCK, READPAST) ORDER BY {2}", schema, table, columnName);
+            sb.AppendFormat(@"SELECT TOP 1 * FROM {0} WITH (UPDLOCK, ROWLOCK, READPAST) ORDER BY {1}", GetSchemaTableName(schema, table), columnName);
+        }
+
+        private static string GetSchemaTableName(string schema, string table)
+        {
+            return string.IsNullOrEmpty(schema) ? $"{table}" : $"[{schema}].{table}";
         }
     }
 }

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementProvider.cs
@@ -3,10 +3,8 @@
     public class SqlServerLockStatementProvider :
         SqlLockStatementProvider
     {
-        const string DefaultSchemaName = "dbo";
-
         public SqlServerLockStatementProvider(bool enableSchemaCaching = true)
-            : base(DefaultSchemaName, new SqlServerLockStatementFormatter(), enableSchemaCaching)
+            : base(null, new SqlServerLockStatementFormatter(), enableSchemaCaching)
         {
         }
 


### PR DESCRIPTION
Fixed #4222
Entity Framework generates an SQL script without the schema if it has not been explicitly specified. The behavior of LockStatementFormatter when generating SQL instructions should be the same. Therefore, it is not necessary to explicitly pass the schema to the SqlLockStatementProvider:

- If the schema is not specified (empty or null), then LockStatementFormatter will not add it to the SQL and the default schema in the database will be used or the schema specified in the connection string.
- If the schema has been explicitly specified in the modelBuilder, it will be obtained from the EntityType and passed to LockStatementFormatter.

However, I left the DefaultSchema parameter in SqlLockStatementProvider to avoid breaking the existing API.