### PR TITLE
Correct body length message attribute name

### DIFF
--- a/src/MassTransit/Logging/Diagnostics/DiagnosticHeaders.cs
+++ b/src/MassTransit/Logging/Diagnostics/DiagnosticHeaders.cs
@@ -41,7 +41,7 @@ namespace MassTransit.Logging
 
         public static class Messaging
         {
-            public const string BodyLength = "messaging.message_payload_size_bytes";
+            public const string BodyLength = "messaging.message.payload_size_bytes";
             public const string ConversationId = "messaging.message.conversation_id";
             public const string DestinationName = "messaging.destination.name";
             public const string TransportMessageId = "messaging.message.id";


### PR DESCRIPTION
While going through some opentelemetry config with MassTransit, noticed the BodyLength diagnostics property has a typo compared to the default spec at https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/messaging/#messaging-attributes