### PR TITLE
Update docs for ServiceBusBusFactoryConfiguratorExtensions.ReceiveEndpoint

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/ServiceBusBusFactoryConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/ServiceBusBusFactoryConfiguratorExtensions.cs
@@ -105,9 +105,7 @@
         }
 
         /// <summary>
-        /// Declare a ReceiveEndpoint using a unique generated queue name. This queue defaults to auto-delete
-        /// and non-durable. By default all services bus instances include a default receiveEndpoint that is
-        /// of this type (created automatically upon the first receiver binding).
+        /// Declare a ReceiveEndpoint using the name from the endpoint definition.
         /// </summary>
         /// <param name="configurator"></param>
         /// <param name="definition"></param>


### PR DESCRIPTION
The documentation for the overload accepting an `IEndpointDefinition` is a bit confusing, since there is no "default" behavior. It depends on the kind of `IEndpointDefinition` passed. This phrasing is just a suggestion, I am open to improvements.