### PR TITLE
Adding the full job type name to the JobTypeSaga table.

### DIFF
--- a/src/MassTransit.Abstractions/JobService/Contracts/JobService/SetConcurrentJobLimit.cs
+++ b/src/MassTransit.Abstractions/JobService/Contracts/JobService/SetConcurrentJobLimit.cs
@@ -10,6 +10,8 @@ namespace MassTransit.Contracts.JobService
     {
         Guid JobTypeId { get; }
 
+        string JobTypeName { get; }
+
         Uri InstanceAddress { get; }
 
         int ConcurrentJobLimit { get; }

--- a/src/MassTransit/JobService/Configuration/JobServiceConsumerConfigurationObserver.cs
+++ b/src/MassTransit/JobService/Configuration/JobServiceConsumerConfigurationObserver.cs
@@ -52,8 +52,9 @@ namespace MassTransit.Configuration
                 var options = consumerConfigurator.Options<JobOptions<TMessage>>();
 
                 var jobTypeId = JobMetadataCache<T, TMessage>.GenerateJobTypeId(_configurator.InputAddress.GetEndpointName());
+                var jobTypeName = JobMetadataCache<T, TMessage>.GenerateJobTypeName(_configurator.InputAddress.GetEndpointName());
 
-                _jobServiceOptions.JobService.RegisterJobType(_configurator, options, jobTypeId);
+                _jobServiceOptions.JobService.RegisterJobType(_configurator, options, jobTypeId, jobTypeName);
             }
         }
     }

--- a/src/MassTransit/JobService/JobService/IJobService.cs
+++ b/src/MassTransit/JobService/JobService/IJobService.cs
@@ -42,8 +42,9 @@
         /// <param name="configurator"></param>
         /// <param name="options"></param>
         /// <param name="jobTypeId"></param>
+        /// <param name="jobTypeName"></param>
         /// <typeparam name="T"></typeparam>
-        void RegisterJobType<T>(IReceiveEndpointConfigurator configurator, JobOptions<T> options, Guid jobTypeId)
+        void RegisterJobType<T>(IReceiveEndpointConfigurator configurator, JobOptions<T> options, Guid jobTypeId, string jobTypeName)
             where T : class;
 
         Task BusStarted(IPublishEndpoint publishEndpoint);

--- a/src/MassTransit/JobService/JobService/JobMetadataCache.cs
+++ b/src/MassTransit/JobService/JobService/JobMetadataCache.cs
@@ -11,16 +11,22 @@ namespace MassTransit.JobService
     {
         public static Guid GenerateJobTypeId(string queueName)
         {
-            var consumerTypeName = TypeCache<TConsumer>.ShortName;
-            var jobTypeName = TypeCache<TJob>.ShortName;
-
-            var key = $"{consumerTypeName}:{jobTypeName}:{queueName}";
+            var key = GenerateJobTypeName(queueName);
 
             using var hasher = MD5.Create();
 
             var data = hasher.ComputeHash(Encoding.UTF8.GetBytes(key));
 
             return new Guid(data);
+        }
+        public static string GenerateJobTypeName(string queueName)
+        {
+            var consumerTypeName = TypeCache<TConsumer>.ShortName;
+            var jobTypeName = TypeCache<TJob>.ShortName;
+
+            var name = $"{consumerTypeName}:{jobTypeName}:{queueName}";
+
+            return name;
         }
     }
 }

--- a/src/MassTransit/JobService/JobService/JobService.cs
+++ b/src/MassTransit/JobService/JobService/JobService.cs
@@ -104,13 +104,13 @@
             await Task.WhenAll(_jobTypes.Values.Select(x => x.PublishJobInstanceStopped(publishEndpoint, InstanceAddress))).ConfigureAwait(false);
         }
 
