### PR TITLE
Get parent activity context for send and outbox send activities

### DIFF
--- a/src/MassTransit/Logging/Diagnostics/LogContextActivityExtensions.cs
+++ b/src/MassTransit/Logging/Diagnostics/LogContextActivityExtensions.cs
@@ -17,7 +17,7 @@ namespace MassTransit.Logging
             params (string Key, object? Value)[] tags)
             where T : class
         {
-            var parentActivityContext = GetParentActivityContext(context.Headers);
+            var parentActivityContext = System.Diagnostics.Activity.Current?.Context ?? GetParentActivityContext(context.Headers);
 
             var activity = Cached.Source.Value.CreateActivity(transportContext.ActivityName, ActivityKind.Producer, parentActivityContext);
             if (activity == null)
@@ -33,7 +33,7 @@ namespace MassTransit.Logging
         public static StartedActivity? StartOutboxSendActivity<T>(this ILogContext logContext, SendContext<T> context)
             where T : class
         {
-            var parentActivityContext = GetParentActivityContext(context.Headers);
+            var parentActivityContext = System.Diagnostics.Activity.Current?.Context ?? GetParentActivityContext(context.Headers);
 
             var activity = Cached.Source.Value.CreateActivity("outbox send", ActivityKind.Producer, parentActivityContext);
             if (activity == null)

--- a/src/MassTransit/Logging/Diagnostics/LogContextActivityExtensions.cs
+++ b/src/MassTransit/Logging/Diagnostics/LogContextActivityExtensions.cs
@@ -17,7 +17,9 @@ namespace MassTransit.Logging
             params (string Key, object? Value)[] tags)
             where T : class
         {
-            var activity = Cached.Source.Value.CreateActivity(transportContext.ActivityName, ActivityKind.Producer);
+            var parentActivityContext = GetParentActivityContext(context.Headers);
+
+            var activity = Cached.Source.Value.CreateActivity(transportContext.ActivityName, ActivityKind.Producer, parentActivityContext);
             if (activity == null)
                 return null;
 
@@ -31,7 +33,9 @@ namespace MassTransit.Logging
         public static StartedActivity? StartOutboxSendActivity<T>(this ILogContext logContext, SendContext<T> context)
             where T : class
         {
-            var activity = Cached.Source.Value.CreateActivity("outbox send", ActivityKind.Producer);
+            var parentActivityContext = GetParentActivityContext(context.Headers);
+
+            var activity = Cached.Source.Value.CreateActivity("outbox send", ActivityKind.Producer, parentActivityContext);
             if (activity == null)
                 return null;
 


### PR DESCRIPTION
Adds parent activity context checks to `send` and `outbox send` activities. This fixed an issue where scheduled messages (experienced this through Hangfire) do not inherit the original trace ID.

This shows what happens when a message is scheduled in develop:
![image](https://github.com/MassTransit/MassTransit/assets/23037278/622d5002-e38e-4d5d-8078-5017dae58d42)

Scheduled send is shown as a different trace.

After fix: scheduled send is included in parent trace after the delay:
![image](https://github.com/MassTransit/MassTransit/assets/23037278/f7ea8e01-6594-4faf-9024-1f0ad912a75d)
