### PR TITLE
Configure the cancellation timeout for the IJobConsumer

### DIFF
--- a/src/MassTransit/Configuration/JobOptions.cs
+++ b/src/MassTransit/Configuration/JobOptions.cs
@@ -20,6 +20,7 @@ namespace MassTransit
         {
             ConcurrentJobLimit = 1;
             JobTimeout = TimeSpan.FromMinutes(5);
+            JobCancellationTimeout = TimeSpan.FromSeconds(30);
 
             RetryPolicy = Retry.None;
         }
@@ -28,6 +29,11 @@ namespace MassTransit
         /// Set the allowed time for a job to complete (per attempt). If the job timeout expires and the job has not yet completed, it will be canceled.
         /// </summary>
         public TimeSpan JobTimeout { get; set; }
+
+        /// <summary>
+        /// Set the allowed time for a job to stop execution after the cancellation. If the job cancellation timeout expires and the job has not yet completed, it will be fully canceled.
+        /// </summary>
+        public TimeSpan JobCancellationTimeout { get; set; }
 
         /// <summary>
         /// Set the concurrent job limit. The limit is applied to each instance if the job consumer is scaled out.
@@ -48,6 +54,8 @@ namespace MassTransit
                 yield return this.Failure("JobOptions", "ConcurrentJobLimit", "Must be > 0");
             if (JobTimeout <= TimeSpan.Zero)
                 yield return this.Failure("JobOptions", "JobTimeout", "Must be > TimeSpan.Zero");
+            if (JobCancellationTimeout <= TimeSpan.Zero)
+                yield return this.Failure("JobOptions", "JobCancellationTimeout", "Must be > TimeSpan.Zero");
         }
 
         /// <summary>
@@ -58,6 +66,18 @@ namespace MassTransit
         public JobOptions<TJob> SetJobTimeout(TimeSpan timeout)
         {
             JobTimeout = timeout;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Set the allowed time for a job to stop execution after the cancellation. If the job cancellation timeout expires and the job has not yet completed, it will be fully canceled.
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <returns></returns>
+        public JobOptions<TJob> SetJobCancellationTimeout(TimeSpan timeout)
+        {
+            JobCancellationTimeout = timeout;
 
             return this;
         }

--- a/src/MassTransit/JobService/JobService/ConsumerJobHandle.cs
+++ b/src/MassTransit/JobService/JobService/ConsumerJobHandle.cs
@@ -10,10 +10,12 @@
         where T : class
     {
         readonly ConsumeJobContext<T> _context;
+        readonly TimeSpan _jobCancellationTimeout;
 
-        public ConsumerJobHandle(ConsumeJobContext<T> context, Task task)
+        public ConsumerJobHandle(ConsumeJobContext<T> context, Task task, TimeSpan jobCancellationTimeout)
         {
             _context = context;
+            _jobCancellationTimeout = jobCancellationTimeout;
             JobTask = task;
         }
 
@@ -29,7 +31,7 @@
 
             try
             {
-                await JobTask.OrTimeout(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+                await JobTask.OrTimeout(_jobCancellationTimeout).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/MassTransit/JobService/JobService/IJobService.cs
+++ b/src/MassTransit/JobService/JobService/IJobService.cs
@@ -19,8 +19,9 @@
         /// <param name="job">The job command</param>
         /// <param name="jobPipe">The pipe which executes the job</param>
         /// <param name="timeout">The job timeout, after which the job is cancelled</param>
+        /// <param name="cancellationTimeout">The job cancellation timeout, after which the job is fully cancelled</param>
         /// <returns>The newly created job's handle</returns>
-        Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, TimeSpan timeout)
+        Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, TimeSpan timeout, TimeSpan cancellationTimeout)
             where T : class;
 
         /// <summary>

--- a/src/MassTransit/JobService/JobService/IJobService.cs
+++ b/src/MassTransit/JobService/JobService/IJobService.cs
@@ -18,10 +18,9 @@
         /// <param name="context">The context of the message being consumed</param>
         /// <param name="job">The job command</param>
         /// <param name="jobPipe">The pipe which executes the job</param>
-        /// <param name="timeout">The job timeout, after which the job is cancelled</param>
-        /// <param name="cancellationTimeout">The job cancellation timeout, after which the job is fully cancelled</param>
+        /// <param name="jobOptions">The job options</param>
         /// <returns>The newly created job's handle</returns>
-        Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, TimeSpan timeout, TimeSpan cancellationTimeout)
+        Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, JobOptions<T> jobOptions)
             where T : class;
 
         /// <summary>

