### PR TITLE
Add MT version to ActivitySource

### DIFF
--- a/src/MassTransit/Logging/Diagnostics/LogContextActivityExtensions.cs
+++ b/src/MassTransit/Logging/Diagnostics/LogContextActivityExtensions.cs
@@ -7,6 +7,7 @@ namespace MassTransit.Logging
     using System.Collections.Generic;
     using System.Diagnostics;
     using Courier.Contracts;
+    using Metadata;
     using Middleware;
     using Transports;
 
@@ -266,7 +267,7 @@ namespace MassTransit.Logging
 
         static class Cached
         {
-            internal static readonly Lazy<ActivitySource> Source = new Lazy<ActivitySource>(() => new ActivitySource(DiagnosticHeaders.DefaultListenerName));
+            internal static readonly Lazy<ActivitySource> Source = new Lazy<ActivitySource>(() => new ActivitySource(DiagnosticHeaders.DefaultListenerName, HostMetadataCache.Host.MassTransitVersion));
             internal static readonly ConcurrentDictionary<string, string> OperationNames = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
         }
     }


### PR DESCRIPTION
Currently, MassTransit's activity source does not include its version, so OTel traces will not show the `otel.library.version` tag:
![image](https://github.com/MassTransit/MassTransit/assets/23037278/7ee710cd-e623-403d-9ddc-33b62513b915)

After this change, the `Version` tag will be filled:
![image](https://github.com/MassTransit/MassTransit/assets/23037278/6f8d9639-f872-465a-81d4-033a3419a241)
