### PR TITLE
Fix "AddConsumer" link in concepts documentation

### DIFF
--- a/doc/content/3.documentation/1.concepts/2.consumers.md
+++ b/doc/content/3.documentation/1.concepts/2.consumers.md
@@ -33,7 +33,7 @@ class SubmitOrderConsumer :
 }
 ```
 
-To add a consumer and automatically configure a receive endpoint for the consumer, call one of the [_AddConsumer_](/documentation/configuration/bus/consumers) methods and call _ConfigureEndpoints_ as shown below.
+To add a consumer and automatically configure a receive endpoint for the consumer, call one of the [_AddConsumer_](/documentation/configuration/consumers) methods and call _ConfigureEndpoints_ as shown below.
 
 ```csharp
 services.AddMassTransit(x =>


### PR DESCRIPTION
Fixed a link on the Concepts -> Consumers page that pointed to `/documentation/configuration/bus/consumers` instead of `/documentation/configuration/consumers`