### PR TITLE
Update entity-framework.md for other DB Engines

### DIFF
--- a/doc/content/3.documentation/5.configuration/4.persistence/entity-framework.md
+++ b/doc/content/3.documentation/5.configuration/4.persistence/entity-framework.md
@@ -140,8 +140,7 @@ public class OrderStateMap :
         entity.Property(x => x.RowVersion)
             .HasColumnName("xmin")
             .HasColumnType("xid")
-            .ValueGeneratedOnAddOrUpdate()
-            .IsConcurrencyToken();
+            .IsRowVersion()
     }
 }
 ```


### PR DESCRIPTION
The following is a documentation update. It specifies that UsePostgres() must be used when setting up Saga State Machines with PostgreSQL. I also found references to MySQL and Sqlite during my code review so I added these to the documentation too.