### PR TITLE
Added Mermaid StateMachine visualizer

### DIFF
--- a/src/MassTransit.StateMachineVisualizer/Abstractions/StateMachineGenerator.cs
+++ b/src/MassTransit.StateMachineVisualizer/Abstractions/StateMachineGenerator.cs
@@ -14,7 +14,7 @@
             Graph = CreateAdjacencyGraph(data);
         }
 
-        private static AdjacencyGraph<Vertex, Edge<Vertex>> CreateAdjacencyGraph(StateMachineGraph data)
+        static AdjacencyGraph<Vertex, Edge<Vertex>> CreateAdjacencyGraph(StateMachineGraph data)
         {
             var graph = new AdjacencyGraph<Vertex, Edge<Vertex>>();
 

--- a/src/MassTransit.StateMachineVisualizer/Abstractions/StateMachineGenerator.cs
+++ b/src/MassTransit.StateMachineVisualizer/Abstractions/StateMachineGenerator.cs
@@ -1,0 +1,33 @@
+﻿namespace MassTransit.Visualizer.Abstractions
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using QuikGraph;
+    using SagaStateMachine;
+
+    public abstract class StateMachineGenerator
+    {
+        protected readonly AdjacencyGraph<Vertex, Edge<Vertex>> Graph;
+
+        public StateMachineGenerator(StateMachineGraph data)
+        {
+            Graph = CreateAdjacencyGraph(data);
+        }
+
+        private static AdjacencyGraph<Vertex, Edge<Vertex>> CreateAdjacencyGraph(StateMachineGraph data)
+        {
+            var graph = new AdjacencyGraph<Vertex, Edge<Vertex>>();
+
+            List<Vertex> compositeTargets = data.Edges.Where(x => x.From.IsComposite).Select(x => x.To).ToList();
+
+            List<Vertex> targets = data.Edges.Select(x => x.To).ToList();
+            List<Vertex> vertices = data.Vertices.Where(v => targets.Contains(v) || v.Title == "Initial").ToList();
+            List<Edge> edges = data.Edges.Where(x => vertices.Contains(x.From) && !compositeTargets.Contains(x.From)).ToList();
+
+            graph.AddVertexRange(vertices);
+            graph.AddEdgeRange(edges.Select(x => new Edge<Vertex>(x.From, x.To)));
+
+            return graph;
+        }
+    }
+}

--- a/src/MassTransit.StateMachineVisualizer/StateMachineGraphvizGenerator.cs
+++ b/src/MassTransit.StateMachineVisualizer/StateMachineGraphvizGenerator.cs
@@ -1,27 +1,22 @@
 ﻿namespace MassTransit.Visualizer
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Internals;
+    using MassTransit.Visualizer.Abstractions;
     using QuikGraph;
     using QuikGraph.Graphviz;
     using QuikGraph.Graphviz.Dot;
     using SagaStateMachine;
 
-
-    public class StateMachineGraphvizGenerator
+    public class StateMachineGraphvizGenerator : StateMachineGenerator
     {
-        readonly AdjacencyGraph<Vertex, Edge<Vertex>> _graph;
-
-        public StateMachineGraphvizGenerator(StateMachineGraph data)
+        public StateMachineGraphvizGenerator(StateMachineGraph data) : base(data)
         {
-            _graph = CreateAdjacencyGraph(data);
         }
 
         public string CreateDotFile()
         {
-            var algorithm = new GraphvizAlgorithm<Vertex, Edge<Vertex>>(_graph);
+            var algorithm = new GraphvizAlgorithm<Vertex, Edge<Vertex>>(Graph);
             algorithm.FormatVertex += VertexStyler;
             return algorithm.Generate();
         }
@@ -63,21 +58,6 @@
 
                 args.VertexFormat.Shape = GraphvizVertexShape.Ellipse;
             }
-        }
-
-        static AdjacencyGraph<Vertex, Edge<Vertex>> CreateAdjacencyGraph(StateMachineGraph data)
-        {
-            var graph = new AdjacencyGraph<Vertex, Edge<Vertex>>();
-
-            List<Vertex> compositeTargets = data.Edges.Where(x => x.From.IsComposite).Select(x => x.To).ToList();
-
-            List<Vertex> targets = data.Edges.Select(x => x.To).ToList();
-            List<Vertex> vertices = data.Vertices.Where(v => targets.Contains(v) || v.Title == "Initial").ToList();
-            List<Edge> edges = data.Edges.Where(x => vertices.Contains(x.From) && !compositeTargets.Contains(x.From)).ToList();
-
-            graph.AddVertexRange(vertices);
-            graph.AddEdgeRange(edges.Select(x => new Edge<Vertex>(x.From, x.To)));
-            return graph;
         }
     }
 }

