### PR TITLE
Upgrading MediatR for benchmark

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Ionic.Zlib.Core" Version="1.0.0" />
     <PackageVersion Include="Marten" Version="5.11.0" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="MediatR" Version="12.0.1"/>
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.16" />

--- a/tests/MassTransit.BenchmarkConsole/MassTransit.BenchmarkConsole.csproj
+++ b/tests/MassTransit.BenchmarkConsole/MassTransit.BenchmarkConsole.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" />
+    <PackageReference Include="MediatR"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 

--- a/tests/MassTransit.BenchmarkConsole/MediatorBenchmark.cs
+++ b/tests/MassTransit.BenchmarkConsole/MediatorBenchmark.cs
@@ -10,7 +10,7 @@ namespace MassTransit.BenchmarkConsole
 
 
     public class ExampleCommand :
-        IRequest
+        IRequest<Unit>
     {
         public ExampleCommand(string arg1, int arg2)
         {
@@ -37,7 +37,7 @@ namespace MassTransit.BenchmarkConsole
         public void Setup()
         {
             var services = new ServiceCollection();
-            services.AddMediatR(typeof(MediatorBenchmark));
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<MediatorBenchmark>());
 
             _mediator = Bus.Factory.CreateMediator(cfg =>
             {
@@ -123,7 +123,7 @@ namespace MassTransit.BenchmarkConsole
 
 
     public class ExampleCommandHandler :
-        IRequestHandler<ExampleCommand>,
+        IRequestHandler<ExampleCommand, Unit>,
         IConsumer<ExampleCommand>
     {
         public Task Consume(ConsumeContext<ExampleCommand> context)


### PR DESCRIPTION
still working:

|      Method |         Mean |        Error |       StdDev |    Gen0 |   Gen1 | Allocated |
|------------ |-------------:|-------------:|-------------:|--------:|-------:|----------:|
|      Direct |     12.81 ns |     0.147 ns |     0.130 ns |  0.0153 | 0.0000 |      32 B |
|     MediatR |    237.40 ns |     3.216 ns |     2.851 ns |  0.1297 | 0.0005 |     272 B |
| MassTransit |  1,697.75 ns |    20.726 ns |    19.387 ns |  1.4763 |      - |    3088 B |
| InMemoryBus | 78,391.04 ns | 1,406.559 ns | 1,174.541 ns | 17.5781 |      - |   36462 B |

