### PR TITLE
feat: add MessageUrnAttribute to support customization of message urn resolution

### DIFF
--- a/doc/content/3.documentation/1.concepts/1.messages.md
+++ b/doc/content/3.documentation/1.concepts/1.messages.md
@@ -56,7 +56,7 @@ namespace Company.Application.Contracts
 
 When defining a message type using an interface, MassTransit will create a dynamic class implementing the interface for serialization, allowing the interface with get-only properties to be presented to the consumer. To create an interface message, use a [message initializer](/documentation/concepts/producers##message-initialization).
 
-### Classes 
+### Classes
 
 ```csharp
 namespace Company.Application.Contracts
@@ -85,11 +85,12 @@ A common mistake when engineers are new to messaging is to create a base class f
 
 ## Message Attributes
 
-| Attribute                   | Description                                                                   |
-|:----------------------------|:------------------------------------------------------------------------------|
-| EntityName                  | The exchange or topic name                                                    |
-| ExcludeFromTopology         | Don't create an exchange or topic unless it is directly consumed or published |
-| ExcludeFromImplementedTypes | Don't create a middleware filter for the message type                         |
+| Attribute                                                                                                | Description                                                                   |
+|:---------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------|
+| [EntityName](/documentation/configuration/topology/message#entityname)                                   | The exchange or topic name                                                    |
+| [ExcludeFromTopology](/documentation/configuration/topology/message#excludefromtopology)                 | Don't create an exchange or topic unless it is directly consumed or published |
+| [ExcludeFromImplementedTypes](/documentation/configuration/topology/message#excludefromimplementedtypes) | Don't create a middleware filter for the message type                         |
+| [MessageUrn](/documentation/configuration/topology/message#messageurn)                                   | The message urn                                                               |
 
 ## Message Names
 
@@ -97,7 +98,7 @@ There are two main message types, _events_ and _commands_. When choosing a name 
 
 ### Commands
 
-A command tells _a_ service to do something, and typically a command should only be consumed by a single consumer. If you have a command, such as `SubmitOrder`, then you should have only one consumer that implements `IConsumer<SubmitOrder>` or one saga state machine with the `Event<SubmitOrder>` configured. By maintaining the one-to-one relationship of a command to a consumer, commands may by _published_ and they will be automatically routed to the consumer. 
+A command tells _a_ service to do something, and typically a command should only be consumed by a single consumer. If you have a command, such as `SubmitOrder`, then you should have only one consumer that implements `IConsumer<SubmitOrder>` or one saga state machine with the `Event<SubmitOrder>` configured. By maintaining the one-to-one relationship of a command to a consumer, commands may by _published_ and they will be automatically routed to the consumer.
 
 When using RabbitMQ, there is _no additional overhead_ using this approach. However, both Azure Service Bus and Amazon SQS have a more complicated routing structure and because of that structure, additional charges may be incurred since messages need to be forwarded from topics to queues. For low- to medium-volume message loads this isn't a major concern, but for larger high-volume loads it may be preferable to _[send](/documentation/concepts/producers#send)_ (using `Send`) commands directly to the queue to reduce latency and cost.
 
@@ -211,7 +212,7 @@ When defining message contracts, what follows is general guidance based upon yea
 
 ::list{type="success"}
   - Use records, define properties as `public` and specify `{ get; init; }` accessors. Create messages using the constructor/object initializer or a [message initializer](producers#message-initialization).
-  -	Use interfaces, specify only `{ get; }` accessors. Create messages using message initializers and use the Roslyn Analyzer to identify missing or incompatible properties. 
+  -	Use interfaces, specify only `{ get; }` accessors. Create messages using message initializers and use the Roslyn Analyzer to identify missing or incompatible properties.
   - Limit the use of inheritance, pay attention to polymorphic message routing.  A message type containing a dozen interfaces is a bit annoying to untangle if you need to delve deep into message routing to troubleshoot an issue.
   -	Class inheritance has the same guidance as interfaces, but with more caution.
 ::

--- a/doc/content/3.documentation/5.configuration/5.topology/1.message.md
+++ b/doc/content/3.documentation/5.configuration/5.topology/1.message.md
@@ -130,4 +130,41 @@ x.UsingRabbitMq((context,cfg) =>
 {
     cfg.Publish<ICommand>(p => p.Exclude = true);
 });
+
+```
+
+### ExcludeFromImplementedTypes
+
+_ExcludeFromImplementedTypes_ is an optional attribute that may be specified on a base message type to prevent scope filters being created for the message type.
+
+```csharp
+[ExcludeFromImplementedTypes]
+public interface ICommand
+{
+}
+
+public record ReformatHardDrive :
+    ICommand
+{
+}
+```
+
+### MessageUrn
+
+_MessageUrn_ is an optional attribute that may be specified on a message type to provide a custom Urn that will be used when the message is published or consumed. The generated Urn will be prefixed with `urn:messages:` by default, however a full Urn may be provided by specifying `useDefaultPrefix: false` in the attribute declaration.
+
+```csharp
+[MessageUrn("publish-command")]
+public record PublishCommand
+{
+    // Will generate a urn of: urn:messages:publish-command
+}
+```
+
+```csharp
+[MessageUrn("scheme:publish-command", useDefaultPrefix: false)]
+public record PublishCommand
+{
+    // Will generate a urn of: scheme:publish-command
+}
 ```

--- a/src/MassTransit.Abstractions/Attributes/MessageUrnAttribute.cs
+++ b/src/MassTransit.Abstractions/Attributes/MessageUrnAttribute.cs
@@ -1,0 +1,45 @@
+﻿namespace MassTransit
+{
+    using System;
+
+    /// <summary>
+    /// Specify the URN used for this message contract
+    /// if configured.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+    public class MessageUrnAttribute :
+        Attribute
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="urn">The urn value to use for this message type.</param>
+        /// <param name="useDefaultPrefix">Prefixes with default scheme and namespace if true.</param>
+        public MessageUrnAttribute(string urn, bool useDefaultPrefix = true)
+        {
+            Urn = GetValidUrn(urn, useDefaultPrefix);
+        }
+
+        public Uri Urn { get; }
+
+        private static Uri GetValidUrn(string urn, bool useDefaultPrefix)
+        {
+            if (urn == null)
+                throw new ArgumentNullException(nameof(urn));
+
+            if (string.IsNullOrWhiteSpace(urn))
+                throw new ArgumentException("Value cannot be empty or whitespace only string.", nameof(urn));
+
+            if (urn.StartsWith(MessageUrn.Prefix))
+                throw new ArgumentException($"Value should not contain the default prefix '{MessageUrn.Prefix}'.", nameof(urn));
+
+            var fullValue = useDefaultPrefix ? MessageUrn.Prefix + urn : urn;
+
+
+            if (Uri.TryCreate(fullValue, UriKind.Absolute, out var uri))
+                return uri;
+
+            throw new UriFormatException($"'{fullValue}' is not a valid URI.");
+        }
+    }
+}

