### PR TITLE
Expose `RabbitMqSslOptions.Protocol` option

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqSslOptions.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqSslOptions.cs
@@ -1,5 +1,9 @@
 namespace MassTransit
 {
+    using System.Security.Authentication;
+    using RabbitMqTransport.Configuration;
+
+
     public class RabbitMqSslOptions
     {
         public string ServerName { get; set; }
@@ -7,5 +11,6 @@ namespace MassTransit
         public string CertPath { get; set; }
         public string CertPassphrase { get; set; }
         public bool CertIdentity { get; set; }
+        public SslProtocols Protocol { get; set; } = ConfigurationHostSettings.DefaultSslProtocols;
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/ConfigurationHostSettings.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/ConfigurationHostSettings.cs
@@ -12,13 +12,15 @@ namespace MassTransit.RabbitMqTransport.Configuration
     class ConfigurationHostSettings :
         RabbitMqHostSettings
     {
+        internal const SslProtocols DefaultSslProtocols = SslProtocols.Tls12;
+
         readonly ConfigurationBatchSettings _batchSettings;
         readonly Lazy<Uri> _hostAddress;
 
         public ConfigurationHostSettings()
         {
             var defaultOptions = new SslOption();
-            SslProtocol = SslProtocols.Tls12;
+            SslProtocol = DefaultSslProtocols;
 
             AcceptablePolicyErrors = defaultOptions.AcceptablePolicyErrors | SslPolicyErrors.RemoteCertificateChainErrors;
 

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqHostConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqHostConfigurator.cs
@@ -1,7 +1,6 @@
 namespace MassTransit.RabbitMqTransport.Configuration
 {
     using System;
-    using System.Security.Authentication;
 
 
     public class RabbitMqHostConfigurator :
@@ -18,7 +17,6 @@ namespace MassTransit.RabbitMqTransport.Configuration
             {
                 UseSsl(s =>
                 {
-                    s.Protocol = SslProtocols.Tls12;
                 });
             }
 
@@ -36,6 +34,13 @@ namespace MassTransit.RabbitMqTransport.Configuration
                 Port = port,
                 VirtualHost = virtualHost
             };
+
+            if (_settings.Port == 5671)
+            {
+                UseSsl(s =>
+                {
+                });
+            }
 
             if (!string.IsNullOrEmpty(connectionName))
                 _settings.ClientProvidedName = connectionName;

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqRegistrationBusFactory.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqRegistrationBusFactory.cs
@@ -47,7 +47,7 @@ namespace MassTransit.RabbitMqTransport.Configuration
                 {
                     h.UseSsl(s =>
                     {
-                        var sslOptions = context.GetRequiredService<IOptions<RabbitMqSslOptions>>().Value;
+                        var sslOptions = context.GetRequiredService<IOptionsMonitor<RabbitMqSslOptions>>().Get(busName);
 
                         if (!string.IsNullOrWhiteSpace(sslOptions.ServerName))
                             s.ServerName = sslOptions.ServerName;
@@ -56,6 +56,8 @@ namespace MassTransit.RabbitMqTransport.Configuration
                         if (!string.IsNullOrWhiteSpace(sslOptions.CertPassphrase))
                             s.CertificatePassphrase = sslOptions.CertPassphrase;
                         s.UseCertificateAsAuthenticationIdentity = sslOptions.CertIdentity;
+
+                        s.Protocol = sslOptions.Protocol;
 
                         if (sslOptions.Trust)
                         {


### PR DESCRIPTION
Related to #4522, this commit exposes an option from the existing `RabbitMqSslOptions` to allow users to explicitly set a specific `SslProtocols` value per multi-bus instance (e.g. for cases where multi-bus instances point to different clusters with differing security requirements).

See: #4522

___

> **Note**
> _I'd very much like to contribute some tests for this, but I'm not quite sure where to start, so opening this for consideration/discussion before I go much further._