### PR TITLE
Enable System.Text.Json source generator

### DIFF
--- a/src/MassTransit/Serialization/SystemTextJsonMessageSerializer.cs
+++ b/src/MassTransit/Serialization/SystemTextJsonMessageSerializer.cs
@@ -38,6 +38,10 @@ namespace MassTransit.Serialization
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             };
 
+#if NET8_0_OR_GREATER
+            Options.TypeInfoResolverChain.Insert(0, SystemTextJsonSerializationContext.Default);
+#endif
+
             Options.Converters.Add(new StringDecimalJsonConverter());
             Options.Converters.Add(new SystemTextJsonMessageDataConverter());
             Options.Converters.Add(new SystemTextJsonConverterFactory());

--- a/src/MassTransit/Serialization/SystemTextJsonMessageSerializer.cs
+++ b/src/MassTransit/Serialization/SystemTextJsonMessageSerializer.cs
@@ -7,6 +7,7 @@ namespace MassTransit.Serialization
     using System.Runtime.Serialization;
     using System.Text.Encodings.Web;
     using System.Text.Json;
+    using System.Text.Json.Serialization.Metadata;
     using Initializers;
     using Initializers.TypeConverters;
     using JsonConverters;
@@ -36,11 +37,15 @@ namespace MassTransit.Serialization
                 ReadCommentHandling = JsonCommentHandling.Skip,
                 WriteIndented = true,
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            };
 
 #if NET8_0_OR_GREATER
-            Options.TypeInfoResolverChain.Insert(0, SystemTextJsonSerializationContext.Default);
+                // Set the TypeInfoResolver property based on whether reflection-based is enabled.
+                // If reflection is enabled, combine the default resolver (reflection-based) context with the custom serializer context
+                // Otherwise, use only the custom serializer context.
+                // User can overwrite it directly or by modifying the TypeInfoResolverChain.
+                TypeInfoResolver = JsonSerializer.IsReflectionEnabledByDefault ? JsonTypeInfoResolver.Combine(SystemTextJsonSerializationContext.Default, new DefaultJsonTypeInfoResolver()) : SystemTextJsonSerializationContext.Default
 #endif
+            };
 
             Options.Converters.Add(new StringDecimalJsonConverter());
             Options.Converters.Add(new SystemTextJsonMessageDataConverter());

