### PR TITLE
Added `Action` and `Func` SendContext overloads for ScheduleSend and SchedulePublish

### DIFF
--- a/src/MassTransit.Abstractions/Contexts/TimeSpanContextScheduleExtensions.cs
+++ b/src/MassTransit.Abstractions/Contexts/TimeSpanContextScheduleExtensions.cs
@@ -45,6 +45,44 @@ namespace MassTransit
         }
 
         /// <summary>
+        /// Send a message, using a callback to modify the send context instead of building a pipe from scratch
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="message">The message</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">To cancel the send from happening</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, T message,
+            Action<SendContext<T>> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a message, using a callback to modify the send context instead of building a pipe from scratch
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="message">The message</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">To cancel the send from happening</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, T message,
+            Func<SendContext<T>, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
         /// Send a message
         /// </summary>
         /// <typeparam name="T">The message type</typeparam>
@@ -61,6 +99,44 @@ namespace MassTransit
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.ScheduleSend(scheduledTime, message, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a message, using a callback to modify the send context instead of building a pipe from scratch
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="message">The message</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">To cancel the send from happening</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, T message,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a message, using a callback to modify the send context instead of building a pipe from scratch
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="message">The message</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">To cancel the send from happening</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, T message,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, message, callback.ToPipe(), cancellationToken);
         }
 
         /// <summary>
@@ -121,6 +197,43 @@ namespace MassTransit
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this MessageSchedulerContext scheduler, TimeSpan delay, object message,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this MessageSchedulerContext scheduler, TimeSpan delay, object message,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
         /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
         /// <param name="pipe"></param>
@@ -132,6 +245,40 @@ namespace MassTransit
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.ScheduleSend(scheduledTime, message, messageType, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this MessageSchedulerContext scheduler, TimeSpan delay, object message, Type messageType,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+        {
+            return scheduler.ScheduleSend(delay, message, messageType, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this MessageSchedulerContext scheduler, TimeSpan delay, object message, Type messageType,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+        {
+            return scheduler.ScheduleSend(delay, message, messageType, callback.ToPipe(), cancellationToken);
         }
 
         /// <summary>
@@ -181,6 +328,46 @@ namespace MassTransit
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="values">The property values to initialize on the interface</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, object values,
+            Action<SendContext<T>> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, object values,
+            Func<SendContext<T>, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
         /// <param name="pipe"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
@@ -191,6 +378,46 @@ namespace MassTransit
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.ScheduleSend<T>(scheduledTime, values, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, object values,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend<T>(scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this MessageSchedulerContext scheduler, TimeSpan delay, object values,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend<T>(scheduledTime, values, callback.ToPipe(), cancellationToken);
         }
     }
 }

--- a/src/MassTransit.Abstractions/Contexts/TimeSpanScheduleExtensions.cs
+++ b/src/MassTransit.Abstractions/Contexts/TimeSpanScheduleExtensions.cs
@@ -54,6 +54,46 @@
         /// <param name="message">The message</param>
         /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, T message,
+            Action<SendContext<T>> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, T message,
+            Func<SendContext<T>, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
         /// <param name="pipe"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
@@ -64,6 +104,46 @@
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, T message,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Send a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, T message,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, callback.ToPipe(), cancellationToken);
         }
 
         /// <summary>
@@ -127,6 +207,44 @@
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">The token used to cancel the operation</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object message,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The callback for the send context</param>
+        /// <param name="cancellationToken">The token used to cancel the operation</param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object message,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
         /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
         /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
@@ -139,6 +257,46 @@
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, messageType, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object message,
+            Type messageType, Action<SendContext> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, messageType, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> ScheduleSend(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object message,
+            Type messageType, Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, message, messageType, callback.ToPipe(), cancellationToken);
         }
 
         /// <summary>
@@ -188,6 +346,48 @@
         /// </summary>
         /// <typeparam name="T">The interface type to send</typeparam>
         /// <param name="scheduler">The message scheduler</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object values,
