### PR TITLE
Add Protocol Buffer serialization support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.4.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
     <PackageVersion Include="prometheus-net" Version="6.0.0" />
+    <PackageVersion Include="protobuf-net" Version="3.2.26" />
     <PackageVersion Include="Quartz" Version="3.6.2" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.6.2" />
     <PackageVersion Include="Quartz.Plugins.TimeZoneConverter" Version="3.6.2" />

--- a/MassTransit.sln
+++ b/MassTransit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Persistence", "Persistence", "{56F516D7-BC3C-49E1-A639-83C5F14953F8}"
 EndProject
@@ -25,12 +25,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Containers.Test
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".solution", ".solution", "{2C8A15FA-A445-4916-AAC2-3BE53AA247A7}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
+		NuGet.README.md = NuGet.README.md
 		README.md = README.md
 		signing.props = signing.props
-		.github\workflows\build.yml = .github\workflows\build.yml
-		NuGet.README.md = NuGet.README.md
-		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scheduling", "Scheduling", "{FDC1A760-D4E5-44F4-B0D9-C19F2E14253A}"
@@ -121,37 +121,39 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.EventHubIntegra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.EventHubIntegration.Tests", "tests\MassTransit.EventHubIntegration.Tests\MassTransit.EventHubIntegration.Tests.csproj", "{24CC1B47-AE01-4871-A939-2BF6EB789860}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Azure.Table", "src\Persistence\MassTransit.Azure.Table\MassTransit.Azure.Table.csproj", "{338E2B7E-4301-4547-9172-4415F739C029}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Azure.Table", "src\Persistence\MassTransit.Azure.Table\MassTransit.Azure.Table.csproj", "{338E2B7E-4301-4547-9172-4415F739C029}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Azure.Table.Tests", "tests\MassTransit.Azure.Table.Tests\MassTransit.Azure.Table.Tests.csproj", "{17E04A9B-5DB5-4857-99CD-E9AF22DA00E4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Azure.Table.Tests", "tests\MassTransit.Azure.Table.Tests\MassTransit.Azure.Table.Tests.csproj", "{17E04A9B-5DB5-4857-99CD-E9AF22DA00E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.GrpcTransport", "src\Transports\MassTransit.GrpcTransport\MassTransit.GrpcTransport.csproj", "{AF56509B-0B95-4ACE-9CFC-F9A79756C357}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.GrpcTransport", "src\Transports\MassTransit.GrpcTransport\MassTransit.GrpcTransport.csproj", "{AF56509B-0B95-4ACE-9CFC-F9A79756C357}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.GrpcTransport.Tests", "tests\MassTransit.GrpcTransport.Tests\MassTransit.GrpcTransport.Tests.csproj", "{082488F6-6322-462A-85D7-9E893A67B8CD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.GrpcTransport.Tests", "tests\MassTransit.GrpcTransport.Tests\MassTransit.GrpcTransport.Tests.csproj", "{082488F6-6322-462A-85D7-9E893A67B8CD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Transports.Tests", "tests\MassTransit.Transports.Tests\MassTransit.Transports.Tests.csproj", "{7632EDAF-29A1-4E69-952F-C75D3BF34B3B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Transports.Tests", "tests\MassTransit.Transports.Tests\MassTransit.Transports.Tests.csproj", "{7632EDAF-29A1-4E69-952F-C75D3BF34B3B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Abstractions", "src\MassTransit.Abstractions\MassTransit.Abstractions.csproj", "{2CAF0C51-2F64-4EB0-8E27-AE3E0085CA75}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Abstractions", "src\MassTransit.Abstractions\MassTransit.Abstractions.csproj", "{2CAF0C51-2F64-4EB0-8E27-AE3E0085CA75}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.StateMachineVisualizer", "src\MassTransit.StateMachineVisualizer\MassTransit.StateMachineVisualizer.csproj", "{8CD4298E-962B-4D04-821D-274343099E83}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.StateMachineVisualizer", "src\MassTransit.StateMachineVisualizer\MassTransit.StateMachineVisualizer.csproj", "{8CD4298E-962B-4D04-821D-274343099E83}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Abstractions.Tests", "tests\MassTransit.Abstractions.Tests\MassTransit.Abstractions.Tests.csproj", "{AB188378-1BAC-4ECB-98A7-91E12C861381}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Abstractions.Tests", "tests\MassTransit.Abstractions.Tests\MassTransit.Abstractions.Tests.csproj", "{AB188378-1BAC-4ECB-98A7-91E12C861381}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.BenchmarkConsole", "tests\MassTransit.BenchmarkConsole\MassTransit.BenchmarkConsole.csproj", "{2B6ACCF2-0CAF-4152-901F-0048390971E4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.BenchmarkConsole", "tests\MassTransit.BenchmarkConsole\MassTransit.BenchmarkConsole.csproj", "{2B6ACCF2-0CAF-4152-901F-0048390971E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Benchmark", "tests\MassTransit.Benchmark\MassTransit.Benchmark.csproj", "{667E52D5-E1D9-49EE-B364-3CB7E43EE160}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Benchmark", "tests\MassTransit.Benchmark\MassTransit.Benchmark.csproj", "{667E52D5-E1D9-49EE-B364-3CB7E43EE160}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.Newtonsoft", "src\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj", "{388085C8-1BC8-48F8-8EA2-3698FCB385E5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Newtonsoft", "src\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj", "{388085C8-1BC8-48F8-8EA2-3698FCB385E5}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarking", "Benchmarking", "{BF384860-70ED-47F0-B276-13D2DA9ECD87}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.DynamoDbIntegration", "src\Persistence\MassTransit.DynamoDbIntegration\MassTransit.DynamoDbIntegration.csproj", "{186D6491-ECCD-49EB-8E99-AFD7AD6037D2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.DynamoDbIntegration", "src\Persistence\MassTransit.DynamoDbIntegration\MassTransit.DynamoDbIntegration.csproj", "{186D6491-ECCD-49EB-8E99-AFD7AD6037D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.DynamoDbIntegration.Tests", "tests\MassTransit.DynamoDbIntegration.Tests\MassTransit.DynamoDbIntegration.Tests.csproj", "{694E06CF-2842-4E71-8CD2-81FA7C1B3D13}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.DynamoDbIntegration.Tests", "tests\MassTransit.DynamoDbIntegration.Tests\MassTransit.DynamoDbIntegration.Tests.csproj", "{694E06CF-2842-4E71-8CD2-81FA7C1B3D13}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AmazonS3", "src\Persistence\MassTransit.AmazonS3\MassTransit.AmazonS3.csproj", "{86905425-64C4-4EB0-8884-F2BD27782310}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AmazonS3", "src\Persistence\MassTransit.AmazonS3\MassTransit.AmazonS3.csproj", "{86905425-64C4-4EB0-8884-F2BD27782310}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MassTransit.AmazonS3.Tests", "tests\MassTransit.AmazonS3.Tests\MassTransit.AmazonS3.Tests.csproj", "{6E090598-2FED-41B9-9D4C-E27732985C61}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.AmazonS3.Tests", "tests\MassTransit.AmazonS3.Tests\MassTransit.AmazonS3.Tests.csproj", "{6E090598-2FED-41B9-9D4C-E27732985C61}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassTransit.Protobuf", "src\MassTransit.Protobuf\MassTransit.Protobuf.csproj", "{A8A192A6-283B-4808-B08B-DF7769B5950F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -852,6 +854,18 @@ Global
 		{6E090598-2FED-41B9-9D4C-E27732985C61}.ReleaseUnsigned|Any CPU.Build.0 = Debug|Any CPU
 		{6E090598-2FED-41B9-9D4C-E27732985C61}.ReleaseUnsigned|x86.ActiveCfg = Debug|Any CPU
 		{6E090598-2FED-41B9-9D4C-E27732985C61}.ReleaseUnsigned|x86.Build.0 = Debug|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Debug|x86.Build.0 = Debug|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Release|x86.ActiveCfg = Release|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.Release|x86.Build.0 = Release|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{A8A192A6-283B-4808-B08B-DF7769B5950F}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -905,13 +919,14 @@ Global
 		{AF56509B-0B95-4ACE-9CFC-F9A79756C357} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{082488F6-6322-462A-85D7-9E893A67B8CD} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
 		{7632EDAF-29A1-4E69-952F-C75D3BF34B3B} = {0006D6BB-1382-4B32-AD32-CA037F5CD4F6}
-		{388085C8-1BC8-48F8-8EA2-3698FCB385E5} = {4F40E08B-7C24-4D2A-8476-B7F93D0A2910}
-		{667E52D5-E1D9-49EE-B364-3CB7E43EE160} = {BF384860-70ED-47F0-B276-13D2DA9ECD87}
 		{2B6ACCF2-0CAF-4152-901F-0048390971E4} = {BF384860-70ED-47F0-B276-13D2DA9ECD87}
+		{667E52D5-E1D9-49EE-B364-3CB7E43EE160} = {BF384860-70ED-47F0-B276-13D2DA9ECD87}
+		{388085C8-1BC8-48F8-8EA2-3698FCB385E5} = {4F40E08B-7C24-4D2A-8476-B7F93D0A2910}
 		{186D6491-ECCD-49EB-8E99-AFD7AD6037D2} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
 		{694E06CF-2842-4E71-8CD2-81FA7C1B3D13} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
 		{86905425-64C4-4EB0-8884-F2BD27782310} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
 		{6E090598-2FED-41B9-9D4C-E27732985C61} = {56F516D7-BC3C-49E1-A639-83C5F14953F8}
+		{A8A192A6-283B-4808-B08B-DF7769B5950F} = {4F40E08B-7C24-4D2A-8476-B7F93D0A2910}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {43D3A7D5-0945-435E-8D03-1E631E5CDBA8}

--- a/src/MassTransit.Protobuf/Configuration/ProtobufConfigurationExtensions.cs
+++ b/src/MassTransit.Protobuf/Configuration/ProtobufConfigurationExtensions.cs
@@ -1,0 +1,28 @@
+﻿namespace MassTransit.Configuration
+{
+    using MassTransit.Serialization;
+
+    public static class ProtobufConfigurationExtensions
+    {
+        /// <summary>
+        /// Registers the Protobuf serializer with the bus, using the default Protobuf message contract.
+        /// </summary>
+        public static void UseProtobufSerializer(this IBusFactoryConfigurator configurator)
+        {
+            var factory = new ProtobufSerializerFactory<object>();
+
+            configurator.AddSerializer(factory);
+        }
+
+        /// <summary>
+        /// Register the Protobuf deserializer for a specific message type on the receive endpoint.
+        /// </summary>
+        public static void UseProtobufDeserializer<TProtoMessage>(this IReceiveEndpointConfigurator configurator, bool isDefault = true)
+            where TProtoMessage : class
+        {
+            var factory = new ProtobufSerializerFactory<TProtoMessage>();
+
+            configurator.AddDeserializer(factory, isDefault);
+        }
+    }
+}

--- a/src/MassTransit.Protobuf/MassTransit.Protobuf.csproj
+++ b/src/MassTransit.Protobuf/MassTransit.Protobuf.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../signing.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <RootNamespace>MassTransit</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsWindows)' == 'true' ">
+    <TargetFrameworks>$(TargetFrameworks);net462</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>MassTransit.Protobuf</PackageId>
+    <Title>MassTransit.Protobuf</Title>
+    <PackageTags>MassTransit;Protobuf</PackageTags>
+    <Description>MassTransit Protobuf support; $(Description)</Description>
+    <Version>1.0.0-alpha.38</Version>
+    <Copyright>Copyright 2023 - Reuben Sonnenberg</Copyright>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MassTransit.Abstractions\MassTransit.Abstractions.csproj" />
+    <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/MassTransit.Protobuf/MassTransit.Protobuf.csproj.DotSettings
+++ b/src/MassTransit.Protobuf/MassTransit.Protobuf.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=configuration/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/MassTransit.Protobuf/NullableAttributes.cs
+++ b/src/MassTransit.Protobuf/NullableAttributes.cs
@@ -1,0 +1,24 @@
+#if !NET6_0_OR_GREATER && !NETSTANDARD2_1
+namespace System.Diagnostics.CodeAnalysis
+{
+    using System;
+
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    sealed class NotNullWhenAttribute :
+        Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+}
+#endif

--- a/src/MassTransit.Protobuf/Serialization/ProtoMessageEnvelope.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtoMessageEnvelope.cs
@@ -1,0 +1,49 @@
+﻿#nullable enable
+namespace MassTransit.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using MassTransit;
+    using Metadata;
+    using ProtoBuf;
+
+    [Serializable]
+    public class ProtoMessageEnvelope<TProtoMessage> : MessageEnvelope
+        where TProtoMessage : class
+    {
+        public string? MessageId { get; set; }
+        public string? RequestId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string? ConversationId { get; set; }
+        public string? InitiatorId { get; set; }
+        public string? SourceAddress { get; set; }
+        public string? DestinationAddress { get; set; }
+        public string? ResponseAddress { get; set; }
+        public string? FaultAddress { get; set; }
+        public string[]? MessageType { get; set; }
+        public object? Message { get; set; }
+        public DateTime? ExpirationTime { get; set; }
+        public DateTime? SentTime { get; set; }
+        public HostInfo? Host { get; set; }
+        public Dictionary<string, object?>? Headers { get; }
+
+        public ProtoMessageEnvelope(ProtobufMessageEnvelope<TProtoMessage> envelope)
+        {
+            MessageId = envelope.MessageId;
+            RequestId = envelope.RequestId;
+            CorrelationId = envelope.CorrelationId;
+            ConversationId = envelope.ConversationId;
+            InitiatorId = envelope.InitiatorId;
+            SourceAddress = envelope.SourceAddress;
+            DestinationAddress = envelope.DestinationAddress;
+            ResponseAddress = envelope.ResponseAddress;
+            FaultAddress = envelope.FaultAddress;
+            MessageType = envelope.MessageType;
+            Message = envelope.Message;
+            ExpirationTime = envelope.ExpirationTime;
+            SentTime = envelope.SentTime;
+            Headers = envelope.Headers;
+        }
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufBodyMessageSerializer.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufBodyMessageSerializer.cs
@@ -1,0 +1,42 @@
+﻿#nullable enable
+namespace MassTransit.Serialization
+{
+    using System.IO;
+    using System.Net.Mime;
+    using ProtoBuf.Meta;
+
+    public class ProtobufBodyMessageSerializer : IMessageSerializer
+    {
+        private readonly ContentType _contentType;
+        private readonly ProtobufMessageEnvelope<object> _envelope;
+        private readonly RuntimeTypeModel _typeModel;
+
+        public ProtobufBodyMessageSerializer(MessageEnvelope envelope, ContentType contentType, RuntimeTypeModel typeModel)
+        {
+            _envelope = new ProtobufMessageEnvelope<object>(envelope);
+            _contentType = contentType;
+            _typeModel = typeModel;
+        }
+
+        public ContentType ContentType => _contentType;
+
+        public MessageBody GetMessageBody<T>(SendContext<T> context)
+            where T : class
+        {
+            _envelope.Update(context);
+
+            return new ProtobufMessageBody<T>(context, _typeModel, _envelope as ProtobufMessageEnvelope<T>);
+        }
+
+        public void Overlay(object message)
+        {
+            using (var stream = new MemoryStream())
+            {
+                _typeModel.Serialize(stream, message);
+                stream.Position = 0;
+                var overlayMessage = _typeModel.Deserialize(_envelope.Message?.GetType(), stream);
+                _envelope.Message = overlayMessage;
+            }
+        }
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufHostInfo.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufHostInfo.cs
@@ -1,0 +1,34 @@
+﻿using ProtoBuf;
+
+namespace MassTransit.Serialization
+{
+#nullable enable
+    [ProtoContract]
+    [ProtoInclude(100, typeof(HostInfo))]
+    public class ProtobufHostInfo : HostInfo
+    {
+        [ProtoMember(1)]
+        public string? MachineName { set; get; }
+
+        [ProtoMember(2)]
+        public string? ProcessName { set; get; }
+
+        [ProtoMember(3)]
+        public int ProcessId { set; get; }
+
+        [ProtoMember(4)]
+        public string? Assembly { set; get; }
+
+        [ProtoMember(5)]
+        public string? AssemblyVersion { set; get; }
+
+        [ProtoMember(6)]
+        public string? FrameworkVersion { set; get; }
+
+        [ProtoMember(7)]
+        public string? MassTransitVersion { set; get; }
+
+        [ProtoMember(8)]
+        public string? OperatingSystemVersion { set; get; }
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufMessageBody.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufMessageBody.cs
@@ -1,0 +1,63 @@
+﻿#nullable enable
+namespace MassTransit.Serialization
+{
+    using ProtoBuf.Meta;
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization;
+    using System.Text;
+    public class ProtobufMessageBody<TProtoMessage> : MessageBody where TProtoMessage : class
+    {
+        readonly SendContext<TProtoMessage> _context;
+        byte[]? _bytes;
+        ProtobufMessageEnvelope<TProtoMessage>? _envelope;
+        string? _string;
+        readonly RuntimeTypeModel _typeModel;
+
+        public ProtobufMessageBody(SendContext<TProtoMessage> context, RuntimeTypeModel typeModel, ProtobufMessageEnvelope<TProtoMessage>? envelope = null)
+        {
+            _context = context;
+            _typeModel = typeModel;
+            _envelope = envelope;
+        }
+
+        public long? Length => _bytes?.Length;
+
+        public byte[] GetBytes()
+        {
+            if (_bytes != null)
+                return _bytes;
+
+            try
+            {
+                var envelope = _envelope ??= new ProtobufMessageEnvelope<TProtoMessage>(_context, _context.Message, MessageTypeCache<TProtoMessage>.MessageTypeNames);
+                using var stream = new MemoryStream();
+                _typeModel.Serialize(stream, envelope);
+                _bytes = stream.ToArray();
+                return _bytes;
+            }
+            catch (SerializationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new SerializationException("Failed to serialize the message", ex);
+            }
+        }
+
+        public Stream GetStream()
+        {
+            return new MemoryStream(GetBytes(), false);
+        }
+
+        public string GetString()
+        {
+            if (_string != null)
+                return _string;
+
+            _string = Encoding.UTF8.GetString(GetBytes());
+            return _string;
+        }
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufMessageDeserializer.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufMessageDeserializer.cs
@@ -1,0 +1,60 @@
+﻿#nullable enable
+namespace MassTransit.Serialization
+{
+    using System;
+    using System.Net.Mime;
+    using System.Runtime.Serialization;
+    using ProtoBuf.Meta;
+
+    public class ProtobufMessageDeserializer<TProtoMessage> : IMessageDeserializer
+        where TProtoMessage : class
+    {
+        private readonly RuntimeTypeModel _typeModel;
+        private readonly IObjectDeserializer _objectDeserializer;
+
+        public ProtobufMessageDeserializer(RuntimeTypeModel typeModel)
+        {
+            _typeModel = typeModel;
+            _objectDeserializer = new ProtobufObjectDeserializer(typeModel);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("protobuf");
+            scope.Add("contentType", ContentType.MediaType);
+        }
+
+        public ContentType ContentType => new ContentType("application/vnd.masstransit+pbuf");
+
+        public ConsumeContext Deserialize(ReceiveContext receiveContext)
+        {
+            return new BodyConsumeContext(receiveContext, Deserialize(receiveContext.Body, receiveContext.TransportHeaders, receiveContext.InputAddress));
+        }
+
+        public SerializerContext Deserialize(MessageBody body, Headers headers, Uri? destinationAddress = null)
+        {
+            try
+            {
+                using var stream = body.GetStream();
+                var envelope = _typeModel.Deserialize<ProtobufMessageEnvelope<TProtoMessage>>(stream);
+
+                return envelope == null
+                    ? throw new SerializationException("The message envelope was not found.")
+                    : (SerializerContext)new ProtobufSerializerContext(_typeModel, _objectDeserializer, new ProtoMessageEnvelope<TProtoMessage>(envelope), ContentType);
+            }
+            catch (SerializationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new SerializationException("An exception occurred while deserializing the message envelope", ex);
+            }
+        }
+
+        public MessageBody GetMessageBody(string text)
+        {
+            throw new NotSupportedException("ProtobufMessageDeserializer does not support deserializing from text.");
+        }
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufMessageEnvelope.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufMessageEnvelope.cs
@@ -1,0 +1,208 @@
+﻿#nullable enable
+namespace MassTransit.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using MassTransit;
+    using Metadata;
+    using ProtoBuf;
+
+    [Serializable]
+    [ProtoContract]
+    [ProtoInclude(100, typeof(HostInfo))]
+    [ProtoInclude(101, typeof(ProtobufHostInfo))]
+    public class ProtobufMessageEnvelope<TProtoMessage>
+        where TProtoMessage : class
+    {
+        [ProtoMember(1)]
+        public string? MessageId { get; set; }
+        [ProtoMember(2)]
+        public string? RequestId { get; set; }
+        [ProtoMember(3)]
+        public string? CorrelationId { get; set; }
+        [ProtoMember(4)]
+        public string? ConversationId { get; set; }
+        [ProtoMember(5)]
+        public string? InitiatorId { get; set; }
+        [ProtoMember(6)]
+        public string? SourceAddress { get; set; }
+        [ProtoMember(7)]
+        public string? DestinationAddress { get; set; }
+        [ProtoMember(8)]
+        public string? ResponseAddress { get; set; }
+        [ProtoMember(9)]
+        public string? FaultAddress { get; set; }
+        [ProtoMember(10)]
+        public string[]? MessageType { get; set; }
+        [ProtoMember(11)]
+        public TProtoMessage? _message;
+        [ProtoMember(12)]
+        public DateTime? ExpirationTime { get; set; }
+        [ProtoMember(13)]
+        public DateTime? SentTime { get; set; }
+        [ProtoMember(14)]
+        public ProtobufHostInfo? _host;
+
+        [ProtoMember(15)]
+        Dictionary<string, TProtoMessage?>? _headers { get; set; }
+
+        public HostInfo? Host
+        {
+            get => _host;
+            set => _host = ToProtobufHostInfo(value!);
+        }
+
+        public object? Message
+        {
+            get => _message as object;
+            set => _message = (TProtoMessage?)value;
+        }
+
+        public Dictionary<string, object?>? Headers
+        {
+            get => _headers?.ToDictionary(kv => kv.Key, kv => kv.Value as object);
+            set => _headers = value?.ToDictionary(kv => kv.Key, kv => kv.Value as TProtoMessage);
+        }
+
+        private ProtobufHostInfo ToProtobufHostInfo(HostInfo hostInfo)
+        {
+            return new ProtobufHostInfo()
+            {
+                MachineName = hostInfo.MachineName,
+                ProcessName = hostInfo.ProcessName,
+                ProcessId = hostInfo.ProcessId,
+                Assembly = hostInfo.Assembly,
+                AssemblyVersion = hostInfo.AssemblyVersion,
+                FrameworkVersion = hostInfo.FrameworkVersion,
+                MassTransitVersion = hostInfo.MassTransitVersion,
+                OperatingSystemVersion = hostInfo.OperatingSystemVersion
+            };
+        }
+
+        public ProtobufMessageEnvelope()
+        {
+        }
+
+        public ProtobufMessageEnvelope(SendContext context, TProtoMessage message, string[] messageTypeNames)
+        {
+            if (context.MessageId.HasValue)
+                MessageId = context.MessageId.Value.ToString();
+            if (context.RequestId.HasValue)
+                RequestId = context.RequestId.Value.ToString();
+            if (context.CorrelationId.HasValue)
+                CorrelationId = context.CorrelationId.Value.ToString();
+            if (context.ConversationId.HasValue)
+                ConversationId = context.ConversationId.Value.ToString();
+            if (context.InitiatorId.HasValue)
+                InitiatorId = context.InitiatorId.Value.ToString();
+            if (context.SourceAddress != null)
+                SourceAddress = context.SourceAddress.ToString();
+            if (context.DestinationAddress != null)
+                DestinationAddress = context.DestinationAddress.ToString();
+            if (context.ResponseAddress != null)
+                ResponseAddress = context.ResponseAddress.ToString();
+            if (context.FaultAddress != null)
+                FaultAddress = context.FaultAddress.ToString();
+            MessageType = messageTypeNames;
+            Message = message as TProtoMessage;
+            if (context.TimeToLive.HasValue)
+                ExpirationTime = DateTime.UtcNow + context.TimeToLive;
+            SentTime = context.SentTime ?? DateTime.UtcNow;
+            Headers = new Dictionary<string, object?>();
+            foreach (KeyValuePair<string, object> header in context.Headers.GetAll())
+                Headers[header.Key] = header.Value as TProtoMessage;
+            Host = HostMetadataCache.Host;
+        }
+
+        public ProtobufMessageEnvelope(MessageContext context, TProtoMessage message, string[] messageTypeNames)
+        {
+            if (context.MessageId.HasValue)
+                MessageId = context.MessageId.Value.ToString();
+            if (context.RequestId.HasValue)
+                RequestId = context.RequestId.Value.ToString();
+            if (context.CorrelationId.HasValue)
+                CorrelationId = context.CorrelationId.Value.ToString();
+            if (context.ConversationId.HasValue)
+                ConversationId = context.ConversationId.Value.ToString();
+            if (context.InitiatorId.HasValue)
+                InitiatorId = context.InitiatorId.Value.ToString();
+            if (context.SourceAddress != null)
+                SourceAddress = context.SourceAddress.ToString();
+            if (context.DestinationAddress != null)
+                DestinationAddress = context.DestinationAddress.ToString();
+            if (context.ResponseAddress != null)
+                ResponseAddress = context.ResponseAddress.ToString();
+            if (context.FaultAddress != null)
+                FaultAddress = context.FaultAddress.ToString();
+            MessageType = messageTypeNames;
+            Message = message as TProtoMessage;
+            if (context.ExpirationTime.HasValue)
+                ExpirationTime = context.ExpirationTime;
+            SentTime = context.SentTime ?? DateTime.UtcNow;
+            Headers = new Dictionary<string, object?>();
+            foreach (KeyValuePair<string, object> header in context.Headers.GetAll())
+                Headers[header.Key] = header.Value as TProtoMessage;
+            Host = HostMetadataCache.Host;
+        }
+
+        public ProtobufMessageEnvelope(MessageEnvelope envelope)
+        {
+            MessageId = envelope.MessageId;
+            RequestId = envelope.RequestId;
+            CorrelationId = envelope.CorrelationId;
+            ConversationId = envelope.ConversationId;
+            InitiatorId = envelope.InitiatorId;
+            SourceAddress = envelope.SourceAddress;
+            DestinationAddress = envelope.DestinationAddress;
+            ResponseAddress = envelope.ResponseAddress;
+            FaultAddress = envelope.FaultAddress;
+            MessageType = envelope.MessageType;
+            Message = envelope.Message as TProtoMessage;
+            ExpirationTime = envelope.ExpirationTime;
+            SentTime = envelope.SentTime ?? DateTime.UtcNow;
+            Headers = envelope.Headers != null
+                ? new Dictionary<string, object?>(envelope.Headers, StringComparer.OrdinalIgnoreCase) as Dictionary<string, object?>
+                : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            Host = envelope.Host ?? HostMetadataCache.Host;
+        }
+
+        public void Update(SendContext context)
+        {
+            DestinationAddress = context.DestinationAddress?.ToString();
+
+            if (context.SourceAddress != null)
+                SourceAddress = context.SourceAddress.ToString();
+
+            if (context.ResponseAddress != null)
+                ResponseAddress = context.ResponseAddress.ToString();
+
+            if (context.FaultAddress != null)
+                FaultAddress = context.FaultAddress.ToString();
+
+            if (context.MessageId.HasValue)
+                MessageId = context.MessageId.ToString();
+
+            if (context.RequestId.HasValue)
+                RequestId = context.RequestId.ToString();
+
+            if (context.ConversationId.HasValue)
+                ConversationId = context.ConversationId.ToString();
+
+            if (context.CorrelationId.HasValue)
+                CorrelationId = context.CorrelationId.ToString();
+
+            if (context.InitiatorId.HasValue)
+                InitiatorId = context.InitiatorId.ToString();
+
+            if (context.TimeToLive.HasValue)
+                ExpirationTime = DateTime.UtcNow + (context.TimeToLive > TimeSpan.Zero ? context.TimeToLive : TimeSpan.FromSeconds(1));
+
+            foreach (KeyValuePair<string, object> header in context.Headers.GetAll())
+                if (Headers != null)
+                    Headers[header.Key] = header.Value as TProtoMessage;
+                else
+                    Headers = new Dictionary<string, object?> { { header.Key, header.Value as TProtoMessage } };
+        }
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufMessageSerializer.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufMessageSerializer.cs
@@ -1,0 +1,27 @@
+﻿namespace MassTransit.Serialization
+{
+    using System;
+    using System.Net.Mime;
+    using ProtoBuf.Meta;
+
+    public class ProtobufMessageSerializer : IMessageSerializer
+    {
+        // might be application/vnd.google.protobuf or application/x-protobuf or application/x-google-protobuf or application/protobuf
+        public const string ContentTypeHeaderValue = "application/vnd.masstransit+pbuf";
+        public static readonly ContentType ProtobufContentType = new ContentType(ContentTypeHeaderValue);
+        private static RuntimeTypeModel _typeModel;
+
+        public ContentType ContentType => ProtobufContentType;
+
+        public ProtobufMessageSerializer(RuntimeTypeModel typeModel)
+        {
+            _typeModel = typeModel;
+        }
+
+        public MessageBody GetMessageBody<T>(SendContext<T> context) where T : class
+        {
+            return new ProtobufMessageBody<T>(context, _typeModel);
+        }
+
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufObjectDeserializer.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufObjectDeserializer.cs
@@ -1,0 +1,82 @@
+﻿#nullable enable
+namespace MassTransit.Serialization
+{
+    using System;
+    using System.IO;
+    using Initializers;
+    using Initializers.TypeConverters;
+    using MassTransit.Metadata;
+    using ProtoBuf.Meta;
+
+    public class ProtobufObjectDeserializer : IObjectDeserializer
+    {
+        private readonly RuntimeTypeModel _typeModel;
+
+        public ProtobufObjectDeserializer(RuntimeTypeModel typeModel)
+        {
+            _typeModel = typeModel;
+        }
+
+        public T? DeserializeObject<T>(object? value, T? defaultValue = default)
+            where T : class
+        {
+            switch (value)
+            {
+                case null:
+                    return defaultValue;
+                case T headerValue:
+                    return headerValue;
+                case string text when string.IsNullOrWhiteSpace(text):
+                    return defaultValue;
+                case string json when typeof(T).IsInterface && TypeMetadataCache<T>.IsValidMessageType:
+                    using (var stream = new MemoryStream())
+                    {
+                        var bytes = Convert.FromBase64String(json);
+                        stream.Write(bytes, 0, bytes.Length);
+                        stream.Position = 0;
+                        return _typeModel.Deserialize<T>(stream);
+                    }
+                case string text when TypeConverterCache.TryGetTypeConverter(out ITypeConverter<T, string>? typeConverter)
+                                   && typeConverter.TryConvert(text, out var result):
+                    return result;
+            }
+
+            throw new InvalidOperationException($"Unsupported deserialization type: {typeof(T)}");
+        }
+
+        public T? DeserializeObject<T>(object? value, T? defaultValue = null)
+            where T : struct
+        {
+            switch (value)
+            {
+                case null:
+                    return defaultValue;
+                case T headerValue:
+                    return headerValue;
+                case string text when string.IsNullOrWhiteSpace(text):
+                    return defaultValue;
+                case string text when TypeConverterCache.TryGetTypeConverter(out ITypeConverter<T, string>? typeConverter)
+                                   && typeConverter.TryConvert(text, out var result):
+                    return result;
+            }
+
+            throw new InvalidOperationException($"Unsupported deserialization type: {typeof(T)}");
+        }
+
+        public MessageBody SerializeObject(object? value)
+        {
+            if (value == null)
+                return new EmptyMessageBody();
+
+            using (var stream = new MemoryStream())
+            {
+                _typeModel.Serialize(stream, value);
+                stream.Position = 0;
+                var bytes = stream.ToArray();
+                var base64String = Convert.ToBase64String(bytes);
+                return new StringMessageBody(base64String);
+            }
+        }
+    }
+
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufSerializerContext.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufSerializerContext.cs
@@ -1,0 +1,128 @@
+﻿#nullable enable
+namespace MassTransit.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Net.Mime;
+    using ProtoBuf;
+    using ProtoBuf.Meta;
+    using MassTransit;
+    using System.IO;
+
+    public abstract class ProtobufBodySerializerContext :
+        BaseSerializerContext
+    {
+        readonly RuntimeTypeModel _typeModel;
+        private object? _message;
+
+        protected ProtobufBodySerializerContext(RuntimeTypeModel typeModel, IObjectDeserializer objectDeserializer, MessageContext messageContext,
+            object? message, string[] supportedMessageTypes)
+            : base(objectDeserializer, messageContext, supportedMessageTypes)
+        {
+            _typeModel = typeModel;
+            _message = message;
+        }
+
+        public override bool TryGetMessage<T>(out T? message)
+            where T : class
+        {
+            if (_typeModel.CanSerialize(typeof(T)))
+            {
+                if (_message is T messageOfT)
+                {
+                    message = messageOfT;
+                    return true;
+                }
+
+                using (var stream = new System.IO.MemoryStream())
+                {
+                    _typeModel.Serialize(stream, _message);
+                    stream.Position = 0;
+
+                    message = (T)_typeModel.Deserialize(stream, null, typeof(T));
+                    return true;
+                }
+            }
+
+            message = null;
+            return false;
+        }
+
+        public override bool TryGetMessage(Type messageType, [NotNullWhen(true)] out object? message)
+        {
+            if (_message != null && messageType.IsInstanceOfType(_message))
+            {
+                message = _message;
+                return true;
+            }
+
+            if (_typeModel.CanSerialize(messageType))
+            {
+                using (var stream = new System.IO.MemoryStream())
+                {
+                    _typeModel.Serialize(stream, _message);
+                    stream.Position = 0;
+
+                    message = _typeModel.Deserialize(stream, null, messageType);
+                    return true;
+                }
+            }
+
+            message = null;
+            return false;
+        }
+
+        public override Dictionary<string, object> ToDictionary<T>(T? message)
+            where T : class
+        {
+            if (message == null)
+                return new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            using var stream = new MemoryStream();
+            _typeModel.Serialize(stream, message);
+            stream.Position = 0;
+            return Serializer.Merge(stream, new Dictionary<string, object>())!;
+        }
+    }
+
+#nullable enable
+    public class ProtobufSerializerContext :
+        ProtobufBodySerializerContext
+    {
+        readonly ContentType _contentType;
+        readonly MessageEnvelope _envelope;
+        readonly RuntimeTypeModel _typeModel;
+
+        public ProtobufSerializerContext(RuntimeTypeModel typeModel, IObjectDeserializer objectDeserializer, MessageEnvelope envelope,
+            ContentType contentType)
+            : base(typeModel, objectDeserializer, new EnvelopeMessageContext(envelope, objectDeserializer), envelope.Message,
+                envelope.MessageType ?? Array.Empty<string>())
+        {
+            _contentType = contentType;
+            _envelope = envelope;
+            _typeModel = typeModel;
+        }
+
+        public override IMessageSerializer GetMessageSerializer()
+        {
+            return new ProtobufBodyMessageSerializer(_envelope, _contentType, _typeModel);
+        }
+
+        public override IMessageSerializer GetMessageSerializer<T>(MessageEnvelope envelope, T message)
+        {
+            var serializer = new ProtobufBodyMessageSerializer(envelope, _contentType, _typeModel);
+
+            serializer.Overlay(message);
+
+            return serializer;
+        }
+
+        public override IMessageSerializer GetMessageSerializer(object message, string[] messageTypes)
+        {
+            var envelope = new ProtobufMessageEnvelope<object>(this, message, messageTypes);
+
+            return new ProtobufBodyMessageSerializer((MessageEnvelope)envelope, _contentType, _typeModel);
+        }
+    }
+}

--- a/src/MassTransit.Protobuf/Serialization/ProtobufSerializerFactory.cs
+++ b/src/MassTransit.Protobuf/Serialization/ProtobufSerializerFactory.cs
@@ -1,0 +1,36 @@
+﻿namespace MassTransit.Serialization
+{
+    using MassTransit.Events;
+    using ProtoBuf.Meta;
+    using System.Net.Mime;
+    public class ProtobufSerializerFactory<TProtoMessage> : ISerializerFactory
+        where TProtoMessage : class
+    {
+        private readonly RuntimeTypeModel _typeModel;
+
+        public ContentType ContentType => ProtobufMessageSerializer.ProtobufContentType;
+
+        public ProtobufSerializerFactory()
+        {
+            _typeModel = RuntimeTypeModel.Create();
+
+            _typeModel.UseImplicitZeroDefaults = false;
+            _typeModel.AutoAddMissingTypes = true;
+            _typeModel.AllowParseableTypes = true;
+            _typeModel.AutoCompile = true;
+
+            _typeModel.Add<ReceiveFaultEvent>(true);
+            var receiveFaultModel = _typeModel.Add<ReceiveFault>(true);
+            receiveFaultModel.AddSubType(100, typeof(ReceiveFaultEvent));
+        }
+
+        public IMessageSerializer CreateSerializer()
+        {
+            return new ProtobufMessageSerializer(_typeModel);
+        }
+        public IMessageDeserializer CreateDeserializer()
+        {
+            return new ProtobufMessageDeserializer<TProtoMessage>(_typeModel);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

### Summary

Adds support for Protocol Buffer serialization/deserialization to MassTransit using [protobuf-net](https://github.com/protobuf-net/protobuf-net).

### History

I was tasked with evaluating MassTransit as a possible solution to some of our messaging needs as it did simplify and optimize some of our codebases. Our company uses Protocol Buffers for the transmission of messages, specifically with RabbitMQ. Because MassTransit did not appear to support Protocol Buffers, I decided to attempt to add support for them. To that end, I was somewhat successful.

The sad part of the story now though is that we have decided to move away from MassTransit as we were able to attain similar performance in our use cases through some optimizations of our codebases. We have decided to re-evaluate MassTransit in the future if it gains better support for Protocol Buffers.

However, rather than let this work die, I decided to create this PR that allows for simple protocol buffer support.

### Description

A lot of the inspiration for this implementation was take from the MassTransit.Newtonsoft project, since it appeared to be the only other "add-in" serialization solution supported by MassTransit. I will not claim to be extremely knowledgeable as to the purpose of all the different pieces of this implementation, but I did my best and verified that it does, in fact, function.

The configuration of this serialization is very particular, as I found the deserialization process difficult because of the lack of support for the `object` type in protobuf-net. This lack of support for dynamic types was one of the primary limiting factors that forced me to not be able to just have a single `config.UseProtobufSerializer()` that sets up the serializer and deserializer. In some cases, I had to certain types into the RuntimeTypeModel like `ReceiveFault` and its subtype explicitly.

As previously noted, I am not going to maintain this project moving forward. I am putting this solution out here for others to work with in the hopes that the MassTransit team will be able to use some pieces of this work.

### Usage/Example

The example configuration below is written in F#.

```fsharp
// Add MassTransit to an IServiceCollection
.AddMassTransit(fun (x: IBusRegistrationConfigurator) ->
    x.UsingRabbitMq (fun ctx cfg ->
		// Setup RMQ hosts
        let rootConfig = ctx.GetRequiredService<IOptions<RootConfig>>().Value

        let defaultConfig = rootConfig.RabbitMQConnection
        defaultConfig.Hosts
        |> Seq.iter (fun host ->
            cfg.Host(
                host,
                defaultConfig.VirtualHost,
                fun host ->
                    host.Username(defaultConfig.Username)
                    host.Password(defaultConfig.Password)
            ))

        // Setup exponential retry strategy
        cfg.UseMessageRetry (fun r ->
            r.Exponential(5, TimeSpan.FromSeconds(1.0), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2.0))
            |> ignore)

        // This only sets up the serialization of sent messages
        cfg.UseProtobufSerializer()

	// Define the main exchange that all messages get sent to
        let exchangeUri rk =
            new Uri($"exchange:%s{rootConfig.Exchange}?type=topic&routingKey={rk}")

        // These map the routing keys to use when sending messages of specified types
	let SOME_ROUTING_KEY = 'something'
	let ANOTHER_ROUTING_KEY = 'another-something'
        EndpointConvention.Map<SomeProtoEvent>(exchangeUri SOME_ROUTING_KEY)
        EndpointConvention.Map<AnotherProtoEvent>(exchangeUri ANOTHER_ROUTING_KEY)

        // The following sections set up the consumers, producers, and queues
        let scope = ctx.CreateScope()
        let provider = scope.ServiceProvider

        // "Some"
        cfg.Send<SomeProtoEvent>
            (fun (c: IRabbitMqMessageSendTopologyConfigurator<SomeProtoEvent>) ->
                c.UseRoutingKeyFormatter(fun _ -> SOME_ROUTING_KEY))

        cfg.Message<SomeProtoEvent>(fun c -> c.SetEntityName(rootConfig.Exchange))

        cfg.ReceiveEndpoint(
            "something",
            fun (endpoint: IRabbitMqReceiveEndpointConfigurator) ->
                endpoint.ConfigureConsumeTopology <- false

                // This sets us the deserialization for this event type
		// The SomeProtoEvent type is a protobuf-net ProtoContract type
                endpoint.UseProtobufDeserializer<SomeProtoEvent>()

                endpoint.Consumer<SomeEventConsumer>(provider)

                endpoint.Bind(
                    rootConfig.Exchange,
                    fun x ->
                        x.ExchangeType <- ExchangeType.Topic
                        x.RoutingKey <- SOME_ROUTING_KEY
                )
        )

        // "Another"
        cfg.Send<AnotherProtoEvent>
            (fun (c: IRabbitMqMessageSendTopologyConfigurator<AnotherProtoEvent>) ->
                c.UseRoutingKeyFormatter(fun _ -> ANOTHER_ROUTING_KEY))

        cfg.Message<AnotherProtoEvent>(fun c -> c.SetEntityName(rootConfig.Exchange))

        cfg.ReceiveEndpoint(
            "another-something",
            fun (endpoint: IRabbitMqReceiveEndpointConfigurator) ->
                endpoint.ConfigureConsumeTopology <- false

                // This sets us the deserialization for this event type
		// The AnotherProtoEvent type is a protobuf-net ProtoContract type
                endpoint.UseProtobufDeserializer<AnotherProtoEvent>()

                endpoint.Consumer<AnotherEventConsumer>(provider)

                endpoint.Bind(
                    rootConfig.Exchange,
                    fun x ->
                        x.ExchangeType <- ExchangeType.Topic
                        x.RoutingKey <- ANOTHER_ROUTING_KEY
                )
        )

        cfg.ConfigureEndpoints(ctx)
	)
)
.AddScoped<SomeEventConsumer>()
.AddScoped<AnotherEventConsumer>()
```