--- a/src/MassTransit/Serialization/SystemTextJsonSerializationContext.cs
+++ b/src/MassTransit/Serialization/SystemTextJsonSerializationContext.cs
@@ -1,14 +1,74 @@
-﻿namespace MassTransit.Serialization
+﻿#if NET8_0_OR_GREATER
+namespace MassTransit.Serialization
 {
     using System.Text.Json.Serialization;
+    using Batching;
+    using Courier.Contracts;
+    using Courier.Messages;
+    using Events;
     using Metadata;
+    using Scheduling;
 
 
+    [JsonSerializable(typeof(Fault))]
+    [JsonSerializable(typeof(FaultEvent))]
+    // [JsonSerializable(typeof(FaultEvent<>))]
+    [JsonSerializable(typeof(FaultEvent<RoutingSlip>))]
+    [JsonSerializable(typeof(ReceiveFault))]
+    [JsonSerializable(typeof(ReceiveFaultEvent))]
+    [JsonSerializable(typeof(ExceptionInfo))]
+    [JsonSerializable(typeof(FaultExceptionInfo))]
+    [JsonSerializable(typeof(HostInfo))]
+    [JsonSerializable(typeof(BusHostInfo))]
+    // [JsonSerializable(typeof(MessageBatch<>))]
+    [JsonSerializable(typeof(ScheduleMessage))]
+    [JsonSerializable(typeof(ScheduleMessageCommand))]
+    // [JsonSerializable(typeof(ScheduleMessageCommand<>))]
+    [JsonSerializable(typeof(ScheduleRecurringMessage))]
+    [JsonSerializable(typeof(ScheduleRecurringMessageCommand))]
+    // [JsonSerializable(typeof(ScheduleRecurringMessageCommand<>))]
+    [JsonSerializable(typeof(CancelScheduledMessage))]
+    [JsonSerializable(typeof(CancelScheduledRecurringMessage))]
+    [JsonSerializable(typeof(CancelScheduledRecurringMessageCommand))]
+    [JsonSerializable(typeof(PauseScheduledRecurringMessage))]
+    [JsonSerializable(typeof(PauseScheduledRecurringMessageCommand))]
+    [JsonSerializable(typeof(ResumeScheduledRecurringMessage))]
+    [JsonSerializable(typeof(ResumeScheduledRecurringMessageCommand))]
     [JsonSerializable(typeof(MessageEnvelope))]
     [JsonSerializable(typeof(JsonMessageEnvelope))]
-    [JsonSerializable(typeof(BusHostInfo))]
+    [JsonSerializable(typeof(RoutingSlip))]
+    [JsonSerializable(typeof(RoutingSlipRoutingSlip))]
+    [JsonSerializable(typeof(Activity))]
+    [JsonSerializable(typeof(RoutingSlipActivity))]
+    [JsonSerializable(typeof(ActivityLog))]
+    [JsonSerializable(typeof(RoutingSlipActivityLog))]
+    [JsonSerializable(typeof(CompensateLog))]
+    [JsonSerializable(typeof(RoutingSlipCompensateLog))]
+    [JsonSerializable(typeof(ActivityException))]
+    [JsonSerializable(typeof(RoutingSlipActivityException))]
+    [JsonSerializable(typeof(Subscription))]
+    [JsonSerializable(typeof(RoutingSlipSubscription))]
+    [JsonSerializable(typeof(RoutingSlipCompleted))]
+    [JsonSerializable(typeof(RoutingSlipCompletedMessage))]
+    [JsonSerializable(typeof(RoutingSlipFaulted))]
+    [JsonSerializable(typeof(RoutingSlipFaultedMessage))]
+    [JsonSerializable(typeof(RoutingSlipActivityCompleted))]
+    [JsonSerializable(typeof(RoutingSlipActivityCompletedMessage))]
+    [JsonSerializable(typeof(RoutingSlipActivityFaulted))]
+    [JsonSerializable(typeof(RoutingSlipActivityFaultedMessage))]
+    [JsonSerializable(typeof(RoutingSlipActivityCompensated))]
+    [JsonSerializable(typeof(RoutingSlipActivityCompensatedMessage))]
+    [JsonSerializable(typeof(RoutingSlipActivityCompensationFailed))]
+    [JsonSerializable(typeof(RoutingSlipActivityCompensationFailedMessage))]
+    [JsonSerializable(typeof(RoutingSlipCompensationFailed))]
+    [JsonSerializable(typeof(RoutingSlipCompensationFailedMessage))]
+    [JsonSerializable(typeof(RoutingSlipTerminated))]
+    [JsonSerializable(typeof(RoutingSlipTerminatedMessage))]
+    [JsonSerializable(typeof(RoutingSlipRevised))]
+    [JsonSerializable(typeof(RoutingSlipRevisedMessage))]
     partial class SystemTextJsonSerializationContext :
         JsonSerializerContext
     {
     }
 }
+#endif

--- a/src/MassTransit/Serialization/SystemTextJsonSerializationContext.cs
+++ b/src/MassTransit/Serialization/SystemTextJsonSerializationContext.cs
@@ -1,0 +1,14 @@
+﻿namespace MassTransit.Serialization
+{
+    using System.Text.Json.Serialization;
+    using Metadata;
+
+
+    [JsonSerializable(typeof(MessageEnvelope))]
+    [JsonSerializable(typeof(JsonMessageEnvelope))]
+    [JsonSerializable(typeof(BusHostInfo))]
+    partial class SystemTextJsonSerializationContext :
+        JsonSerializerContext
+    {
+    }
+}


### PR DESCRIPTION
Use System.Text.Json source generator to improve performance. This also allows applications that use MT to disable serialization via reflection (https://devblogs.microsoft.com/dotnet/system-text-json-in-dotnet-8#disabling-reflection-defaults) by configuring the `JsonSerializerOptions` to add their own `JsonSerializerContext` (for their own messages) like:

```cs
services.AddMassTransit(cfg =>
{
    cfg.Using[Broker](broker => 
    {
        broker.ConfigureJsonSerializerOptions(options =>
        {
            options.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
            return options;
        });
    })
})

[JsonSerializable(typeof(CreateTodoCommand))]
[JsonSerializable(typeof(OrderPublishedEvent))]
internal partial class AppJsonSerializerContext : JsonSerializerContext
{
}
```

This PR depends on #4791.