### PR TITLE
Fix #4568 by avoiding calling Clear() on the AuthMechanisms for RabbitMq transport

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqAddressExtensions.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqAddressExtensions.cs
@@ -61,8 +61,7 @@ namespace MassTransit.RabbitMqTransport
 
             if (settings.UseClientCertificateAsAuthenticationIdentity)
             {
-                factory.AuthMechanisms.Clear();
-                factory.AuthMechanisms.Add(new ExternalMechanismFactory());
+                factory.AuthMechanisms = new List<IAuthMechanismFactory> { new ExternalMechanismFactory() };
                 factory.UserName = "";
                 factory.Password = "";
             }


### PR DESCRIPTION
Fix #4568 by avoiding calling Clear() on the AuthMechanisms for RabbitMq transport