+            Action<SendContext<T>> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object values,
+            Func<SendContext<T>, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend(destinationAddress, scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
         /// <param name="values">The property values to initialize on the interface</param>
         /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
@@ -201,6 +401,48 @@
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.ScheduleSend<T>(destinationAddress, scheduledTime, values, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object values,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend<T>(destinationAddress, scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> ScheduleSend<T>(this IMessageScheduler scheduler, Uri destinationAddress, TimeSpan delay, object values,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.ScheduleSend<T>(destinationAddress, scheduledTime, values, callback.ToPipe(), cancellationToken);
         }
     }
 }

--- a/src/MassTransit.Abstractions/Contexts/TimeSpanSchedulePublishExtensions.cs
+++ b/src/MassTransit.Abstractions/Contexts/TimeSpanSchedulePublishExtensions.cs
@@ -51,6 +51,44 @@ namespace MassTransit
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, T message,
+            Action<SendContext<T>> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publish a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, T message,
+            Func<SendContext<T>, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publish a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
         /// <param name="pipe"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
@@ -61,6 +99,44 @@ namespace MassTransit
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.SchedulePublish(scheduledTime, message, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Publish a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, T message,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publish a message
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, T message,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, callback.ToPipe(), cancellationToken);
         }
 
         /// <summary>
@@ -121,6 +197,42 @@ namespace MassTransit
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> SchedulePublish(this IMessageScheduler scheduler, TimeSpan delay, object message,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> SchedulePublish(this IMessageScheduler scheduler, TimeSpan delay, object message,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
         /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
         /// <param name="pipe"></param>
@@ -132,6 +244,44 @@ namespace MassTransit
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.SchedulePublish(scheduledTime, message, messageType, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> SchedulePublish(this IMessageScheduler scheduler, TimeSpan delay, object message,
+            Type messageType, Action<SendContext> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, messageType, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
+        /// to the specified message type, an exception will be thrown.
+        /// </summary>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="message">The message object</param>
+        /// <param name="messageType">The type of the message (use message.GetType() if desired)</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage> SchedulePublish(this IMessageScheduler scheduler, TimeSpan delay, object message,
+            Type messageType, Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, message, messageType, callback.ToPipe(), cancellationToken);
         }
 
         /// <summary>
@@ -181,6 +331,46 @@ namespace MassTransit
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="values">The property values to initialize on the interface</param>
         /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, object values,
+            Action<SendContext<T>> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, object values,
+            Func<SendContext<T>, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish(scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
         /// <param name="pipe"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
@@ -191,6 +381,46 @@ namespace MassTransit
             var scheduledTime = DateTime.UtcNow + delay;
 
             return scheduler.SchedulePublish<T>(scheduledTime, values, pipe, cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, object values,
+            Action<SendContext> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish<T>(scheduledTime, values, callback.ToPipe(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes an interface message, initializing the properties of the interface using the anonymous
+        /// object specified
+        /// </summary>
+        /// <typeparam name="T">The interface type to send</typeparam>
+        /// <param name="scheduler">The message scheduler</param>
+        /// <param name="values">The property values to initialize on the interface</param>
+        /// <param name="delay">The time at which the message should be delivered to the queue</param>
+        /// <param name="callback">The send callback</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The task which is completed once the Publish is acknowledged by the broker</returns>
+        public static Task<ScheduledMessage<T>> SchedulePublish<T>(this IMessageScheduler scheduler, TimeSpan delay, object values,
+            Func<SendContext, Task> callback, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var scheduledTime = DateTime.UtcNow + delay;
+
+            return scheduler.SchedulePublish<T>(scheduledTime, values, callback.ToPipe(), cancellationToken);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces new `ScheduleSend` and `SchedulePublish` extension methods for `MessageSchedulerContext`, `IMessageScheduler`, and `IMessageScheduler` constructs. This update ensures uniformity between scheduled and [unscheduled](https://github.com/MassTransit/MassTransit/blob/develop/src/MassTransit.Abstractions/Contexts/SendExecuteExtensions.cs) message sending methods.

It also aligns the scheduled senders with the Message Correlation configuration documentation for consistency.
![image](https://user-images.githubusercontent.com/2610199/231619201-b195d000-143f-43be-8933-e85e9b755739.png)
