### PR TITLE
Setting Azure ServiceBusAdministrationClientOptions

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ConnectionContextFactory.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ConnectionContextFactory.cs
@@ -67,34 +67,44 @@ namespace MassTransit.AzureServiceBusTransport
                 EnableCrossEntityTransactions = false,
             };
 
+            var managementOptions = new ServiceBusAdministrationClientOptions
+            {
+                Retry =
+                {
+                    MaxRetries = settings.RetryLimit,
+                    Mode = Azure.Core.RetryMode.Exponential,
+                    MaxDelay = settings.RetryMaxBackoff
+                }
+            };
+
             if (settings.TokenCredential != null)
             {
                 client ??= new ServiceBusClient(endpoint, settings.TokenCredential, clientOptions);
-                managementClient ??= new ServiceBusAdministrationClient(endpoint, settings.TokenCredential);
+                managementClient ??= new ServiceBusAdministrationClient(endpoint, settings.TokenCredential, managementOptions);
             }
             else if (settings.NamedKeyCredential != null)
             {
                 client ??= new ServiceBusClient(endpoint, settings.NamedKeyCredential, clientOptions);
-                managementClient ??= new ServiceBusAdministrationClient(endpoint, settings.NamedKeyCredential);
+                managementClient ??= new ServiceBusAdministrationClient(endpoint, settings.NamedKeyCredential, managementOptions);
             }
             else if (settings.SasCredential != null)
             {
                 client ??= new ServiceBusClient(endpoint, settings.SasCredential, clientOptions);
-                managementClient ??= new ServiceBusAdministrationClient(endpoint, settings.SasCredential);
+                managementClient ??= new ServiceBusAdministrationClient(endpoint, settings.SasCredential, managementOptions);
             }
             else
             {
                 if (settings.ConnectionString != null && HasSharedAccess(settings.ConnectionString))
                 {
                     client ??= new ServiceBusClient(settings.ConnectionString, clientOptions);
-                    managementClient ??= new ServiceBusAdministrationClient(settings.ConnectionString);
+                    managementClient ??= new ServiceBusAdministrationClient(settings.ConnectionString, managementOptions);
                 }
                 else
                 {
                     var defaultAzureCredential = new DefaultAzureCredential();
 
                     client ??= new ServiceBusClient(endpoint, defaultAzureCredential, clientOptions);
-                    managementClient ??= new ServiceBusAdministrationClient(endpoint, defaultAzureCredential);
+                    managementClient ??= new ServiceBusAdministrationClient(endpoint, defaultAzureCredential, managementOptions);
                 }
             }
 


### PR DESCRIPTION
For Azure Service Bus transport,  MassTransit allows the Retry setting of ServiceBusClientOptions to be customized via host settings, However, in Azure Service Bus SDK, ServiceBusAdministrationClient also has its own ServiceBusAdministrationClientOptions and retry settings and MassTransit does not set those options.

On the other hand, MassTransit is using  ServiceBusAdministrationClient  for send and publish, as it checks if the queue does not exist to be created. 

So, when sending or publishing a message and there is a connection problem, Azure Service Bus always uses the default retry setting not what is set by MassTransit in host settings.

This this was discussed here:
https://github.com/MassTransit/MassTransit/discussions/4480

