### PR TITLE
Use ReceiveEndpointDependencyFilter to manage dependencies

### DIFF
--- a/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointConfigurator.cs
+++ b/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointConfigurator.cs
@@ -10,6 +10,7 @@ namespace MassTransit
     /// </summary>
     public interface IReceiveEndpointConfigurator :
         IEndpointConfigurator,
+        IReceiveEndpointObserverConnector,
         IReceiveEndpointDependencyConnector,
         IReceiveEndpointDependentConnector
     {

--- a/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependencyConnector.cs
+++ b/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependencyConnector.cs
@@ -1,11 +1,14 @@
 namespace MassTransit
 {
+    using Transports;
+
+
     public interface IReceiveEndpointDependencyConnector
     {
         /// <summary>
-        /// Add the observable receive endpoint as a dependent
+        /// Add receive endpoint dependency. Endpoint will be started when dependency is Ready
         /// </summary>
-        /// <param name="dependent"></param>
-        void AddDependency(IReceiveEndpointDependentConnector dependent);
+        /// <param name="dependency"></param>
+        void AddDependency(IReceiveEndpointDependency dependency);
     }
 }

--- a/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependentConnector.cs
+++ b/src/MassTransit.Abstractions/Configuration/Middleware/IReceiveEndpointDependentConnector.cs
@@ -1,12 +1,14 @@
 namespace MassTransit
 {
-    public interface IReceiveEndpointDependentConnector :
-        IReceiveEndpointObserverConnector
+    using Transports;
+
+
+    public interface IReceiveEndpointDependentConnector
     {
         /// <summary>
-        /// Add the observable receive endpoint as a dependency
+        /// Add the dependent to receive endpoint. Receive endpoint will be stopped when dependent is Completed
         /// </summary>
-        /// <param name="dependency"></param>
-        void AddDependent(IReceiveEndpointObserverConnector dependency);
+        /// <param name="dependent"></param>
+        void AddDependent(IReceiveEndpointDependent dependent);
     }
 }

--- a/src/MassTransit.Abstractions/Configuration/Middleware/ReceiveEndpointConfiguratorDependencyExtensions.cs
+++ b/src/MassTransit.Abstractions/Configuration/Middleware/ReceiveEndpointConfiguratorDependencyExtensions.cs
@@ -1,0 +1,99 @@
+namespace MassTransit
+{
+    using System.Threading.Tasks;
+    using Transports;
+
+
+    public static class ReceiveEndpointConfiguratorDependencyExtensions
+    {
+        public static void AddDependency(this IReceiveEndpointConfigurator connector, IReceiveEndpointConfigurator dependency)
+        {
+            connector.AddDependency(new ReceiveEndpointDependency(dependency));
+            dependency.AddDependent(new ReceiveEndpointDependent(connector));
+        }
+
+
+        class ReceiveEndpointDependency :
+            IReceiveEndpointDependency,
+            IReceiveEndpointObserver
+        {
+            readonly ConnectHandle _handle;
+            readonly TaskCompletionSource<ReceiveEndpointReady> _ready;
+
+            public ReceiveEndpointDependency(IReceiveEndpointObserverConnector connector)
+            {
+                _ready = new TaskCompletionSource<ReceiveEndpointReady>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                _handle = connector.ConnectReceiveEndpointObserver(this);
+            }
+
+            public Task Ready => _ready.Task;
+
+            Task IReceiveEndpointObserver.Ready(ReceiveEndpointReady ready)
+            {
+                _handle.Disconnect();
+
+                _ready.TrySetResult(ready);
+
+                return Task.CompletedTask;
+            }
+
+            Task IReceiveEndpointObserver.Stopping(ReceiveEndpointStopping stopping)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task IReceiveEndpointObserver.Completed(ReceiveEndpointCompleted completed)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task IReceiveEndpointObserver.Faulted(ReceiveEndpointFaulted faulted)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+
+        class ReceiveEndpointDependent :
+            IReceiveEndpointDependent,
+            IReceiveEndpointObserver
+        {
+            readonly TaskCompletionSource<ReceiveEndpointCompleted> _completed;
+            readonly ConnectHandle _handle;
+
+            public ReceiveEndpointDependent(IReceiveEndpointObserverConnector connector)
+            {
+                _completed = new TaskCompletionSource<ReceiveEndpointCompleted>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                _handle = connector.ConnectReceiveEndpointObserver(this);
+            }
+
+            public Task Completed => _completed.Task;
+
+            Task IReceiveEndpointObserver.Ready(ReceiveEndpointReady ready)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task IReceiveEndpointObserver.Stopping(ReceiveEndpointStopping stopping)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task IReceiveEndpointObserver.Completed(ReceiveEndpointCompleted completed)
+            {
+                _handle.Disconnect();
+
+                _completed.TrySetResult(completed);
+
+                return Task.CompletedTask;
+            }
+
+            Task IReceiveEndpointObserver.Faulted(ReceiveEndpointFaulted faulted)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/MassTransit/Configuration/Configuration/IReceiveEndpointConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/IReceiveEndpointConfiguration.cs
@@ -8,6 +8,7 @@
 
     public interface IReceiveEndpointConfiguration :
         IEndpointConfiguration,
+        IReceiveEndpointObserverConnector,
         IReceiveEndpointDependentConnector
     {
         IConsumePipe ConsumePipe { get; }

--- a/src/MassTransit/Configuration/Configuration/ReceiverConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/ReceiverConfiguration.cs
@@ -3,6 +3,7 @@ namespace MassTransit.Configuration
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Transports;
 
 
     public class ReceiverConfiguration :
@@ -35,7 +36,7 @@ namespace MassTransit.Configuration
             set { }
         }
 
-        public void AddDependency(IReceiveEndpointDependentConnector dependent)
+        public void AddDependency(IReceiveEndpointDependency dependent)
         {
         }
 
@@ -44,7 +45,7 @@ namespace MassTransit.Configuration
             return _configuration.ConnectReceiveEndpointObserver(observer);
         }
 
-        public void AddDependent(IReceiveEndpointObserverConnector dependency)
+        public void AddDependent(IReceiveEndpointDependent dependent)
         {
         }
 

--- a/src/MassTransit/Middleware/ReceiveEndpointDependencyFilter.cs
+++ b/src/MassTransit/Middleware/ReceiveEndpointDependencyFilter.cs
@@ -1,0 +1,32 @@
+namespace MassTransit.Middleware
+{
+    using System.Threading.Tasks;
+    using Internals;
+    using Transports;
+
+
+    public class ReceiveEndpointDependencyFilter<TContext> :
+        IFilter<TContext>
+        where TContext : class, PipeContext
+    {
+        readonly ReceiveEndpointContext _context;
+
+        public ReceiveEndpointDependencyFilter(ReceiveEndpointContext context)
+        {
+            _context = context;
+        }
+
+        public async Task Send(TContext context, IPipe<TContext> next)
+        {
+            await _context.DependenciesReady.OrCanceled(context.CancellationToken).ConfigureAwait(false);
+
+            await next.Send(context).ConfigureAwait(false);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("receiveEndpointDependencies");
+            scope.Add("contextType", typeof(TContext).Name);
+        }
+    }
+}

--- a/src/MassTransit/Transports/ReceiveTransport.cs
+++ b/src/MassTransit/Transports/ReceiveTransport.cs
@@ -189,7 +189,9 @@ namespace MassTransit.Transports
                     if (_preStartPipe.IsNotEmpty())
                         await _supervisor.Send(_preStartPipe, Stopping).ConfigureAwait(false);
 
-                    await _context.OnTransportStartup(_supervisor, Stopping).ConfigureAwait(false);
+                    // Nothing connected to the pipe, so signal early we are available
+                    if (!_context.ReceivePipe.Connected.IsCompleted)
+                        await _context.OnTransportStartup(_supervisor, Stopping).ConfigureAwait(false);
 
                     if (!IsStopping)
                         await _supervisor.Send(_transportPipe, Stopped).ConfigureAwait(false);

--- a/src/MassTransit/Transports/TransportStartExtensions.cs
+++ b/src/MassTransit/Transports/TransportStartExtensions.cs
@@ -12,17 +12,11 @@ namespace MassTransit.Transports
             CancellationToken cancellationToken)
             where T : class, PipeContext
         {
-            // Nothing connected to the pipe, so signal early we are available
-            if (!context.ReceivePipe.Connected.IsCompleted)
-            {
-                using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, supervisor.ConsumeStopping);
+            using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, supervisor.ConsumeStopping);
 
-                var pipe = new WaitForConnectionPipe<T>(context, tokenSource.Token);
+            var pipe = new WaitForConnectionPipe<T>(context, tokenSource.Token);
 
-                await supervisor.Send(pipe, cancellationToken).ConfigureAwait(false);
-            }
-
-            await context.DependenciesReady.OrCanceled(cancellationToken).ConfigureAwait(false);
+            await supervisor.Send(pipe, cancellationToken).ConfigureAwait(false);
         }
 
 

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/ActiveMqReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/ActiveMqReceiveEndpointConfiguration.cs
@@ -56,7 +56,10 @@
             if (_hostConfiguration.DeployTopologyOnly)
                 _sessionConfigurator.UseFilter(new TransportReadyFilter<SessionContext>(context));
             else
+            {
+                _sessionConfigurator.UseFilter(new ReceiveEndpointDependencyFilter<SessionContext>(context));
                 _sessionConfigurator.UseFilter(new ActiveMqConsumerFilter(context));
+            }
 
             IPipe<SessionContext> sessionPipe = _sessionConfigurator.Build();
 

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
@@ -61,6 +61,7 @@
                 if (_settings.PurgeOnStartup)
                     _clientConfigurator.UseFilter(new PurgeOnStartupFilter(_settings.EntityName));
 
+                _clientConfigurator.UseFilter(new ReceiveEndpointDependencyFilter<ClientContext>(context));
                 _clientConfigurator.UseFilter(new AmazonSqsConsumerFilter(context));
             }
 

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
@@ -127,6 +127,7 @@
                 ClientPipeConfigurator.UseFilter(new TransportReadyFilter<ClientContext>(receiveEndpointContext));
             else
             {
+                ClientPipeConfigurator.UseFilter(new ReceiveEndpointDependencyFilter<ClientContext>(receiveEndpointContext));
                 ClientPipeConfigurator.UseFilter(_settings.RequiresSession
                     ? new MessageSessionReceiverFilter(receiveEndpointContext)
                     : new MessageReceiverFilter(receiveEndpointContext));

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointConfigurator.cs
@@ -6,6 +6,7 @@ namespace MassTransit.EventHubIntegration.Configuration
     using Azure.Messaging.EventHubs.Processor;
     using Azure.Storage.Blobs;
     using MassTransit.Configuration;
+    using MassTransit.Middleware;
     using Middleware;
     using Transports;
 
@@ -110,6 +111,7 @@ namespace MassTransit.EventHubIntegration.Configuration
             var context = CreateEventHubReceiveContext();
 
             _processorConfigurator.UseFilter(new EventHubBlobContainerFactoryFilter(_blobClient.Value));
+            _processorConfigurator.UseFilter(new ReceiveEndpointDependencyFilter<ProcessorContext>(context));
             _processorConfigurator.UseFilter(new EventHubConsumerFilter(context));
 
             IPipe<ProcessorContext> processorPipe = _processorConfigurator.Build();

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaTopicReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaTopicReceiveEndpointConfiguration.cs
@@ -4,6 +4,7 @@ namespace MassTransit.KafkaIntegration.Configuration
     using System.Collections.Generic;
     using Confluent.Kafka;
     using MassTransit.Configuration;
+    using MassTransit.Middleware;
     using Middleware;
     using Serializers;
     using Transports;
@@ -235,6 +236,7 @@ namespace MassTransit.KafkaIntegration.Configuration
             if (_options.TryGetOptions(out KafkaTopicOptions options))
                 _consumerConfigurator.UseFilter(new ConfigureKafkaTopologyFilter<TKey, TValue>(_hostConfiguration.Configuration, options));
 
+            _consumerConfigurator.UseFilter(new ReceiveEndpointDependencyFilter<ConsumerContext>(context));
             _consumerConfigurator.UseFilter(new KafkaConsumerFilter<TKey, TValue>(context));
 
             IPipe<ConsumerContext> consumerPipe = _consumerConfigurator.Build();

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointConfiguration.cs
@@ -71,6 +71,7 @@ namespace MassTransit.RabbitMqTransport.Configuration
                     _modelConfigurator.UseFilter(new PurgeOnStartupFilter(_settings.QueueName));
 
                 _modelConfigurator.UseFilter(new PrefetchCountFilter(_settings.PrefetchCount));
+                _modelConfigurator.UseFilter(new ReceiveEndpointDependencyFilter<ModelContext>(context));
                 _modelConfigurator.UseFilter(new RabbitMqConsumerFilter(context));
             }
 

