### PR TITLE
Made NotifyConsumed and NotifyFaulted of the ConsumeContext internal.

### DIFF
--- a/src/MassTransit.Abstractions/Contexts/ConsumeContext.cs
+++ b/src/MassTransit.Abstractions/Contexts/ConsumeContext.cs
@@ -169,7 +169,7 @@
         /// <param name="context"></param>
         /// <param name="duration"></param>
         /// <param name="consumerType">The consumer type</param>
-        Task NotifyConsumed<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType)
+        internal Task NotifyConsumed<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType)
             where T : class;
 
         /// <summary>
@@ -179,7 +179,7 @@
         /// <param name="duration"></param>
         /// <param name="consumerType">The message consumer type</param>
         /// <param name="exception">The exception that occurred</param>
-        Task NotifyFaulted<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception)
+        internal Task NotifyFaulted<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception)
             where T : class;
     }
 
@@ -195,7 +195,7 @@
         /// </summary>
         /// <param name="duration"></param>
         /// <param name="consumerType">The consumer type</param>
-        Task NotifyConsumed(TimeSpan duration, string consumerType);
+        internal Task NotifyConsumed(TimeSpan duration, string consumerType);
 
         /// <summary>
         /// Notify that a fault occurred during message consumption -- note that this is internal, and should not be called by a consumer
@@ -203,6 +203,6 @@
         /// <param name="duration"></param>
         /// <param name="consumerType"></param>
         /// <param name="exception"></param>
-        Task NotifyFaulted(TimeSpan duration, string consumerType, Exception exception);
+        internal Task NotifyFaulted(TimeSpan duration, string consumerType, Exception exception);
     }
 }

--- a/src/MassTransit.Abstractions/MassTransit.Abstractions.csproj
+++ b/src/MassTransit.Abstractions/MassTransit.Abstractions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../signing.props" />
 
   <PropertyGroup>
@@ -25,6 +25,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MassTransit" />
+    <InternalsVisibleTo Include="MassTransit.Tests" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The methods NotifyConsumed and NotifyFaulted of the ConsumeContext interface are made internal. 
Like the note in the code doc suggests. As C# supports declaring methods in interfaces as internal we should use this feature and not rely on the developer reading docs and acting like they are told. 😉

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
