### PR TITLE
Add DisconnectReceiveEndpoint feature to Transports

### DIFF
--- a/src/MassTransit.Abstractions/BusInstance.cs
+++ b/src/MassTransit.Abstractions/BusInstance.cs
@@ -154,6 +154,16 @@ namespace MassTransit
             return _busControl.ConnectReceiveEndpoint(queueName, configureEndpoint);
         }
 
+        public async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter? endpointNameFormatter = null)
+        {
+            return await _busControl.DisconnectReceiveEndpoint(definition, endpointNameFormatter).ConfigureAwait(false);
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await _busControl.DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
         public void Probe(ProbeContext context)
         {
             _busControl.Probe(context);

--- a/src/MassTransit.Abstractions/Configuration/IReceiveConnector.cs
+++ b/src/MassTransit.Abstractions/Configuration/IReceiveConnector.cs
@@ -1,6 +1,7 @@
 namespace MassTransit
 {
     using System;
+    using System.Threading.Tasks;
 
 
     public interface IReceiveConnector<out TEndpointConfigurator> :
@@ -47,5 +48,20 @@ namespace MassTransit
         /// <param name="queueName">The queue name for the receive endpoint</param>
         /// <param name="configureEndpoint">The configuration callback</param>
         HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator>? configureEndpoint = null);
+
+        /// <summary>
+        /// Removes a receive endpoint
+        /// </summary>
+        /// <param name="definition">
+        /// An endpoint definition, which abstracts specific endpoint behaviors from the transport
+        /// </param>
+        /// <param name="endpointNameFormatter"></param>
+        Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter? endpointNameFormatter = null);
+
+        /// <summary>
+        /// Removes a receive endpoint
+        /// </summary>
+        /// <param name="queueName">The queue name for the receive endpoint</param>
+        Task<bool> DisconnectReceiveEndpoint(string queueName);
     }
 }

--- a/src/MassTransit/Configuration/Configuration/IEndpointName.cs
+++ b/src/MassTransit/Configuration/Configuration/IEndpointName.cs
@@ -1,0 +1,7 @@
+namespace MassTransit.Configuration
+{
+    public interface IEndpointName
+    {
+        string Name { get; }
+    }
+}

--- a/src/MassTransit/DependencyInjection/DependencyInjection/Registration/RegistrationBusFactory.cs
+++ b/src/MassTransit/DependencyInjection/DependencyInjection/Registration/RegistrationBusFactory.cs
@@ -2,6 +2,7 @@ namespace MassTransit.DependencyInjection.Registration
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -80,6 +81,16 @@ namespace MassTransit.DependencyInjection.Registration
 
                     configure?.Invoke(_busRegistrationContext, configurator);
                 });
+            }
+
+            public async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+            {
+                return await BusControl.DisconnectReceiveEndpoint(definition, endpointNameFormatter).ConfigureAwait(false);
+            }
+
+            public async Task<bool> DisconnectReceiveEndpoint(string queueName)
+            {
+                return await BusControl.DisconnectReceiveEndpoint(queueName);
             }
         }
     }

--- a/src/MassTransit/IReceiveEndpointConnector.cs
+++ b/src/MassTransit/IReceiveEndpointConnector.cs
@@ -1,6 +1,7 @@
 namespace MassTransit
 {
     using System;
+    using System.Threading.Tasks;
 
 
     public interface IReceiveEndpointConnector<out TEndpointConfigurator> :
@@ -46,5 +47,20 @@ namespace MassTransit
         /// <param name="queueName">The queue name for the receive endpoint</param>
         /// <param name="configure">The configuration callback</param>
         HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IBusRegistrationContext, IReceiveEndpointConfigurator> configure = null);
+
+        /// <summary>
+        /// Disconnects a receive endpoint
+        /// </summary>
+        /// <param name="definition">
+        /// An endpoint definition, which abstracts specific endpoint behaviors from the transport
+        /// </param>
+        /// <param name="endpointNameFormatter"></param>
+        Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter? endpointNameFormatter = null);
+
+        /// <summary>
+        /// Disconnects a receive endpoint
+        /// </summary>
+        /// <param name="queueName">The queue name for the receive endpoint</param>
+        Task<bool> DisconnectReceiveEndpoint(string queueName);
     }
 }

