### PR TITLE
Trim and simplify package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,6 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" Condition="'$(TargetFramework)' == 'net7.0'"/>
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
     <PackageVersion Include="MongoDB.Driver" Version="2.24.0"/>
     <PackageVersion Include="MongoDB.Driver.GridFS" Version="2.24.0"/>
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
@@ -102,19 +101,16 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.7.33"/>
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6"/>
     <PackageVersion Include="System.Data.SQLite" Version="1.0.118"/>
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net8.0'"/>
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.1" Condition="'$(TargetFramework)' == 'net7.0'"/>
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'"/>
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'net472'"/>
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0"/>
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0"/>
-    <PackageVersion Include="System.Text.Json" Version="6.0.8" Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net8.0'"/>
-    <PackageVersion Include="System.Text.Json" Version="7.0.3" Condition="'$(TargetFramework)' == 'net7.0'"/>
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'"/>
-    <PackageVersion Include="System.Threading.Channels" Version="6.0.0" Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net8.0'"/>
-    <PackageVersion Include="System.Threading.Channels" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'"/>
-    <PackageVersion Include="System.Threading.Channels" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'"/>
+    <PackageVersion Include="System.Text.Json" Version="6.0.8" />
+    <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
     <PackageVersion Include="System.ValueTuple" Version="4.5.0"/>
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/MassTransit.Abstractions/MassTransit.Abstractions.csproj
+++ b/src/MassTransit.Abstractions/MassTransit.Abstractions.csproj
@@ -24,10 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Futures\Futures"/>
   </ItemGroup>
 </Project>

--- a/src/MassTransit.Interop.NServiceBus/MassTransit.Interop.NServiceBus.csproj
+++ b/src/MassTransit.Interop.NServiceBus/MassTransit.Interop.NServiceBus.csproj
@@ -17,10 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>

--- a/src/MassTransit.Newtonsoft/MassTransit.Newtonsoft.csproj
+++ b/src/MassTransit.Newtonsoft/MassTransit.Newtonsoft.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Newtonsoft.Json.Bson" />
   </ItemGroup>

--- a/src/MassTransit.SignalR/MassTransit.SignalR.csproj
+++ b/src/MassTransit.SignalR/MassTransit.SignalR.csproj
@@ -23,10 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/MassTransit.StateMachineVisualizer/MassTransit.StateMachineVisualizer.csproj
+++ b/src/MassTransit.StateMachineVisualizer/MassTransit.StateMachineVisualizer.csproj
@@ -19,7 +19,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="QuikGraph" />
     <PackageReference Include="QuikGraph.Graphviz" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />

--- a/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
+++ b/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
@@ -17,7 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="NUnit" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../signing.props"/>
+  <Import Project="../../signing.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
@@ -15,31 +15,30 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Transactions"/>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
-    <PackageReference Include="System.Threading.Tasks.Extensions"/>
+    <Reference Include="System.Transactions" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
-    <PackageReference Include="System.Reflection.Emit.Lightweight"/>
-    <PackageReference Include="System.Reflection.Emit"/>
-    <PackageReference Include="System.Threading.Tasks.Extensions"/>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" />
+    <PackageReference Include="System.Reflection.Emit" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
-    <PackageReference Include="Microsoft.Extensions.Options"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource"/>
-    <PackageReference Include="System.Text.Json"/>
-    <PackageReference Include="System.Threading.Channels"/>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
+    <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
+    <PackageReference Include="System.Threading.Channels" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MassTransit.Abstractions\MassTransit.Abstractions.csproj"/>
+    <ProjectReference Include="..\MassTransit.Abstractions\MassTransit.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MassTransit/MassTransit.csproj
+++ b/src/MassTransit/MassTransit.csproj
@@ -33,9 +33,12 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
-    <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
-    <PackageReference Include="System.Threading.Channels" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Persistence/MassTransit.AmazonS3/MassTransit.AmazonS3.csproj
+++ b/src/Persistence/MassTransit.AmazonS3/MassTransit.AmazonS3.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Persistence/MassTransit.Azure.Cosmos/MassTransit.Azure.Cosmos.csproj
+++ b/src/Persistence/MassTransit.Azure.Cosmos/MassTransit.Azure.Cosmos.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
   </ItemGroup>

--- a/src/Persistence/MassTransit.Azure.Storage/MassTransit.Azure.Storage.csproj
+++ b/src/Persistence/MassTransit.Azure.Storage/MassTransit.Azure.Storage.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Persistence/MassTransit.DapperIntegration/MassTransit.DapperIntegration.csproj
+++ b/src/Persistence/MassTransit.DapperIntegration/MassTransit.DapperIntegration.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Dapper" />
     <PackageReference Include="dapper.contrib" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Persistence/MassTransit.DynamoDbIntegration/MassTransit.DynamoDbIntegration.csproj
