### PR TITLE
chore: fix incorrect entity framework reference in mongo db summary documentation

### DIFF
--- a/src/Persistence/MassTransit.MongoDbIntegration/Configuration/MongoDbOutboxConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/Configuration/MongoDbOutboxConfigurationExtensions.cs
@@ -9,7 +9,7 @@ namespace MassTransit
     public static class MongoDbOutboxConfigurationExtensions
     {
         /// <summary>
-        /// Configures the Mongo DB Outbox on the bus, which can subsequently be used to configure
+        /// Configures the Mongo DB outbox on the bus, which can subsequently be used to configure
         /// the transactional outbox on a receive endpoint.
         /// </summary>
         /// <param name="configurator"></param>
@@ -24,7 +24,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Configure the Mongo DB Outbox outbox on the receive endpoint
+        /// Configure the Mongo DB outbox on the receive endpoint
         /// </summary>
         /// <param name="configurator"></param>
         /// <param name="provider">Configuration service provider</param>

--- a/src/Persistence/MassTransit.MongoDbIntegration/Configuration/MongoDbOutboxConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/Configuration/MongoDbOutboxConfigurationExtensions.cs
@@ -9,7 +9,7 @@ namespace MassTransit
     public static class MongoDbOutboxConfigurationExtensions
     {
         /// <summary>
-        /// Configures the Entity Framework Outbox on the bus, which can subsequently be used to configure
+        /// Configures the Mongo DB Outbox on the bus, which can subsequently be used to configure
         /// the transactional outbox on a receive endpoint.
         /// </summary>
         /// <param name="configurator"></param>
@@ -24,7 +24,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Configure the Entity Framework outbox on the receive endpoint
+        /// Configure the Mongo DB Outbox outbox on the receive endpoint
         /// </summary>
         /// <param name="configurator"></param>
         /// <param name="provider">Configuration service provider</param>


### PR DESCRIPTION
I kept noticing this error in summary documentation so decided to just fix it.

Thanks for a phenomenal framework.
