### PR TITLE
Fix: MassTransit ignores IHealthCheckOptionsConfigurator.FailureStatus value despite allowing it to be set

### DIFF
--- a/doc/content/3.documentation/2.configuration/0.index.md
+++ b/doc/content/3.documentation/2.configuration/0.index.md
@@ -602,8 +602,9 @@ builder.Services.AddMassTransit(bus =>
     {
         options.Name = "masstransit";
         options.MinimalFailureStatus = HealthStatus.Unhealthy;
-        options.Tags = new [] { "masstransit", "ready" };
+        options.Tags.Add("health");
     });
+
 }
 ```
 
@@ -616,3 +617,5 @@ builder.Services.AddMassTransit(bus =>
 By default MassTransit reports all three statuses depending on application state.
 If `MinimalFailureStatus` is set to `Healthy`, MassTransit will log any issues, but the health check will always report `Healthy`.
 If `MinimalFailureStatus` is set to `Degraded`, MassTransit will report `Degraded` if any issues occur, but never report `Unhealthy`.
+
+Tags inside options will override default tags. You will need to add `ready` and `masstransit` tags manually if you want to keep them.

--- a/doc/content/3.documentation/2.configuration/0.index.md
+++ b/doc/content/3.documentation/2.configuration/0.index.md
@@ -62,9 +62,9 @@ services.AddOptions<MassTransitHostOptions>()
 | Option              | Description                                                                                                                                                                                                                                          |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | WaitUntilStarted    | By default, MassTransit connects to the broker asynchronously. When set to _true_, the MassTransit Hosted Service will block startup until the broker connection has been established.                                                               |
-| StartTimeout        | By default, MassTransit waits infinitely until the broker connection is established. If specified, MassTransit will give up after the timeout has expired.                                                                                           | 
-| StopTimeout         | MassTransit waits infinitely for the bus to stop, including any active message consumers. If specified, MassTransit will force the bus to stop after the timeout has expired.                                                                        | 
-| ConsumerStopTimeout | If specified, the `ConsumeContext.CancellationToken` will be canceled after the specified timeout when the bus is stopping. This allows long-running consumers to observe the cancellation token and react accordingly. Must be <= the `StopTimeout` | 
+| StartTimeout        | By default, MassTransit waits infinitely until the broker connection is established. If specified, MassTransit will give up after the timeout has expired.                                                                                           |
+| StopTimeout         | MassTransit waits infinitely for the bus to stop, including any active message consumers. If specified, MassTransit will force the bus to stop after the timeout has expired.                                                                        |
+| ConsumerStopTimeout | If specified, the `ConsumeContext.CancellationToken` will be canceled after the specified timeout when the bus is stopping. This allows long-running consumers to observe the cancellation token and react accordingly. Must be <= the `StopTimeout` |
 
 ::callout{type="info"}
 #summary
@@ -586,3 +586,33 @@ app.UseEndpoints(endpoints =>
   }
 }
 ```
+
+- When everything works correctly, MassTransit will report `Healthy`.
+- If any problems occur on application startup, MassTransit will report `Unhealthy`. This can cause an orcestrator to restart your application.
+- If any problems occur while the application is working (for example, application loses connection to broker), MassTransit will report `Degraded`. 
+
+### Health Check Options
+
+Health Checks can be further configured using _ConfigureHealthCheckOptions_:
+
+```C#
+builder.Services.AddMassTransit(bus =>
+{
+    bus.ConfigureHealthCheckOptions(options =>
+    {
+        options.Name = "masstransit";
+        options.MinimalFailureStatus = HealthStatus.Unhealthy;
+        options.Tags = new [] { "masstransit", "ready" };
+    });
+}
+```
+
+| Setting              | Description                                                                    | Default value          |
+|:---------------------|:-------------------------------------------------------------------------------|:-----------------------|
+| Name                 | Set the health check name, overrides the default bus type name.                | Bus name.              |
+| MinimalFailureStatus | The minimal `HealthStatus` that will be reported when the health check fails.  | `Unhealthy`            |
+| Tags                 | A list of tags that can be used to filter sets of health checks.               | "ready", "masstransit" |
+
+By default MassTransit reports all three statuses depending on application state.
+If `MinimalFailureStatus` is set to `Healthy`, MassTransit will log any issues, but the health check will always report `Healthy`.
+If `MinimalFailureStatus` is set to `Degraded`, MassTransit will report `Degraded` if any issues occur, but never report `Unhealthy`.

