### PR TITLE
Adding method for cleaning ContainerTestHarness state.

### DIFF
--- a/src/MassTransit/DependencyInjection/DependencyInjection/Testing/ContainerTestHarness.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Testing/ContainerTestHarness.cs
@@ -233,5 +233,12 @@ namespace MassTransit.DependencyInjection.Testing
             _handles.Add(bus.ConnectReceiveObserver(_received.Value));
             _handles.Add(bus.ConnectSendObserver(_sent.Value));
         }
+
+        public void ClearMessages()
+        {
+            _consumed?.Value.ClearMessages();
+            _published?.Value.ClearMessages();
+            _sent?.Value.ClearMessages();
+        }
     }
 }

--- a/src/MassTransit/Testing/Implementations/AsyncElementList.cs
+++ b/src/MassTransit/Testing/Implementations/AsyncElementList.cs
@@ -173,6 +173,14 @@ namespace MassTransit.Testing.Implementations
             }
         }
 
+        public void Clear()
+        {
+            lock (_messages)
+            {
+                _messages.Clear();
+            }
+        }
+
         protected void Add(TElement context)
         {
             if (!context.ElementId.HasValue)

--- a/src/MassTransit/Testing/Implementations/BusTestConsumeObserver.cs
+++ b/src/MassTransit/Testing/Implementations/BusTestConsumeObserver.cs
@@ -44,5 +44,10 @@
 
             return Interlocked.Decrement(ref _activeCount) == 0 ? NotifyInactive() : Task.CompletedTask;
         }
+
+        public void ClearMessages()
+        {
+            _messages.Clear();
+        }
     }
 }

--- a/src/MassTransit/Testing/Implementations/BusTestPublishObserver.cs
+++ b/src/MassTransit/Testing/Implementations/BusTestPublishObserver.cs
@@ -38,5 +38,10 @@
 
             return RestartTimer(false);
         }
+
+        public void ClearMessages()
+        {
+            _messages.Clear();
+        }
     }
 }

--- a/src/MassTransit/Testing/Implementations/BusTestSendObserver.cs
+++ b/src/MassTransit/Testing/Implementations/BusTestSendObserver.cs
@@ -41,5 +41,10 @@ namespace MassTransit.Testing.Implementations
 
             return RestartTimer(false);
         }
+
+        public void ClearMessages()
+        {
+            _messages.Clear();
+        }
     }
 }


### PR DESCRIPTION
# Purpose of change
Currently when using `AddMassTransitTestHarness` with `WebApplicationFactory` there is no way to "reset" the state of the `ITestHarness` after a test.

While this is completely fine in most cases, in the case where someone might want to use `ICollectionFixture<WebApplicationFactory<T>>` (XUnit class allowing to share context between tests in collection) this feature becomes needed.

For example, in my case I am using the Respawn NuGet package to reset the database state between tests, but I have no way to reset the harness state (no way that I have found at least, if it exists, would like to know how and throw away this PR)

# Implementation
I tried to have as minimal of a change as possible, because this is a rather niche feature. If it is okay to have it exposed to the user, it's possible to add it to the `ITestHarness` interface as well.

# How to validate it works
In this fork, I have made a new branch called `Testing-Harness-Reset` which has the following test:
```csharp
    public class ContainerTestHarnessTests
    {
        public class SampleConsumer : IConsumer<WeatherForecast>
        {
            public Task Consume(ConsumeContext<WeatherForecast> context)
            {
                return Task.CompletedTask;
            }
        }

        public record WeatherForecast(int temperature);

        [Test]
        public async Task ClearMessages_Should_Reset_Consumed_Published_Sent()
        {
            await using ServiceProvider provider = new ServiceCollection()
                .AddMassTransitTestHarness(x =>
                {
                    x.AddConsumer<SampleConsumer>();
                })
                .BuildServiceProvider(true);
            ITestHarness harness = provider.GetRequiredService<ITestHarness>();
            WeatherForecast weatherForecast = new(1);
            await harness.Start();

            await harness.Bus.Publish(weatherForecast);
            ISendEndpoint sendEndpoint = await harness.GetConsumerEndpoint<SampleConsumer>();
            await sendEndpoint.Send(weatherForecast);
            Assert.IsTrue(await harness.Sent.Any<WeatherForecast>());
            Assert.IsTrue(await harness.Published.Any<WeatherForecast>());
            Assert.IsTrue(await harness.Consumed.Any<WeatherForecast>());

            ((ContainerTestHarness)harness).ClearMessages();

            Assert.False(await harness.Sent.Any<WeatherForecast>());
            Assert.False(await harness.Published.Any<WeatherForecast>());
            Assert.False(await harness.Consumed.Any<WeatherForecast>());
        }
    }
```
![image](https://user-images.githubusercontent.com/44773462/230574604-b4e3b969-3ef0-4a2d-adcb-89cc102cbb46.png)