--- a/tests/MassTransit.Containers.Tests/ReceiveEndpointDependency_Specs.cs
+++ b/tests/MassTransit.Containers.Tests/ReceiveEndpointDependency_Specs.cs
@@ -1,0 +1,128 @@
+namespace MassTransit.Containers.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+    using NUnit.Framework;
+    using TestFramework;
+    using Testing;
+    using Transports;
+
+
+    public class ReceiveEndpointDependency_Specs
+    {
+        [Test]
+        public async Task Should_not_receive_message_before_dependency_ready()
+        {
+            await using var provider = SetupServiceCollection();
+
+            var harness = provider.GetTestHarness();
+
+            var healthChecks = provider.GetService<HealthCheckService>();
+
+            await harness.Start();
+
+            await harness.Bus.Publish<DependentMessage>(new { });
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            Assert.That(await harness.Published.Any<DependentMessage>(cts.Token), Is.True);
+            Assert.That(await harness.Consumed.Any<DependentMessage>(cts.Token), Is.False);
+
+            await healthChecks.WaitForHealthStatus(HealthStatus.Unhealthy);
+
+            await harness.Bus.Publish<DependencyReadyMessage>(new { });
+
+            await healthChecks.WaitForHealthStatus(HealthStatus.Healthy);
+
+            Assert.That(await harness.Consumed.Any<DependencyReadyMessage>(cts.Token), Is.True);
+            Assert.That(await harness.Consumed.Any<DependentMessage>(cts.Token), Is.True);
+        }
+
+        static ServiceProvider SetupServiceCollection()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<IReceiveEndpointDependency, TestDependency>()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.AddConsumer<DependencyConsumer>();
+                    x.AddConsumer<DependentConsumer>(typeof(DependentConsumerDefinition));
+
+                    x.AddTaskCompletionSource<bool>();
+                });
+
+            services.AddOptions<MassTransitHostOptions>().Configure(x => x.WaitUntilStarted = false);
+
+            return services.BuildServiceProvider(true);
+        }
+
+
+        class DependentConsumerDefinition :
+            ConsumerDefinition<DependentConsumer>
+        {
+            readonly IReceiveEndpointDependency _dependency;
+
+            public DependentConsumerDefinition(IReceiveEndpointDependency dependency)
+            {
+                _dependency = dependency;
+            }
+
+            protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator,
+                IConsumerConfigurator<DependentConsumer> consumerConfigurator)
+            {
+                endpointConfigurator.AddDependency(_dependency);
+            }
+        }
+
+
+        class TestDependency :
+            IReceiveEndpointDependency
+        {
+            public TestDependency(TaskCompletionSource<bool> taskCompletionSource)
+            {
+                Ready = taskCompletionSource.Task;
+            }
+
+            public Task Ready { get; }
+        }
+
+
+        public interface DependencyReadyMessage
+        {
+        }
+
+
+        public interface DependentMessage
+        {
+        }
+
+
+        class DependencyConsumer :
+            IConsumer<DependencyReadyMessage>
+        {
+            readonly TaskCompletionSource<bool> _taskCompletionSource;
+
+            public DependencyConsumer(TaskCompletionSource<bool> taskCompletionSource)
+            {
+                _taskCompletionSource = taskCompletionSource;
+            }
+
+            public Task Consume(ConsumeContext<DependencyReadyMessage> context)
+            {
+                _taskCompletionSource.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        }
+
+
+        class DependentConsumer :
+            IConsumer<DependentMessage>
+        {
+            public Task Consume(ConsumeContext<DependentMessage> context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stopping log with 5sec delay for Stop Completed (to make it visible in logs) for: https://github.com/MassTransit/MassTransit/blob/252aa619a381f778b9f1a55952c5958639a80d8d/tests/MassTransit.Tests/JobConsumer_Specs.cs#L49
```bash
13:16:17.163-D Job Service Instance Stopped: loopback://localhost/instance-pywoyyg6ww5pdhu6bdpudap3f9
13:16:17.163-D RECEIVE loopback://localhost/job-type 68290000-dea5-36d1-cad2-08db31e1baa1 MassTransit.Contracts.JobService.SetConcurrentJobLimit MassTransit.JobTypeSaga(00:00:00.0002460)
13:16:17.164-D Stopping bus: loopback://localhost/
13:16:17.167-D Endpoint Stopping: loopback://localhost/odd-job
13:16:17.167-D Consumer Stopping: loopback://localhost/odd-job (Stop Receive Transport)
13:16:17.170-D Endpoint Stopping: loopback://localhost/odd-job-completed
13:16:17.170-D Consumer Stopping: loopback://localhost/odd-job-completed (Stop Receive Transport)
13:16:17.170-D Endpoint Completed: loopback://localhost/odd-job-completed
13:16:17.170-D Endpoint Completed: loopback://localhost/odd-job
13:16:17.171-D Consumer Completed: loopback://localhost/odd-job-completed: 1 received, 1 concurrent
13:16:17.171-D Consumer Completed: loopback://localhost/odd-job: 2 received, 1 concurrent
13:16:22.173-D Endpoint Stopping: loopback://localhost/instance-pywoyyg6ww5pdhu6bdpudap3f9
13:16:22.173-D Endpoint Stopping: loopback://localhost/job
13:16:22.173-D Endpoint Stopping: loopback://localhost/job-type
13:16:22.173-D Consumer Stopping: loopback://localhost/job-type (Stop Receive Transport)
13:16:22.173-D Consumer Stopping: loopback://localhost/job (Stop Receive Transport)
13:16:22.173-D Consumer Stopping: loopback://localhost/instance-pywoyyg6ww5pdhu6bdpudap3f9 (Stop Receive Transport)
13:16:22.173-D Endpoint Stopping: loopback://localhost/job-attempt
13:16:22.173-D Consumer Stopping: loopback://localhost/job-attempt (Stop Receive Transport)
13:16:22.174-D Endpoint Completed: loopback://localhost/instance-pywoyyg6ww5pdhu6bdpudap3f9
13:16:22.174-D Endpoint Completed: loopback://localhost/job-attempt
13:16:22.174-D Endpoint Completed: loopback://localhost/job
13:16:22.174-D Endpoint Completed: loopback://localhost/job-type
13:16:22.174-D Consumer Completed: loopback://localhost/instance-pywoyyg6ww5pdhu6bdpudap3f9: 1 received, 1 concurrent
13:16:22.174-D Consumer Completed: loopback://localhost/job-attempt: 3 received, 1 concurrent
13:16:22.174-D Consumer Completed: loopback://localhost/job: 5 received, 2 concurrent
13:16:22.174-D Consumer Completed: loopback://localhost/job-type: 4 received, 1 concurrent
13:16:22.174-D Endpoint Stopping: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_pywoyyg6ww5pdy44bdpudap3gi
13:16:22.174-D Consumer Stopping: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_pywoyyg6ww5pdy44bdpudap3gi (Stop Receive Transport)
13:16:22.174-D Endpoint Completed: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_pywoyyg6ww5pdy44bdpudap3gi
13:16:22.174-D Consumer Completed: loopback://localhost/DenyssLaptop_ReSharperTestRunner_bus_pywoyyg6ww5pdy44bdpudap3gi: 1 received, 1 concurrent
13:16:22.183-I Bus stopped: loopback://localhost/
```