### PR TITLE
SQL Transport DbExists, support Azure SQL

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
@@ -9,7 +9,7 @@ namespace MassTransit.SqlTransport.SqlServer
     public class SqlServerDatabaseMigrator :
         ISqlTransportDatabaseMigrator
     {
-        const string DbExistsSql = @"SELECT DB_ID('{0}')";
+        const string DbExistsSql = @"SELECT [database_id] from [sys].[databases] WHERE name = '{0}'";
         const string DbCreateSql = @"CREATE DATABASE {0}";
 
         const string SchemaCreateSql = @"USE {0};


### PR DESCRIPTION
In [SqlServerDatabaseMigrator.CreateDatabaseIfNotExist](https://github.com/MassTransit/MassTransit/blob/2ac69e8c877c9f255cc4eb047c4830898f78711b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs#L1354) the SQL connection is made by connecting to the `master` database with [SqlServerSqlTransportConnection.GetSystemDatabaseConnection](https://github.com/MassTransit/MassTransit/blob/2ac69e8c877c9f255cc4eb047c4830898f78711b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerSqlTransportConnection.cs#L49).

When then checking for the existence of the database with [SqlServerDatabaseMigrator.DbExistsSql](https://github.com/MassTransit/MassTransit/blob/2ac69e8c877c9f255cc4eb047c4830898f78711b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs#L12) using `SELECT DB_ID('{0}')` we will always get a `null` response because `DB_ID` [only works for the current database in Azure SQL Database](https://learn.microsoft.com/en-us/sql/t-sql/functions/db-id-transact-sql?view=sql-server-ver16#remarks).

> `DB_ID` may only be used to return the database identifier of the current database in Azure SQL Database. NULL is returned if the specified database name is other than the current database.

