### PR TITLE
Use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.

### DIFF
--- a/docs/quick-starts/in-memory.md
+++ b/docs/quick-starts/in-memory.md
@@ -23,7 +23,7 @@ This example requires the following:
 MassTransit includes project and item [templates](/usage/templates) simplifying the creation of new projects. Install the templates by executing `dotnet new -i MassTransit.Templates` at the console. A video introducing the templates is available on [YouTube](https://youtu.be/nYKq61-DFBQ).
 
 ```
-dotnet new --install MassTransit.Templates
+dotnet new install MassTransit.Templates
 ```
 
 ## Initial Project Creation


### PR DESCRIPTION
The `dotnet` executable uses `dotnet new install` now.

> Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.
> For more information, run:
>   dotnet new install -h

From [dotnet new install](https://github.com/dotnet/docs/blob/main/docs/core/tools/dotnet-new-install.md) at [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-install):

> # dotnet new install
> 
> **This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
> 
> ## Name
> 
> `dotnet new install` - installs a template package.
> 
> ## Synopsis
> 
> ```dotnetcli
> dotnet new install <PATH|NUGET_ID>  [--interactive] [--add-source|--nuget-source <SOURCE>] [--force] 
>     [-d|--diagnostics] [--verbosity <LEVEL>] [-h|--help]
> ```
> 
> ## Description
> 
> The `dotnet new install` command installs a template package from the `PATH` or `NUGET_ID` provided. If you want to install a specific version or prerelease version of a template package, specify the version in the format `<package-name>::<package-version>`. By default, `dotnet new` passes \* for the version, which represents the latest stable package version. For more information, see the [Examples](#examples) section.
> 
> If a version of the template package was already installed when you run this command, the template package will be updated to the specified version. If no version is specified, the package is updated to the latest stable version. Starting with .NET SDK 6.0.100, if the argument specifies the version, and that version of the NuGet package is already installed, it won't be reinstalled. If the argument is a `PATH` and it's already installed, it won't be reinstalled.
> 
> Prior to .NET SDK 6.0.100, template packages were managed individually for each .NET SDK version, including [patch versions](../releases-and-support.md#servicing-updates). For example, if you install the template package using `dotnet new --install` in .NET SDK 5.0.100, it will be installed only for .NET SDK 5.0.100. Templates from the package won't be available in other .NET SDK versions installed on your machine.
> 
> Starting with .NET SDK 6.0.100, installed template packages are available in later .NET SDK versions installed on your machine. A template package installed in .NET SDK 6.0.100 will also be available in .NET SDK 6.0.101, .NET SDK 6.0.200, and so on. However, these template packages won't be available in .NET SDK versions prior to .NET SDK 6.0.100. To use a template package installed in .NET SDK 6.0.100 or later in earlier .NET SDK versions, you need to install it using `dotnet new install` in that .NET SDK version.
> 
> > [!NOTE]
> > [!INCLUDE [new syntax](../../../includes/dotnet-new-7-0-syntax.md)]
> >
> > Examples of old syntax:
> >
> > - Install the latest version of Azure web jobs project template package:
> >
> >   ```dotnetcli
> >   dotnet new --install Microsoft.Azure.WebJobs.ProjectTemplates
> >   ```
> 

https://github.com/dotnet/docs/issues/32195

![image](https://github.com/MassTransit/MassTransit/assets/5055400/1041fec0-a601-4362-ace2-afaa453fad55)
