### PR TITLE
Updated AWS SQS queue access policy to be less permissive

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
@@ -229,6 +229,8 @@ namespace MassTransit.AmazonSqsTransport
 
         static bool QueueHasTopicPermission(Policy policy, string topicArn, string sqsQueueArn)
         {
+            var topicArnPattern = topicArn.Substring(0, topicArn.LastIndexOf(':') + 1) + "*";
+
             IEnumerable<Condition> conditions = policy.Statements
                 .Where(s => s.Resources.Any(r => r.Id.Equals(sqsQueueArn)))
                 .SelectMany(s => s.Conditions);
@@ -236,7 +238,7 @@ namespace MassTransit.AmazonSqsTransport
             return conditions.Any(c =>
                 string.Equals(c.Type, ConditionFactory.ArnComparisonType.ArnLike.ToString(), StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(c.ConditionKey, ConditionFactory.SOURCE_ARN_CONDITION_KEY, StringComparison.OrdinalIgnoreCase) &&
-                c.Values.Contains(topicArn));
+                c.Values.Any(v => v == topicArnPattern || v == topicArn));
         }
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
@@ -229,8 +229,6 @@ namespace MassTransit.AmazonSqsTransport
 
         static bool QueueHasTopicPermission(Policy policy, string topicArn, string sqsQueueArn)
         {
-            var topicArnPattern = topicArn.Substring(0, topicArn.LastIndexOf(':') + 1) + "*";
-
             IEnumerable<Condition> conditions = policy.Statements
                 .Where(s => s.Resources.Any(r => r.Id.Equals(sqsQueueArn)))
                 .SelectMany(s => s.Conditions);
@@ -238,7 +236,7 @@ namespace MassTransit.AmazonSqsTransport
             return conditions.Any(c =>
                 string.Equals(c.Type, ConditionFactory.ArnComparisonType.ArnLike.ToString(), StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(c.ConditionKey, ConditionFactory.SOURCE_ARN_CONDITION_KEY, StringComparison.OrdinalIgnoreCase) &&
-                c.Values.Any(v => v == topicArnPattern || v == topicArn));
+                c.Values.Contains(topicArn));
         }
     }
 }


### PR DESCRIPTION
Currently, the AWS SQS transport creates queue access policies that are overly permissive and allow for any topic within the AWS owner account to send messages to a created queue. This PR removes wild-card conditions within a created queue's access policy and instead uses the complete ARN information available about the appropriate SNS topic.

These changes should also be backward compatible for queues that have already been created with wild-carded `aws:SourceArn`s as it takes that into account when determining if existing queues already permit the topic to send messages to the queue.

# Created Access Policy - Before
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"
      },
      "Action": "sqs:SendMessage",
      "Resource": "arn:aws:sqs:<region>:<account id>:<queue name>",
      "Condition": {
        "ArnLike": {
          "aws:SourceArn": "arn:aws:sns:<region>:<account id>:*"
        }
      }
    }
  ]
}
```

# Created Access Policy - After
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Service": "sns.amazonaws.com"
      },
      "Action": "sqs:SendMessage",
      "Resource": "arn:aws:sqs:<region>:<account id>:<queue name>",
      "Condition": {
        "ArnEquals": {
          "aws:SourceArn": "arn:aws:sns:<region>:<account id>:<topic name>"
        }
      }
    }
  ]
}
```