### PR TITLE
Update Scoped Mediator on mediator.md

### DIFF
--- a/doc/content/3.documentation/1.concepts/mediator.md
+++ b/doc/content/3.documentation/1.concepts/mediator.md
@@ -35,7 +35,8 @@ _Publish_, on the other hand, does not require the message to be consumed and do
 
 ### Scoped Mediator
 
-Main mediator interface `IMediator` is registered as a singleton but there is another scoped version of it `IScopedMediator`. This interface is registered as a part of current IoC scope (`HttpContext` or manually created) and can be used in order to share it for the entire pipeline.
+Main mediator interface `IMediator` is registered as a singleton but there is another scoped version of it `IScopedMediator`. This interface is registered as a part of current IoC scope (`HttpContext` or manually created) and can be used in order to share the scope for the entire pipeline.
+By default with `IMediator`, each consumer has its own scope. By using `IScopedMediator`, the scope is shared between several consumers.
 
 ::alert{type="success"}
 No additional configuration is required as long as Mediator is configured via `services.AddMediator()`


### PR DESCRIPTION
In the sentence "be used in order to share it for the entire pipeline", it was not clear that "it" was referencing "Main mediator" and not "IoC scope". Since I saw other question about sharing scope between multiple consumers, I wanted to update directly the documentation