### PR TITLE
Add `OverrideExchangeName()` in `ReceiveEndpointConfiguration`

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqReceiveEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqReceiveEndpointConfigurator.cs
@@ -61,5 +61,11 @@
         /// </summary>
         /// <param name="consumerTag">The consumer tag to use for this receive endpoint.</param>
         void OverrideConsumerTag(string consumerTag);
+
+        /// <summary>
+        /// By default, the exchange and queue name would be same
+        /// </summary>
+        /// <param name="exchangeName">The new exchange name for this endpoint</param>
+        void OverrideExchangeName(string exchangeName);
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointConfiguration.cs
@@ -252,6 +252,11 @@ namespace MassTransit.RabbitMqTransport.Configuration
             _settings.ConsumerTag = consumerTag;
         }
 
+        public void OverrideExchangeName(string exchangeName)
+        {
+            _settings.ExchangeName = exchangeName;
+        }
+
         RabbitMqReceiveEndpointContext CreateRabbitMqReceiveEndpointContext()
         {
             var builder = new RabbitMqReceiveEndpointBuilder(_hostConfiguration, this);


### PR DESCRIPTION
Add ability to override the default exchange name in rabbitmq endpoint configuration