--- a/src/MassTransit/Configuration/DependencyInjection/IHealthCheckOptionsConfigurator.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/IHealthCheckOptionsConfigurator.cs
@@ -23,7 +23,7 @@ namespace MassTransit
         /// The minimal <see cref="HealthStatus" /> that should be reported when the health check fails.
         /// If null then all statuses from <see cref="HealthStatus.Unhealthy"/> to <see cref="HealthStatus.Healthy"/> will be reported depending on app health.
         /// </summary>
-        public HealthStatus? MinimalFailureStatus { get;  }
+        public HealthStatus? MinimalFailureStatus { set;  }
 
         /// <summary>
         /// A list of tags that can be used to filter sets of health checks

--- a/src/MassTransit/Configuration/DependencyInjection/IHealthCheckOptionsConfigurator.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/IHealthCheckOptionsConfigurator.cs
@@ -1,5 +1,6 @@
 namespace MassTransit
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -15,7 +16,14 @@ namespace MassTransit
         /// The <see cref="HealthStatus" /> that should be reported when the health check fails.
         /// If null then the default status of <see cref="HealthStatus.Unhealthy" /> will be reported.
         /// </summary>
+        [Obsolete("Use MinimalFailureStatus instead.", true)]
         public HealthStatus? FailureStatus { set; }
+
+        /// <summary>
+        /// The minimal <see cref="HealthStatus" /> that should be reported when the health check fails.
+        /// If null then all statuses from <see cref="HealthStatus.Unhealthy"/> to <see cref="HealthStatus.Healthy"/> will be reported depending on app health.
+        /// </summary>
+        public HealthStatus? MinimalFailureStatus { get;  }
 
         /// <summary>
         /// A list of tags that can be used to filter sets of health checks

--- a/src/MassTransit/DependencyInjection/Configuration/IHealthCheckOptions.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/IHealthCheckOptions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 namespace MassTransit.Configuration
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -16,7 +17,14 @@ namespace MassTransit.Configuration
         /// The <see cref="HealthStatus" /> that should be reported when the health check fails.
         /// If null then the default status of <see cref="HealthStatus.Unhealthy" /> will be reported.
         /// </summary>
-        public HealthStatus? FailureStatus { get; }
+        [Obsolete("Use MinimalFailureStatus instead.", true)]
+        public HealthStatus? FailureStatus { set; }
+
+        /// <summary>
+        /// The minimal <see cref="HealthStatus" /> that should be reported when the health check fails.
+        /// If null then all statuses from <see cref="HealthStatus.Unhealthy"/> to <see cref="HealthStatus.Healthy"/> will be reported depending on app health.
+        /// </summary>
+        public HealthStatus? MinimalFailureStatus { get; }
 
         /// <summary>
         /// A list of tags that can be used to filter sets of health checks

--- a/src/MassTransit/DependencyInjection/Configuration/IHealthCheckOptions.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/IHealthCheckOptions.cs
@@ -18,7 +18,7 @@ namespace MassTransit.Configuration
         /// If null then the default status of <see cref="HealthStatus.Unhealthy" /> will be reported.
         /// </summary>
         [Obsolete("Use MinimalFailureStatus instead.", true)]
-        public HealthStatus? FailureStatus { set; }
+        public HealthStatus? FailureStatus { get; }
 
         /// <summary>
         /// The minimal <see cref="HealthStatus" /> that should be reported when the health check fails.

--- a/src/MassTransit/DependencyInjection/Configuration/MassTransitHealthCheckOptions.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/MassTransitHealthCheckOptions.cs
@@ -32,7 +32,7 @@ namespace MassTransit.Configuration
         /// The minimal <see cref="HealthStatus" /> that should be reported when the health check fails.
         /// If null then all statuses from <see cref="HealthStatus.Unhealthy"/> to <see cref="HealthStatus.Healthy"/> will be reported depending on app health.
         /// </summary>
-        public HealthStatus? MinimalFailureStatus { get; }
+        public HealthStatus? MinimalFailureStatus { get; set; }
 
 
         /// <summary>

--- a/src/MassTransit/DependencyInjection/Configuration/MassTransitHealthCheckOptions.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/MassTransitHealthCheckOptions.cs
@@ -25,7 +25,15 @@ namespace MassTransit.Configuration
         /// The <see cref="HealthStatus" /> that should be reported when the health check fails.
         /// If null then the default status of <see cref="HealthStatus.Unhealthy" /> will be reported.
         /// </summary>
