### PR TITLE
Return xmin auto column from subquery

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/PostgresLockStatementFormatter.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/PostgresLockStatementFormatter.cs
@@ -26,7 +26,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration
 
         public void CreateOutboxStatement(StringBuilder sb, string schema, string table, string columnName)
         {
-            sb.AppendFormat(@"SELECT * FROM {0} ORDER BY ""{1}"" LIMIT 1 FOR UPDATE SKIP LOCKED", FormatTableName(schema, table), columnName);
+            sb.AppendFormat(@"SELECT *, xmin FROM {0} ORDER BY ""{1}"" LIMIT 1 FOR UPDATE SKIP LOCKED", FormatTableName(schema, table), columnName);
         }
 
         static string FormatTableName(string schema, string table)


### PR DESCRIPTION
Very happy user of MassTransit here - thanks for a great piece of software.

We've been integrating the EF Core outbox with Postgresql and ran into an issue with the `PostgresLockStatementFormatter` - it does not return `xmin` from the subquery so the outer query fails with `column m.xmin does not exist`.

This simple PR fixes that.

To really use `xmin` you would also have to override the `RowVersion` on `InboxState` and `OutboxState` like so,

```cs
var converter = new ValueConverter<byte[]?, long>(
    v => v == null ? 0 : BitConverter.ToInt64(v, 0),
    v => BitConverter.GetBytes(v));

modelBuilder.AddOutboxStateEntity(x =>
{
    x.Property(p => p.RowVersion)
        .HasColumnName("xmin")
        .HasColumnType("xid")
        .HasConversion(converter);
});
```

A future fix might be to make the `RowVersion` a `uint` type which would make the above override unnecessary as Npgsql would automatically map that to xmin according to the docs here - https://www.npgsql.org/efcore/modeling/concurrency.html.

ℹ️ _Edit_ - just wanted to say - we do not use (and can not use) the EF Core migrations, in which case I guess the tables would have a `RowVersion` column created and perhaps work (I haven't tested)