### PR TITLE
Allow to set the CosmosClientOptions

### DIFF
--- a/src/Persistence/MassTransit.Azure.Cosmos/Configuration/Configuration/CosmosSagaRepositoryConfigurator.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/Configuration/Configuration/CosmosSagaRepositoryConfigurator.cs
@@ -9,6 +9,7 @@ namespace MassTransit.Configuration
     using Microsoft.Azure.Cosmos;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Options;
     using Saga;
     using Serialization;
 
@@ -165,16 +166,17 @@ namespace MassTransit.Configuration
             configurator.TryAddSingleton(DatabaseContextFactory);
             configurator.RegisterSagaRepository<TSaga, DatabaseContext<TSaga>, SagaConsumeContextFactory<DatabaseContext<TSaga>, TSaga>,
                 CosmosSagaRepositoryContextFactory<TSaga>>();
+            configurator.AddOptions<CosmosClientOptions>();
         }
 
         void RegisterNewtonsoftJsonClientFactory(ISagaRepositoryRegistrationConfigurator<TSaga> configurator)
         {
-            configurator.TryAddSingleton<ICosmosClientFactory>(provider => new NewtonsoftJsonCosmosClientFactory(_settings));
+            configurator.TryAddSingleton<ICosmosClientFactory>(provider => new NewtonsoftJsonCosmosClientFactory(_settings, provider.GetRequiredService<IOptions<CosmosClientOptions>>()));
         }
 
         void RegisterSystemTextJsonClientFactory(ISagaRepositoryRegistrationConfigurator<TSaga> configurator)
         {
-            configurator.TryAddSingleton<ICosmosClientFactory>(provider => new SystemTextJsonCosmosClientFactory(_settings, PropertyNamingPolicy));
+            configurator.TryAddSingleton<ICosmosClientFactory>(provider => new SystemTextJsonCosmosClientFactory(_settings, provider.GetRequiredService<IOptions<CosmosClientOptions>>(), PropertyNamingPolicy));
         }
 
         DatabaseContext<TSaga> DatabaseContextFactory(IServiceProvider provider)

--- a/src/Persistence/MassTransit.Azure.Cosmos/Configuration/CosmosRepositoryConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.Azure.Cosmos/Configuration/CosmosRepositoryConfigurationExtensions.cs
@@ -4,7 +4,9 @@ namespace MassTransit
     using Azure.Core;
     using AzureCosmos;
     using Configuration;
+    using Microsoft.Azure.Cosmos;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Options;
     using Serialization;
 
 
@@ -176,7 +178,7 @@ namespace MassTransit
         static IServiceCollection AddCosmosClientFactory(this IServiceCollection collection, CosmosAuthSettings authSettings)
         {
             return collection.AddSingleton<ICosmosClientFactory>(provider =>
-                new SystemTextJsonCosmosClientFactory(authSettings, SystemTextJsonMessageSerializer.Options.PropertyNamingPolicy));
+                new SystemTextJsonCosmosClientFactory(authSettings, provider.GetRequiredService<IOptions<CosmosClientOptions>>(), SystemTextJsonMessageSerializer.Options.PropertyNamingPolicy));
         }
 
         /// <summary>
@@ -228,7 +230,7 @@ namespace MassTransit
         /// <param name="authSettings"></param>
         static IServiceCollection AddNewtonsoftCosmosClientFactory(this IServiceCollection collection, CosmosAuthSettings authSettings)
         {
-            return collection.AddSingleton<ICosmosClientFactory>(provider => new NewtonsoftJsonCosmosClientFactory(authSettings));
+            return collection.AddSingleton<ICosmosClientFactory>(provider => new NewtonsoftJsonCosmosClientFactory(authSettings, provider.GetRequiredService<IOptions<CosmosClientOptions>>()));
         }
 
         /// <summary>


### PR DESCRIPTION
I added the possibility to set the `CosmosClientOptions` while configuring Cosmos as a repository. Many properties were not exposed until now and we were not able to configure them (https://learn.microsoft.com/fr-fr/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions?view=azure-dotnet#properties).