### PR TITLE
[EntityFrameworkCore] Add a way to register existing db context by providing a Type

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/IEntityFrameworkSagaRepositoryConfigurator.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/IEntityFrameworkSagaRepositoryConfigurator.cs
@@ -42,8 +42,14 @@ namespace MassTransit
         /// <typeparam name="TContext"></typeparam>
         void ExistingDbContext<TContext>()
             where TContext : DbContext;
-    }
 
+        /// <summary>
+        /// Use an existing (already configured in the container) DbContext that will be resolved
+        /// within the container scope
+        /// </summary>
+        /// <param name="dbContextImpl">DbContext implementation type</param>
+        void ExistingDbContext(Type dbContextImpl);
+    }
 
     public interface IEntityFrameworkSagaRepositoryConfigurator<TSaga> :
         IEntityFrameworkSagaRepositoryConfigurator

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/Saga/ContainerSagaDbContextFactory.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/Saga/ContainerSagaDbContextFactory.cs
@@ -5,14 +5,13 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Saga
     using Microsoft.EntityFrameworkCore;
 
 
-    public class ContainerSagaDbContextFactory<TContext, TSaga> :
+    public class ContainerSagaDbContextFactory<TSaga> :
         ISagaDbContextFactory<TSaga>
-        where TContext : DbContext
         where TSaga : class, ISaga
     {
-        readonly TContext _dbContext;
+        readonly DbContext _dbContext;
 
-        public ContainerSagaDbContextFactory(TContext dbContext)
+        public ContainerSagaDbContextFactory(DbContext dbContext)
         {
             _dbContext = dbContext;
         }

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Future_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/Future_Specs.cs
@@ -20,7 +20,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
                     r.ConcurrencyMode = ConcurrencyMode.Pessimistic;
                     r.LockStatementProvider = new SqlServerLockStatementProvider();
 
-                    r.ExistingDbContext<FutureSagaDbContext>();
+                    r.ExistingDbContext(typeof(FutureSagaDbContext));
                 });
         }
 


### PR DESCRIPTION
Hi @phatboyg 

I'm opening this as a draft and as first-time contributor, to seek out thoughts and whether or not to expand / go in other direction.

I have tested by changing one of the fixtures to use the newly exposed method. I'm not sure if that's enough I didn't find any specific tests for these so I just chipped into one of the specs that used to use the generic `ExistingDbContext<TCtx>`.
 
I'd enjoy a way to register existing db context by providing a type (or even assembly scanning). 
Let me know if this makes sense to you.

I'm opening this because I'm working with a project that's shaping with clean architecture having two separate assemblies for `Infrastructure` and `Persistence` and I'd like to avoid having to introduce a third one. The saga contexts live in `Persistence` and MT lives in `Infrastructure` so this integration and registration are kind of in the middle unless I can work with something else.

