### PR TITLE
Feature/key rotation encryption

### DIFF
--- a/docs/architecture/encrypted-messages.md
+++ b/docs/architecture/encrypted-messages.md
@@ -73,7 +73,7 @@ var bus = Bus.Factory.CreateUsingRabbitMq(sbc =>
 {
     // ...
 
-    sbc.UseEncryption(keyProvider)
+    sbc.UseEncryption(keyProvider);
 });
 ```
 
@@ -86,7 +86,22 @@ var bus = Bus.Factory.CreateUsingRabbitMq(sbc =>
 {
     // ...
     sbc.ClearMessageDeserializers();
-    sbc.UseEncryption(key)
+    sbc.UseEncryption(key);
 });
 ```
 
+### Key Rotation Support
+
+This feature enables support Key Rotation without downtime. For the encryption part the ```firstKey``` will be used. Whilst decryption will be commenced using the ```firstKey```, if decryption fails the ```secondarykey``` will be used to deserialize the message.
+
+```csharp
+var bus = Bus.Factory.CreateUsingRabbitMq(sbc =>
+{
+    // ...
+    sbc.ClearMessageDeserializers();
+    sbc.UseDualDecryptionWithNewtonsoftJson(primaryKey, secondaryKey);
+});
+```
+
+To rotate the keys simply move the ```firstKey``` value to the ```secondarykey```, making the current-key the old-key. 
+Now generate a new key and set the ```firstKey``` value, this key will now be used to encrypt new messages. Rotating the keys can be done while there are still messages in the bus which are encrypted with the old-key since both keys are used to attempt decryption. 

