### PR TITLE
Add IsPartitionEof to ConsumeContextExtension for Kafka

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/KafkaConsumeContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaConsumeContext.cs
@@ -9,6 +9,7 @@ namespace MassTransit
         string Topic { get; }
         int Partition { get; }
         long Offset { get; }
+        bool IsPartitionEof { get; }
         DateTime CheckpointUtcDateTime { get; }
     }
 

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaConsumeContextExtensions.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaConsumeContextExtensions.cs
@@ -16,5 +16,10 @@ namespace MassTransit
         {
             return context.TryGetPayload(out KafkaConsumeContext<TKey> consumeContext) ? consumeContext.Key : default;
         }
+
+        public static bool IsPartitionEof(this ConsumeContext context)
+        {
+            return context.TryGetPayload(out KafkaConsumeContext consumeContext) ? consumeContext.IsPartitionEof : default;
+        }
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaBaseReceiveContext.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaBaseReceiveContext.cs
@@ -49,6 +49,7 @@
         public int Partition => _result.Partition;
 
         public long Offset => _result.Offset;
+        public bool IsPartitionEof => _result.IsPartitionEOF;
 
         public DateTime CheckpointUtcDateTime => _result.Message.Timestamp.UtcDateTime;
     }


### PR DESCRIPTION
ConfluentKafka presents IsPartitionEof information for each ConsumeResult.
MassTransit Kafka Rider should have this.

That is necessary to handle if the event is the last event in the partition.