### PR TITLE
feat: add JobStarted<T> which is published after the job starts

### DIFF
--- a/src/MassTransit.Abstractions/JobService/Contracts/JobService/JobStarted.cs
+++ b/src/MassTransit.Abstractions/JobService/Contracts/JobService/JobStarted.cs
@@ -28,4 +28,32 @@ namespace MassTransit.Contracts.JobService
         /// </summary>
         DateTime Timestamp { get; }
     }
+
+
+    /// <summary>
+    /// Event published when a node starts processing a job (separately from <see cref="JobStarted"/>)
+    /// </summary>
+    public interface JobStarted<T>
+        where T : class
+    {
+        /// <summary>
+        /// The job identifier
+        /// </summary>
+        Guid JobId { get; }
+
+        /// <summary>
+        /// Identifies this attempt to run the job
+        /// </summary>
+        Guid AttemptId { get; }
+
+        /// <summary>
+        /// Zero if the job is being started for the first time, otherwise, the number of previous failures
+        /// </summary>
+        int RetryAttempt { get; }
+
+        /// <summary>
+        /// The time the job was started
+        /// </summary>
+        DateTime Timestamp { get; }
+    }
 }

--- a/src/MassTransit/JobService/JobService/StartJobConsumer.cs
+++ b/src/MassTransit/JobService/JobService/StartJobConsumer.cs
@@ -31,6 +31,7 @@ namespace MassTransit.JobService
             var job = context.GetJob<TJob>() ?? throw new SerializationException($"The job could not be deserialized: {TypeCache<TJob>.ShortName}");
 
             await _jobService.StartJob(context, job, _jobPipe, _options.JobTimeout);
+            await context.Publish<JobStarted<TJob>>(context.Message);
         }
     }
 }

--- a/tests/MassTransit.ActiveMqTransport.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/JobConsumer_Specs.cs
@@ -69,7 +69,9 @@ namespace MassTransit.ActiveMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -101,7 +103,9 @@ namespace MassTransit.ActiveMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             IRequestClient<GetJobState> stateClient = harness.GetRequestClient<GetJobState>();
 
@@ -144,7 +148,9 @@ namespace MassTransit.ActiveMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -227,7 +233,9 @@ namespace MassTransit.ActiveMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
@@ -248,7 +256,9 @@ namespace MassTransit.ActiveMqTransport.Tests
             await harness.Bus.Publish<OddJob>(new { Duration = TimeSpan.FromSeconds(1) });
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);

--- a/tests/MassTransit.Azure.Cosmos.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/JobConsumer_Specs.cs
@@ -117,7 +117,9 @@ namespace MassTransit.Azure.Cosmos.Tests
                 Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
                 Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
                 Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
                 Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
                 Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);

--- a/tests/MassTransit.Azure.Table.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.Azure.Table.Tests/JobConsumer_Specs.cs
@@ -119,7 +119,9 @@ namespace MassTransit.Azure.Table.Tests
                 Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
                 Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
                 Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
                 Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
                 Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/JobConsumer_Specs.cs
@@ -110,7 +110,9 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
                 Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
                 Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
                 Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
                 Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
                 Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);

--- a/tests/MassTransit.MongoDbIntegration.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/JobConsumer_Specs.cs
@@ -98,7 +98,9 @@ namespace MassTransit.MongoDbIntegration.Tests
                 Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
                 Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
                 Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
                 Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
                 Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);

--- a/tests/MassTransit.RabbitMqTransport.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/JobConsumer_Specs.cs
@@ -69,7 +69,9 @@ namespace MassTransit.RabbitMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -101,7 +103,9 @@ namespace MassTransit.RabbitMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             IRequestClient<GetJobState> stateClient = harness.GetRequestClient<GetJobState>();
 
@@ -144,7 +148,9 @@ namespace MassTransit.RabbitMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -227,7 +233,9 @@ namespace MassTransit.RabbitMqTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
@@ -248,7 +256,9 @@ namespace MassTransit.RabbitMqTransport.Tests
             await harness.Bus.Publish<OddJob>(new { Duration = TimeSpan.FromSeconds(1) });
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);

--- a/tests/MassTransit.SqlTransport.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/JobConsumer_Specs.cs
@@ -73,7 +73,9 @@ namespace MassTransit.DbTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -105,7 +107,9 @@ namespace MassTransit.DbTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             IRequestClient<GetJobState> stateClient = harness.GetRequestClient<GetJobState>();
 
@@ -148,7 +152,9 @@ namespace MassTransit.DbTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -233,7 +239,9 @@ namespace MassTransit.DbTransport.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
@@ -254,7 +262,9 @@ namespace MassTransit.DbTransport.Tests
             await harness.Bus.Publish<OddJob>(new { Duration = TimeSpan.FromSeconds(1) });
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);

--- a/tests/MassTransit.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.Tests/JobConsumer_Specs.cs
@@ -94,7 +94,9 @@ namespace MassTransit.Tests
                 Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
                 Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
                 Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
                 Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
                 Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
@@ -163,7 +165,9 @@ namespace MassTransit.Tests
                 Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
                 Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
                 Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
                 Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
                 Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
@@ -216,7 +220,9 @@ namespace MassTransit.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -248,7 +254,9 @@ namespace MassTransit.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             IRequestClient<GetJobState> stateClient = harness.GetRequestClient<GetJobState>();
 
@@ -291,7 +299,9 @@ namespace MassTransit.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -374,7 +384,9 @@ namespace MassTransit.Tests
             Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
@@ -395,7 +407,9 @@ namespace MassTransit.Tests
             await harness.Bus.Publish<OddJob>(new { Duration = TimeSpan.FromSeconds(1) });
 
             Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+
             Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
             Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
             Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);


### PR DESCRIPTION
adds a `JobStarted<T>` contract, similar to `JobCompleted<T>` which is published after a job starts, it'll be useful in state machines where multiple jobs start events need to be tracked. Specifically so that the generic `JobStarted<T>` can be tracked without needing to create custom message contracts that would need to be published in each individual job consumer.