### PR TITLE
feat: support MessageBody on ReceiveContext for Kafka Transport

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaBaseReceiveContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaBaseReceiveContext.cs
@@ -22,6 +22,7 @@
             _result = result;
             _context = context;
 
+            Body = new BytesMessageBody(_result.Message.Value);
             InputAddress = context.GetInputAddress(_result.Topic);
 
             _key = new Lazy<TKey>(() => _context.KeyDeserializer.DeserializeKey(result));
@@ -38,7 +39,7 @@
 
         protected override IHeaderProvider HeaderProvider => _headerProvider.Value;
 
-        public override MessageBody Body => new NotSupportedMessageBody();
+        public override MessageBody Body { get; }
 
         public string GroupId => _context.GroupId;
 


### PR DESCRIPTION
Hi All!

This PR simply adds `MessageBody` on ReceiveContext for Kafka Transport instead of throw a `NotSupportedMessageBody`.
With this change we will be able to retrieve the message that come from topic that can be useful in some cases. 
Currently, the only way that I found was use Reflection to extract the message from `_result` property and with this PR I will be able to remove this ugly part of code from my project (rs).