### PR TITLE
Make it possible to run only the infrastructure migrations for the SQL Transport

### DIFF
--- a/src/MassTransit/SqlTransport/Configuration/SqlTransportMigrationOptions.cs
+++ b/src/MassTransit/SqlTransport/Configuration/SqlTransportMigrationOptions.cs
@@ -8,6 +8,13 @@ namespace MassTransit
         public bool CreateDatabase { get; set; }
 
         /// <summary>
+        /// If true, the infrastructure components for the transport will be created/updated on startup
+        ///
+        /// Use this, without CreateDatabase, if you do not have the required permissions to create databases and logins
+        /// </summary>
+        public bool CreateInfrastructure { get; set; }
+
+        /// <summary>
         /// If true, the database and all transport components will be deleted on shutdown
         /// </summary>
         public bool DeleteDatabase { get; set; }

--- a/src/MassTransit/SqlTransport/SqlTransport/ISqlTransportDatabaseMigrator.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/ISqlTransportDatabaseMigrator.cs
@@ -7,6 +7,7 @@ namespace MassTransit.SqlTransport
     public interface ISqlTransportDatabaseMigrator
     {
         Task CreateDatabase(SqlTransportOptions options, CancellationToken cancellationToken = default);
+        Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken = default);
         Task DeleteDatabase(SqlTransportOptions options, CancellationToken cancellationToken = default);
     }
 }

