### PR TITLE
Add missing configuration for RabbitMQ connection name

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqHostConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqHostConfigurator.cs
@@ -90,5 +90,10 @@
         /// Configure the Max message size for RabbitMQ.Client
         /// </summary>
         void MaxMessageSize(uint maxMessageSize);
+
+        /// <summary>
+        /// Sets the connection name for the connection to RabbitMQ
+        /// </summary>
+        void ConnectionName(string connectionName);
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqTransportOptions.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqTransportOptions.cs
@@ -28,6 +28,7 @@ namespace MassTransit
         public string VHost { get; set; }
         public string User { get; set; }
         public string Pass { get; set; }
+        public string ConnectionName { get; set; }
 
         public bool UseSsl
         {

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqHostConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqHostConfigurator.cs
@@ -151,5 +151,10 @@ namespace MassTransit.RabbitMqTransport.Configuration
 
             throw new FormatException("The host path must be empty or contain a single virtual host name");
         }
+
+        public void ConnectionName(string connectionName)
+        {
+            _settings.ClientProvidedName = connectionName;
+        }
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqRegistrationBusFactory.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqRegistrationBusFactory.cs
@@ -35,7 +35,7 @@ namespace MassTransit.RabbitMqTransport.Configuration
 
             var options = context.GetRequiredService<IOptionsMonitor<RabbitMqTransportOptions>>().Get(busName);
 
-            configurator.Host(options.Host, options.Port, options.VHost, h =>
+            configurator.Host(options.Host, options.Port, options.VHost, options.ConnectionName, h =>
             {
                 if (!string.IsNullOrWhiteSpace(options.User))
                     h.Username(options.User);


### PR DESCRIPTION
# Issue description

MassTransit allows setting a custom connection name for RabbitMQ connections, using the constructors in `RabbitMqHostConfigurator`:

https://github.com/MassTransit/MassTransit/blob/7f8220b9b5d805b301941b06805f06e37e43c447/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqHostConfigurator.cs#L12

Or one of the overloads in `RabbitMqHostConfigurationExtensions`:

https://github.com/MassTransit/MassTransit/blob/7f8220b9b5d805b301941b06805f06e37e43c447/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqHostConfigurationExtensions.cs#L43-L45

However there is no way to access this setting using either the configuration methods, or using the options pattern. There is no method to set it in [IRabbitMqHostConfigurator](https://github.com/MassTransit/MassTransit/blob/develop/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqHostConfigurator.cs), and no property for it in [RabbitMqTransportOptions](https://github.com/MassTransit/MassTransit/blob/7f8220b9b5d805b301941b06805f06e37e43c447/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqTransportOptions.cs).

I like to configure MassTransit using `RabbitMqTransportOptions`, and letting [RabbitMqRegistrationBusFactory](src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqRegistrationBusFactory.cs) do the work of interpreting it, which nicely takes care of parsing all configuration options and passing them on to the RabbitMQ host builder. All options, except the connection name.

https://github.com/MassTransit/MassTransit/blob/7f8220b9b5d805b301941b06805f06e37e43c447/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqRegistrationBusFactory.cs#L36-L38

This means the only way to set it is by manually calling the `RabbitMqHostConfigurator` constructor or one of the `RabbitMqBusFactoryConfigurator.Host(...)` overloads, and that means all configuration has to be done manually, basically copying all the existing logic from `RabbitMqRegistrationBusFactory`.

# Proposed changes

This PR adds the `ConnectionName` property to `RabbitMqTransportOptions`, and adds a `ConnectionName(string)` method to the configurator.

There is a bit of a naming inconsistency where the the public api uses the term `ConnectionName` and internally it sets the value for `ClientProvidedName`. I've followed that existing naming pattern and used `ConnectionName` for the additions to the public api.

# Tests 

There are no additional unit tests since I found no existing tests for `RabbitMqTransportOptions` and the proposed changes are very trivial.

I have run the following tests this locally with RabbitMQ 3.11.4 running in Docker.

## Using no configuration at all

```csharp
Host.CreateDefaultBuilder()
	.ConfigureServices((ctx, services) => services
		.AddMassTransit(c => c.UsingRabbitMq())
	)
	.Build()
	.Run();
```

Results in the following connection log entry on the RabbitMQ server:

> <0.4624.0> connection <0.4624.0> (172.19.0.1:40306 -> 172.19.0.2:5672 - connectionnametest): user 'guest' authenticated and granted access to vhost '/'

When not providing any options, there are no differences to the current version of MassTransit: The value `connectionnametest` is the name of the executable used to test.

## Using `IOptions` pattern

Providing the following configuration:

```json
{
  "RabbitMqTransportOptions": {
    "ConnectionName": "foobar"
  }
}
```

And a setup configuring `RabbitMqTransportOptions`:

```csharp
Host.CreateDefaultBuilder()
	.ConfigureServices((ctx, services) => services
		.Configure<RabbitMqTransportOptions>(ctx.Configuration.GetSection("RabbitMqTransportOptions"))
		.AddMassTransit(c => c.UsingRabbitMq())
	)
	.Build()
	.Run();
```

The connection log entry on the RabbitMQ server correctly displays the configured name "foobar" instead of the executable name.

> <0.1906.0> connection <0.1906.0> (172.19.0.1:45526 -> 172.19.0.2:5672 - foobar): user 'guest' authenticated and granted access to vhost '/'

## Using the `IRabbitMqHostConfigurator`:

Setting the connection name using the configuration method:

```csharp
Host.CreateDefaultBuilder()
	.ConfigureServices((ctx, services) => services
		.AddMassTransit(c => c.UsingRabbitMq((bus, rmq) => 
			rmq.Host("rabbitmq://localhost", host => host.ConnectionName("foobar"))
		))
	)
	.Build()
	.Run();
```

The connection log entry on the RabbitMQ server also correctly displays the configured client name.

> <0.2651.0> connection <0.2651.0> (172.19.0.1:57420 -> 172.19.0.2:5672 - foobar): user 'guest' authenticated and granted access to vhost '/'
