### PR TITLE
RabbitMQ Basic Consumer support for sequential processing with ConcurrentMessageLimit = 1

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqBasicConsumer.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqBasicConsumer.cs
@@ -239,7 +239,7 @@ namespace MassTransit.RabbitMqTransport
 
         Task OnConsumerCancelled(object obj, ConsumerEventArgs args)
         {
-            _sequentialDeliveryBlockingCollection.CompleteAdding();
+            _sequentialDeliveryBlockingCollection?.CompleteAdding();
             _onConsumerCancelled?.Invoke(obj, args);           
 
             return Task.CompletedTask;

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqBasicConsumer.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqBasicConsumer.cs
@@ -59,7 +59,7 @@ namespace MassTransit.RabbitMqTransport
 
         /// <summary>
         /// Starts a background task awaiting message delivery to preserve message order processing
-        /// when ConcurrentMessageLimit is set to 1 and prefetch is higher than 1
+        /// when ConcurrentMessageLimit is set to 1 and prefetch is 0 or higher than 1
         /// </summary>
         /// <param name="sequentialDeliveryBlockingCollection"></param>
         /// <returns></returns>

--- a/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
@@ -141,7 +141,7 @@
             long _deliveryCount;
             int _maxPendingDeliveryCount;
             int _previousSequenceIndex;
-            bool _completedConsumingSequentially;
+            bool _completedConsumingSequentially = true;
 
             public int MaxDeliveryCount => _maxPendingDeliveryCount;
             public bool CompletedConsumingSequentially => _completedConsumingSequentially;

--- a/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
@@ -92,4 +92,109 @@
         {
         }
     }
+
+    [TestFixture]
+    [Category("Flaky")]
+    public class Using_a_consumer_concurrency_limit_set_to_1 :
+        RabbitMqTestFixture
+    {
+        [Test]
+        public async Task Should_limit_the_consumer_and_consume_messages_sequentially()
+        {
+            _complete = GetTask<bool>();
+
+            var tasks = new List<Task>(_messageCount * 2);
+            int sequenceIndex = 1;
+            for (var i = 0; i < _messageCount; i++)
+            {
+                tasks.Add(Bus.Publish(new A(sequenceIndex++)));
+                tasks.Add(Bus.Publish(new B(sequenceIndex++)));
+            }
+
+            await Task.WhenAll(tasks);
+
+            await _complete.Task;
+
+            Assert.AreEqual(1, _consumer.MaxDeliveryCount);
+            Assert.AreEqual(true, _consumer.CompletedConsumingSequentially);
+        }
+
+        Consumer _consumer;
+        static readonly int _messageCount = 50;
+        static TaskCompletionSource<bool> _complete;
+
+        protected override void ConfigureRabbitMqReceiveEndpoint(IRabbitMqReceiveEndpointConfigurator configurator)
+        {
+            base.ConfigureRabbitMqReceiveEndpoint(configurator);
+
+            _consumer = new Consumer();
+            configurator.ConcurrentMessageLimit = 1;
+        }
+
+
+        class Consumer :
+            IConsumer<A>,
+            IConsumer<B>
+        {
+            int _currentPendingDeliveryCount;
+            long _deliveryCount;
+            int _maxPendingDeliveryCount;
+            int _previousSequenceIndex;
+            bool _completedConsumingSequentially;
+
+            public int MaxDeliveryCount => _maxPendingDeliveryCount;
+            public bool CompletedConsumingSequentially => _completedConsumingSequentially;
+
+            public Task Consume(ConsumeContext<A> context)
+            {
+                return OnConsume(context.Message.SequenceIndex);
+            }
+
+            public Task Consume(ConsumeContext<B> context)
+            {
+                return OnConsume(context.Message.SequenceIndex);
+            }
+
+            async Task OnConsume(int sequenceIndex)
+            {
+                Interlocked.Increment(ref _deliveryCount);
+
+                var current = Interlocked.Increment(ref _currentPendingDeliveryCount);
+                while (current > _maxPendingDeliveryCount)
+                    Interlocked.CompareExchange(ref _maxPendingDeliveryCount, current, _maxPendingDeliveryCount);
+
+                await Task.Delay(10);
+
+                Interlocked.Decrement(ref _currentPendingDeliveryCount);
+
+                _completedConsumingSequentially = _previousSequenceIndex == sequenceIndex - 1;
+                _previousSequenceIndex = sequenceIndex;
+
+                if (_deliveryCount >= _messageCount * 2)
+                    _complete.TrySetResult(true);
+            }
+        }
+
+
+        class A
+        {
+            public A(int sequenceIndex)
+            {
+                SequenceIndex = sequenceIndex;
+            }
+
+            public int SequenceIndex { get; }
+        }
+
+
+        class B
+        {
+            public B(int sequenceIndex)
+            {
+                SequenceIndex = sequenceIndex;
+            }
+
+            public int SequenceIndex { get; }
+        }
+    }
 }

--- a/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
@@ -168,7 +168,7 @@
 
                 Interlocked.Decrement(ref _currentPendingDeliveryCount);
 
-                _completedConsumingSequentially = _previousSequenceIndex == sequenceIndex - 1;
+                _completedConsumingSequentially = _completedConsumingSequentially && _previousSequenceIndex == sequenceIndex - 1;
                 _previousSequenceIndex = sequenceIndex;
 
                 if (_deliveryCount >= _messageCount * 2)

--- a/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
@@ -103,15 +103,12 @@
         {
             _complete = GetTask<bool>();
 
-            var tasks = new List<Task>(_messageCount * 2);
             int sequenceIndex = 1;
             for (var i = 0; i < _messageCount; i++)
             {
-                tasks.Add(Bus.Publish(new A(sequenceIndex++)));
-                tasks.Add(Bus.Publish(new B(sequenceIndex++)));
+                await Bus.Publish(new A(sequenceIndex++));
+                await Bus.Publish(new B(sequenceIndex++));
             }
-
-            await Task.WhenAll(tasks);
 
             await _complete.Task;
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
@@ -129,6 +129,7 @@
 
             _consumer = new Consumer();
             configurator.ConcurrentMessageLimit = 1;
+            configurator.Instance(_consumer, x => x.UseConcurrentMessageLimit(1));
         }
 
 


### PR DESCRIPTION
This is an implementation proposal to support for RabbitMQ consumer to process messages sequentially when PrefetchCount is set to 0 or 2+ and `RabbitMqReceiveEndpointContext.ConcurrentMessageLimit` is set to 1 to avoid concurrent message processing.

In some scenario, such capability can be useful. 

See the integration test `Using_a_consumer_concurrency_limit_set_to_1.Should_limit_the_consumer_and_consume_messages_sequentially()` method for a concrete example.

Here is a visual summary of the change:

### Before

![image](https://github.com/MassTransit/MassTransit/assets/5232883/b88fc21b-d2f1-4b12-96fa-733eb4e805af)

### After

![image](https://github.com/MassTransit/MassTransit/assets/5232883/a18e1026-d496-45db-b7b1-70db2b607035)