--- a/src/MassTransit/InMemoryTransport/InMemoryTransport/InMemoryHost.cs
+++ b/src/MassTransit/InMemoryTransport/InMemoryTransport/InMemoryHost.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.InMemoryTransport
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -41,6 +42,18 @@ namespace MassTransit.InMemoryTransport
         public override HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint = null)
         {
             return ConnectReceiveEndpoint(queueName, configureEndpoint);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            var queueName = definition.GetEndpointName(endpointNameFormatter ?? DefaultEndpointNameFormatter.Instance);
+
+            return await DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await ReceiveEndpoints.Remove(queueName).ConfigureAwait(false);
         }
 
         public HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IInMemoryReceiveEndpointConfigurator> configure = null)

--- a/src/MassTransit/MassTransitBus.cs
+++ b/src/MassTransit/MassTransitBus.cs
@@ -338,6 +338,16 @@ namespace MassTransit
             return _host.ConnectReceiveEndpoint(queueName, configureEndpoint);
         }
 
+        public async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter? endpointNameFormatter = null)
+        {
+            return await _host.DisconnectReceiveEndpoint(definition, endpointNameFormatter).ConfigureAwait(false);
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await _host.DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
         void IProbeSite.Probe(ProbeContext context)
         {
             var scope = context.CreateScope("bus");

--- a/src/MassTransit/Testing/Implementations/InMemoryTestHarnessBusInstance.cs
+++ b/src/MassTransit/Testing/Implementations/InMemoryTestHarnessBusInstance.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Testing.Implementations
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -57,6 +58,16 @@ namespace MassTransit.Testing.Implementations
 
                 configure?.Invoke(_busRegistrationContext, configurator);
             });
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            return await BusControl.DisconnectReceiveEndpoint(definition, endpointNameFormatter).ConfigureAwait(false);
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await BusControl.DisconnectReceiveEndpoint(queueName);
         }
     }
 }

--- a/src/MassTransit/Transactions/BaseTransactionalBus.cs
+++ b/src/MassTransit/Transactions/BaseTransactionalBus.cs
@@ -153,6 +153,16 @@
             return _bus.ConnectReceiveEndpoint(queueName, configureEndpoint);
         }
 
+        public async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            return await _bus.DisconnectReceiveEndpoint(definition, endpointNameFormatter).ConfigureAwait(false);
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await _bus.DisconnectReceiveEndpoint(queueName);
+        }
+
         public void Probe(ProbeContext context)
         {
             _bus.Probe(context);

--- a/src/MassTransit/Transports/BaseHost.cs
+++ b/src/MassTransit/Transports/BaseHost.cs
@@ -35,6 +35,10 @@ namespace MassTransit.Transports
 
         public abstract HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint = null);
 
+        public abstract Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null);
+
+        public abstract Task<bool> DisconnectReceiveEndpoint(string queueName);
+
         ConnectHandle IConsumeMessageObserverConnector.ConnectConsumeMessageObserver<T>(IConsumeMessageObserver<T> observer)
         {
             return ReceiveEndpoints.ConnectConsumeMessageObserver(observer);

--- a/src/MassTransit/Transports/IReceiveEndpointCollection.cs
+++ b/src/MassTransit/Transports/IReceiveEndpointCollection.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Threading;
+    using System.Threading.Tasks;
 
 
     public interface IReceiveEndpointCollection :
@@ -16,6 +17,13 @@
         /// <param name="endpointName"></param>
         /// <param name="endpoint"></param>
         void Add(string endpointName, ReceiveEndpoint endpoint);
+
+        /// <summary>
+        /// Remove an endpoint from the collection
+        /// </summary>
+        /// <param name="endpointName"></param>
+        /// <param name="cancellationToken"></param>
+        Task<bool> Remove(string endpointName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Start all endpoints in the collection which have not been started, and return the handles

--- a/src/MassTransit/Transports/MultiBusInstance.cs
+++ b/src/MassTransit/Transports/MultiBusInstance.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Transports
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
 
 
@@ -47,6 +48,16 @@ namespace MassTransit.Transports
             Action<IBusRegistrationContext, IReceiveEndpointConfigurator> configure = null)
         {
             return BusInstance.ConnectReceiveEndpoint(queueName, configure);
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            return await BusInstance.DisconnectReceiveEndpoint(definition, endpointNameFormatter).ConfigureAwait(false);
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await BusInstance.DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
         }
 
         static string FormatBusName()

--- a/src/MassTransit/Transports/ReceiveEndpointCollection.cs
+++ b/src/MassTransit/Transports/ReceiveEndpointCollection.cs
@@ -148,6 +148,23 @@
             _endpoints.TryRemove(endpointName, out _);
         }
 