--- a/src/MassTransit.Abstractions/MessageUrn.cs
+++ b/src/MassTransit.Abstractions/MessageUrn.cs
@@ -11,6 +11,8 @@ namespace MassTransit
     public class MessageUrn :
         Uri
     {
+        public const string Prefix = "urn:message:";
+
         static readonly ConcurrentDictionary<Type, Cached> _cache = new ConcurrentDictionary<Type, Cached>();
 
         MessageUrn(string uriString)
@@ -82,16 +84,33 @@ namespace MassTransit
 
         static string GetUrnForType(Type type)
         {
-            var sb = new StringBuilder("urn:message:");
-
-            return GetMessageName(sb, type, true);
+            return GetMessageName(type, true);
         }
 
-        static string GetMessageName(StringBuilder sb, Type type, bool includeScope)
+        static string GetMessageName(Type type, bool includeScope)
+        {
+            var fromAttribute = GetMessageNameFromAttribute(type);
+
+            if (!string.IsNullOrWhiteSpace(fromAttribute))
+            {
+                return fromAttribute;
+            }
+
+            return GetMessageNameFromType(new StringBuilder(Prefix), type, includeScope);
+        }
+
+        static string? GetMessageNameFromAttribute(Type type)
+        {
+            var attribute = type.GetCustomAttribute<MessageUrnAttribute>();
+            return attribute?.Urn.ToString();
+        }
+
+        static string GetMessageNameFromType(StringBuilder sb, Type type, bool includeScope)
         {
             var typeInfo = type.GetTypeInfo();
+            
             if (typeInfo.IsGenericParameter)
-                return "";
+                return string.Empty;
 
             if (includeScope && typeInfo.Namespace != null)
             {
@@ -103,7 +122,7 @@ namespace MassTransit
 
             if (typeInfo.IsNested && typeInfo.DeclaringType != null)
             {
-                GetMessageName(sb, typeInfo.DeclaringType, false);
+                GetMessageNameFromType(sb, typeInfo.DeclaringType, false);
                 sb.Append('+');
             }
 
@@ -127,7 +146,7 @@ namespace MassTransit
                         sb.Append(',');
 
                     sb.Append('[');
-                    GetMessageName(sb, arguments[i], true);
+                    GetMessageNameFromType(sb, arguments[i], true);
                     sb.Append(']');
                 }
 

--- a/tests/MassTransit.Tests/MessageUrnSpecs.cs
+++ b/tests/MassTransit.Tests/MessageUrnSpecs.cs
@@ -36,6 +36,72 @@ namespace MassTransit.Tests
             Assert.AreEqual(urn.AbsolutePath, "message:MassTransit.TestFramework.Messages:PingMessage");
         }
 
+        [Test]
+        public void AttributedMessage()
+        {
+            var urn = MessageUrn.ForType(typeof(Attributed));
+            Assert.AreEqual(urn.AbsolutePath, "message:MyCustomName");
+        }
+
+        [Test]
+        public void AttributedMessage_with_symbols()
+        {
+            var urn = MessageUrn.ForType(typeof(AttributedSymbols));
+            Assert.AreEqual(urn, "urn:message:\\|,./<>?;'#:@~[]{}¬!\"£$%25^&*()_+`¦€");
+        }
+
+        [Test]
+        public void AttributedMessage_with_null_throws_error()
+        {
+            Assert.That(
+                () => MessageUrn.ForType(typeof(AttributedNull)),
+                Throws.TypeOf<TypeInitializationException>()
+                .And.InnerException.TypeOf<ArgumentNullException>()
+                .And.InnerException.Message.EqualTo("Value cannot be null. (Parameter 'urn')"));
+        }
+
+        [Test]
+        public void AttributedMessage_with_empty_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedEmpty)),
+                Throws.TypeOf<TypeInitializationException>()
+                .And.InnerException.TypeOf<ArgumentException>()
+                .And.InnerException.Message.EqualTo("Value cannot be empty or whitespace only string. (Parameter 'urn')"));
+        }
+
+        [Test]
+        public void AttributedMessage_with_whitespace_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedWhitespace)),
+                Throws.TypeOf<TypeInitializationException>()
+                .And.InnerException.TypeOf<ArgumentException>()
+                .And.InnerException.Message.EqualTo("Value cannot be empty or whitespace only string. (Parameter 'urn')"));
+        }
+
+        [Test]
+        public void AttributedMessage_with_default_prefix_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedKnownPrefix)),
+                Throws.TypeOf<TypeInitializationException>()
+                .And.InnerException.TypeOf<ArgumentException>()
+                .And.InnerException.Message.EqualTo("Value should not contain the default prefix 'urn:message:'. (Parameter 'urn')"));
+        }
+
+        [Test]
+        public void AttributedMessage_without_default_prefix()
+        {
+            var urn = MessageUrn.ForType(typeof(AttributedNoDefaults));
+            Assert.AreEqual(urn, "scheme:identifier");
+        }
+
+        [Test]
+        public void AttributedMessage_without_default_prefix_and_invalid_urn_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedNoDefaultsInvalidUrn)),
+                Throws.TypeOf<TypeInitializationException>()
+                .And.InnerException.TypeOf<UriFormatException>()
+                .And.InnerException.Message.EqualTo("'scheme' is not a valid URI."));
+        }
 
         class X
         {
@@ -45,5 +111,53 @@ namespace MassTransit.Tests
 
     public class G<T>
     {
+    }
+
+    [MessageUrn("MyCustomName")]
+    public class Attributed
+    {
+
+    }
+
+    [MessageUrn(null)]
+    public class AttributedNull
+    {
+
+    }
+
+    [MessageUrn("")]
+    public class AttributedEmpty
+    {
+
+    }
+
+    [MessageUrn("\t\t   ")]
+    public class AttributedWhitespace
+    {
+
+    }
+
+    [MessageUrn("urn:message:MyCustomName")]
+    public class AttributedKnownPrefix
+    {
+
+    }
+
+    [MessageUrn("\\|,./<>?;'#:@~[]{}¬!\"£$%^&*()_+`¦€")]
+    public class AttributedSymbols
+    {
+
+    }
+
+    [MessageUrn("scheme:identifier", useDefaultPrefix: false)]
+    public class AttributedNoDefaults
+    {
+
+    }
+
+    [MessageUrn("scheme", useDefaultPrefix: false)]
+    public class AttributedNoDefaultsInvalidUrn
+    {
+
     }
 }


