### PR TITLE
Throw separate exception for Amazon Bad Request exception

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/QueueSqsReceiveEndpointContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/QueueSqsReceiveEndpointContext.cs
@@ -1,6 +1,8 @@
 ﻿namespace MassTransit.AmazonSqsTransport
 {
     using System;
+    using System.Net;
+    using Amazon.SQS;
     using Configuration;
     using Topology;
     using Transports;
@@ -42,6 +44,11 @@
 
         public override Exception ConvertException(Exception exception, string message)
         {
+            if (exception is AmazonSQSException { StatusCode: HttpStatusCode.BadRequest })
+            {
+                return new AmazonSqsValidationException(message + _hostConfiguration.Settings, exception);
+            }
+
             return new AmazonSqsConnectionException(message + _hostConfiguration.Settings, exception);
         }
 

--- a/src/Transports/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsValidationException.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Exceptions/AmazonSqsValidationException.cs
@@ -1,0 +1,29 @@
+﻿namespace MassTransit
+{
+    using System;
+    using System.Runtime.Serialization;
+
+
+    [Serializable]
+    public sealed class AmazonSqsValidationException : ConfigurationException
+    {
+        public AmazonSqsValidationException()
+        {
+        }
+
+        public AmazonSqsValidationException(string message)
+            : base(message)
+        {
+        }
+
+        public AmazonSqsValidationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected AmazonSqsValidationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
In my case, when I have sqs name more than 80 character ands I get exception from Amazon but original exception AmazonSQSException converts to MassTransit's exception AmazonSqsConnectionException. In file AmazonSqsHostConfiguration.cs in ctor, it initializes ReceiveTransportRetryPolicy which has 1000 retries and handles AmazonSqsConnectionException, so it will execute 1000 times request to create SQS and always get Bad Request. In my case, I configured to wait until Masstransit started and from the first glance it looks like it hanged out. So, there is no reason to retry such exception, we can throw immediately, I've create separate exception when we get Bad Request from Amazon
