### PR TITLE
Update documentation for job consumers

### DIFF
--- a/doc/content/3.documentation/3.patterns/13.job-consumers.md
+++ b/doc/content/3.documentation/3.patterns/13.job-consumers.md
@@ -55,6 +55,10 @@ services.AddMassTransit(x =>
 
 In this example, the job timeout as well as the number of concurrent jobs allowed is specified using `JobOptions<T>` when configuring the consumer. The job options can also be specified using a consumer definition in the same way.
 
+::alert{type="warning"}
+The number of concurrent jobs can only be configured using the `JobOptions<TJob>.SetConcurrentJobLimit(int limit)` method. The `ConcurrentMessageLimit` on the consumer definition must not be used with job consumers.
+::
+
 ## Submitting a job
 
 To submit jobs to the job consumer, you can use the request client as shown to request. In this example, the _RequestId_ will be used as the _JobId_.


### PR DESCRIPTION
Added a note that ConcurrentMessageLimit (consumer definition) must not be used for job consumers.

This is not clear because Intellisence offers the property within the consumer definition, for example:

![image](https://github.com/MassTransit/MassTransit/assets/3825484/2a80560d-85df-445e-aba9-b8bdfd2c874a)