### PR DESCRIPTION
## Description

MassTransit provides an opinionated `MessageUrn` class which is used to identify the types for a message during serialization/deserialization. 80% of the time or more I am certain this is sufficient for most users of Mass Transit.

In our scenario we have many services publishing and subscribing to messages, some are dotnet implementations using MassTransit, others are consumers operating in different contexts.  We'd like to uniformly apply a naming convention that is not bound to a specific toolchain implementation.  By restricting the `MessageUrn` to be derived from a namespace, this feels like a leaking of an implementation detail of the message producer, while the consumer should only be held to the contract of the message.

## Changes Implemented

This PR adds a `MessageUrnAttribute` that may be added to a class when publishing to provide a custom URN value.  Additionally the same attribute may be placed on a class in a consumer implementation to specify the custom URN for deserialization.

## Tests

Additional unit tests have been added and some base smoke testing performed with a simple consumer/producer project.  When testing using RabbitMq the custom URN can be seen in the correct location:
![image](https://user-images.githubusercontent.com/351423/228663527-74759760-eb89-413f-bfb4-556019640ab3.png)

## Request for Feedback

As the URN is built using a `StringBuilder` the current implementation in this PR only overrides the part of the URN normally derived from the type.  Therefore the URN still starts with `urn:message:`.  It seems feasible to fully override the URN format to an arbitrary string, allowing full customization. However it would appear the URN format is of value for diagnostics.  Would it be sensible to provide the current URN implementation for diagnostics, but allow the full string override value to only be supplied during serialization/deserialization operations? If so I can easily make the change.