### PR TITLE
Update to latest version of Marten [Breaking]

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,6 +65,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" Condition="'$(TargetFramework)' != 'net7.0'" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" Condition="'$(TargetFramework)' != 'net7.0'" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" Condition="'$(TargetFramework)' != 'net7.0'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,8 @@
     <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.0" />
     <PackageVersion Include="Iesi.Collections" Version="4.0.5" />
     <PackageVersion Include="Ionic.Zlib.Core" Version="1.0.0" />
-    <PackageVersion Include="Marten" Version="5.11.0" />
+    <PackageVersion Include="Marten" Version="5.11.0" Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0'" />
+    <PackageVersion Include="Marten" Version="6.0.5" Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="MediatR" Version="12.1.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/src/Persistence/MassTransit.MartenIntegration/Configuration/MartenSagaRepositoryRegistrationExtensions.cs
+++ b/src/Persistence/MassTransit.MartenIntegration/Configuration/MartenSagaRepositoryRegistrationExtensions.cs
@@ -107,10 +107,15 @@ namespace MassTransit
         [Obsolete("AddMarten should be used to set up and configure Marten and use SetMartenSagaRepositoryProvider() with no arguments.")]
         public static void SetMartenSagaRepositoryProvider(this IRegistrationConfigurator configurator, string connectionString)
         {
-            configurator.AddMarten(options =>
-            {
-                options.Connection(connectionString);
-            });
+            var martenRegistrationPipeline = configurator.AddMarten(
+                options =>
+                {
+                    options.Connection(connectionString);
+                });
+
+#if NET6_0_OR_GREATER
+            martenRegistrationPipeline.ApplyAllDatabaseChangesOnStartup();
+#endif
 
             configurator.SetSagaRepositoryProvider(new MartenSagaRepositoryRegistrationProvider());
         }
@@ -125,12 +130,17 @@ namespace MassTransit
         public static void SetMartenSagaRepositoryProvider(this IRegistrationConfigurator configurator, string connectionString,
             Action<StoreOptions> configureOptions)
         {
-            configurator.AddMarten(options =>
-            {
-                options.Connection(connectionString);
+            var martenRegistrationPipeline = configurator.AddMarten(
+                options =>
+                {
+                    options.Connection(connectionString);
 
-                configureOptions?.Invoke(options);
-            });
+                    configureOptions?.Invoke(options);
+                });
+
+#if NET6_0_OR_GREATER
+            martenRegistrationPipeline.ApplyAllDatabaseChangesOnStartup();
+#endif
 
             configurator.SetSagaRepositoryProvider(new MartenSagaRepositoryRegistrationProvider());
         }
@@ -145,12 +155,17 @@ namespace MassTransit
         public static void SetMartenSagaRepositoryProvider(this IRegistrationConfigurator configurator, Func<NpgsqlConnection> connectionFactory,
             Action<StoreOptions> configureOptions)
         {
-            configurator.AddMarten(options =>
-            {
-                options.Connection(connectionFactory);
+            var martenRegistrationPipeline = configurator.AddMarten(
+                options =>
+                {
+                    options.Connection(connectionFactory);
 
-                configureOptions?.Invoke(options);
-            });
+                    configureOptions?.Invoke(options);
+                });
+
+#if NET6_0_OR_GREATER
+            martenRegistrationPipeline.ApplyAllDatabaseChangesOnStartup();
+#endif
 
             configurator.SetSagaRepositoryProvider(new MartenSagaRepositoryRegistrationProvider());
         }

--- a/src/Persistence/MassTransit.MartenIntegration/MartenIntegration/Saga/MartenSagaRepositoryContextFactory.cs
+++ b/src/Persistence/MassTransit.MartenIntegration/MartenIntegration/Saga/MartenSagaRepositoryContextFactory.cs
@@ -71,7 +71,12 @@ namespace MassTransit.MartenIntegration.Saga
         async Task<T> ExecuteAsyncMethod<T>(Func<MartenSagaRepositoryContext<TSaga>, Task<T>> asyncMethod, CancellationToken cancellationToken)
             where T : class
         {
+
+#if NET6_0_OR_GREATER
+            var session = _documentStore.LightweightSession();
+#else
             var session = _documentStore.OpenSession();
+#endif
             try
             {
                 var repositoryContext = new MartenSagaRepositoryContext<TSaga>(session, cancellationToken);

--- a/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
+++ b/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
@@ -24,4 +24,5 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
+
 </Project>

--- a/tests/MassTransit.MartenIntegration.Tests/MassTransit.MartenIntegration.Tests.csproj
+++ b/tests/MassTransit.MartenIntegration.Tests/MassTransit.MartenIntegration.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/tests/MassTransit.MartenIntegration.Tests/SagaPersistenceTests.cs
+++ b/tests/MassTransit.MartenIntegration.Tests/SagaPersistenceTests.cs
@@ -74,7 +74,7 @@
         [OneTimeSetUp]
         public async Task OneTime()
         {
-            await _store.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+            await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
         }
 
         public LocatingAnExistingSaga()


### PR DESCRIPTION

### 🚀 Feature Description
This PR updates Marten to the latest major and minor version. (6.0.5)
- OpenSession was deprecated in favour of using a named session type, LightSession being the prefered.
- Schema was removed on document session with methods being moved to storage.

=======================================================

### ⚠️ Breaking Changes
- Marten dropped support for legacy .NET framework, as well as .net standard, so the change unfortunately means MT would also have to drop support for them, meaning MassTransit.Marten would have TargetFrameworks net6 and net7 only.

### 🧯 Bugfixes
- Fixes the ability to add MassTransit.Marten to a solution which references NpgSql 7.
  5.11.0 had a dependency on Weasel which in turn had a package version constraint of '< 7.0' so would throw an error without explicitly referencing assemblies yourself, muddling the dependancy graph. 