--- a/src/MassTransit.StateMachineVisualizer/StateMachineMermaidGenerator.cs
+++ b/src/MassTransit.StateMachineVisualizer/StateMachineMermaidGenerator.cs
@@ -29,7 +29,7 @@
             {
                 string source = FormatVertex(edge.Source, vertices);
                 string target = FormatVertex(edge.Target, vertices);
-                string line = $"{Environment.NewLine}    {source} --> {target}";
+                string line = $"{Environment.NewLine}    {source} --> {target};";
 
                 output.Append(line);
             }

--- a/src/MassTransit.StateMachineVisualizer/StateMachineMermaidGenerator.cs
+++ b/src/MassTransit.StateMachineVisualizer/StateMachineMermaidGenerator.cs
@@ -1,0 +1,70 @@
+﻿namespace MassTransit.Visualizer
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using Internals;
+    using MassTransit.SagaStateMachine;
+    using MassTransit.Visualizer.Abstractions;
+    using QuikGraph;
+
+    public class StateMachineMermaidGenerator : StateMachineGenerator
+    {
+        const string OpenBracket = "«";
+        const string CloseBracket = "»";
+
+        public StateMachineMermaidGenerator(StateMachineGraph data) : base(data)
+        {
+        }
+
+        public string CreateMermaidFile()
+        {
+            StringBuilder output = new();
+            List<Vertex> vertices = Graph.Vertices.ToList();
+
+            output.Append("flowchart TB;");
+
+            foreach (Edge<Vertex> edge in Graph.Edges)
+            {
+                string source = FormatVertex(edge.Source, vertices);
+                string target = FormatVertex(edge.Target, vertices);
+                string line = $"{Environment.NewLine}    {source} --> {target}";
+
+                output.Append(line);
+            }
+
+            return output.ToString();
+        }
+
+        static string GetVertexLabel(Vertex vertex, bool includeOptionalType)
+        {
+            if (includeOptionalType && vertex.TargetType != typeof(Event) && vertex.TargetType != typeof(Exception))
+            {
+                if (vertex.TargetType.ClosesType(typeof(Fault<>), out Type[] arguments))
+                    return $"{vertex.Title}{OpenBracket}{arguments[0].Name}{CloseBracket}";
+
+                return $"{vertex.Title}{OpenBracket}{vertex.TargetType.Name}{CloseBracket}";
+            }
+
+            return vertex.Title;
+        }
+
+        static string FormatVertex(Vertex vertex, List<Vertex> vertices)
+        {
+            int index = vertices.IndexOf(vertex);
+
+            if (vertex.VertexType == typeof(Event))
+            {
+                string vertexLabel = GetVertexLabel(vertex, true);
+
+                if (vertex.IsComposite)
+                    return $"{index}[\\\"{vertexLabel}\"/])";
+
+                return $"{index}[\"{vertexLabel}\"]";
+            }
+
+            return $"{index}([\"{GetVertexLabel(vertex, false)}\"])";
+        }
+    }
+}

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
@@ -104,18 +104,18 @@
 }";
 
         const string ExpectedMermaidFile = @"flowchart TB;
-    0([""Initial""]) --> 5[""Initialized""]
-    1([""Running""]) --> 7[""Finished""]
-    1([""Running""]) --> 8[""Suspend""]
-    2([""Failed""]) --> 10[""Restart«RestartData»""]
-    4([""Suspended""]) --> 9[""Resume""]
-    5[""Initialized""] --> 1([""Running""])
-    5[""Initialized""] --> 6[""Exception""]
-    6[""Exception""] --> 2([""Failed""])
-    7[""Finished""] --> 3([""Final""])
-    8[""Suspend""] --> 4([""Suspended""])
-    9[""Resume""] --> 1([""Running""])
-    10[""Restart«RestartData»""] --> 1([""Running""])";
+    0([""Initial""]) --> 5[""Initialized""];
+    1([""Running""]) --> 7[""Finished""];
+    1([""Running""]) --> 8[""Suspend""];
+    2([""Failed""]) --> 10[""Restart«RestartData»""];
+    4([""Suspended""]) --> 9[""Resume""];
+    5[""Initialized""] --> 1([""Running""]);
+    5[""Initialized""] --> 6[""Exception""];
+    6[""Exception""] --> 2([""Failed""]);
+    7[""Finished""] --> 3([""Final""]);
+    8[""Suspend""] --> 4([""Suspended""]);
+    9[""Resume""] --> 1([""Running""]);
+    10[""Restart«RestartData»""] --> 1([""Running""]);";
 
 
         class Instance :

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
@@ -16,17 +16,31 @@
         }
 
         [Test]