-        public void RegisterJobType<T>(IReceiveEndpointConfigurator configurator, JobOptions<T> options, Guid jobTypeId)
+        public void RegisterJobType<T>(IReceiveEndpointConfigurator configurator, JobOptions<T> options, Guid jobTypeId, string jobTypeName)
             where T : class
         {
             if (_jobTypes.ContainsKey(typeof(T)))
                 throw new ConfigurationException($"A job type can only be registered once per service instance: {TypeCache<T>.ShortName}");
 
-            _jobTypes.Add(typeof(T), new JobTypeRegistration<T>(configurator, options, jobTypeId));
+            _jobTypes.Add(typeof(T), new JobTypeRegistration<T>(configurator, options, jobTypeId, jobTypeName));
         }
 
         public async Task BusStarted(IPublishEndpoint publishEndpoint)
@@ -181,12 +181,15 @@
             readonly IReceiveEndpointConfigurator _configurator;
             readonly JobOptions<T> _options;
 
-            public JobTypeRegistration(IReceiveEndpointConfigurator configurator, JobOptions<T> options, Guid jobTypeId)
+            public JobTypeRegistration(IReceiveEndpointConfigurator configurator, JobOptions<T> options, Guid jobTypeId, string jobTypeName)
             {
                 _configurator = configurator;
                 _options = options;
                 JobTypeId = jobTypeId;
+                JobTypeName = jobTypeName;
             }
+
+
 
             public Task PublishConcurrentJobLimit(IPublishEndpoint publishEndpoint, Uri instanceAddress)
             {
@@ -195,6 +198,7 @@
                 return publishEndpoint.Publish<SetConcurrentJobLimit>(new
                 {
                     JobTypeId,
+                    JobTypeName,
                     instanceAddress,
                     ServiceAddress = _configurator.InputAddress,
                     _options.ConcurrentJobLimit,
@@ -207,6 +211,7 @@
                 return publishEndpoint.Publish<SetConcurrentJobLimit>(new
                 {
                     JobTypeId,
+                    JobTypeName,
                     instanceAddress,
                     ServiceAddress = _configurator.InputAddress,
                     _options.ConcurrentJobLimit,
@@ -219,6 +224,7 @@
                 return publishEndpoint.Publish<SetConcurrentJobLimit>(new
                 {
                     JobTypeId,
+                    JobTypeName,
                     instanceAddress,
                     ServiceAddress = _configurator.InputAddress,
                     _options.ConcurrentJobLimit,
@@ -227,6 +233,7 @@
             }
 
             public Guid JobTypeId { get; }
+            string JobTypeName { get; }
         }
     }
 }

--- a/src/MassTransit/JobService/JobTypeSaga.cs
+++ b/src/MassTransit/JobService/JobTypeSaga.cs
@@ -30,6 +30,11 @@ namespace MassTransit
         public int ConcurrentJobLimit { get; set; }
 
         /// <summary>
+        /// The name of the job type
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
         /// The job limit may be overridden temporarily, to either reduce or increase the number of concurrent jobs. Once the
         /// override job limit expires, the concurrent job limit returns to the original value.
         /// </summary>

--- a/src/MassTransit/JobService/JobTypeStateMachine.cs
+++ b/src/MassTransit/JobService/JobTypeStateMachine.cs
@@ -180,6 +180,7 @@ namespace MassTransit
                 if (context.Message.Kind == ConcurrentLimitKind.Configured)
                 {
                     context.Saga.ConcurrentJobLimit = context.Message.ConcurrentJobLimit;
+                    context.Saga.Name = context.Message.JobTypeName;
 
                     LogContext.Debug?.Log("Concurrent Job Limit: {ConcurrencyLimit}", context.Saga.ConcurrentJobLimit);
                 }


### PR DESCRIPTION
Adding the full job type name ($"{consumerTypeName}:{jobTypeName}:{queueName}") to the JobTypeSaga table.

This helps a lot for debugging purposes. 

Without this, you need to rely on the Id property and there is no way to reverse it to a human readable string because it's an MD5 hash.