### PR TITLE
Fixed "Submitted policy is over max allowed size" exception

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/ConfigureAmazonSqsTopologyFilter.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/ConfigureAmazonSqsTopologyFilter.cs
@@ -72,7 +72,11 @@ public class ConfigureAmazonSqsTopologyFilter<TSettings> :
         await Task.WhenAll(queues).ConfigureAwait(false);
 
         IEnumerable<Task> subscriptions = _brokerTopology.QueueSubscriptions.Select(subscription => Declare(context, subscription));
-        await Task.WhenAll(subscriptions).ConfigureAwait(false);
+
+        foreach (var subscription in subscriptions)
+        {
+            await subscription.ConfigureAwait(false);
+        }
     }
 
     bool AnyAutoDelete()


### PR DESCRIPTION
In the following PR  https://github.com/MassTransit/MassTransit/pull/4695, was introduced a bug that makes MassTransit hit the SQS Policy max statements limit (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-policies.html)


New changes are compatible with existing policies and will create now only one statement with a single `ArnLike` condition that contains one line for each topic ARN:
`
{
    "Attributes": {
        "Policy": {
            "Version": "2012-10-17",
            "Statement": [
                {
                    "Sid": "727c7025abef408da066ef2934664280",
                    "Effect": "Allow",
                    "Principal": {
                        "Service": "sns.amazonaws.com"
                    },
                    "Action": "sqs:SendMessage",
                    "Resource": "arn:aws:sqs:us-east-1:000000000000:development-test-queue",
                    "Condition": {
                        "ArnLike": {
                            "aws:SourceArn": [
                                "arn:aws:sns:us-east-1:000000000000:development-Message1",
                                "arn:aws:sns:us-east-1:000000000000:development-Message2",
                                "arn:aws:sns:us-east-1:000000000000:development-Message3",
                                "arn:aws:sns:us-east-1:000000000000:development-<MessageN*>"
                            ]
                        }
                    }
                }
            ]
        }
    }
}`

