### PR TITLE
Enable null returns from Mediator request handlers

### DIFF
--- a/src/MassTransit.Abstractions/Mediator/Internals/Null.cs
+++ b/src/MassTransit.Abstractions/Mediator/Internals/Null.cs
@@ -1,0 +1,21 @@
+﻿namespace MassTransit.Mediator.Internals
+{
+    /// <summary>
+    /// Represents a null object for a given reference type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class Null<T> where T : class
+    {
+        /// <summary>
+        /// The singleton instance representing a null object of type <typeparamref name="T"/>.
+        /// </summary>
+        public static readonly Null<T> Value = new();
+
+        private Null() { }
+
+        /// <inheritdoc/>
+        public override string ToString() => "null";
+
+        public static explicit operator T(Null<T> _) => null!;
+    }
+}

--- a/src/MassTransit.Abstractions/Mediator/MediatorRequestHandler.cs
+++ b/src/MassTransit.Abstractions/Mediator/MediatorRequestHandler.cs
@@ -1,5 +1,6 @@
 namespace MassTransit.Mediator
 {
+    using Internals;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -37,7 +38,14 @@ namespace MassTransit.Mediator
         {
             var response = await Handle(context.Message, context.CancellationToken).ConfigureAwait(false);
 
-            await context.RespondAsync(response).ConfigureAwait(false);
+            if (response is not null)
+            {
+                await context.RespondAsync(response).ConfigureAwait(false);
+            }
+            else
+            {
+                await context.RespondAsync(Null<TResponse>.Value).ConfigureAwait(false);
+            }
         }
 
         protected abstract Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken);

--- a/tests/MassTransit.Tests/MediatorNullableResponse_Specs.cs
+++ b/tests/MassTransit.Tests/MediatorNullableResponse_Specs.cs
@@ -1,0 +1,136 @@
+﻿namespace MassTransit.Tests
+{
+    using MassTransit.Mediator;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class MediatorNullableResponse_Specs
+    {
+        [Test]
+        public async Task Should_return_the_response_by_default()
+        {
+            // Arrange
+            await using var provider = new ServiceCollection()
+                .AddMediator(cfg =>
+                {
+                    cfg.AddConsumer<SampleRequestHandler>();
+                })
+                .BuildServiceProvider(validateScopes: true);
+
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            var response = await mediator.SendRequest(new SampleRequest());
+
+            // Assert
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response, Is.TypeOf<SampleResponse>());
+        }
+
+        [Test]
+        public async Task Should_return_null_when_response_is_null()
+        {
+            // Arrange
+            await using var provider = new ServiceCollection()
+                .AddMediator(cfg =>
+                {
+                    cfg.AddConsumer<SampleRequestHandler>();
+                })
+                .BuildServiceProvider(validateScopes: true);
+
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            var response = await mediator.SendRequest(new SampleRequest(new RequestConfiguration { ReturnNull = true }));
+
+            // Assert
+            Assert.That(response, Is.Null);
+        }
+
+        [Test]
+        public async Task Should_throw_request_exception_when_request_fails()
+        {
+            // Arrange
+            await using var provider = new ServiceCollection()
+                .AddMediator(cfg =>
+                {
+                    cfg.AddConsumer<SampleRequestHandler>();
+                })
+                .BuildServiceProvider(validateScopes: true);
+
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            Task action() => mediator.SendRequest(new SampleRequest(new RequestConfiguration { ThrowRequestException = true }));
+
+            // Assert
+            Assert.That(action, Throws.TypeOf<RequestException>());
+        }
+
+        [Test]
+        public async Task Should_throw_the_inner_exception_when_there_is_one()
+        {
+            // Arrange
+            await using var provider = new ServiceCollection()
+                .AddMediator(cfg =>
+                {
+                    cfg.AddConsumer<SampleRequestHandler>();
+                })
+                .BuildServiceProvider(validateScopes: true);
+
+            var mediator = provider.GetRequiredService<IMediator>();
+
+            // Act
+            Task action() => mediator.SendRequest(new SampleRequest(new RequestConfiguration { ThrowApplicationException = true }));
+
+            // Assert
+            Assert.That(action, Throws.TypeOf<ApplicationException>());
+        }
+
+        #region Fixtures
+        class RequestConfiguration
+        {
+            public bool ReturnNull { get; set; }
+            public bool ThrowRequestException { get; set; }
+            public bool ThrowApplicationException { get; set; }
+        }
+
+        class SampleRequest : Request<SampleResponse>
+        {
+            public SampleRequest() : this(new RequestConfiguration()) { }
+            public SampleRequest(RequestConfiguration configuration) => Configuration = configuration;
+
+            public RequestConfiguration Configuration { get; }
+        }
+
+        class SampleResponse { }
+
+        class SampleRequestHandler : MediatorRequestHandler<SampleRequest, SampleResponse>
+        {
+            protected override Task<SampleResponse> Handle(SampleRequest request, CancellationToken cancellationToken)
+            {
+                if (request.Configuration.ThrowRequestException)
+                {
+                    throw new RequestException();
+                }
+
+                if (request.Configuration.ThrowApplicationException)
+                {
+                    throw new ApplicationException();
+                }
+
+                if (request.Configuration.ReturnNull)
+                {
+                    return Task.FromResult<SampleResponse>(null);
+                }
+
+                return Task.FromResult(new SampleResponse());
+            }
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
## Enable null returns from Mediator request handlers

### Overview
Implemented the ability for Mediator request handlers to return `null`, which aligns with common object-oriented practices where `null` indicates the absence of a value.

### Modifications
- MediatorRequestHandler: Adapted to allow `null` responses. Previously it would fail with an `ArgumentNullException`.
- MediatorRequestExtensions: Updated SendRequest method to recognize and handle these `null` responses appropriately.
- No changes to APIs.

### Justification
This update brings MassTransit's implementation of the Mediator pattern in line with standard conventions, particularly in query operations where a result may not be present.

