### PR TITLE
Add function to overide retry policy when adding redis saga repository

### DIFF
--- a/src/Persistence/MassTransit.RedisIntegration/Configuration/Configuration/RedisSagaRepositoryConfigurator.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/Configuration/Configuration/RedisSagaRepositoryConfigurator.cs
@@ -32,6 +32,7 @@ namespace MassTransit.Configuration
         public string LockSuffix { get; set; }
         public TimeSpan LockTimeout { get; set; }
         public TimeSpan? Expiry { get; set; }
+        public IRetryPolicy RetryPolicy { get; set; }
 
         public void DatabaseConfiguration(string configuration)
         {
@@ -72,7 +73,7 @@ namespace MassTransit.Configuration
             where T : class, ISagaVersion
         {
             configurator.TryAddSingleton(_connectionFactory);
-            configurator.TryAddSingleton(new RedisSagaRepositoryOptions<T>(ConcurrencyMode, LockTimeout, LockSuffix, KeyPrefix, _databaseSelector, Expiry));
+            configurator.TryAddSingleton(new RedisSagaRepositoryOptions<T>(ConcurrencyMode, LockTimeout, LockSuffix, KeyPrefix, _databaseSelector, Expiry, RetryPolicy));
             configurator.RegisterLoadSagaRepository<T, RedisSagaRepositoryContextFactory<T>>();
             configurator
                 .RegisterSagaRepository<T, DatabaseContext<T>, SagaConsumeContextFactory<DatabaseContext<T>, T>, RedisSagaRepositoryContextFactory<T>>();

--- a/src/Persistence/MassTransit.RedisIntegration/Configuration/IRedisSagaRepositoryConfigurator.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/Configuration/IRedisSagaRepositoryConfigurator.cs
@@ -16,6 +16,8 @@ namespace MassTransit
 
         TimeSpan? Expiry { set; }
 
+        IRetryPolicy RetryPolicy { set; }
+        
         /// <summary>
         /// Set the database factory using configuration, which caches a <see cref="ConnectionMultiplexer" /> under the hood.
         /// </summary>

--- a/src/Persistence/MassTransit.RedisIntegration/Configuration/RedisSagaRepositoryOptions.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/Configuration/RedisSagaRepositoryOptions.cs
@@ -7,7 +7,7 @@ namespace MassTransit
         where TSaga : class, ISaga
     {
         public RedisSagaRepositoryOptions(ConcurrencyMode concurrencyMode, TimeSpan? lockTimeout, string lockSuffix, string keyPrefix,
-            SelectDatabase databaseSelector, TimeSpan? expiry)
+            SelectDatabase databaseSelector, TimeSpan? expiry, IRetryPolicy retryPolicy)
         {
             ConcurrencyMode = concurrencyMode;
 
@@ -17,7 +17,7 @@ namespace MassTransit
 
             KeyPrefix = string.IsNullOrWhiteSpace(keyPrefix) ? null : keyPrefix.EndsWith(":") ? keyPrefix : $"{keyPrefix}:";
 
-            RetryPolicy = Retry.Exponential(10, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(918));
+            RetryPolicy = (retryPolicy == null) ? Retry.Exponential(10, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(918)) : retryPolicy;
 
             DatabaseSelector = databaseSelector;
 

--- a/src/Persistence/MassTransit.RedisIntegration/RedisIntegration/Saga/RedisSagaRepository.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/RedisIntegration/Saga/RedisSagaRepository.cs
@@ -9,10 +9,10 @@
         where TSaga : class, ISagaVersion
     {
         public static ISagaRepository<TSaga> Create(Func<IDatabase> redisDbFactory, bool optimistic = true, TimeSpan? lockTimeout = null, TimeSpan?
-            lockRetryTimeout = null, string keyPrefix = "", TimeSpan? expiry = null)
+            lockRetryTimeout = null, string keyPrefix = "", TimeSpan? expiry = null, IRetryPolicy retryPolicy = null)
         {
             var options = new RedisSagaRepositoryOptions<TSaga>(optimistic ? ConcurrencyMode.Optimistic : ConcurrencyMode.Pessimistic, lockTimeout, null,
-                keyPrefix, SelectDefaultDatabase, expiry);
+                keyPrefix, SelectDefaultDatabase, expiry, retryPolicy);
 
             var consumeContextFactory = new SagaConsumeContextFactory<DatabaseContext<TSaga>, TSaga>();
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Hello Chris,

I get struck with 918 millisecs when redis get locked. I found that retry policy was hard coded with Retry.Exponential(10, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(918)) 

I would like to override this retry policy when call RedisSagaRepository.  Is it possible to do this?