+++ b/src/Persistence/MassTransit.DynamoDbIntegration/MassTransit.DynamoDbIntegration.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/MassTransit.EntityFrameworkCoreIntegration.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
+++ b/src/Persistence/MassTransit.EntityFrameworkIntegration/MassTransit.EntityFrameworkIntegration.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
+++ b/src/Persistence/MassTransit.MartenIntegration/MassTransit.MartenIntegration.csproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <PackageReference Include="Marten" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" />
     <PackageReference Include="MongoDB.Driver.GridFS" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Persistence/MassTransit.NHibernateIntegration/MassTransit.NHibernateIntegration.csproj
+++ b/src/Persistence/MassTransit.NHibernateIntegration/MassTransit.NHibernateIntegration.csproj
@@ -21,10 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-        <PackageReference Include="Iesi.Collections" />
-        <PackageReference Include="NHibernate" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-        <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
+    <PackageReference Include="Iesi.Collections" />
+    <PackageReference Include="NHibernate" />
+    <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Persistence/MassTransit.RedisIntegration/MassTransit.RedisIntegration.csproj
+++ b/src/Persistence/MassTransit.RedisIntegration/MassTransit.RedisIntegration.csproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Scheduling/MassTransit.HangfireIntegration/MassTransit.HangfireIntegration.csproj
+++ b/src/Scheduling/MassTransit.HangfireIntegration/MassTransit.HangfireIntegration.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <PackageReference Include="Hangfire.Core" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Scheduling/MassTransit.QuartzIntegration/MassTransit.QuartzIntegration.csproj
+++ b/src/Scheduling/MassTransit.QuartzIntegration/MassTransit.QuartzIntegration.csproj
@@ -27,6 +27,5 @@
     <PackageReference Include="Quartz.Plugins.TimeZoneConverter" />
     <PackageReference Include="Quartz.Serialization.Json" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Transports/MassTransit.ActiveMqTransport/MassTransit.ActiveMqTransport.csproj
+++ b/src/Transports/MassTransit.ActiveMqTransport/MassTransit.ActiveMqTransport.csproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <PackageReference Include="Apache.NMS.ActiveMQ" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net472'"/>
   </ItemGroup>
 

--- a/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleNotificationService" />
     <PackageReference Include="AWSSDK.SQS" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/MassTransit.Azure.ServiceBus.Core.csproj
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/MassTransit.Azure.ServiceBus.Core.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Transports/MassTransit.EventHubIntegration/MassTransit.EventHubIntegration.csproj
+++ b/src/Transports/MassTransit.EventHubIntegration/MassTransit.EventHubIntegration.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Transports/MassTransit.KafkaIntegration/MassTransit.KafkaIntegration.csproj
+++ b/src/Transports/MassTransit.KafkaIntegration/MassTransit.KafkaIntegration.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/src/Transports/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
+++ b/src/Transports/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/MassTransit.SqlTransport.PostgreSql.csproj
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/MassTransit.SqlTransport.PostgreSql.csproj
@@ -18,8 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+    <PackageReference Include="Dapper" />
     <PackageReference Include="Npgsql" />
   </ItemGroup>
 

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/MassTransit.SqlTransport.SqlServer.csproj
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/MassTransit.SqlTransport.SqlServer.csproj
@@ -18,9 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper"/>
+    <PackageReference Include="Dapper" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Transports/MassTransit.WebJobs.EventHubsIntegration/MassTransit.WebJobs.EventHubsIntegration.csproj
+++ b/src/Transports/MassTransit.WebJobs.EventHubsIntegration/MassTransit.WebJobs.EventHubsIntegration.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <ProjectReference Include="..\MassTransit.Azure.ServiceBus.Core\MassTransit.Azure.ServiceBus.Core.csproj" />
     <ProjectReference Include="..\MassTransit.WebJobs.ServiceBusIntegration\MassTransit.WebJobs.ServiceBusIntegration.csproj" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />

--- a/src/Transports/MassTransit.WebJobs.ServiceBusIntegration/MassTransit.WebJobs.ServiceBusIntegration.csproj
+++ b/src/Transports/MassTransit.WebJobs.ServiceBusIntegration/MassTransit.WebJobs.ServiceBusIntegration.csproj
@@ -22,11 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Azure.Identity" />
-      <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-      <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-      <ProjectReference Include="..\MassTransit.Azure.ServiceBus.Core\MassTransit.Azure.ServiceBus.Core.csproj" />
-      <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" />
+    <ProjectReference Include="..\MassTransit.Azure.ServiceBus.Core\MassTransit.Azure.ServiceBus.Core.csproj" />
+    <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/MassTransit.Abstractions.Tests/MassTransit.Abstractions.Tests.csproj
+++ b/tests/MassTransit.Abstractions.Tests/MassTransit.Abstractions.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* use global package reference for `Microsoft.SourceLink.GitHub` (will be private assets always)
* only reference `System.*` packages for MassTransit when needed (these are included in NET6+)

Now for System packages it's only needed to have the minimal version in `Directory.Packages.props` as they are only referenced by full framework and netstandard.