### PR TITLE
Remove Microsoft.Data.SqlClient dependency from TestFramework

### DIFF
--- a/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
+++ b/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
@@ -15,7 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />

--- a/tests/MassTransit.DapperIntegration.Tests/Container_Specs.cs
+++ b/tests/MassTransit.DapperIntegration.Tests/Container_Specs.cs
@@ -6,6 +6,7 @@ namespace MassTransit.DapperIntegration.Tests
         using System.Threading.Tasks;
         using Dapper;
         using Dapper.Contrib.Extensions;
+        using MassTransit.Tests;
         using Microsoft.Data.SqlClient;
         using Microsoft.Extensions.DependencyInjection;
         using NUnit.Framework;

--- a/tests/MassTransit.DapperIntegration.Tests/DapperSagaRepositoryTests.cs
+++ b/tests/MassTransit.DapperIntegration.Tests/DapperSagaRepositoryTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using Dapper;
+    using MassTransit.Tests;
     using MassTransit.Tests.Saga.Messages;
     using Microsoft.Data.SqlClient;
     using NUnit.Framework;

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/FutureSagaDbContextFactory.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/FutureSagaDbContextFactory.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.EntityFrameworkCoreIntegration.Tests
 {
     using System.Reflection;
+    using MassTransit.Tests;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Design;
     using TestFramework;

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/Outbox_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/Outbox_Specs.cs
@@ -207,6 +207,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
         using System.Collections.Generic;
         using System.Reflection;
         using DependencyInjection;
+        using MassTransit.Tests;
         using Microsoft.EntityFrameworkCore;
         using Microsoft.EntityFrameworkCore.Design;
         using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/ReliableDbContextFactory.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/ReliableDbContextFactory.cs
@@ -1,6 +1,7 @@
 namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
 {
     using System.Reflection;
+    using MassTransit.Tests;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Design;
     using TestFramework;

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Shared/SqlServerResiliencyTestDbParameters.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Shared/SqlServerResiliencyTestDbParameters.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Reflection;
+    using MassTransit.Tests;
     using Microsoft.EntityFrameworkCore;
     using TestFramework;
 

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Shared/SqlServerTestDbParameters.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Shared/SqlServerTestDbParameters.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Reflection;
+    using MassTransit.Tests;
     using Microsoft.EntityFrameworkCore;
     using TestFramework;
 

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/TransactionalBusOutbox_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/TransactionalBusOutbox_Specs.cs
@@ -4,6 +4,7 @@
     using System.Threading.Tasks;
     using System.Transactions;
     using Internals;
+    using MassTransit.Tests;
     using MassTransit.Tests.Saga.Messages;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.ChangeTracking;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/AuditStore_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/AuditStore_Specs.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Audit;
+    using MassTransit.Tests;
     using NUnit.Framework;
     using Shouldly;
     using TestFramework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/Container_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/Container_Specs.cs
@@ -7,6 +7,7 @@ namespace MassTransit.EntityFrameworkIntegration.Tests
         using System.Data.Entity;
         using System.Data.Entity.ModelConfiguration;
         using System.Threading.Tasks;
+        using MassTransit.Tests;
         using Microsoft.Extensions.DependencyInjection;
         using NUnit.Framework;
         using TestFramework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/DiscardEvent_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/DiscardEvent_Specs.cs
@@ -6,6 +6,7 @@
     using System.Data.Entity.ModelConfiguration;
     using System.Linq;
     using System.Threading.Tasks;
+    using MassTransit.Tests;
     using NUnit.Framework;
     using Saga;
     using TestFramework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/PreInsert_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/PreInsert_Specs.cs
@@ -7,6 +7,7 @@
         using System.Data.Entity;
         using System.Data.Entity.ModelConfiguration;
         using System.Threading.Tasks;
+        using MassTransit.Tests;
         using NUnit.Framework;
         using Saga;
         using TestFramework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/SagaLocator_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/SagaLocator_Specs.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using MassTransit.Tests;
     using MassTransit.Tests.Saga;
     using MassTransit.Tests.Saga.Messages;
     using NUnit.Framework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Data.Entity;
     using System.Threading.Tasks;
+    using MassTransit.Tests;
     using NUnit.Framework;
     using Saga;
     using TestFramework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
@@ -5,6 +5,7 @@
     using System.Data.Entity;
     using System.Data.Entity.Infrastructure;
     using System.Threading.Tasks;
+    using MassTransit.Tests;
     using NUnit.Framework;
     using Saga;
     using TestFramework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Data.Entity;
     using System.Threading.Tasks;
+    using MassTransit.Tests;
     using NUnit.Framework;
     using Saga;
     using TestFramework;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFramework_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFramework_Specs.cs
@@ -7,6 +7,7 @@
     using System.Data.Entity.ModelConfiguration;
     using System.Linq;
     using System.Threading.Tasks;
+    using MassTransit.Tests;
     using NUnit.Framework;
     using Saga;
     using TestFramework;

--- a/tests/MassTransit.SqlTransport.Tests/MassTransit.SqlTransport.Tests.csproj
+++ b/tests/MassTransit.SqlTransport.Tests/MassTransit.SqlTransport.Tests.csproj
@@ -25,5 +25,6 @@
         <ProjectReference Include="..\..\src\Persistence\MassTransit.EntityFrameworkCoreIntegration\MassTransit.EntityFrameworkCoreIntegration.csproj" />
         <ProjectReference Include="..\..\src\Transports\MassTransit.SqlTransport.PostgreSql\MassTransit.SqlTransport.PostgreSql.csproj" />
         <ProjectReference Include="..\..\src\Transports\MassTransit.SqlTransport.SqlServer\MassTransit.SqlTransport.SqlServer.csproj" />
+        <ProjectReference Include="..\MassTransit.Tests\MassTransit.Tests.csproj" />
     </ItemGroup>
 </Project>

--- a/tests/MassTransit.SqlTransport.Tests/SqlServerDatabaseTestConfiguration.cs
+++ b/tests/MassTransit.SqlTransport.Tests/SqlServerDatabaseTestConfiguration.cs
@@ -3,10 +3,10 @@ namespace MassTransit.DbTransport.Tests;
 using System;
 using System.Reflection;
 using EntityFrameworkCoreIntegration;
+using MassTransit.Tests;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using SqlServer;
-using TestFramework;
 
 
 public class SqlServerDatabaseTestConfiguration :

--- a/tests/MassTransit.Tests/LocalDbConnectionStringProvider.cs
+++ b/tests/MassTransit.Tests/LocalDbConnectionStringProvider.cs
@@ -1,4 +1,4 @@
-namespace MassTransit.TestFramework
+namespace MassTransit.Tests
 {
     using System;
     using System.Collections.Generic;

--- a/tests/MassTransit.Tests/MassTransit.Tests.csproj
+++ b/tests/MassTransit.Tests/MassTransit.Tests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="MathNet.Numerics" />


### PR DESCRIPTION
`Microsoft.Data.SqlClient`  probably shouldn't be a core dependency for testing MassTransit solutions. It also has [a funny transitive license](https://github.com/dotnet/SqlClient/issues/790) via `Microsoft.Data.SqlClient.SNI.runtime` that can make alarm bells go off with some dependency scanners which check licenses. 

There's only `LocalDbConnectionStringProvider` which causes the dependency so I'm suggesting moving it to `MassTransit.Tests` as it's only needed by MassTransit's own tests, I'm open for better ideas of course.