+        public async Task<bool> Remove(string endpointName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(endpointName))
+                throw new ArgumentException($"The {nameof(endpointName)} must not be null or empty", nameof(endpointName));
+
+            _ = _endpoints.TryGetValue(endpointName, out var endpoint);
+
+            if (endpoint == null)
+                throw new ConfigurationException($"A receive endpoint with the key was not found: {endpointName}");
+
+            var removed = _endpoints.TryRemove(endpointName, out _);
+
+            await endpoint.Stop(removed, cancellationToken).ConfigureAwait(false);
+
+            return removed;
+        }
+
 
         class Handle :
             HostReceiveEndpointHandle

--- a/src/MassTransit/Transports/TransportBusInstance.cs
+++ b/src/MassTransit/Transports/TransportBusInstance.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.Transports
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
 
 
@@ -60,6 +61,16 @@ namespace MassTransit.Transports
             {
                 configure?.Invoke(RegistrationContext, configurator);
             });
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            return await _host.DisconnectReceiveEndpoint(definition, endpointNameFormatter).ConfigureAwait(false);
+        }
+
+        public async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await _host.DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
         }
 
         public HostReceiveEndpointHandle ConnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter,

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqHost.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/ActiveMqHost.cs
@@ -1,6 +1,7 @@
 ﻿namespace MassTransit.ActiveMqTransport
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -29,6 +30,18 @@
         public override HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint = null)
         {
             return ConnectReceiveEndpoint(queueName, configureEndpoint);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            var queueName = definition.GetEndpointName(endpointNameFormatter ?? DefaultEndpointNameFormatter.Instance);
+
+            return await DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await ReceiveEndpoints.Remove(queueName).ConfigureAwait(false);
         }
 
         public HostReceiveEndpointHandle ConnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null,

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsHost.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsHost.cs
@@ -1,6 +1,7 @@
 ﻿namespace MassTransit.AmazonSqsTransport
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -29,6 +30,18 @@
         public override HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint = null)
         {
             return ConnectReceiveEndpoint(queueName, configureEndpoint);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            var queueName = definition.GetEndpointName(endpointNameFormatter ?? DefaultEndpointNameFormatter.Instance);
+
+            return await DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await ReceiveEndpoints.Remove(queueName).ConfigureAwait(false);
         }
 
         public HostReceiveEndpointHandle ConnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null,

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ServiceBusHost.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ServiceBusHost.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.AzureServiceBusTransport
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -29,6 +30,18 @@ namespace MassTransit.AzureServiceBusTransport
         public override HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint = null)
         {
             return ConnectReceiveEndpoint(queueName, configureEndpoint);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            var queueName = definition.GetEndpointName(endpointNameFormatter ?? DefaultEndpointNameFormatter.Instance);
+
+            return await DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await ReceiveEndpoints.Remove(queueName).ConfigureAwait(false);
         }
 
         public HostReceiveEndpointHandle ConnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null,

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubEndpointName.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubEndpointName.cs
@@ -1,0 +1,17 @@
+namespace MassTransit
+{
+    using Configuration;
+
+
+    public class EventHubEndpointName : IEndpointName
+    {
+        public string Name { get; private set; }
+
+        public EventHubEndpointName(string eventHubName, string consumerGroup)
+        {
+            Name = $"{EventHubEndpointAddress.PathPrefix}/{eventHubName}";
+            if (!string.IsNullOrWhiteSpace(consumerGroup))
+                Name = $"{Name}/{consumerGroup}";
+        }
+    }
+}

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubFactoryConfigurator.cs
@@ -171,14 +171,14 @@ namespace MassTransit.EventHubIntegration.Configuration
 
             var endpoints = new ReceiveEndpointCollection();
             foreach (var endpoint in _endpoints)
