### PR TITLE
Update configure documentation for Kebab formater

### DIFF
--- a/doc/content/3.documentation/5.configuration/0.index.md
+++ b/doc/content/3.documentation/5.configuration/0.index.md
@@ -186,7 +186,7 @@ _ConfigureEndpoints_ uses an `IEndpointNameFormatter` to format the queue names 
 The endpoint name formatters can also be customized by constructing a new instance and configuring MassTransit to use it.
 
 ```csharp
-x.SetEndpointNameFormatter(new KebabCaseEndpointNameFormatter(prefix: "Dev"));
+x.SetEndpointNameFormatter(new KebabCaseEndpointNameFormatter(prefix: "Dev", includeNamespace: false));
 ```
 
 By specifying a prefix, the endpoint name would be `dev-submit-order`. This is useful when sharing a single broker with multiple developers (Amazon SQS is account-wide, for instance).
@@ -197,7 +197,7 @@ When using MultiBus with different endpoint name formatters for each bus...
 #content
 Specify the endpoint name formatter when calling `ConfigureEndpoints` as shown. 
 ```csharp
-cfg.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter(prefix: "Mobile"));
+cfg.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter(prefix: "Mobile", includeNamespace: false));
 ```
 ::
 


### PR DESCRIPTION
As per:
https://masstransit.io/documentation/configuration#endpoint-name-formatters

But the class has a bool param:
https://github.com/MassTransit/MassTransit/blob/9a6916d681b3601a3ff8b4830027d34a6a05fb93/src/MassTransit/Configuration/KebabCaseEndpointNameFormatter.cs#L28

I did a copy and past to my code and it didn't compile. 

Fix the doc to prevent that happened to next person googling the issue.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