--- a/src/MassTransit/JobService/JobService/JobService.cs
+++ b/src/MassTransit/JobService/JobService/JobService.cs
@@ -48,7 +48,7 @@
             return false;
         }
 
-        public async Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, TimeSpan timeout, TimeSpan cancellationTimeout)
+        public async Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, JobOptions<T> jobOptions)
             where T : class
         {
             var startJob = context.Message;
@@ -56,14 +56,14 @@
             if (_jobs.ContainsKey(startJob.JobId))
                 throw new JobAlreadyExistsException(startJob.JobId);
 
-            var jobContext = new ConsumeJobContext<T>(context, InstanceAddress, startJob.JobId, startJob.AttemptId, startJob.RetryAttempt, job, timeout);
+            var jobContext = new ConsumeJobContext<T>(context, InstanceAddress, startJob.JobId, startJob.AttemptId, startJob.RetryAttempt, job, jobOptions.JobTimeout);
 
             LogContext.Debug?.Log("Executing job: {JobType} {JobId} ({RetryAttempt})", TypeCache<T>.ShortName, startJob.JobId,
                 startJob.RetryAttempt);
 
             var jobTask = jobPipe.Send(jobContext);
 
-            var jobHandle = new ConsumerJobHandle<T>(jobContext, jobTask, cancellationTimeout);
+            var jobHandle = new ConsumerJobHandle<T>(jobContext, jobTask, jobOptions.JobCancellationTimeout);
 
             Add(jobHandle);
 

--- a/src/MassTransit/JobService/JobService/JobService.cs
+++ b/src/MassTransit/JobService/JobService/JobService.cs
@@ -48,7 +48,7 @@
             return false;
         }
 
-        public async Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, TimeSpan timeout)
+        public async Task<JobHandle> StartJob<T>(ConsumeContext<StartJob> context, T job, IPipe<ConsumeContext<T>> jobPipe, TimeSpan timeout, TimeSpan cancellationTimeout)
             where T : class
         {
             var startJob = context.Message;
@@ -63,7 +63,7 @@
 
             var jobTask = jobPipe.Send(jobContext);
 
-            var jobHandle = new ConsumerJobHandle<T>(jobContext, jobTask);
+            var jobHandle = new ConsumerJobHandle<T>(jobContext, jobTask, cancellationTimeout);
 
             Add(jobHandle);
 

--- a/src/MassTransit/JobService/JobService/StartJobConsumer.cs
+++ b/src/MassTransit/JobService/JobService/StartJobConsumer.cs
@@ -30,7 +30,7 @@ namespace MassTransit.JobService
 
             var job = context.GetJob<TJob>() ?? throw new SerializationException($"The job could not be deserialized: {TypeCache<TJob>.ShortName}");
 
-            await _jobService.StartJob(context, job, _jobPipe, _options.JobTimeout, _options.JobCancellationTimeout);
+            await _jobService.StartJob(context, job, _jobPipe, _options);
             await context.Publish<JobStarted<TJob>>(context.Message);
         }
     }

--- a/src/MassTransit/JobService/JobService/StartJobConsumer.cs
+++ b/src/MassTransit/JobService/JobService/StartJobConsumer.cs
@@ -30,7 +30,7 @@ namespace MassTransit.JobService
 
             var job = context.GetJob<TJob>() ?? throw new SerializationException($"The job could not be deserialized: {TypeCache<TJob>.ShortName}");
 
-            await _jobService.StartJob(context, job, _jobPipe, _options.JobTimeout);
+            await _jobService.StartJob(context, job, _jobPipe, _options.JobTimeout, _options.JobCancellationTimeout);
             await context.Publish<JobStarted<TJob>>(context.Message);
         }
     }


### PR DESCRIPTION
Add a possibility to configure the timeout within which the long-running job consumer can be fully cancelled or the current work finished. Previously it was hard coded as 30 seconds.