--- a/src/MassTransit.Newtonsoft/Serialization/DualDecryptionExtensions.cs
+++ b/src/MassTransit.Newtonsoft/Serialization/DualDecryptionExtensions.cs
@@ -1,0 +1,107 @@
+namespace MassTransit.Serialization
+{
+    using MassTransit;
+
+    public static class DualDecryptionExtensions
+    {
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="primaryProvider"></param>
+        /// <param name="secondaryProvider"></param>
+        public static void UseDualDecryptionWithNewtonsoftJson(this IBusFactoryConfigurator configurator, ICryptoStreamProviderV2 primaryProvider, ICryptoStreamProviderV2 secondaryProvider)
+        {
+            var factory = new DualNewtonsoftDecryptionV2SerializerFactory(primaryProvider, secondaryProvider);
+
+            configurator.AddSerializer(factory);
+            configurator.AddDeserializer(factory);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="primaryProvider"></param>
+        /// <param name="secondaryProvider"></param>
+        public static void UseDualDecryptionWithNewtonsoftJson(this IReceiveEndpointConfigurator configurator, ICryptoStreamProviderV2 primaryProvider, ICryptoStreamProviderV2 secondaryProvider)
+        {
+            var factory = new DualNewtonsoftDecryptionV2SerializerFactory(primaryProvider, secondaryProvider);
+
+            configurator.AddSerializer(factory);
+            configurator.AddDeserializer(factory);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="primarySymmetricKey">
+        /// Cryptographic key for both encryption of plaintext message and decryption of ciphertext message
+        /// </param>
+        /// <param name="secondarySymmetricKey">
+        /// Cryptographic key for decryption of ciphertext message if the primary key fails
+        /// </param>
+        public static void UseDualDecryptionWithNewtonsoftJson(this IBusFactoryConfigurator configurator, byte[] primarySymmetricKey, byte[] secondarySymmetricKey)
+        {
+            var primaryKeyProvider = new ConstantSecureKeyProvider(primarySymmetricKey);
+            var secondaryKeyProvider = new ConstantSecureKeyProvider(secondarySymmetricKey);
+
+            configurator.UseDualDecryptionWithNewtonsoftJson(primaryKeyProvider, secondaryKeyProvider);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="primarySymmetricKey">
+        /// Cryptographic key for both encryption of plaintext message and decryption of ciphertext message
+        /// </param>
+        /// <param name="secondarySymmetricKey">
+        /// Cryptographic key for decryption of ciphertext message if the primary key fails
+        /// </param>
+        public static void UseDualDecryptionWithNewtonsoftJson(this IReceiveEndpointConfigurator configurator, byte[] primarySymmetricKey, byte[] secondarySymmetricKey)
+        {
+            var primaryKeyProvider = new ConstantSecureKeyProvider(primarySymmetricKey);
+            var secondaryKeyProvider = new ConstantSecureKeyProvider(secondarySymmetricKey);
+
+            configurator.UseDualDecryptionWithNewtonsoftJson(primaryKeyProvider, secondaryKeyProvider);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="primaryKeyProvider">
+        /// The custom key provider to provide the symmetric key for encryption of plaintext message and decryption of ciphertext message
+        /// </param>
+        /// <param name="secondaryKeyProvider">
+        /// The custom key provider to provide the symmetric key for decryption of ciphertext message if the primary key fails
+        /// </param>
+        public static void UseDualDecryptionWithNewtonsoftJson(this IBusFactoryConfigurator configurator, ISecureKeyProvider primaryKeyProvider, ISecureKeyProvider secondaryKeyProvider)
+        {
+            var primaryProvider = new AesCryptoStreamProviderV2(primaryKeyProvider);
+            var secondaryProvider = new AesCryptoStreamProviderV2(secondaryKeyProvider);
+
+            configurator.UseDualDecryptionWithNewtonsoftJson(primaryProvider, secondaryProvider);
+        }
+
+        /// <summary>
+        /// Serialize messages using the BSON message serializer with AES Encryption
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="primaryKeyProvider">
+        /// The custom key provider to provide the symmetric key for encryption of plaintext message and decryption of ciphertext message
+        /// </param>
+        /// <param name="secondaryKeyProvider">
+        /// The custom key provider to provide the symmetric key for decryption of ciphertext message if the primary key fails
+        /// </param>
+        public static void UseDualDecryptionWithNewtonsoftJson(this IReceiveEndpointConfigurator configurator, ISecureKeyProvider primaryKeyProvider, ISecureKeyProvider secondaryKeyProvider)
+        {
+            var primaryProvider = new AesCryptoStreamProviderV2(primaryKeyProvider);
+            var secondaryProvider = new AesCryptoStreamProviderV2(secondaryKeyProvider);
+
+            configurator.UseDualDecryptionWithNewtonsoftJson(primaryProvider, secondaryProvider);
+        }
+    }
+}

--- a/src/MassTransit.Newtonsoft/Serialization/DualDecryptionMessageDeserializerV2.cs
+++ b/src/MassTransit.Newtonsoft/Serialization/DualDecryptionMessageDeserializerV2.cs
@@ -1,0 +1,108 @@
+namespace MassTransit.Serialization
+{
+    using System;
+    using System.Linq;
+    using System.Net.Mime;
+    using System.Runtime.Serialization;
+    using MassTransit;
+
+
+    public class DualDecryptionMessageDeserializerV2 : IMessageDeserializer
+    {
+        readonly IMessageDeserializer _primaryMessageDeserializer;
+        readonly IMessageDeserializer _secondaryMessageDeserializer;
+
+        static readonly Type[] ExceptionsToRetry = {
+            typeof(ArgumentOutOfRangeException),
+            typeof(Newtonsoft.Json.JsonReaderException)
+        };
+
+        public ContentType ContentType => _primaryMessageDeserializer.ContentType;
+
+        public DualDecryptionMessageDeserializerV2(ICryptoStreamProviderV2 primaryCryptoStream, ICryptoStreamProviderV2 secondaryCryptoStream)
+        {
+            _primaryMessageDeserializer = new EncryptedMessageDeserializerV2(BsonMessageSerializer.Deserializer, primaryCryptoStream);
+            _secondaryMessageDeserializer = new EncryptedMessageDeserializerV2(BsonMessageSerializer.Deserializer, secondaryCryptoStream);
+        }
+
+        public DualDecryptionMessageDeserializerV2(IMessageDeserializer primaryMessageDeserializer, IMessageDeserializer secondaryMessageDeserializer)
+        {
+            _primaryMessageDeserializer = primaryMessageDeserializer;
+            _secondaryMessageDeserializer = secondaryMessageDeserializer;
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            _primaryMessageDeserializer.Probe(context);
+            _secondaryMessageDeserializer.Probe(context);
+        }
+
+        public ConsumeContext Deserialize(ReceiveContext receiveContext)
+        {
+            return Deserialize(receiveContext, false);
+        }
+
+        public SerializerContext Deserialize(MessageBody body, Headers headers, Uri? destinationAddress = null)
+        {
+            return Deserialize(body, headers, false, destinationAddress);
+        }
+
+        public MessageBody GetMessageBody(string text)
+        {
+            return GetMessageBody(text, false);
+        }
+
+        ConsumeContext Deserialize(ReceiveContext receiveContext, bool isRetry)
+        {
+            try
+            {
+                return _primaryMessageDeserializer.Deserialize(receiveContext);
+            }
+            catch(SerializationException e) when(ShouldRetry(isRetry, e))
+            {
+                return Deserialize(receiveContext, true);
+            }
+            catch
+            {
+                return _secondaryMessageDeserializer.Deserialize(receiveContext);
+            }
+        }
+
+        SerializerContext Deserialize(MessageBody body, Headers headers, bool isRetry, Uri? destinationAddress = null)
+        {
+            try
+            {
+                return _primaryMessageDeserializer.Deserialize(body, headers, destinationAddress);
+            }
+            catch(SerializationException e) when(ShouldRetry(isRetry, e))
+            {
+                return Deserialize(body, headers, true, destinationAddress);
+            }
+            catch
+            {
+                return _secondaryMessageDeserializer.Deserialize(body, headers, destinationAddress);
+            }
+        }
+
+        MessageBody GetMessageBody(string text, bool isRetry)
+        {
+            try
+            {
+                return _primaryMessageDeserializer.GetMessageBody(text);
+            }
+            catch(SerializationException e) when(ShouldRetry(isRetry, e))
+            {
+                return GetMessageBody(text, true);
+            }
+            catch
+            {
+                return _secondaryMessageDeserializer.GetMessageBody(text);
+            }
+        }
+
+        static bool ShouldRetry(bool isRetry, SerializationException e)
+        {
+            return ExceptionsToRetry.Contains(e.InnerException?.GetType()) && !isRetry;
+        }
+    }
+}

--- a/src/MassTransit.Newtonsoft/Serialization/DualNewtonsoftDecryptionV2SerializerFactory.cs
+++ b/src/MassTransit.Newtonsoft/Serialization/DualNewtonsoftDecryptionV2SerializerFactory.cs
@@ -1,0 +1,30 @@
+namespace MassTransit.Serialization
+{
+    using System.Net.Mime;
+    using MassTransit;
+
+
+    public class DualNewtonsoftDecryptionV2SerializerFactory : ISerializerFactory
+    {
+        readonly ICryptoStreamProviderV2 _primaryCryptoStream;
+        readonly ICryptoStreamProviderV2 _secondaryCryptoStream;
+
+        public DualNewtonsoftDecryptionV2SerializerFactory(ICryptoStreamProviderV2 primaryCryptoStream, ICryptoStreamProviderV2 secondaryCryptoStream)
+        {
+            _primaryCryptoStream = primaryCryptoStream;
+            _secondaryCryptoStream = secondaryCryptoStream;
+        }
+
+        public ContentType ContentType => EncryptedMessageSerializerV2.EncryptedContentType;
+
+        public IMessageSerializer CreateSerializer()
+        {
+            return new EncryptedMessageSerializerV2(_primaryCryptoStream);
+        }
+
+        public IMessageDeserializer CreateDeserializer()
+        {
+            return new DualDecryptionMessageDeserializerV2(_primaryCryptoStream, _secondaryCryptoStream);
+        }
+    }
+}

--- a/tests/MassTransit.Tests/Encryption/DualDecryptionTest.cs
+++ b/tests/MassTransit.Tests/Encryption/DualDecryptionTest.cs
@@ -1,0 +1,140 @@
+﻿#nullable enable
+namespace MassTransit.Tests.Encryption
+{
+    using System;
+    using System.Runtime.Serialization;
+    using System.Security.Cryptography;
+    using InMemoryTransport;
+    using MassTransit.Serialization;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class DualDecryptionTest
+    {
+        [Test]
+        public void MessageEncryptionTest_HavingMessageIsEncrypted_WhenMessageIsReceived_MessageIsDecryptedWithPrimairyKey()
+        {
+            // Arrange
+            var keys = GenerateEncryptionKeys();
+
+            var factory = CreateSerializerFactory(keys);
+
+            var serializer = factory.CreateSerializer();
+            var deserializer = factory.CreateDeserializer();
+
+            var inputMessage = CreateTestMessage(out var inputTestEvent);
+
+            // Act
+            var inMemorySendContext = new InMemorySendContext<TestMessage>(inputTestEvent);
+            var messageBody = serializer.GetMessageBody(inMemorySendContext);
+            var encryptedMessage = messageBody.GetString();
+
+            var deserializerContext = deserializer.Deserialize(messageBody, EmptyHeaders.Instance);
+            var canDecryptMessage = deserializerContext.TryGetMessage(out TestMessage? decryptedReceivedTestEvent);
+
+            // Assert
+            Assert.AreNotEqual(inputMessage, encryptedMessage);
+            Assert.IsTrue(canDecryptMessage);
+            Assert.AreEqual(inputTestEvent, decryptedReceivedTestEvent);
+        }
+
+        [Test]
+        public void MessageEncryptionTest_HavingMessageIsEncrypted_WhenMessageIsReceived_MessageIsDecryptedWithSecondaryKey()
+        {
+            // Arrange
+            var firstServiceKeyset = GenerateEncryptionKeys();
+
+            // second factory, representing another service.
+            var keyNotInUse = GenerateEncryptionKeys().Item1;
+            var secondServiceKeySet = new Tuple<string, string>(keyNotInUse, firstServiceKeyset.Item1);
+
+            var firstFactory = CreateSerializerFactory(firstServiceKeyset);
+            var firstSerializer = firstFactory.CreateSerializer();
+
+            var secondFactory = CreateSerializerFactory(secondServiceKeySet);
+            var secondDeserializer = secondFactory.CreateDeserializer();
+
+            var inputMessage = CreateTestMessage(out var inputTestEvent);
+
+            // Act
+            var inMemorySendContext = new InMemorySendContext<TestMessage>(inputTestEvent);
+            var messageBody = firstSerializer.GetMessageBody(inMemorySendContext);
+            var encryptedMessage = messageBody.GetString();
+
+            var deserializerContext = secondDeserializer.Deserialize(messageBody, EmptyHeaders.Instance);
+            var canDecryptMessage = deserializerContext.TryGetMessage(out TestMessage? decryptedReceivedTestEvent);
+
+            // Assert
+            Assert.AreNotEqual(inputMessage, encryptedMessage);
+            Assert.IsTrue(canDecryptMessage);
+            Assert.AreEqual(inputTestEvent, decryptedReceivedTestEvent);
+        }
+        
+        [Test]
+        public void MessageEncryptionTest_HavingMessageIsEncrypted_WhenMessageIsReceived_MessageCannotBeDecryptedWithDifferentKeyset()
+        {
+            // Arrange
+            var firstServiceKeyset = GenerateEncryptionKeys();
+
+            // second factory, representing another service.
+            var secondServiceKeySet = GenerateEncryptionKeys();
+
+            var firstFactory = CreateSerializerFactory(firstServiceKeyset);
+            var firstSerializer = firstFactory.CreateSerializer();
+
+            var secondFactory = CreateSerializerFactory(secondServiceKeySet);
+            var secondDeserializer = secondFactory.CreateDeserializer();
+
+            var inputMessage = CreateTestMessage(out var inputTestEvent);
+
+            // Act
+            var inMemorySendContext = new InMemorySendContext<TestMessage>(inputTestEvent);
+            var messageBody = firstSerializer.GetMessageBody(inMemorySendContext);
+            var encryptedMessage = messageBody.GetString();
+
+            void DeserializeAction() => secondDeserializer.Deserialize(messageBody, EmptyHeaders.Instance);
+
+            // Assert
+
+            Assert.AreNotEqual(inputMessage, encryptedMessage);
+            Assert.Throws<SerializationException>(DeserializeAction);
+        }
+
+        static string CreateTestMessage(out TestMessage inputTestEvent)
+        {
+            var inputMessage = "test message";
+            inputTestEvent = new TestMessage(Guid.NewGuid(), inputMessage);
+
+            return inputMessage;
+        }
+
+        static DualNewtonsoftDecryptionV2SerializerFactory CreateSerializerFactory(Tuple<string, string> keys)
+        {
+            var primaryKey = Convert.FromBase64String(keys.Item1);
+            var keyProvider = new ConstantSecureKeyProvider(primaryKey);
+            var primaryCrypto = new AesCryptoStreamProviderV2(keyProvider);
+
+            var secondaryKey = Convert.FromBase64String(keys.Item2);
+            var keyProvider2 = new ConstantSecureKeyProvider(secondaryKey);
+            var secondaryCrypto = new AesCryptoStreamProviderV2(keyProvider2);
+
+            return new DualNewtonsoftDecryptionV2SerializerFactory(primaryCrypto, secondaryCrypto);
+        }
+
+        static Tuple<string, string> GenerateEncryptionKeys()
+        {
+            var aes = Aes.Create();
+            aes.GenerateKey();
+
+            var key1 = Convert.ToBase64String(aes.Key);
+
+            aes.GenerateKey();
+            var key2 = Convert.ToBase64String(aes.Key);
+
+            return new Tuple<string, string>(key1, key2);
+        }
+        
+    }
+}

--- a/tests/MassTransit.Tests/Encryption/TestMessage.cs
+++ b/tests/MassTransit.Tests/Encryption/TestMessage.cs
@@ -1,0 +1,44 @@
+﻿namespace MassTransit.Tests.Encryption
+{
+    using System;
+
+    public class TestMessage
+    {
+        public Guid Id { get; }
+        public string TestValue { get; }
+
+        public TestMessage(Guid id, string testValue)
+        {
+            Id = id;
+            TestValue = testValue;
+        }
+
+    #region Equality members
+
+        protected bool Equals(TestMessage other)
+        {
+            return Id.Equals(other.Id) && TestValue == other.TestValue;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((TestMessage)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Id.GetHashCode() * 397) ^ TestValue.GetHashCode();
+            }
+        }
+
+    #endregion
+    }
+}


### PR DESCRIPTION
Feature to support Key Rotation without downtime.

Provide two keys to decryption.
This enables a transition between keys, when the primary key cannot decrypt the message, the secondary key is tried.
After a while all the messages with the old key are consumed rendering the first key obsolete and thus kan be rotated to a new key.

We required this for our security setup, so the feature is for PR.