--- a/src/MassTransit/SqlTransport/SqlTransport/SqlTransportMigrationHostedService.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/SqlTransportMigrationHostedService.cs
@@ -29,9 +29,16 @@ namespace MassTransit.SqlTransport
         {
             if (_options.CreateDatabase)
             {
-                _logger.LogInformation("MassTransit DbTransport creating PostgreSQL database {Database}", _transportOptions.Database);
+                _logger.LogInformation("MassTransit DbTransport creating database {Database}", _transportOptions.Database);
 
                 await _migrator.CreateDatabase(_transportOptions, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (_options.CreateInfrastructure)
+            {
+                _logger.LogInformation("MassTransit DbTransport creating infrastructure for database {Database}", _transportOptions.Database);
+
+                await _migrator.CreateInfrastructure(_transportOptions, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -39,7 +46,7 @@ namespace MassTransit.SqlTransport
         {
             if (_options.DeleteDatabase)
             {
-                _logger.LogInformation("Deleting PostgreSQL Database {Database}", _transportOptions.Database);
+                _logger.LogInformation("Deleting Database {Database}", _transportOptions.Database);
 
                 await _migrator.DeleteDatabase(_transportOptions, cancellationToken).ConfigureAwait(false);
             }

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
@@ -10,17 +10,12 @@ namespace MassTransit
     {
         public static IServiceCollection AddPostgresMigrationHostedService(this IServiceCollection services, bool create = true, bool delete = false)
         {
-            services.AddTransient<ISqlTransportDatabaseMigrator, PostgresDatabaseMigrator>();
-
-            services.AddOptions<SqlTransportOptions>();
-            services.AddOptions<SqlTransportMigrationOptions>()
-                .Configure(options =>
-                {
-                    options.CreateDatabase = create;
-                    options.DeleteDatabase = delete;
-                    options.CreateInfrastructure = create;
-                });
-            services.AddHostedService<SqlTransportMigrationHostedService>();
+            services.AddPostgresMigrationHostedService(options =>
+            {
+                options.CreateDatabase = create;
+                options.DeleteDatabase = delete;
+                options.CreateInfrastructure = create;
+            });
 
             return services;
         }

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 namespace MassTransit
 {
+    using System;
     using Microsoft.Extensions.DependencyInjection;
     using SqlTransport;
     using SqlTransport.PostgreSql;
@@ -7,7 +8,7 @@ namespace MassTransit
 
     public static class PostgresSqlTransportConfigurationExtensions
     {
-        public static IServiceCollection AddPostgresMigrationHostedService(this IServiceCollection services, bool createDatabase = true, bool delete = false, bool createInfrastructure = true)
+        public static IServiceCollection AddPostgresMigrationHostedService(this IServiceCollection services, bool create = true, bool delete = false)
         {
             services.AddTransient<ISqlTransportDatabaseMigrator, PostgresDatabaseMigrator>();
 
@@ -15,10 +16,22 @@ namespace MassTransit
             services.AddOptions<SqlTransportMigrationOptions>()
                 .Configure(options =>
                 {
-                    options.CreateDatabase = createDatabase;
-                    options.CreateInfrastructure = createInfrastructure;
+                    options.CreateDatabase = create;
                     options.DeleteDatabase = delete;
+                    options.CreateInfrastructure = create;
                 });
+            services.AddHostedService<SqlTransportMigrationHostedService>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddPostgresMigrationHostedService(this IServiceCollection services, Action<SqlTransportMigrationOptions> options)
+        {
+            services.AddTransient<ISqlTransportDatabaseMigrator, PostgresDatabaseMigrator>();
+
+            services.AddOptions<SqlTransportOptions>();
+            services.AddOptions<SqlTransportMigrationOptions>()
+                .Configure(options);
             services.AddHostedService<SqlTransportMigrationHostedService>();
 
             return services;

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
@@ -7,7 +7,7 @@ namespace MassTransit
 
     public static class PostgresSqlTransportConfigurationExtensions
     {
-        public static IServiceCollection AddPostgresMigrationHostedService(this IServiceCollection services, bool create = true, bool delete = false)
+        public static IServiceCollection AddPostgresMigrationHostedService(this IServiceCollection services, bool createDatabase = true, bool delete = false, bool createInfrastructure = true)
         {
             services.AddTransient<ISqlTransportDatabaseMigrator, PostgresDatabaseMigrator>();
 
@@ -15,7 +15,8 @@ namespace MassTransit
             services.AddOptions<SqlTransportMigrationOptions>()
                 .Configure(options =>
                 {
-                    options.CreateDatabase = create;
+                    options.CreateDatabase = createDatabase;
+                    options.CreateInfrastructure = createInfrastructure;
                     options.DeleteDatabase = delete;
                 });
             services.AddHostedService<SqlTransportMigrationHostedService>();

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
@@ -974,8 +974,6 @@ namespace MassTransit.SqlTransport.PostgreSql
             await CreateDatabaseIfNotExist(options, cancellationToken);
 
             await CreateSchemaIfNotExist(options, cancellationToken);
-
-            await CreateInfrastructure(options, cancellationToken);
         }
 
         public async Task DeleteDatabase(SqlTransportOptions options, CancellationToken cancellationToken = default)
@@ -1034,7 +1032,7 @@ namespace MassTransit.SqlTransport.PostgreSql
             }
         }
 
-        async Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken)
+        public async Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken)
         {
             await using var connection = PostgresSqlTransportConnection.GetDatabaseConnection(options);
             await connection.Open(cancellationToken);

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 namespace MassTransit
 {
+    using System;
     using Microsoft.Extensions.DependencyInjection;
     using SqlTransport;
     using SqlTransport.SqlServer;
@@ -7,7 +8,7 @@ namespace MassTransit
 
     public static class SqlServerDbTransportConfigurationExtensions
     {
-        public static IServiceCollection AddSqlServerMigrationHostedService(this IServiceCollection services, bool createDatabase = true, bool delete = false, bool createInfrastructure = true)
+        public static IServiceCollection AddSqlServerMigrationHostedService(this IServiceCollection services, bool create = true, bool delete = false)
         {
             services.AddTransient<ISqlTransportDatabaseMigrator, SqlServerDatabaseMigrator>();
 
@@ -15,10 +16,22 @@ namespace MassTransit
             services.AddOptions<SqlTransportMigrationOptions>()
                 .Configure(options =>
                 {
-                    options.CreateDatabase = createDatabase;
-                    options.CreateInfrastructure = createInfrastructure;
+                    options.CreateDatabase = create;
                     options.DeleteDatabase = delete;
+                    options.CreateInfrastructure = create;
                 });
+            services.AddHostedService<SqlTransportMigrationHostedService>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddSqlServerMigrationHostedService(this IServiceCollection services, Action<SqlTransportMigrationOptions> options)
+        {
+            services.AddTransient<ISqlTransportDatabaseMigrator, SqlServerDatabaseMigrator>();
+
+            services.AddOptions<SqlTransportOptions>();
+            services.AddOptions<SqlTransportMigrationOptions>()
+                .Configure(options);
             services.AddHostedService<SqlTransportMigrationHostedService>();
 
             return services;

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
@@ -10,17 +10,12 @@ namespace MassTransit
     {
         public static IServiceCollection AddSqlServerMigrationHostedService(this IServiceCollection services, bool create = true, bool delete = false)
         {
-            services.AddTransient<ISqlTransportDatabaseMigrator, SqlServerDatabaseMigrator>();
-
-            services.AddOptions<SqlTransportOptions>();
-            services.AddOptions<SqlTransportMigrationOptions>()
-                .Configure(options =>
-                {
-                    options.CreateDatabase = create;
-                    options.DeleteDatabase = delete;
-                    options.CreateInfrastructure = create;
-                });
-            services.AddHostedService<SqlTransportMigrationHostedService>();
+            services.AddSqlServerMigrationHostedService(options =>
+            {
+                options.CreateDatabase = create;
+                options.DeleteDatabase = delete;
+                options.CreateInfrastructure = create;
+            });
 
             return services;
         }

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
@@ -7,7 +7,7 @@ namespace MassTransit
 
     public static class SqlServerDbTransportConfigurationExtensions
     {
-        public static IServiceCollection AddSqlServerMigrationHostedService(this IServiceCollection services, bool create = true, bool delete = false)
+        public static IServiceCollection AddSqlServerMigrationHostedService(this IServiceCollection services, bool createDatabase = true, bool delete = false, bool createInfrastructure = true)
         {
             services.AddTransient<ISqlTransportDatabaseMigrator, SqlServerDatabaseMigrator>();
 
@@ -15,7 +15,8 @@ namespace MassTransit
             services.AddOptions<SqlTransportMigrationOptions>()
                 .Configure(options =>
                 {
-                    options.CreateDatabase = create;
+                    options.CreateDatabase = createDatabase;
+                    options.CreateInfrastructure = createInfrastructure;
                     options.DeleteDatabase = delete;
                 });
             services.AddHostedService<SqlTransportMigrationHostedService>();

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
@@ -1333,8 +1333,6 @@ END
             await CreateDatabaseIfNotExist(options, cancellationToken);
 
             await CreateSchemaIfNotExist(options, cancellationToken);
-
-            await CreateInfrastructure(options, cancellationToken);
         }
 
         public async Task DeleteDatabase(SqlTransportOptions options, CancellationToken cancellationToken)
@@ -1393,7 +1391,7 @@ END
             }
         }
 
-        async Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken)
+        public async Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken)
         {
             await using var connection = SqlServerSqlTransportConnection.GetDatabaseConnection(options);
             await connection.Open(cancellationToken);


### PR DESCRIPTION
This pull request adds an option of only running the infrastructure migrations when utilizing `AddSqlServerMigrationHostedService` or `AddPostgresMigrationHostedService`.

This will support the scenario where the application using MassTransit and the SQL transport does not have system or admin level access to the database.

Concretely we have a production setup where we have created a dedicated database for MassTransit and also created the login, user, schema and role by hand. While all of this is simple for us to do ourselves, we would like to let MassTransit handle the creation of the infrastructure as this a lot more complex.

**Possible backwards compatibility issue**

If anyone has used

```
services.AddSqlServerMigrationHostedService(false, false);
```

they will now experience that the infrastructure migrations run on startup. I don't know why anyone would have done that though.