-                endpoints.Add(endpoint.EndpointName, endpoint.CreateReceiveEndpoint(busInstance));
+                endpoints.Add(endpoint.EndpointName.Name, endpoint.CreateReceiveEndpoint(busInstance));
 
             return new EventHubRider(this, busInstance, endpoints, context);
         }
 
         public IEnumerable<ValidationResult> Validate()
         {
-            foreach (KeyValuePair<string, IEventHubReceiveEndpointSpecification[]> kv in _endpoints.GroupBy(x => x.EndpointName)
+            foreach (KeyValuePair<string, IEventHubReceiveEndpointSpecification[]> kv in _endpoints.GroupBy(x => x.EndpointName.Name)
                          .ToDictionary(x => x.Key, x => x.ToArray()))
             {
                 if (kv.Value.Length > 1)

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointSpecification.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/EventHubReceiveEndpointSpecification.cs
@@ -28,14 +28,12 @@ namespace MassTransit.EventHubIntegration.Configuration
             _hostSettings = hostSettings;
             _storageSettings = storageSettings;
             _configure = configure;
-            EndpointName = $"{EventHubEndpointAddress.PathPrefix}/{_eventHubName}";
-            if (!string.IsNullOrWhiteSpace(_consumerGroup))
-                EndpointName = $"{EndpointName}/{_consumerGroup}";
+            EndpointName = new EventHubEndpointName(_eventHubName, _consumerGroup);
 
             _endpointObservers = new ReceiveEndpointObservable();
         }
 
-        public string EndpointName { get; }
+        public EventHubEndpointName EndpointName { get; }
 
         public ConnectHandle ConnectReceiveEndpointObserver(IReceiveEndpointObserver observer)
         {
@@ -60,7 +58,7 @@ namespace MassTransit.EventHubIntegration.Configuration
 
         public ReceiveEndpoint CreateReceiveEndpoint(IBusInstance busInstance)
         {
-            var endpointConfiguration = busInstance.HostConfiguration.CreateReceiveEndpointConfiguration(EndpointName);
+            var endpointConfiguration = busInstance.HostConfiguration.CreateReceiveEndpointConfiguration(EndpointName.Name);
 
             var configurator = new EventHubReceiveEndpointConfigurator(_hostConfiguration, busInstance, endpointConfiguration, _hostSettings,
                 _storageSettings, _eventHubName, _consumerGroup);

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/IEventHubReceiveEndpointSpecification.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Configuration/IEventHubReceiveEndpointSpecification.cs
@@ -10,7 +10,7 @@ namespace MassTransit.EventHubIntegration.Configuration
         /// <summary>
         /// EventHub name
         /// </summary>
-        string EndpointName { get; }
+        EventHubEndpointName EndpointName { get; }
 
         ReceiveEndpoint CreateReceiveEndpoint(IBusInstance busInstance);
     }

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubRider.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/EventHubRider.cs
@@ -45,9 +45,15 @@ namespace MassTransit.EventHubIntegration
                 configure?.Invoke(_context, configurator);
             });
 
-            _endpoints.Add(specification.EndpointName, specification.CreateReceiveEndpoint(_busInstance));
+            _endpoints.Add(specification.EndpointName.Name, specification.CreateReceiveEndpoint(_busInstance));
 
-            return _endpoints.Start(specification.EndpointName);
+            return _endpoints.Start(specification.EndpointName.Name);
+        }
+
+        public async Task<bool> DisconnectEventHubEndpoint(string eventHubName, string consumerGroup)
+        {
+            var endpoint = new EventHubEndpointName(eventHubName, consumerGroup);
+            return await _endpoints.Remove(endpoint.Name).ConfigureAwait(false);
         }
 
         public RiderHandle Start(CancellationToken cancellationToken = default)

--- a/src/Transports/MassTransit.EventHubIntegration/IEventHubEndpointConnector.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/IEventHubEndpointConnector.cs
@@ -1,11 +1,14 @@
 namespace MassTransit
 {
     using System;
+    using System.Threading.Tasks;
 
 
     public interface IEventHubEndpointConnector
     {
         HostReceiveEndpointHandle ConnectEventHubEndpoint(string eventHubName, string consumerGroup,
             Action<IRiderRegistrationContext, IEventHubReceiveEndpointConfigurator> configure);
+
+        Task<bool> DisconnectEventHubEndpoint(string eventHubName, string consumerGroup);
     }
 }