-        public void Should_show_the_goods()
+        public void Should_show_graphviz_output()
         {
             var generator = new StateMachineGraphvizGenerator(_graph);
 
-            string dots = generator.CreateDotFile();
+            string output = generator.CreateDotFile();
 
-            Console.WriteLine(dots);
+            Console.WriteLine(output);
 
-            var expected = Expected.Replace("\r", "").Replace("\n", Environment.NewLine);
+            var expected = ExpectedGraphvizFile.Replace("\r", "").Replace("\n", Environment.NewLine);
 
-            Assert.AreEqual(expected, dots);
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void Should_show_mermaid_output()
+        {
+            var generator = new StateMachineMermaidGenerator(_graph);
+
+            string output = generator.CreateMermaidFile();
+
+            Console.WriteLine(output);
+
+            var expected = ExpectedMermaidFile.Replace("\r", "").Replace("\n", Environment.NewLine);
+
+            Assert.AreEqual(expected, output);
         }
 
         StateMachine<Instance> _machine;
@@ -63,7 +77,7 @@
             _graph = _machine.GetGraph();
         }
 
-        const string Expected = @"digraph G {
+        const string ExpectedGraphvizFile = @"digraph G {
 0 [shape=ellipse, label=""Initial""];
 1 [shape=ellipse, label=""Running""];
 2 [shape=ellipse, label=""Failed""];
@@ -88,6 +102,20 @@
 9 -> 1;
 10 -> 1;
 }";
+
+        const string ExpectedMermaidFile = @"flowchart TB;
+    0([""Initial""]) --> 5[""Initialized""]
+    1([""Running""]) --> 7[""Finished""]
+    1([""Running""]) --> 8[""Suspend""]
+    2([""Failed""]) --> 10[""Restart«RestartData»""]
+    4([""Suspended""]) --> 9[""Resume""]
+    5[""Initialized""] --> 1([""Running""])
+    5[""Initialized""] --> 6[""Exception""]
+    6[""Exception""] --> 2([""Failed""])
+    7[""Finished""] --> 3([""Final""])
+    8[""Suspend""] --> 4([""Suspended""])
+    9[""Resume""] --> 1([""Running""])
+    10[""Restart«RestartData»""] --> 1([""Running""])";
 
 
         class Instance :


### PR DESCRIPTION
This PR adds a Mermaid StateMachine visualizer, follow the existing code style as close as possible :)

As opposed to the DOT format from Graphviz, Mermaid graphs can be rendered natively on the web, including in GIthub.

https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/
https://mermaid.js.org/syntax/flowchart.html

The implementation is made to look and feel as close as possible to the existing DOT visualization.

One caveat with the implementation is the Mermaid flowchart not supporting <> that well. Using eg. _\&lt;_ instead would normally work, but the Github Mermaid renderer pipeline ignores that, so as a compromise, it's using « and » instead.

Mermaid graph example
```mermaid
flowchart TB;
    0(["Initial"]) --> 5["Initialized"]
    1(["Running"]) --> 7["Finished"]
    1(["Running"]) --> 8["Suspend"]
    2(["Failed"]) --> 10["Restart«RestartData»"]
    4(["Suspended"]) --> 9["Resume"]
    5["Initialized"] --> 1(["Running"])
    5["Initialized"] --> 6["Exception"]
    6["Exception"] --> 2(["Failed"])
    7["Finished"] --> 3(["Final"])
    8["Suspend"] --> 4(["Suspended"])
    9["Resume"] --> 1(["Running"])
    10["Restart«RestartData»"] --> 1(["Running"])
```