### PR TITLE
Update batch publishing to collect messages before waiting

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Batcher.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Batcher.cs
@@ -70,7 +70,7 @@ namespace MassTransit.AmazonSqsTransport
         async Task ReadBatch()
         {
             var batchToken = new CancellationTokenSource(_settings.Timeout);
-            var batch = new List<BatchEntry<TEntry>>();
+            var batch = new List<BatchEntry<TEntry>>(_settings.MessageLimit);
             try
             {
                 try

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/BatchCheckpointer.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/BatchCheckpointer.cs
@@ -73,16 +73,20 @@ namespace MassTransit.EventHubIntegration.Checkpoints
             {
                 try
                 {
-                    for (var i = 0; i < _settings.CheckpointMessageCount; i++)
+                    var messageCount = 0;
+
+                    while (messageCount < _settings.CheckpointMessageCount)
                     {
-                        var confirmation = await _channel.Reader.ReadAsync(batchToken.Token).ConfigureAwait(false);
-
-                        await confirmation.Confirmed.OrCanceled(_cancellationToken).ConfigureAwait(false);
-
-                        batch.Add(confirmation);
-
-                        if (await _channel.Reader.WaitToReadAsync(batchToken.Token).ConfigureAwait(false) == false)
+                        if (_channel.Reader.TryRead(out var confirmation))
+                        {
+                            await confirmation.Confirmed.OrCanceled(_cancellationToken).ConfigureAwait(false);
+                            batch.Add(confirmation);
+                            messageCount++;
+                        }
+                        else if (await _channel.Reader.WaitToReadAsync(batchToken.Token).ConfigureAwait(false) == false)
+                        {
                             break;
+                        }
                     }
                 }
                 catch (Exception) when (batch.Count > 0)

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/BatchPublisher.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/BatchPublisher.cs
@@ -88,7 +88,7 @@ namespace MassTransit.RabbitMqTransport
         async Task ReadBatch()
         {
             var batchToken = new CancellationTokenSource(_settings.Timeout);
-            var batch = new List<BatchPublish>();
+            var batch = new List<BatchPublish>(_settings.MessageLimit);
             try
             {
                 try


### PR DESCRIPTION
Batch publishers should gather as many messages as possible before waiting for new messages.
This should make it slightly more likely for batch limits to be filled.

* Only waits for new messages if there are none available
* Always checks batch limits (count/size) before waiting for new messages (allows for 0ms timeouts)