--- a/src/Transports/MassTransit.GrpcTransport/GrpcTransport/GrpcHost.cs
+++ b/src/Transports/MassTransit.GrpcTransport/GrpcTransport/GrpcHost.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.GrpcTransport
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -38,6 +39,18 @@ namespace MassTransit.GrpcTransport
         public override HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint = null)
         {
             return ConnectReceiveEndpoint(queueName, configureEndpoint);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            var queueName = definition.GetEndpointName(endpointNameFormatter ?? DefaultEndpointNameFormatter.Instance);
+
+            return await DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await ReceiveEndpoints.Remove(queueName).ConfigureAwait(false);
         }
 
         public HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IGrpcReceiveEndpointConfigurator> configure = null)

--- a/src/Transports/MassTransit.KafkaIntegration/IKafkaTopicEndpointConnector.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/IKafkaTopicEndpointConnector.cs
@@ -1,6 +1,7 @@
 namespace MassTransit
 {
     using System;
+    using System.Threading.Tasks;
     using Confluent.Kafka;
 
 
@@ -13,5 +14,7 @@ namespace MassTransit
         HostReceiveEndpointHandle ConnectTopicEndpoint<TKey, TValue>(string topicName, ConsumerConfig consumerConfig,
             Action<IRiderRegistrationContext, IKafkaTopicReceiveEndpointConfigurator<TKey, TValue>> configure)
             where TValue : class;
+
+        Task<bool> DisconnectTopicEndpoint(string topicName, string groupId);
     }
 }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaEndpointName.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaEndpointName.cs
@@ -1,0 +1,21 @@
+namespace MassTransit
+{
+    using Configuration;
+    using Confluent.Kafka;
+
+    public class KafkaEndpointName : IEndpointName
+    {
+        public string Name { get; private set; }
+
+        public KafkaEndpointName(string topicName, ConsumerConfig consumerConfig) : this(topicName, consumerConfig?.GroupId)
+        {
+        }
+
+        public KafkaEndpointName(string topicName, string groupId)
+        {
+            Name = $"{KafkaTopicAddress.PathPrefix}/{topicName}";
+            if (!string.IsNullOrWhiteSpace(groupId))
+                Name = $"{Name}/{groupId}";
+        }
+    }
+}

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/IKafkaConsumerSpecification.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/IKafkaConsumerSpecification.cs
@@ -7,7 +7,7 @@ namespace MassTransit.KafkaIntegration.Configuration
         IReceiveEndpointObserverConnector,
         ISpecification
     {
-        string EndpointName { get; }
+        KafkaEndpointName EndpointName { get; }
 
         /// <summary>
         /// Create the receive endpoint, using the busInstance hostConfiguration

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaConsumerSpecification.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaConsumerSpecification.cs
@@ -35,16 +35,14 @@ namespace MassTransit.KafkaIntegration.Configuration
             _kafkaSerializerFactory = kafkaSerializerFactory;
             _configure = configure;
             _oAuthBearerTokenRefreshHandler = oAuthBearerTokenRefreshHandler;
-            EndpointName = $"{KafkaTopicAddress.PathPrefix}/{_topicName}";
-            if (!string.IsNullOrWhiteSpace(_consumerConfig.GroupId))
-                EndpointName = $"{EndpointName}/{_consumerConfig.GroupId}";
+            EndpointName = new KafkaEndpointName(_topicName, _consumerConfig);
         }
 
