### PR TITLE
Fix typo in request documentaiton

### DIFF
--- a/doc/content/3.documentation/1.concepts/5.requests.md
+++ b/doc/content/3.documentation/1.concepts/5.requests.md
@@ -99,7 +99,7 @@ services.AddMassTransit(x =>
 {
     // configure the consumer on a specific endpoint address
     x.AddConsumer<CheckOrderStatusConsumer>()
-        .Endpoint(e => e.Name = 'order-status');
+        .Endpoint(e => e.Name = "order-status");
         
     // Sends the request to the specified address, instead of publishing it
     x.AddRequestClient<CheckOrderStatus>(new Uri("exchange:order-status"));


### PR DESCRIPTION
Strings in C# should be in **double** quotes.
