### PR TITLE
Default value for AlwaysWriteToRepository correction in doc

### DIFF
--- a/doc/content/3.documentation/3.patterns/8.claim-check.md
+++ b/doc/content/3.documentation/3.patterns/8.claim-check.md
@@ -150,7 +150,7 @@ To configure the threshold, and to optionally turn off storage of data sizes und
 MessageDataDefaults.Threshold = 8192;
 
 // to disable writing to the repository for sizes under the threshold
-// defaults to false, which may change to true in a future release
+// defaults to true, which may change to false in a future release
 MessageDataDefaults.AlwaysWriteToRepository = false;
 ```
 


### PR DESCRIPTION
The comment is a bit confusing
Default value for AlwaysWriteToRepository is true
https://github.com/MassTransit/MassTransit/blob/develop/src/MassTransit.Abstractions/MessageData/MessageDataDefaults.cs

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