-        public string EndpointName { get; }
+        public KafkaEndpointName EndpointName { get; }
 
         public ReceiveEndpoint CreateReceiveEndpoint(IBusInstance busInstance)
         {
-            var endpointConfiguration = busInstance.HostConfiguration.CreateReceiveEndpointConfiguration(EndpointName);
+            var endpointConfiguration = busInstance.HostConfiguration.CreateReceiveEndpointConfiguration(EndpointName.Name);
 
             var configurator = new KafkaTopicReceiveEndpointConfiguration<TKey, TValue>(_hostConfiguration, _consumerConfig, _topicName, busInstance,
                 endpointConfiguration, _oAuthBearerTokenRefreshHandler);

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Configuration/KafkaFactoryConfigurator.cs
@@ -80,8 +80,8 @@ namespace MassTransit.KafkaIntegration.Configuration
             where TValue : class
         {
             var specification = CreateSpecification(topicName, groupId, configure);
-            if (!_topics.TryAdd(specification.EndpointName, _ => specification))
-                throw new ConfigurationException($"A topic consumer with the same key was already added: {specification.EndpointName}");
+            if (!_topics.TryAdd(specification.EndpointName.Name, _ => specification))
+                throw new ConfigurationException($"A topic consumer with the same key was already added: {specification.EndpointName.Name}");
         }
 
         public void TopicEndpoint<TKey, TValue>(string topicName, ConsumerConfig consumerConfig,
@@ -89,8 +89,8 @@ namespace MassTransit.KafkaIntegration.Configuration
             where TValue : class
         {
             var specification = CreateSpecification(topicName, consumerConfig, configure);
-            if (!_topics.TryAdd(specification.EndpointName, _ => specification))
-                throw new ConfigurationException($"A topic consumer with the same key was already added: {specification.EndpointName}");
+            if (!_topics.TryAdd(specification.EndpointName.Name, _ => specification))
+                throw new ConfigurationException($"A topic consumer with the same key was already added: {specification.EndpointName.Name}");
         }
 
         void IKafkaFactoryConfigurator.TopicProducer<TKey, TValue>(string topicName, Action<IKafkaProducerConfigurator<TKey, TValue>> configure)
@@ -336,7 +336,7 @@ namespace MassTransit.KafkaIntegration.Configuration
 
             var endpoints = new ReceiveEndpointCollection();
             foreach (var specification in _topics.Values)
-                endpoints.Add(specification.EndpointName, specification.CreateReceiveEndpoint(busInstance));
+                endpoints.Add(specification.EndpointName.Name, specification.CreateReceiveEndpoint(busInstance));
 
             return new KafkaRider(this, busInstance, endpoints, context);
         }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaRider.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/KafkaRider.cs
@@ -39,9 +39,9 @@ namespace MassTransit.KafkaIntegration
                 configure?.Invoke(_context, configurator);
             });
 
-            _endpoints.Add(specification.EndpointName, specification.CreateReceiveEndpoint(_busInstance));
+            _endpoints.Add(specification.EndpointName.Name, specification.CreateReceiveEndpoint(_busInstance));
 
-            return _endpoints.Start(specification.EndpointName);
+            return _endpoints.Start(specification.EndpointName.Name);
         }
 
         public HostReceiveEndpointHandle ConnectTopicEndpoint<TKey, TValue>(string topicName, ConsumerConfig consumerConfig,
@@ -53,9 +53,15 @@ namespace MassTransit.KafkaIntegration
                 configure?.Invoke(_context, configurator);
             });
 
-            _endpoints.Add(specification.EndpointName, specification.CreateReceiveEndpoint(_busInstance));
+            _endpoints.Add(specification.EndpointName.Name, specification.CreateReceiveEndpoint(_busInstance));
 
-            return _endpoints.Start(specification.EndpointName);
+            return _endpoints.Start(specification.EndpointName.Name);
+        }
+
+        public async Task<bool> DisconnectTopicEndpoint(string topicName, string groupId)
+        {
+            var endpoint = new KafkaEndpointName(topicName, groupId);
+            return await _endpoints.Remove(endpoint.Name).ConfigureAwait(false);
         }
 
         public RiderHandle Start(CancellationToken cancellationToken = default)

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqHost.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/RabbitMqHost.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.RabbitMqTransport
 {
     using System;
+    using System.Threading.Tasks;
     using Configuration;
     using Transports;
 
@@ -29,6 +30,18 @@ namespace MassTransit.RabbitMqTransport
         public override HostReceiveEndpointHandle ConnectReceiveEndpoint(string queueName, Action<IReceiveEndpointConfigurator> configureEndpoint = null)
         {
             return ConnectReceiveEndpoint(queueName, configureEndpoint);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null)
+        {
+            var queueName = definition.GetEndpointName(endpointNameFormatter ?? DefaultEndpointNameFormatter.Instance);
+
+            return await DisconnectReceiveEndpoint(queueName).ConfigureAwait(false);
+        }
+
+        public override async Task<bool> DisconnectReceiveEndpoint(string queueName)
+        {
+            return await ReceiveEndpoints.Remove(queueName).ConfigureAwait(false);
         }
 
         public HostReceiveEndpointHandle ConnectReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter endpointNameFormatter = null,

--- a/tests/MassTransit.AmazonSqsTransport.Tests/Connector_Specs.cs
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/Connector_Specs.cs
@@ -56,6 +56,75 @@ namespace MassTransit.AmazonSqsTransport.Tests
             }
         }
 
