### PR TITLE
Reduce dependencies on non-.NET Standard 2.0.

### DIFF
--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -20,13 +20,10 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net472'">
-    <PackageReference Include="System.Reflection.Emit.Lightweight" />
-    <PackageReference Include="System.Reflection.Emit" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" />
+    <PackageReference Include="System.Reflection.Emit" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 


### PR DESCRIPTION
Reflection.Emit is inbox in all frameworks other than .NET Standard 2.0.