### PR TITLE
Changed SqlServerLockStatementProvider to not use the SERIALIZABLE lo…

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementFormatter.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementFormatter.cs
@@ -6,9 +6,19 @@ namespace MassTransit.EntityFrameworkCoreIntegration
     public class SqlServerLockStatementFormatter :
         ILockStatementFormatter
     {
+        readonly bool _serializable;
+
+        public SqlServerLockStatementFormatter(bool serializable)
+        {
+            _serializable = serializable;
+        }
+
         public void Create(StringBuilder sb, string schema, string table)
         {
-            sb.AppendFormat("SELECT * FROM {0} WITH (UPDLOCK, ROWLOCK, SERIALIZABLE) WHERE ", FormatTableName(schema, table));
+            sb.AppendFormat("SELECT * FROM {0} WITH (UPDLOCK, ROWLOCK", FormatTableName(schema, table));
+            if (_serializable)
+                sb.Append(", SERIALIZABLE");
+            sb.Append(") WHERE ");
         }
 
         public void AppendColumn(StringBuilder sb, int index, string columnName)

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementProvider.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/SqlServerLockStatementProvider.cs
@@ -3,13 +3,13 @@
     public class SqlServerLockStatementProvider :
         SqlLockStatementProvider
     {
-        public SqlServerLockStatementProvider(bool enableSchemaCaching = true)
-            : base(new SqlServerLockStatementFormatter(), enableSchemaCaching)
+        public SqlServerLockStatementProvider(bool enableSchemaCaching = true, bool serializable = false)
+            : base(new SqlServerLockStatementFormatter(serializable), enableSchemaCaching)
         {
         }
 
-        public SqlServerLockStatementProvider(string schemaName, bool enableSchemaCaching = true)
-            : base(schemaName, new SqlServerLockStatementFormatter(), enableSchemaCaching)
+        public SqlServerLockStatementProvider(string schemaName, bool enableSchemaCaching = true, bool serializable = false)
+            : base(schemaName, new SqlServerLockStatementFormatter(serializable), enableSchemaCaching)
         {
         }
     }


### PR DESCRIPTION
The SERIALIZABLE locking hint causes SQL Server to use key range locks which unnecessarily blocks unrelated consumers. This problem gets particularly obvious when using the TX outbox, causing consumers to time out waiting to read the InboxState entity.