+        [Test]
+        public async Task Should_disconnect_connected_endpoint()
+        {
+            var provider = new ServiceCollection()
+                .AddSingleton<ILoggerFactory>(LoggerFactory)
+                .AddSingleton(typeof(ILogger<>), typeof(Logger<>))
+                .AddMassTransit(x =>
+                {
+                    x.UsingAmazonSqs((context, cfg) =>
+                    {
+                        cfg.LocalstackHost();
+                    });
+                }).BuildServiceProvider(true);
+
+            var depot = provider.GetRequiredService<IBusDepot>();
+
+            await depot.Start(TestCancellationToken);
+            try
+            {
+                var connector = provider.GetRequiredService<IReceiveEndpointConnector>();
+                var endpointNameFormatter = provider.GetService<IEndpointNameFormatter>() ?? DefaultEndpointNameFormatter.Instance;
+                var definition = new TemporaryEndpointDefinition();
+                var handle = connector.ConnectReceiveEndpoint(definition, endpointNameFormatter);
+
+                await handle.Ready;
+
+                var disconnected = await connector.DisconnectReceiveEndpoint(definition, endpointNameFormatter);
+
+                Assert.AreEqual(disconnected, true);
+            }
+            finally
+            {
+                await depot.Stop(TimeSpan.FromSeconds(30));
+            }
+        }
+
+        [Test]
+        public async Task Should_throw_ConfigurationException_when_endpoint_is_not_exist()
+        {
+            var provider = new ServiceCollection()
+                .AddSingleton<ILoggerFactory>(LoggerFactory)
+                .AddSingleton(typeof(ILogger<>), typeof(Logger<>))
+                .AddMassTransit(x =>
+                {
+                    x.UsingAmazonSqs((context, cfg) =>
+                    {
+                        cfg.LocalstackHost();
+                    });
+                }).BuildServiceProvider(true);
+
+            var depot = provider.GetRequiredService<IBusDepot>();
+
+            await depot.Start(TestCancellationToken);
+            try
+            {
+                var connector = provider.GetRequiredService<IReceiveEndpointConnector>();
+                var endpointNameFormatter = provider.GetService<IEndpointNameFormatter>() ?? DefaultEndpointNameFormatter.Instance;
+                var handle = connector.ConnectReceiveEndpoint(new TemporaryEndpointDefinition(), endpointNameFormatter);
+
+                await handle.Ready;
+
+                Assert.ThrowsAsync<ConfigurationException>(() => connector.DisconnectReceiveEndpoint(new TemporaryEndpointDefinition(), endpointNameFormatter));
+            }
+            finally
+            {
+                await depot.Stop(TimeSpan.FromSeconds(30));
+            }
+        }
+
         public Connector_Specs()
             : base(new InMemoryTestHarness())
         {

--- a/tests/MassTransit.RabbitMqTransport.Tests/ReceiveEndpoint_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ReceiveEndpoint_Specs.cs
@@ -62,4 +62,35 @@
             }
         }
     }
+
+    [TestFixture]
+    public class Disconnecting_a_receive_endpoint_from_an_existing_bus :
+        RabbitMqTestFixture
+    {
+        [Test]
+        public async Task Should_be_allowed()
+        {
+            Task<ConsumeContext<PingMessage>> pingHandled = null;
+
+            var handle = Bus.ConnectReceiveEndpoint("second_queue");
+            await handle.Ready;
+
+            try
+            {
+                var disconnected = await Bus.DisconnectReceiveEndpoint("second_queue");
+
+                Assert.AreEqual(disconnected, true);
+            }
+            finally
+            {
+                await handle.StopAsync();
+            }
+        }
+
+        [Test]
+        public async Task Should_not_be_allowed_when_it_is_not_exist()
+        {
+            Assert.ThrowsAsync<ConfigurationException>(() => Bus.DisconnectReceiveEndpoint("second_queue"));
+        }
+    }
 }


### PR DESCRIPTION
### Summary

Add DisconnectReceiveEndpoint feature to Transports

### Feature Description
MassTransit provides the possibility to connect a new endpoint while app running.
However, as i see it does not support to remove/disconnect an endpoint while app running.
There might be requirement to remove/disconnect an endpoint dynamically as well as in ConnectReceiveEndpoint.
This PR aims to add remove/disconnect endpoint while bus running.

I wait your reviews and feedbacks.