+        [Obsolete("Use MinimalFailureStatus instead.", true)]
         public HealthStatus? FailureStatus { get; set; }
+
+        /// <summary>
+        /// The minimal <see cref="HealthStatus" /> that should be reported when the health check fails.
+        /// If null then all statuses from <see cref="HealthStatus.Unhealthy"/> to <see cref="HealthStatus.Healthy"/> will be reported depending on app health.
+        /// </summary>
+        public HealthStatus? MinimalFailureStatus { get; }
+
 
         /// <summary>
         /// A list of tags that can be used to filter sets of health checks. If empty, the default tags

--- a/src/MassTransit/Monitoring/BusHealthCheck.cs
+++ b/src/MassTransit/Monitoring/BusHealthCheck.cs
@@ -30,7 +30,16 @@ namespace MassTransit.Monitoring
                 ))
             };
 
-            return Task.FromResult(result.Status switch
+            var minimalHealthcheckLevel = context.Registration.FailureStatus switch
+            {
+                HealthStatus.Healthy => BusHealthStatus.Healthy,
+                HealthStatus.Degraded => BusHealthStatus.Degraded,
+                _ => BusHealthStatus.Unhealthy
+            };
+
+            var usedHealthcheckResult = result.Status < minimalHealthcheckLevel ? minimalHealthcheckLevel : result.Status;
+
+            return Task.FromResult(usedHealthcheckResult switch
             {
                 BusHealthStatus.Healthy => HealthCheckResult.Healthy(result.Description, data),
                 BusHealthStatus.Degraded => HealthCheckResult.Degraded(result.Description, result.Exception, data),

--- a/src/MassTransit/Monitoring/ConfigureBusHealthCheckServiceOptions.cs
+++ b/src/MassTransit/Monitoring/ConfigureBusHealthCheckServiceOptions.cs
@@ -32,7 +32,7 @@ namespace MassTransit.Monitoring
                 var optionsType = typeof(IOptions<>).MakeGenericType(type);
 
                 var name = busInstance.Name;
-                HealthStatus? failureStatus = HealthStatus.Unhealthy;
+                HealthStatus? minimalFailureStatus = HealthStatus.Unhealthy;
                 var tags = new HashSet<string>(_tags, StringComparer.OrdinalIgnoreCase);
 
                 var busOptions = _provider.GetService(optionsType);
@@ -44,14 +44,14 @@ namespace MassTransit.Monitoring
                     if (!string.IsNullOrWhiteSpace(healthCheckOptions.Name))
                         name = healthCheckOptions.Name;
 
-                    if (healthCheckOptions.FailureStatus.HasValue)
-                        failureStatus = healthCheckOptions.FailureStatus.Value;
+                    if (healthCheckOptions.MinimalFailureStatus.HasValue)
+                        minimalFailureStatus = healthCheckOptions.MinimalFailureStatus.Value;
 
                     if (healthCheckOptions.Tags.Any())
                         tags = healthCheckOptions.Tags;
                 }
 
-                options.Registrations.Add(new HealthCheckRegistration(name, new BusHealthCheck(busInstance), failureStatus, tags));
+                options.Registrations.Add(new HealthCheckRegistration(name, new BusHealthCheck(busInstance), minimalFailureStatus, tags));
             }
         }
     }


### PR DESCRIPTION
# Description

This PR adds a new property to options, `MinimalFailureStatus`. This property affects minimal level that will be reported by MassTransit health check.

Also some additional information about configuring health checks was added to documentation.

Closes #4787.

# Breaking Changes

`FailureStatus` property is now deprecated. It didn't affect anything earlier because it wasn't used, so migrating to a new property should be simple.

# Changes
- Deprecated `FailureStatus` property
- Added `MinimalFailureStatus` property
- Modified `BusHealthCheck.CheckHealthAsync`. Now it uses `HealthCheckContext.Registration.FailureStatus` as minimal reported health level
- Updated  `Configuration/Health Checks` documentation.

# Testing

I used my project from issue to test the new behaviour of health checks. If I don't set `MinimalFailureStatus`, then MassTransit reports health status based on app state. If I set if to `Healthy`, then only this status is returned even if Kafka or RabbitMQ is down.

# Additional notes

I couldn't test the documentation syntax because for some reason it didn't want to compile. Maybe my setup of Node.js is wrong. Still, it is markdown, and I work with this format a lot.

Also - I updated only docs in `doc` folder. Doesn't know if something in `docs` needs updating.
