### PR TITLE
Add NUnit.Analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,6 @@ end_of_line = lf
 
 [*.{cmd, bat}]
 end_of_line = crlf
+
+# Set up additional disposal methods for a specific diagnostic rule
+dotnet_diagnostic.NUnit1032.severity = silent

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ indent_size = 2
 
 [*.cs]
 end_of_line = lf
+dotnet_diagnostic.NUnit1032.severity = suggestion
 
 [*.md]
 trim_trailing_whitespace = false
@@ -25,5 +26,3 @@ end_of_line = lf
 [*.{cmd, bat}]
 end_of_line = crlf
 
-# Set up additional disposal methods for a specific diagnostic rule
-dotnet_diagnostic.NUnit1032.severity = silent

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,7 +74,10 @@
     <PackageVersion Include="Npgsql" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="3.10.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />

--- a/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
+++ b/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
@@ -17,6 +17,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <ProjectReference Include="..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 

--- a/tests/MassTransit.Abstractions.Tests/MassTransit.Abstractions.Tests.csproj
+++ b/tests/MassTransit.Abstractions.Tests/MassTransit.Abstractions.Tests.csproj
@@ -11,6 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
   </ItemGroup>

--- a/tests/MassTransit.Abstractions.Tests/NewId/Formatter_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/Formatter_Specs.cs
@@ -7,63 +7,66 @@
     using NewIdParsers;
     using NUnit.Framework;
 
+
     [TestFixture]
     public class Using_the_newid_formatters
     {
-        private readonly Dictionary<string, string[]> _testValues;
-        public Using_the_newid_formatters()
-        {
-            var directory = AppDomain.CurrentDomain.BaseDirectory;
-            var textsFileName = Path.Combine(directory, "NewId", "texts.txt");
-            var fileText = File.ReadAllText(textsFileName);
-
-            _testValues = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string[]>>(fileText);
-        }
-
         // Base32
         [Test]
         public void Should_compare_known_conversions_Base32Lower() => CompareKnownEncoding("Base32Lower", new Base32Formatter());
+
         [Test]
         public void Should_compare_known_conversions_Base32Upper() => CompareKnownEncoding("Base32Upper", new Base32Formatter(true));
-        [Test]
-        public void Should_compare_known_conversions_CustomBase32() => CompareKnownEncoding("CustomBase32", new Base32Formatter("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
 
-        // ZBase32
         [Test]
-        public void Should_compare_known_conversions_ZBase32Lower() => CompareKnownEncoding("ZBase32Lower", new ZBase32Formatter());
+        public void Should_compare_known_conversions_CustomBase32()
+        {
+            CompareKnownEncoding("CustomBase32", new Base32Formatter("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
+        }
+
         [Test]
-        public void Should_compare_known_conversions_ZBase32Upper() => CompareKnownEncoding("ZBase32Upper", new ZBase32Formatter(true));
+        public void Should_compare_known_conversions_DashedHexBase16BracketsLower()
+        {
+            CompareKnownEncoding("DashedHexBase16BracketsLower", new DashedHexFormatter('{', '}'));
+        }
+
+        [Test]
+        public void Should_compare_known_conversions_DashedHexBase16BracketsUpper()
+        {
+            CompareKnownEncoding("DashedHexBase16BracketsUpper", new DashedHexFormatter('{', '}', true));
+        }
+
+        // DashedHex
+        [Test]
+        public void Should_compare_known_conversions_DashedHexBase16Lower()
+        {
+            CompareKnownEncoding("DashedHexBase16Lower", new DashedHexFormatter());
+        }
+
+        [Test]
+        public void Should_compare_known_conversions_DashedHexBase16Upper()
+        {
+            CompareKnownEncoding("DashedHexBase16Upper", new DashedHexFormatter(upperCase: true));
+        }
 
         // Hex
         [Test]
         public void Should_compare_known_conversions_HexBase16Lower() => CompareKnownEncoding("HexBase16Lower", new HexFormatter());
+
         [Test]
         public void Should_compare_known_conversions_HexBase16Upper() => CompareKnownEncoding("HexBase16Upper", new HexFormatter(true));
 
-        // DashedHex
+        // ZBase32
         [Test]
-        public void Should_compare_known_conversions_DashedHexBase16Lower() => CompareKnownEncoding("DashedHexBase16Lower", new DashedHexFormatter());
-        [Test]
-        public void Should_compare_known_conversions_DashedHexBase16Upper() => CompareKnownEncoding("DashedHexBase16Upper", new DashedHexFormatter(upperCase: true));
-        [Test]
-        public void Should_compare_known_conversions_DashedHexBase16BracketsLower() => CompareKnownEncoding("DashedHexBase16BracketsLower", new DashedHexFormatter('{', '}'));
-        [Test]
-        public void Should_compare_known_conversions_DashedHexBase16BracketsUpper() => CompareKnownEncoding("DashedHexBase16BracketsUpper", new DashedHexFormatter('{', '}', upperCase: true));
-
-
-        public void CompareKnownEncoding(string name, INewIdFormatter formatter)
+        public void Should_compare_known_conversions_ZBase32Lower()
         {
-            var guids = _testValues["Guids"];
-            var expectedValues = _testValues[name];
-            Assert.AreEqual(guids.Length, expectedValues.Length);
+            CompareKnownEncoding("ZBase32Lower", new ZBase32Formatter());
+        }
 
-            for (var i = 0; i < guids.Length; i++)
-            {
-                var newId = new NewId(guids[i]);
-                var text = newId.ToString(formatter);
-                Assert.AreEqual(expectedValues[i], text);
-            }
-            Console.WriteLine("Compared {0} equal conversions", guids.Length);
+        [Test]
+        public void Should_compare_known_conversions_ZBase32Upper()
+        {
+            CompareKnownEncoding("ZBase32Upper", new ZBase32Formatter(true));
         }
 
         [Test]
@@ -79,7 +82,7 @@
             var newId = parser.Parse(ns);
 
 
-            Assert.AreEqual(n, newId);
+            Assert.That(newId, Is.EqualTo(n));
         }
 
         [Test]
@@ -95,7 +98,7 @@
             var newId = parser.Parse(ns);
 
 
-            Assert.AreEqual(n, newId);
+            Assert.That(newId, Is.EqualTo(n));
         }
 
         [Test]
@@ -107,7 +110,7 @@
 
             var ns = n.ToString(formatter);
 
-            Assert.AreEqual("UQP7OV4AN129HB4N79GGF8GJ10", ns);
+            Assert.That(ns, Is.EqualTo("UQP7OV4AN129HB4N79GGF8GJ10"));
         }
 
         [Test]
@@ -119,7 +122,7 @@
 
             var ns = n.ToString(formatter);
 
-            Assert.AreEqual("62ZHY7EKXBCJRLEXHJQQPIQTBA", ns);
+            Assert.That(ns, Is.EqualTo("62ZHY7EKXBCJRLEXHJQQPIQTBA"));
         }
 
         [Test]
@@ -131,7 +134,7 @@
 
             var ns = n.ToString(formatter);
 
-            Assert.AreEqual("6438A9RKZBNJTMRZ8JOOXEOUBY", ns);
+            Assert.That(ns, Is.EqualTo("6438A9RKZBNJTMRZ8JOOXEOUBY"));
         }
 
         [Test]
@@ -145,7 +148,34 @@
             var newId = parser.Parse(ns);
 
 
-            Assert.AreEqual(n, newId);
+            Assert.That(newId, Is.EqualTo(n));
+        }
+
+        readonly Dictionary<string, string[]> _testValues;
+
+        public Using_the_newid_formatters()
+        {
+            var directory = AppDomain.CurrentDomain.BaseDirectory;
+            var textsFileName = Path.Combine(directory, "NewId", "texts.txt");
+            var fileText = File.ReadAllText(textsFileName);
+
+            _testValues = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string[]>>(fileText);
+        }
+
+        public void CompareKnownEncoding(string name, INewIdFormatter formatter)
+        {
+            var guids = _testValues["Guids"];
+            var expectedValues = _testValues[name];
+            Assert.That(expectedValues, Has.Length.EqualTo(guids.Length));
+
+            for (var i = 0; i < guids.Length; i++)
+            {
+                var newId = new NewId(guids[i]);
+                var text = newId.ToString(formatter);
+                Assert.That(text, Is.EqualTo(expectedValues[i]));
+            }
+
+            Console.WriteLine("Compared {0} equal conversions", guids.Length);
         }
     }
 }

--- a/tests/MassTransit.Abstractions.Tests/NewId/GuidInterop_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/GuidInterop_Specs.cs
@@ -17,7 +17,7 @@
             var ns = n.ToString();
             var gs = g.ToString();
 
-            Assert.AreEqual(ns, gs);
+            Assert.That(gs, Is.EqualTo(ns));
         }
 
         [Test]
@@ -30,7 +30,7 @@
             var ns = n.ToString();
             var gs = g.ToString();
 
-            Assert.AreEqual(ns, gs);
+            Assert.That(gs, Is.EqualTo(ns));
         }
 
         [Test]
@@ -41,7 +41,7 @@
             var ns = g.ToNewId().ToString();
             var gs = g.ToString();
 
-            Assert.AreEqual(ns, gs);
+            Assert.That(gs, Is.EqualTo(ns));
         }
 
         [Test]
@@ -61,7 +61,7 @@
 
             var gn = new Guid(n.ToByteArray());
 
-            Assert.AreEqual(g, gn);
+            Assert.That(gn, Is.EqualTo(g));
         }
 
         [Test]
@@ -73,7 +73,7 @@
 
             var gn = n.ToGuid();
 
-            Assert.AreEqual(g, gn);
+            Assert.That(gn, Is.EqualTo(g));
         }
 
         [Test]
@@ -85,63 +85,7 @@
 
             var gn = n.ToSequentialGuid();
 
-            Assert.AreEqual(g, gn);
-        }
-
-        [Test]
-        public void Should_match_string_output_b()
-        {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-
-            var g = new Guid(bytes);
-            var n = new NewId(bytes);
-
-            var gs = g.ToString("B");
-            var ns = n.ToString("B");
-
-            Assert.AreEqual(gs, ns);
-        }
-
-        [Test]
-        public void Should_match_string_output_d()
-        {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-
-            var g = new Guid(bytes);
-            var n = new NewId(bytes);
-
-            var gs = g.ToString("d");
-            var ns = n.ToString("d");
-
-            Assert.AreEqual(gs, ns);
-        }
-
-        [Test]
-        public void Should_match_string_output_n()
-        {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-
-            var g = new Guid(bytes);
-            var n = new NewId(bytes);
-
-            var gs = g.ToString("N");
-            var ns = n.ToString("N");
-
-            Assert.AreEqual(gs, ns);
-        }
-
-        [Test]
-        public void Should_match_string_output_p()
-        {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-
-            var g = new Guid(bytes);
-            var n = new NewId(bytes);
-
-            var gs = g.ToString("P");
-            var ns = n.ToString("P");
-
-            Assert.AreEqual(gs, ns);
+            Assert.That(gn, Is.EqualTo(g));
         }
 
         [Test]
@@ -156,7 +100,7 @@
             var gsn = Guid.Parse(ns);
             var g = n.ToSequentialGuid();
 
-            Assert.AreEqual(g, gsn);
+            Assert.That(gsn, Is.EqualTo(g));
         }
 
         [Test]
@@ -171,8 +115,8 @@
             var gsn = Guid.Parse(ns);
             var g = n.ToSequentialGuid();
 
-            Assert.AreEqual(g, gsn);
-            Assert.AreNotEqual(gsn, n.ToGuid());
+            Assert.That(gsn, Is.EqualTo(g));
+            Assert.That(n.ToGuid(), Is.Not.EqualTo(gsn));
         }
 
         [Test]
@@ -187,7 +131,7 @@
             var gsn = Guid.Parse(ns);
             var g = n.ToSequentialGuid();
 
-            Assert.AreEqual(g, gsn);
+            Assert.That(gsn, Is.EqualTo(g));
         }
 
         [Test]
@@ -202,8 +146,95 @@
             var gsn = Guid.Parse(ns);
             var g = n.ToSequentialGuid();
 
-            Assert.AreEqual(g, gsn);
+            Assert.That(gsn, Is.EqualTo(g));
         }
+
+        [Test]
+        public void Should_match_string_output_b()
+        {
+            var bytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+            var g = new Guid(bytes);
+            var n = new NewId(bytes);
+
+            var gs = g.ToString("B");
+            var ns = n.ToString("B");
+
+            Assert.That(ns, Is.EqualTo(gs));
+        }
+
+        [Test]
+        public void Should_match_string_output_d()
+        {
+            var bytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+            var g = new Guid(bytes);
+            var n = new NewId(bytes);
+
+            var gs = g.ToString("d");
+            var ns = n.ToString("d");
+
+            Assert.That(ns, Is.EqualTo(gs));
+        }
+
+        [Test]
+        public void Should_match_string_output_n()
+        {
+            var bytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+            var g = new Guid(bytes);
+            var n = new NewId(bytes);
+
+            var gs = g.ToString("N");
+            var ns = n.ToString("N");
+
+            Assert.That(ns, Is.EqualTo(gs));
+        }
+
+        [Test]
+        public void Should_match_string_output_p()
+        {
+            var bytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+            var g = new Guid(bytes);
+            var n = new NewId(bytes);
+
+            var gs = g.ToString("P");
+            var ns = n.ToString("P");
+
+            Assert.That(ns, Is.EqualTo(gs));
+        }
+
+        [Test]
+        public void Should_parse_newid_guid_as_newid()
+        {
+            var n = NewId.Next(2)[1];
+            var g = n.ToGuid();
+
+            var ng = NewId.FromGuid(g);
+
+            Assert.That(ng, Is.EqualTo(n));
+
+            // Also checks to see if this would throw
+            Assert.IsTrue(ng.Timestamp != default);
+        }
+
+        [Test]
+        public void Should_parse_sequential_guid_as_newid()
+        {
+            var n = NewId.Next(2)[1];
+
+            var nn = n.ToGuid();
+            var g = n.ToSequentialGuid();
+
+            var ng = NewId.FromSequentialGuid(g);
+
+            Assert.That(ng, Is.EqualTo(n));
+
+            // Also checks to see if this would throw
+            Assert.That(ng.Timestamp, Is.Not.EqualTo(default));
+        }
+
         [Test]
         public void Should_properly_handle_string_passthrough()
         {
@@ -215,7 +246,7 @@
 
             var nn = new NewId(g.ToString("D"));
 
-            Assert.AreEqual(n, nn);
+            Assert.That(nn, Is.EqualTo(n));
         }
 
         [Test]
@@ -225,7 +256,7 @@
             var guid = new Guid(0x01020304, 0x0506, 0x0708, 9, 10, 11, 12, 13, 14, 15, 16);
             var newid = new NewId(0x01020304, 0x0506, 0x0708, 9, 10, 11, 12, 13, 14, 15, 16);
 
-            Assert.AreEqual(guid.ToString(), newid.ToString());
+            Assert.That(newid.ToString(), Is.EqualTo(guid.ToString()));
         }
 
         [Test]
@@ -239,38 +270,7 @@
 
             Console.WriteLine(g.ToString("D"));
 
-            Assert.AreEqual(n, ng);
-        }
-
-
-        [Test]
-        public void Should_parse_newid_guid_as_newid()
-        {
-            NewId n = NewId.Next(2)[1];
-            var g = n.ToGuid();
-
-            var ng = NewId.FromGuid(g);
-
-            Assert.AreEqual(n, ng);
-
-            // Also checks to see if this would throw
-            Assert.IsTrue(ng.Timestamp != default);
-        }
-
-        [Test]
-        public void Should_parse_sequential_guid_as_newid()
-        {
-            NewId n = NewId.Next(2)[1];
-
-            var nn = n.ToGuid();
-            var g = n.ToSequentialGuid();
-
-            var ng = NewId.FromSequentialGuid(g);
-
-            Assert.AreEqual(n, ng);
-
-            // Also checks to see if this would throw
-            Assert.IsTrue(ng.Timestamp != default);
+            Assert.That(ng, Is.EqualTo(n));
         }
     }
 }

--- a/tests/MassTransit.Abstractions.Tests/NewId/LongTerm_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/LongTerm_Specs.cs
@@ -23,11 +23,11 @@
 
             for (var i = 0; i < limit - 1; i++)
             {
-                Assert.AreNotEqual(ids[i], ids[i + 1]);
+                Assert.That(ids[i + 1], Is.Not.EqualTo(ids[i]));
 
                 SqlGuid left = ids[i].ToGuid();
                 SqlGuid right = ids[i + 1].ToGuid();
-                Assert.Less(left, right);
+                Assert.That(left, Is.LessThan(right));
                 if (i % 128 == 0)
                     Console.WriteLine("Normal: {0} Sql: {1}", left, ids[i].ToSequentialGuid());
             }

--- a/tests/MassTransit.Abstractions.Tests/NewId/NetworkAddress_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/NetworkAddress_Specs.cs
@@ -30,8 +30,8 @@
 
             var networkId = networkIdProvider.GetWorkerId(0);
 
-            Assert.IsNotNull(networkId);
-            Assert.AreEqual(6, networkId.Length);
+            Assert.That(networkId, Is.Not.Null);
+            Assert.That(networkId, Has.Length.EqualTo(6));
         }
 
         [Test]
@@ -41,8 +41,8 @@
 
             var networkId = networkIdProvider.GetWorkerId(0);
 
-            Assert.IsNotNull(networkId);
-            Assert.AreEqual(6, networkId.Length);
+            Assert.That(networkId, Is.Not.Null);
+            Assert.That(networkId, Has.Length.EqualTo(6));
         }
 
         [Test]

--- a/tests/MassTransit.Abstractions.Tests/NewId/NewId_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/NewId_Specs.cs
@@ -161,7 +161,7 @@
 
             for (var i = 0; i < limit - 1; i++)
             {
-                Assert.AreNotEqual(ids[i], ids[i + 1]);
+                Assert.That(ids[i + 1], Is.Not.EqualTo(ids[i]));
                 Console.WriteLine(ids[i]);
             }
         }
@@ -184,7 +184,7 @@
 
             for (var i = 0; i < limit - 1; i++)
             {
-                Assert.AreNotEqual(ids[i], ids[i + 1]);
+                Assert.That(ids[i + 1], Is.Not.EqualTo(ids[i]));
                 var end = ids[i].ToString().Substring(32, 4);
                 if (end == "0000")
                     Console.WriteLine("{0}", ids[i].ToString());

--- a/tests/MassTransit.Abstractions.Tests/NewId/Order_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/Order_Specs.cs
@@ -22,11 +22,11 @@
 
             for (var i = 0; i < limit - 1; i++)
             {
-                Assert.AreNotEqual(ids[i], ids[i + 1]);
+                Assert.That(ids[i + 1], Is.Not.EqualTo(ids[i]));
 
                 SqlGuid left = ids[i].ToGuid();
                 SqlGuid right = ids[i + 1].ToGuid();
-                Assert.Less(left, right);
+                Assert.That(left, Is.LessThan(right));
                 if (i % 128 == 0)
                     Console.WriteLine("Normal: {0} Sql: {1}", left, ids[i].ToSequentialGuid());
             }
@@ -45,11 +45,11 @@
 
             for (var i = 0; i < limit - 1; i++)
             {
-                Assert.AreNotEqual(ids[i], ids[i + 1]);
+                Assert.That(ids[i + 1], Is.Not.EqualTo(ids[i]));
 
                 var left = ids[i].ToSequentialGuid();
                 var right = ids[i + 1].ToSequentialGuid();
-                Assert.Less(left, right);
+                Assert.That(left, Is.LessThan(right));
                 if (i % 128 == 0)
                     Console.WriteLine("Sql: {0}", left);
             }

--- a/tests/MassTransit.Abstractions.Tests/NewId/Usage_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/Usage_Specs.cs
@@ -12,7 +12,7 @@
         {
             var newId = new NewId();
 
-            Assert.AreEqual("00000000-0000-0000-0000-000000000000", newId.ToString());
+            Assert.That(newId.ToString(), Is.EqualTo("00000000-0000-0000-0000-000000000000"));
         }
 
         [Test]
@@ -20,7 +20,7 @@
         {
             var newId = new NewId();
 
-            Assert.AreEqual("{00000000-0000-0000-0000-000000000000}", newId.ToString("B"));
+            Assert.That(newId.ToString("B"), Is.EqualTo("{00000000-0000-0000-0000-000000000000}"));
         }
 
         [Test]
@@ -28,7 +28,7 @@
         {
             var newId = new NewId();
 
-            Assert.AreEqual("00000000000000000000000000000000", newId.ToString("N"));
+            Assert.That(newId.ToString("N"), Is.EqualTo("00000000000000000000000000000000"));
         }
 
         [Test]
@@ -36,7 +36,7 @@
         {
             var newId = new NewId();
 
-            Assert.AreEqual("(00000000-0000-0000-0000-000000000000)", newId.ToString("P"));
+            Assert.That(newId.ToString("P"), Is.EqualTo("(00000000-0000-0000-0000-000000000000)"));
         }
 
         [Test]
@@ -49,7 +49,7 @@
             var gs = g.ToString("d");
             var ns = n.ToString("d");
 
-            Assert.AreEqual(gs, ns);
+            Assert.That(ns, Is.EqualTo(gs));
         }
     }
 }

--- a/tests/MassTransit.ActiveMqTransport.Tests/MassTransit.ActiveMqTransport.Tests.csproj
+++ b/tests/MassTransit.ActiveMqTransport.Tests/MassTransit.ActiveMqTransport.Tests.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
     <PackageReference Include="SharpZipLib" />

--- a/tests/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/MassTransit.AmazonSqsTransport.Tests.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
     <ProjectReference Include="..\..\src\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj" />

--- a/tests/MassTransit.Analyzers.Tests/MassTransit.Analyzers.Tests.csproj
+++ b/tests/MassTransit.Analyzers.Tests/MassTransit.Analyzers.Tests.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 

--- a/tests/MassTransit.Analyzers.Tests/Verifiers/CodeFixVerifier.cs
+++ b/tests/MassTransit.Analyzers.Tests/Verifiers/CodeFixVerifier.cs
@@ -116,7 +116,7 @@ namespace MassTransit.Analyzers.Tests
                         document.Project.Solution.Workspace));
                     newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
 
-                    Assert.That(false, Is.True,
+                    Assert.Fail(
                         $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{document.GetSyntaxRootAsync().Result.ToFullString()}\r\n");
                 }
 

--- a/tests/MassTransit.Analyzers.Tests/Verifiers/CodeFixVerifier.cs
+++ b/tests/MassTransit.Analyzers.Tests/Verifiers/CodeFixVerifier.cs
@@ -84,7 +84,7 @@ namespace MassTransit.Analyzers.Tests
             bool allowNewCompilerDiagnostics)
         {
             var document = CreateDocument(oldSource, language);
-            Diagnostic[] analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] {document});
+            Diagnostic[] analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
             IEnumerable<Diagnostic> compilerDiagnostics = GetCompilerDiagnostics(document);
             var attempts = analyzerDiagnostics.Length;
 
@@ -104,7 +104,7 @@ namespace MassTransit.Analyzers.Tests
                 }
 
                 document = ApplyFix(document, actions.ElementAt(0));
-                analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] {document});
+                analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
 
                 IEnumerable<Diagnostic> newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
 
@@ -116,10 +116,8 @@ namespace MassTransit.Analyzers.Tests
                         document.Project.Solution.Workspace));
                     newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
 
-                    Assert.IsTrue(false,
-                        string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
-                            string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
-                            document.GetSyntaxRootAsync().Result.ToFullString()));
+                    Assert.That(false, Is.True,
+                        $"Fix introduced new compiler diagnostics:\r\n{string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString()))}\r\n\r\nNew document:\r\n{document.GetSyntaxRootAsync().Result.ToFullString()}\r\n");
                 }
 
                 //check if there are analyzer diagnostics left after the code fix
@@ -130,7 +128,7 @@ namespace MassTransit.Analyzers.Tests
             //after applying all of the code fixes, compare the resulting string to the inputted one
             var actual = GetStringFromDocument(document).Replace("\r\n", "\n");
 
-            Assert.AreEqual(newSource, actual);
+            Assert.That(actual, Is.EqualTo(newSource));
         }
     }
 }

--- a/tests/MassTransit.Azure.Cosmos.Tests/MassTransit.Azure.Cosmos.Tests.csproj
+++ b/tests/MassTransit.Azure.Cosmos.Tests/MassTransit.Azure.Cosmos.Tests.csproj
@@ -8,6 +8,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <ProjectReference Include="..\..\src\Persistence\MassTransit.Azure.Cosmos\MassTransit.Azure.Cosmos.csproj" />
     <ProjectReference Include="..\..\src\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />

--- a/tests/MassTransit.Azure.Cosmos.Tests/MissingInstance_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/MissingInstance_Specs.cs
@@ -175,9 +175,12 @@
 
                 Response<Status, InstanceNotFound> response = await statusClient.GetResponse<Status, InstanceNotFound>(new CheckStatus("A"));
 
-                Assert.That(response.Is(out MassTransit.Response<Status> status), Is.True);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(response.Is(out MassTransit.Response<Status> status), Is.True);
 
-                Assert.AreEqual("A", status.Message.ServiceName);
+                    Assert.That(status.Message.ServiceName, Is.EqualTo("A"));
+                });
             }
 
             readonly string _databaseName;
@@ -237,7 +240,7 @@
 
                 MassTransit.Response<Status> result = await status;
 
-                Assert.AreEqual("A", result.Message.ServiceName);
+                Assert.That(result.Message.ServiceName, Is.EqualTo("A"));
 
                 Assert.That(async () => await notFound, Throws.TypeOf<TaskCanceledException>());
             }
@@ -254,7 +257,7 @@
 
                 MassTransit.Response<InstanceNotFound> result = await notFound;
 
-                Assert.AreEqual("Z", result.Message.ServiceName);
+                Assert.That(result.Message.ServiceName, Is.EqualTo("Z"));
 
                 Assert.That(async () => await status, Throws.TypeOf<TaskCanceledException>());
             }

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/MassTransit.Azure.ServiceBus.Core.Tests.csproj
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/MassTransit.Azure.ServiceBus.Core.Tests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <ProjectReference Include="..\..\src\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj" />

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Publish_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Publish_Specs.cs
@@ -112,7 +112,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             ConsumeContext<PingMessage> received = await _handler;
 
-            Assert.AreEqual(EncryptedMessageSerializerV2.EncryptedContentType, received.ReceiveContext.ContentType);
+            Assert.That(received.ReceiveContext.ContentType, Is.EqualTo(EncryptedMessageSerializerV2.EncryptedContentType));
         }
 
         Task<ConsumeContext<PingMessage>> _handler;

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Send_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Send_Specs.cs
@@ -81,7 +81,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             Response<PongMessage> message = await _response;
 
-            Assert.AreEqual(message.Message.CorrelationId, _ping.Result.Message.CorrelationId);
+            Assert.That(_ping.Result.Message.CorrelationId, Is.EqualTo(message.Message.CorrelationId));
         }
 
         Task<ConsumeContext<PingMessage>> _ping;

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Send_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Send_Specs.cs
@@ -81,7 +81,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             Response<PongMessage> message = await _response;
 
-            Assert.That(_ping.Result.Message.CorrelationId, Is.EqualTo(message.Message.CorrelationId));
+            Assert.That(message.Message.CorrelationId, Is.EqualTo(_ping.Result.Message.CorrelationId));
         }
 
         Task<ConsumeContext<PingMessage>> _ping;

--- a/tests/MassTransit.Azure.Table.Tests/MassTransit.Azure.Table.Tests.csproj
+++ b/tests/MassTransit.Azure.Table.Tests/MassTransit.Azure.Table.Tests.csproj
@@ -6,6 +6,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <ProjectReference Include="..\..\src\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />

--- a/tests/MassTransit.DapperIntegration.Tests/MassTransit.DapperIntegration.Tests.csproj
+++ b/tests/MassTransit.DapperIntegration.Tests/MassTransit.DapperIntegration.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>

--- a/tests/MassTransit.DynamoDbIntegration.Tests/MassTransit.DynamoDbIntegration.Tests.csproj
+++ b/tests/MassTransit.DynamoDbIntegration.Tests/MassTransit.DynamoDbIntegration.Tests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <ProjectReference Include="..\..\src\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/MassTransit.EntityFrameworkCoreIntegration.Tests.csproj
@@ -16,6 +16,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
     <PackageReference Include="Shouldly" />

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/OutboxScopedFilter_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/OutboxScopedFilter_Specs.cs
@@ -132,7 +132,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
                 var myId = harness.Scope.ServiceProvider.GetRequiredService<MyId>();
 
                 var result = await taskCompletionSource.Task;
-                Assert.AreEqual(myId, result);
+                Assert.That(result, Is.EqualTo(myId));
             }
             finally
             {

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/MassTransit.EntityFrameworkIntegration.Tests.csproj
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/MassTransit.EntityFrameworkIntegration.Tests.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <ProjectReference Include="..\..\src\Persistence\MassTransit.EntityFrameworkIntegration\MassTransit.EntityFrameworkIntegration.csproj" />

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/PreInsert_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/PreInsert_Specs.cs
@@ -120,17 +120,20 @@
 
                 ConsumeContext<StartupComplete> received = await messageReceived;
 
-                Assert.AreEqual(message.CorrelationId, received.Message.TransactionId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(received.Message.TransactionId, Is.EqualTo(message.CorrelationId));
 
-                Assert.IsTrue(received.InitiatorId.HasValue, "The initiator should be copied from the CorrelationId");
+                    Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                Assert.AreEqual(received.InitiatorId.Value, message.CorrelationId, "The initiator should be the saga CorrelationId");
+                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
 
-                Assert.AreEqual(received.SourceAddress, InputQueueAddress, "The published message should have the input queue source address");
+                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, _machine.Running, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
             }
 
             public When_pre_inserting_the_state_machine_instance_using_ef()
@@ -173,7 +176,7 @@
 
                     Initially(
                         When(Started)
-                            .Publish(context => new StartupComplete {TransactionId = context.Data.CorrelationId})
+                            .Publish(context => new StartupComplete { TransactionId = context.Data.CorrelationId })
                             .TransitionTo(Running));
                 }
 
@@ -209,17 +212,20 @@
 
                 ConsumeContext<StartupComplete> received = await messageReceived;
 
-                Assert.AreEqual(sagaId, received.Message.TransactionId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(received.Message.TransactionId, Is.EqualTo(sagaId));
 
-                Assert.IsTrue(received.InitiatorId.HasValue, "The initiator should be copied from the CorrelationId");
+                    Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                Assert.AreEqual(received.InitiatorId.Value, message.CorrelationId, "The initiator should be the saga CorrelationId");
+                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
 
-                Assert.AreEqual(received.SourceAddress, InputQueueAddress, "The published message should have the input queue source address");
+                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, _machine.Running, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
             }
 
             public When_pre_inserting_in_an_invalid_state_using_ef()
@@ -267,7 +273,7 @@
                             {
                             }),
                         When(Started)
-                            .Publish(context => new StartupComplete {TransactionId = context.Data.CorrelationId})
+                            .Publish(context => new StartupComplete { TransactionId = context.Data.CorrelationId })
                             .TransitionTo(Running));
                 }
 

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/PreInsert_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/PreInsert_Specs.cs
@@ -126,9 +126,9 @@
 
                     Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
+                    Assert.That(received.InitiatorId.Value, Is.EqualTo(message.CorrelationId), "The initiator should be the saga CorrelationId");
 
-                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                    Assert.That(received.SourceAddress, Is.EqualTo(InputQueueAddress), "The published message should have the input queue source address");
                 });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, _machine.Running, TestTimeout);
@@ -218,9 +218,9 @@
 
                     Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
+                    Assert.That(received.InitiatorId.Value, Is.EqualTo(message.CorrelationId), "The initiator should be the saga CorrelationId");
 
-                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                    Assert.That(received.SourceAddress, Is.EqualTo(InputQueueAddress), "The published message should have the input queue source address");
                 });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, _machine.Running, TestTimeout);

--- a/tests/MassTransit.EventHubIntegration.Tests/BatchReceive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/BatchReceive_Specs.cs
@@ -72,10 +72,10 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<Batch<BatchEventHubMessage>> result = await taskCompletionSource.Task;
 
-                Assert.AreEqual(batchSize, result.Message.Length);
+                Assert.That(result.Message.Length, Is.EqualTo(batchSize));
 
                 for (var i = 0; i < batchSize; i++)
-                    Assert.AreEqual(i, result.Message[i].Message.Index);
+                    Assert.That(result.Message[i].Message.Index, Is.EqualTo(i));
             }
             finally
             {

--- a/tests/MassTransit.EventHubIntegration.Tests/EndpointConnector_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/EndpointConnector_Specs.cs
@@ -78,19 +78,25 @@ namespace MassTransit.EventHubIntegration.Tests
                 await connected.Ready;
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.AreEqual("text", result.Message.Text);
-                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-                Assert.That(result.DestinationAddress,
-                    Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
-                Assert.That(result.MessageId, Is.EqualTo(messageId));
-                Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
-                Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
-                Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Message.Text, Is.EqualTo("text"));
+                    Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                    Assert.That(result.DestinationAddress,
+                        Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
+                    Assert.That(result.MessageId, Is.EqualTo(messageId));
+                    Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
+                    Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
+                    Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+                });
 
                 var headerType = result.Headers.Get<HeaderType>("Special");
                 Assert.That(headerType, Is.Not.Null);
-                Assert.That(headerType.Key, Is.EqualTo("Hello"));
-                Assert.That(headerType.Value, Is.EqualTo("World"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(headerType.Key, Is.EqualTo("Hello"));
+                    Assert.That(headerType.Value, Is.EqualTo("World"));
+                });
             }
             finally
             {

--- a/tests/MassTransit.EventHubIntegration.Tests/Long_Receive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Long_Receive_Specs.cs
@@ -65,7 +65,7 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.AreEqual(messageId, result.MessageId);
+                Assert.That(result.MessageId, Is.EqualTo(messageId));
             }
             finally
             {

--- a/tests/MassTransit.EventHubIntegration.Tests/MassTransit.EventHubIntegration.Tests.csproj
+++ b/tests/MassTransit.EventHubIntegration.Tests/MassTransit.EventHubIntegration.Tests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 

--- a/tests/MassTransit.EventHubIntegration.Tests/Producer_Saga_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Producer_Saga_Specs.cs
@@ -69,8 +69,11 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.AreEqual("Key: ABC123", result.Message.Text);
-                Assert.AreEqual(correlationId, result.InitiatorId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Message.Text, Is.EqualTo("Key: ABC123"));
+                    Assert.That(result.InitiatorId, Is.EqualTo(correlationId));
+                });
             }
             finally
             {

--- a/tests/MassTransit.EventHubIntegration.Tests/Producer_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Producer_Specs.cs
@@ -76,19 +76,25 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.AreEqual("text", result.Message.Text);
-                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-                Assert.That(result.DestinationAddress,
-                    Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
-                Assert.That(result.MessageId, Is.EqualTo(messageId));
-                Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
-                Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
-                Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Message.Text, Is.EqualTo("text"));
+                    Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                    Assert.That(result.DestinationAddress,
+                        Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
+                    Assert.That(result.MessageId, Is.EqualTo(messageId));
+                    Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
+                    Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
+                    Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+                });
 
                 var headerType = result.Headers.Get<HeaderType>("Special");
                 Assert.That(headerType, Is.Not.Null);
-                Assert.That(headerType.Key, Is.EqualTo("Hello"));
-                Assert.That(headerType.Value, Is.EqualTo("World"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(headerType.Key, Is.EqualTo("Hello"));
+                    Assert.That(headerType.Value, Is.EqualTo("World"));
+                });
             }
             finally
             {
@@ -184,10 +190,13 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.AreEqual("text", result.Message.Text);
-                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-                Assert.That(result.DestinationAddress,
-                    Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Message.Text, Is.EqualTo("text"));
+                    Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                    Assert.That(result.DestinationAddress,
+                        Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
+                });
 
                 await postSendCompletionSource.Task;
             }

--- a/tests/MassTransit.EventHubIntegration.Tests/Publish_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Publish_Specs.cs
@@ -76,11 +76,14 @@ namespace MassTransit.EventHubIntegration.Tests
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
                 ConsumeContext<BusPing> ping = await pingTaskCompletionSource.Task;
 
-                Assert.AreEqual(message.Text, result.Message.Text);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Message.Text, Is.EqualTo(message.Text));
 
-                Assert.AreEqual(result.CorrelationId, ping.InitiatorId);
-                Assert.That(ping.SourceAddress,
-                    Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}/{consumerGroup}")));
+                    Assert.That(ping.InitiatorId, Is.EqualTo(result.CorrelationId));
+                    Assert.That(ping.SourceAddress,
+                        Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}/{consumerGroup}")));
+                });
             }
             finally
             {

--- a/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
@@ -64,7 +64,7 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.AreEqual(message.Text, result.Message.Text);
+                Assert.That(result.Message.Text, Is.EqualTo(message.Text));
             }
             finally
             {
@@ -103,6 +103,7 @@ namespace MassTransit.EventHubIntegration.Tests
             }
         }
     }
+
 
     public class ReceiveWithPayload_Specs :
         InMemoryTestFixture

--- a/tests/MassTransit.HangfireIntegration.Tests/MassTransit.HangfireIntegration.Tests.csproj
+++ b/tests/MassTransit.HangfireIntegration.Tests/MassTransit.HangfireIntegration.Tests.csproj
@@ -9,6 +9,10 @@
     <PackageReference Include="Hangfire.MemoryStorage" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <ProjectReference Include="..\..\src\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj" />
     <ProjectReference Include="..\..\src\Scheduling\MassTransit.HangfireIntegration\MassTransit.HangfireIntegration.csproj" />

--- a/tests/MassTransit.HangfireIntegration.Tests/MissingInstanceRedelivery_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/MissingInstanceRedelivery_Specs.cs
@@ -28,7 +28,7 @@ namespace MassTransit.HangfireIntegration.Tests
 
             await status;
 
-            Assert.AreEqual("A", status.Result.Message.ServiceName);
+            Assert.That(status.Result.Message.ServiceName, Is.EqualTo("A"));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.HangfireIntegration.Tests/PastEvent_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/PastEvent_Specs.cs
@@ -69,19 +69,22 @@
 
             ConsumeContext<A> context = await handler;
 
-            Assert.AreEqual(Bus.Address, context.FaultAddress);
-            Assert.AreEqual(InputQueueAddress, context.ResponseAddress);
-            Assert.IsTrue(context.RequestId.HasValue);
-            Assert.AreEqual(requestId, context.RequestId.Value);
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.AreEqual(correlationId, context.CorrelationId.Value);
-            Assert.IsTrue(context.ConversationId.HasValue);
-            Assert.AreEqual(conversationId, context.ConversationId.Value);
-            Assert.IsTrue(context.InitiatorId.HasValue);
-            Assert.AreEqual(initiatorId, context.InitiatorId.Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.FaultAddress, Is.EqualTo(Bus.Address));
+                Assert.That(context.ResponseAddress, Is.EqualTo(InputQueueAddress));
+                Assert.That(context.RequestId.HasValue, Is.True);
+                Assert.That(context.RequestId.Value, Is.EqualTo(requestId));
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(correlationId));
+                Assert.That(context.ConversationId.HasValue, Is.True);
+                Assert.That(context.ConversationId.Value, Is.EqualTo(conversationId));
+                Assert.That(context.InitiatorId.HasValue, Is.True);
+                Assert.That(context.InitiatorId.Value, Is.EqualTo(initiatorId));
 
-            Assert.IsTrue(context.Headers.TryGetHeader("Hello", out var value));
-            Assert.AreEqual("World", value);
+                Assert.That(context.Headers.TryGetHeader("Hello", out var value), Is.True);
+                Assert.That(value, Is.EqualTo("World"));
+            });
         }
 
         [Test]
@@ -127,7 +130,7 @@
             });
 
             ConsumeContext<A> result = await handler;
-            Assert.AreEqual(expected, result.Message.Name);
+            Assert.That(result.Message.Name, Is.EqualTo(expected));
         }
 
         public Specifying_an_event_reschedule_if_exists()

--- a/tests/MassTransit.HangfireIntegration.Tests/Recurring_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/Recurring_Specs.cs
@@ -24,7 +24,7 @@
             await _done;
 
             var countBeforeCancel = _count;
-            Assert.AreEqual(8, _count, "Expected to see 8 interval messages");
+            Assert.That(_count, Is.EqualTo(8), "Expected to see 8 interval messages");
 
             await Bus.CancelScheduledRecurringSend(scheduledRecurringMessage);
 
@@ -32,7 +32,7 @@
 
             await _doneAgain;
 
-            Assert.AreEqual(countBeforeCancel, _count, "Expected to see the count matches.");
+            Assert.That(_count, Is.EqualTo(countBeforeCancel), "Expected to see the count matches.");
         }
 
         [Test]
@@ -45,7 +45,7 @@
 
             await _done;
 
-            Assert.AreEqual(8, _count, "Expected to see 8 interval messages");
+            Assert.That(_count, Is.EqualTo(8), "Expected to see 8 interval messages");
         }
 
         [Test]
@@ -61,7 +61,7 @@
             await _done;
 
             var countBeforeCancel = _count;
-            Assert.AreEqual(8, _count, "Expected to see 8 interval messages");
+            Assert.That(_count, Is.EqualTo(8), "Expected to see 8 interval messages");
 
             await Bus.PauseScheduledRecurringSend(scheduledRecurringMessage);
 
@@ -69,7 +69,7 @@
 
             await _doneAgain;
 
-            Assert.AreEqual(countBeforeCancel, _count, "Expected to see the count matches.");
+            Assert.That(_count, Is.EqualTo(countBeforeCancel), "Expected to see the count matches.");
         }
 
         Task<ConsumeContext<Done>> _done;

--- a/tests/MassTransit.HangfireIntegration.Tests/Reschedule_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/Reschedule_Specs.cs
@@ -25,15 +25,18 @@
 
                 var sagaInstance = _repository[correlationId].Instance;
 
-                Assert.NotNull(rescheduledEvent.Message.NewScheduleTokenId);
-                Assert.AreEqual(sagaInstance.CorrelationId, rescheduledEvent.Message.CorrelationId);
-                Assert.AreEqual(sagaInstance.ScheduleId, rescheduledEvent.Message.NewScheduleTokenId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.Not.Null);
+                    Assert.That(rescheduledEvent.Message.CorrelationId, Is.EqualTo(sagaInstance.CorrelationId));
+                });
+                Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.EqualTo(sagaInstance.ScheduleId));
 
                 await InputQueueSendEndpoint.Send(new StopCommand(correlationId));
 
                 Guid? saga = await LoadSagaRepository.ShouldNotContainSaga(correlationId, TestTimeout);
 
-                Assert.IsNull(saga);
+                Assert.That(saga, Is.Null);
             }
 
             InMemorySagaRepository<TestState> _repository;

--- a/tests/MassTransit.HangfireIntegration.Tests/Reschedule_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/Reschedule_Specs.cs
@@ -29,8 +29,8 @@
                 {
                     Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.Not.Null);
                     Assert.That(rescheduledEvent.Message.CorrelationId, Is.EqualTo(sagaInstance.CorrelationId));
+                    Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.EqualTo(sagaInstance.ScheduleId));
                 });
-                Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.EqualTo(sagaInstance.ScheduleId));
 
                 await InputQueueSendEndpoint.Send(new StopCommand(correlationId));
 

--- a/tests/MassTransit.HangfireIntegration.Tests/SchedulerLoadInMemory_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/SchedulerLoadInMemory_Specs.cs
@@ -29,7 +29,7 @@
 
             await Task.Delay(1000);
 
-            Assert.AreEqual(0, _repository.Count);
+            Assert.That(_repository.Count, Is.EqualTo(0));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.KafkaIntegration.Tests/Avro_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Avro_Specs.cs
@@ -77,13 +77,16 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.AreEqual("text", result.Message.Test);
-            Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-            Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
-            Assert.That(result.MessageId, Is.EqualTo(messageId));
-            Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
-            Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
-            Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.Test, Is.EqualTo("text"));
+                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+                Assert.That(result.MessageId, Is.EqualTo(messageId));
+                Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
+                Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+            });
         }
     }
 

--- a/tests/MassTransit.KafkaIntegration.Tests/ConfigureTopology_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/ConfigureTopology_Specs.cs
@@ -45,14 +45,14 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var meta = client.GetMetadata(topicName, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(1, meta.Topics.Count);
+            Assert.That(meta.Topics.Count, Is.EqualTo(1));
 
             foreach (var topic in meta.Topics)
             {
-                Assert.AreEqual(partitionCount, topic.Partitions.Count);
+                Assert.That(topic.Partitions.Count, Is.EqualTo(partitionCount));
 
                 foreach (var partition in topic.Partitions)
-                    Assert.AreEqual(replicaCount, partition.Replicas.Length);
+                    Assert.That(partition.Replicas.Length, Is.EqualTo(replicaCount));
             }
         }
 

--- a/tests/MassTransit.KafkaIntegration.Tests/MassTransit.KafkaIntegration.Tests.csproj
+++ b/tests/MassTransit.KafkaIntegration.Tests/MassTransit.KafkaIntegration.Tests.csproj
@@ -9,6 +9,10 @@
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 

--- a/tests/MassTransit.KafkaIntegration.Tests/MultiBus_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/MultiBus_Specs.cs
@@ -259,7 +259,7 @@ namespace MassTransit.KafkaIntegration.Tests
                     groupInfo = adminClient.ListGroup(nameof(MultiBus_ReBalance_Specs), TimeSpan.FromSeconds(5));
                 }
 
-                Assert.AreEqual(groupInfo.Members.Count, 2); // this fails, second instance consumer assigned to all partitions
+                Assert.That(groupInfo.Members.Count, Is.EqualTo(2)); // this fails, second instance consumer assigned to all partitions
 
                 await secondBus.BusControl.StopAsync(TestCancellationToken);
             }
@@ -402,7 +402,7 @@ namespace MassTransit.KafkaIntegration.Tests
                     groupInfo = adminClient.ListGroup(nameof(MultiBus_ConcurrentConsumers_ReBalance_Specs), TimeSpan.FromSeconds(5));
                 }
 
-                Assert.AreEqual(groupInfo.Members.Count, 6); // this fails, second instance consumer assigned to all partitions
+                Assert.That(groupInfo.Members.Count, Is.EqualTo(6)); // this fails, second instance consumer assigned to all partitions
 
                 await secondBus.BusControl.StopAsync(TestCancellationToken);
             }

--- a/tests/MassTransit.KafkaIntegration.Tests/ProducerPipe_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/ProducerPipe_Specs.cs
@@ -223,7 +223,7 @@ namespace MassTransit.KafkaIntegration.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(result.TryGetPayload(out KafkaSendContext<Guid, KafkaMessage> context), Is.True);
-                Assert.That(key, Is.EqualTo(context.Key));
+                Assert.That(context.Key, Is.EqualTo(key));
                 Assert.Multiple(() =>
                 {
                     Assert.That(key, Is.EqualTo(context.CorrelationId));

--- a/tests/MassTransit.KafkaIntegration.Tests/ProducerPipe_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/ProducerPipe_Specs.cs
@@ -63,10 +63,13 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<SendContext>();
 
-            Assert.IsTrue(result.TryGetPayload<KafkaSendContext>(out _));
-            Assert.IsTrue(result.TryGetPayload<KafkaSendContext<KafkaMessage>>(out _));
-            Assert.AreEqual(correlationId, result.CorrelationId);
-            Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.TryGetPayload<KafkaSendContext>(out _), Is.True);
+                Assert.That(result.TryGetPayload<KafkaSendContext<KafkaMessage>>(out _), Is.True);
+                Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+            });
 
             await provider.GetTask<ConsumeContext<KafkaMessage>>();
         }
@@ -217,10 +220,16 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<SendContext>();
 
-            Assert.IsTrue(result.TryGetPayload(out KafkaSendContext<Guid, KafkaMessage> context));
-            Assert.AreEqual(context.Key, key);
-            Assert.AreEqual(context.CorrelationId, key);
-            Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.TryGetPayload(out KafkaSendContext<Guid, KafkaMessage> context), Is.True);
+                Assert.That(key, Is.EqualTo(context.Key));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(key, Is.EqualTo(context.CorrelationId));
+                    Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+                });
+            });
 
             await provider.GetTask<ConsumeContext<KafkaMessage>>();
         }

--- a/tests/MassTransit.KafkaIntegration.Tests/Producer_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Producer_Specs.cs
@@ -72,18 +72,24 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.AreEqual("text", result.Message.Text);
-            Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-            Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
-            Assert.That(result.MessageId, Is.EqualTo(messageId));
-            Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
-            Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
-            Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.Text, Is.EqualTo("text"));
+                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+                Assert.That(result.MessageId, Is.EqualTo(messageId));
+                Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
+                Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+            });
 
             var headerType = result.Headers.Get<HeaderType>("Special");
             Assert.That(headerType, Is.Not.Null);
-            Assert.That(headerType.Key, Is.EqualTo("Hello"));
-            Assert.That(headerType.Value, Is.EqualTo("World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(headerType.Key, Is.EqualTo("Hello"));
+                Assert.That(headerType.Value, Is.EqualTo("World"));
+            });
         }
 
 
@@ -208,9 +214,12 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.AreEqual("text", result.Message.Text);
-            Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-            Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.Text, Is.EqualTo("text"));
+                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+            });
 
             await postSendCompletionSource.Task;
         }
@@ -310,8 +319,11 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.AreEqual("text", result.Message.Text);
-            Assert.AreEqual(correlationId, result.InitiatorId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.Text, Is.EqualTo("text"));
+                Assert.That(result.InitiatorId, Is.EqualTo(correlationId));
+            });
         }
 
 

--- a/tests/MassTransit.KafkaIntegration.Tests/Publish_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Publish_Specs.cs
@@ -56,9 +56,12 @@ namespace MassTransit.KafkaIntegration.Tests
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
             var ping = await provider.GetTask<ConsumeContext<BusPing>>();
 
-            Assert.AreEqual(result.CorrelationId, ping.InitiatorId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ping.InitiatorId, Is.EqualTo(result.CorrelationId));
 
-            Assert.That(ping.SourceAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+                Assert.That(ping.SourceAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+            });
         }
 
 

--- a/tests/MassTransit.KafkaIntegration.Tests/Receive_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Receive_Specs.cs
@@ -67,11 +67,14 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.AreEqual(message.Value.Text, result.Message.Text);
-            Assert.AreEqual(sendContext.MessageId, result.MessageId);
-            Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(result.Message.Text, Is.EqualTo(message.Value.Text));
+                Assert.That(result.MessageId, Is.EqualTo(sendContext.MessageId));
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
 
-            Assert.That(await harness.Consumed.Any<KafkaMessage>());
+                Assert.That(await harness.Consumed.Any<KafkaMessage>());
+            });
         }
 
 
@@ -333,7 +336,7 @@ namespace MassTransit.KafkaIntegration.Tests
             var result = await provider.GetTask<ConsumeContext<Batch<KafkaMessage>>>();
 
             for (var i = 0; i < batchSize; i++)
-                Assert.AreEqual(i, result.Message[i].Message.Index);
+                Assert.That(result.Message[i].Message.Index, Is.EqualTo(i));
         }
 
 

--- a/tests/MassTransit.KafkaIntegration.Tests/TopicConnector_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/TopicConnector_Specs.cs
@@ -75,18 +75,24 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.AreEqual("text", result.Message.Text);
-            Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-            Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
-            Assert.That(result.MessageId, Is.EqualTo(messageId));
-            Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
-            Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
-            Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.Text, Is.EqualTo("text"));
+                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                Assert.That(result.DestinationAddress, Is.EqualTo(new Uri($"loopback://localhost/{KafkaTopicAddress.PathPrefix}/{Topic}")));
+                Assert.That(result.MessageId, Is.EqualTo(messageId));
+                Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
+                Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+            });
 
             var headerType = result.Headers.Get<HeaderType>("Special");
             Assert.That(headerType, Is.Not.Null);
-            Assert.That(headerType.Key, Is.EqualTo("Hello"));
-            Assert.That(headerType.Value, Is.EqualTo("World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(headerType.Key, Is.EqualTo("Hello"));
+                Assert.That(headerType.Value, Is.EqualTo("World"));
+            });
         }
 
 

--- a/tests/MassTransit.MartenIntegration.Tests/MassTransit.MartenIntegration.Tests.csproj
+++ b/tests/MassTransit.MartenIntegration.Tests/MassTransit.MartenIntegration.Tests.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <ProjectReference Include="..\..\src\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />

--- a/tests/MassTransit.MongoDbIntegration.Tests/Audit/AuditStore_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/Audit/AuditStore_Specs.cs
@@ -16,17 +16,20 @@
         [Test]
         public async Task Audit_document_gets_created()
         {
-            Assert.AreEqual("Send", _auditDocument.ContextType);
-            Assert.AreEqual(_sent.Context.MessageId.Value.ToString(), _auditDocument.MessageId);
-            Assert.AreEqual(_sent.Context.ConversationId.Value.ToString(), _auditDocument.ConversationId);
-            Assert.AreEqual(_sent.Context.DestinationAddress.ToString(), _auditDocument.DestinationAddress);
-            Assert.AreEqual(typeof(A).FullName, _auditDocument.MessageType);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_auditDocument.ContextType, Is.EqualTo("Send"));
+                Assert.That(_auditDocument.MessageId, Is.EqualTo(_sent.Context.MessageId.Value.ToString()));
+                Assert.That(_auditDocument.ConversationId, Is.EqualTo(_sent.Context.ConversationId.Value.ToString()));
+                Assert.That(_auditDocument.DestinationAddress, Is.EqualTo(_sent.Context.DestinationAddress.ToString()));
+                Assert.That(_auditDocument.MessageType, Is.EqualTo(typeof(A).FullName));
+            });
         }
 
         [Test]
         public void Message_payload_matches_sent_message()
         {
-            Assert.AreEqual(_sent.Context.Message.Data, JsonConvert.DeserializeObject<A>(_auditDocument.Message).Data);
+            Assert.That(JsonConvert.DeserializeObject<A>(_auditDocument.Message).Data, Is.EqualTo(_sent.Context.Message.Data));
         }
 
         [Test]
@@ -74,18 +77,21 @@
         [Test]
         public async Task Audit_document_gets_created()
         {
-            Assert.AreEqual("Consume", _auditDocument.ContextType);
-            Assert.AreEqual(_consumed.Context.MessageId.Value.ToString(), _auditDocument.MessageId);
-            Assert.AreEqual(_consumed.Context.ConversationId.Value.ToString(), _auditDocument.ConversationId);
-            Assert.AreEqual(_consumed.Context.ReceiveContext.InputAddress.ToString(), _auditDocument.InputAddress);
-            Assert.AreEqual(_consumed.Context.DestinationAddress.ToString(), _auditDocument.DestinationAddress);
-            Assert.AreEqual(typeof(A).FullName, _auditDocument.MessageType);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_auditDocument.ContextType, Is.EqualTo("Consume"));
+                Assert.That(_auditDocument.MessageId, Is.EqualTo(_consumed.Context.MessageId.Value.ToString()));
+                Assert.That(_auditDocument.ConversationId, Is.EqualTo(_consumed.Context.ConversationId.Value.ToString()));
+                Assert.That(_auditDocument.InputAddress, Is.EqualTo(_consumed.Context.ReceiveContext.InputAddress.ToString()));
+                Assert.That(_auditDocument.DestinationAddress, Is.EqualTo(_consumed.Context.DestinationAddress.ToString()));
+                Assert.That(_auditDocument.MessageType, Is.EqualTo(typeof(A).FullName));
+            });
         }
 
         [Test]
         public void Message_payload_matches_sent_message()
         {
-            Assert.AreEqual(_consumed.Context.Message.Data, JsonConvert.DeserializeObject<A>(_auditDocument.Message).Data);
+            Assert.That(JsonConvert.DeserializeObject<A>(_auditDocument.Message).Data, Is.EqualTo(_consumed.Context.Message.Data));
         }
 
         [Test]
@@ -134,7 +140,7 @@
         {
             var sentRecord = _audit.FirstOrDefault(x => x.ContextType == "Send");
 
-            Assert.NotNull(sentRecord);
+            Assert.That(sentRecord, Is.Not.Null);
         }
 
         [Test]
@@ -142,13 +148,13 @@
         {
             var consumedRecord = _audit.FirstOrDefault(x => x.ContextType == "Consume");
 
-            Assert.NotNull(consumedRecord);
+            Assert.That(consumedRecord, Is.Not.Null);
         }
 
         [Test]
         public void The_number_of_records_is_two()
         {
-            Assert.AreEqual(2, _audit.Count);
+            Assert.That(_audit, Has.Count.EqualTo(2));
         }
 
         InMemoryTestHarness _harness;

--- a/tests/MassTransit.MongoDbIntegration.Tests/CollectionNameFormatter_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/CollectionNameFormatter_Specs.cs
@@ -13,7 +13,7 @@ namespace MassTransit.MongoDbIntegration.Tests
         public void Should_return_correct_collection()
         {
             var collectionName = _collectionNameFormatter.Saga<SimpleSaga>();
-            Assert.AreEqual("simple.sagas", collectionName);
+            Assert.That(collectionName, Is.EqualTo("simple.sagas"));
         }
 
         readonly ICollectionNameFormatter _collectionNameFormatter;
@@ -32,7 +32,7 @@ namespace MassTransit.MongoDbIntegration.Tests
         public void Should_return_default_collection_when_null()
         {
             var collectionName = _collectionNameFormatter(null).Saga<SimpleSaga>();
-            Assert.AreEqual("sagas", collectionName);
+            Assert.That(collectionName, Is.EqualTo("sagas"));
         }
 
         readonly Func<string, ICollectionNameFormatter> _collectionNameFormatter;
@@ -48,7 +48,7 @@ namespace MassTransit.MongoDbIntegration.Tests
         public void Should_return_correct_collection(string expected, string result)
         {
             var collectionName = _collectionNameFormatter(expected).Saga<SimpleSaga>();
-            Assert.AreEqual(result, collectionName);
+            Assert.That(collectionName, Is.EqualTo(result));
         }
     }
 }

--- a/tests/MassTransit.MongoDbIntegration.Tests/Courier/Complete_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/Courier/Complete_Specs.cs
@@ -19,10 +19,13 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _prepareCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.AreNotEqual(_trackingNumber, context.CorrelationId.Value);
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.Not.EqualTo(_trackingNumber));
+            });
         }
 
         [Test]
@@ -30,10 +33,13 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.AreEqual(_trackingNumber, context.CorrelationId.Value);
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(_trackingNumber));
+            });
         }
 
         [Test]
@@ -41,10 +47,13 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _sendCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.AreNotEqual(_trackingNumber, context.CorrelationId.Value);
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.Not.EqualTo(_trackingNumber));
+            });
         }
 
         [Test]
@@ -61,9 +70,9 @@
 
             var routingSlip = await (await _collection.FindAsync(query).ConfigureAwait(false)).SingleOrDefaultAsync().ConfigureAwait(false);
 
-            Assert.IsNotNull(routingSlip);
-            Assert.IsNotNull(routingSlip.Events);
-            Assert.AreEqual(3, routingSlip.Events.Length);
+            Assert.That(routingSlip, Is.Not.Null);
+            Assert.That(routingSlip.Events, Is.Not.Null);
+            Assert.That(routingSlip.Events, Has.Length.EqualTo(3));
         }
 
         [OneTimeSetUp]

--- a/tests/MassTransit.MongoDbIntegration.Tests/Courier/RoutingSlipCompleted_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/Courier/RoutingSlipCompleted_Specs.cs
@@ -21,10 +21,13 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.AreEqual(_trackingNumber, context.CorrelationId.Value);
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(_trackingNumber));
+            });
         }
 
         [Test]
@@ -38,14 +41,17 @@
 
             var routingSlip = await (await _collection.FindAsync(query).ConfigureAwait(false)).SingleOrDefaultAsync().ConfigureAwait(false);
 
-            Assert.IsNotNull(routingSlip);
-            Assert.IsNotNull(routingSlip.Events);
-            Assert.AreEqual(1, routingSlip.Events.Length);
+            Assert.That(routingSlip, Is.Not.Null);
+            Assert.That(routingSlip.Events, Is.Not.Null);
+            Assert.That(routingSlip.Events.Length, Is.EqualTo(1));
 
             var completed = routingSlip.Events[0] as RoutingSlipCompletedDocument;
-            Assert.IsNotNull(completed);
-            Assert.IsTrue(completed.Variables.ContainsKey("Client"));
-            Assert.AreEqual(27, completed.Variables["Client"]);
+            Assert.That(completed, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(completed.Variables.ContainsKey("Client"), Is.True);
+                Assert.That(completed.Variables["Client"], Is.EqualTo(27));
+            });
             //Assert.AreEqual(received.Timestamp.ToMongoDbDateTime(), read.Timestamp);
         }
 

--- a/tests/MassTransit.MongoDbIntegration.Tests/MassTransit.MongoDbIntegration.Tests.csproj
+++ b/tests/MassTransit.MongoDbIntegration.Tests/MassTransit.MongoDbIntegration.Tests.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <ProjectReference Include="..\..\src\Scheduling\MassTransit.QuartzIntegration\MassTransit.QuartzIntegration.csproj" />
     <ProjectReference Include="..\..\src\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />

--- a/tests/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
+++ b/tests/MassTransit.NHibernateIntegration.Tests/MassTransit.NHibernateIntegration.Tests.csproj
@@ -8,6 +8,10 @@
     <PackageReference Include="Iesi.Collections" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="System.Data.SqlClient" />

--- a/tests/MassTransit.NHibernateIntegration.Tests/MissingInstance_Specs.cs
+++ b/tests/MassTransit.NHibernateIntegration.Tests/MissingInstance_Specs.cs
@@ -56,7 +56,7 @@
 
                 Response<InstanceNotFound> result = await notFound;
 
-                Assert.AreEqual("A", result.Message.ServiceName);
+                Assert.That(result.Message.ServiceName, Is.EqualTo("A"));
 
                 Assert.That(async () => await status, Throws.TypeOf<TaskCanceledException>());
             }

--- a/tests/MassTransit.NHibernateIntegration.Tests/PreInsert_Specs.cs
+++ b/tests/MassTransit.NHibernateIntegration.Tests/PreInsert_Specs.cs
@@ -109,9 +109,9 @@
 
                     Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
+                    Assert.That(received.InitiatorId.Value, Is.EqualTo(message.CorrelationId), "The initiator should be the saga CorrelationId");
 
-                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                    Assert.That(received.SourceAddress, Is.EqualTo(InputQueueAddress), "The published message should have the input queue source address");
                 });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);
@@ -195,9 +195,9 @@
 
                     Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
+                    Assert.That(received.InitiatorId.Value, Is.EqualTo(message.CorrelationId), "The initiator should be the saga CorrelationId");
 
-                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                    Assert.That(received.SourceAddress, Is.EqualTo(InputQueueAddress), "The published message should have the input queue source address");
                 });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);

--- a/tests/MassTransit.NHibernateIntegration.Tests/PreInsert_Specs.cs
+++ b/tests/MassTransit.NHibernateIntegration.Tests/PreInsert_Specs.cs
@@ -103,17 +103,20 @@
 
                 ConsumeContext<StartupComplete> received = await messageReceived;
 
-                Assert.AreEqual(message.CorrelationId, received.Message.TransactionId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(received.Message.TransactionId, Is.EqualTo(message.CorrelationId));
 
-                Assert.IsTrue(received.InitiatorId.HasValue, "The initiator should be copied from the CorrelationId");
+                    Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                Assert.AreEqual(received.InitiatorId.Value, message.CorrelationId, "The initiator should be the saga CorrelationId");
+                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
 
-                Assert.AreEqual(received.SourceAddress, InputQueueAddress, "The published message should have the input queue source address");
+                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
             }
 
             protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -186,17 +189,20 @@
 
                 ConsumeContext<StartupComplete> received = await messageReceived;
 
-                Assert.AreEqual(sagaId, received.Message.TransactionId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(received.Message.TransactionId, Is.EqualTo(sagaId));
 
-                Assert.IsTrue(received.InitiatorId.HasValue, "The initiator should be copied from the CorrelationId");
+                    Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                Assert.AreEqual(received.InitiatorId.Value, message.CorrelationId, "The initiator should be the saga CorrelationId");
+                    Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
 
-                Assert.AreEqual(received.SourceAddress, InputQueueAddress, "The published message should have the input queue source address");
+                    Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                });
 
                 Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
             }
 
             protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.QuartzIntegration.Tests/DelayRetry_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/DelayRetry_Specs.cs
@@ -350,9 +350,9 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
             var customHeaderValue = context.Headers.Get(customHeader, default(int?));
-            Assert.AreEqual(2, customHeaderValue);
+            Assert.That(customHeaderValue, Is.EqualTo(2));
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;

--- a/tests/MassTransit.QuartzIntegration.Tests/JobDetail_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/JobDetail_Specs.cs
@@ -29,9 +29,12 @@
 
             await scheduler.ScheduleJob(jobDetail, trigger).ConfigureAwait(false);
 
-            Assert.IsTrue(MyJob.Signaled.WaitOne(Utils.Timeout));
+            Assert.Multiple(() =>
+            {
+                Assert.That(MyJob.Signaled.WaitOne(Utils.Timeout), Is.True);
 
-            Assert.AreEqual("By Jake", MyJob.SignaledBody);
+                Assert.That(MyJob.SignaledBody, Is.EqualTo("By Jake"));
+            });
         }
 
         [Test]
@@ -52,9 +55,12 @@
 
             await scheduler.ScheduleJob(jobDetail, trigger).ConfigureAwait(false);
 
-            Assert.IsTrue(MyJob.Signaled.WaitOne(Utils.Timeout));
+            Assert.Multiple(() =>
+            {
+                Assert.That(MyJob.Signaled.WaitOne(Utils.Timeout), Is.True);
 
-            Assert.AreEqual("By Jake", MyJob.SignaledBody);
+                Assert.That(MyJob.SignaledBody, Is.EqualTo("By Jake"));
+            });
         }
 
 

--- a/tests/MassTransit.QuartzIntegration.Tests/MassTransit.QuartzIntegration.Tests.csproj
+++ b/tests/MassTransit.QuartzIntegration.Tests/MassTransit.QuartzIntegration.Tests.csproj
@@ -7,6 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <ProjectReference Include="..\..\src\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj" />
     <ProjectReference Include="..\..\src\Scheduling\MassTransit.QuartzIntegration\MassTransit.QuartzIntegration.csproj" />

--- a/tests/MassTransit.QuartzIntegration.Tests/MissingInstanceRedelivery_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/MissingInstanceRedelivery_Specs.cs
@@ -24,10 +24,13 @@ namespace MassTransit.QuartzIntegration.Tests
 
             Response<Status, InstanceNotFound> result = await response;
 
-            Assert.That(result.Is(out Response<InstanceNotFound> _), Is.False);
-            Assert.That(result.Is(out Response<Status> status), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Is(out Response<InstanceNotFound> _), Is.False);
+                Assert.That(result.Is(out Response<Status> status), Is.True);
 
-            Assert.AreEqual("A", status.Message.ServiceName);
+                Assert.That(status.Message.ServiceName, Is.EqualTo("A"));
+            });
 
             (Task<Response<Status>> statusTask, Task<Response<InstanceNotFound>> notFoundTask) = result;
 

--- a/tests/MassTransit.QuartzIntegration.Tests/PastEvent_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/PastEvent_Specs.cs
@@ -69,19 +69,22 @@
 
             ConsumeContext<A> context = await handler;
 
-            Assert.AreEqual(Bus.Address, context.FaultAddress);
-            Assert.AreEqual(InputQueueAddress, context.ResponseAddress);
-            Assert.IsTrue(context.RequestId.HasValue);
-            Assert.AreEqual(requestId, context.RequestId.Value);
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.AreEqual(correlationId, context.CorrelationId.Value);
-            Assert.IsTrue(context.ConversationId.HasValue);
-            Assert.AreEqual(conversationId, context.ConversationId.Value);
-            Assert.IsTrue(context.InitiatorId.HasValue);
-            Assert.AreEqual(initiatorId, context.InitiatorId.Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.FaultAddress, Is.EqualTo(Bus.Address));
+                Assert.That(context.ResponseAddress, Is.EqualTo(InputQueueAddress));
+                Assert.That(context.RequestId.HasValue, Is.True);
+                Assert.That(context.RequestId.Value, Is.EqualTo(requestId));
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(correlationId));
+                Assert.That(context.ConversationId.HasValue, Is.True);
+                Assert.That(context.ConversationId.Value, Is.EqualTo(conversationId));
+                Assert.That(context.InitiatorId.HasValue, Is.True);
+                Assert.That(context.InitiatorId.Value, Is.EqualTo(initiatorId));
 
-            Assert.IsTrue(context.Headers.TryGetHeader("Hello", out var value));
-            Assert.AreEqual("World", value);
+                Assert.That(context.Headers.TryGetHeader("Hello", out var value), Is.True);
+                Assert.That(value, Is.EqualTo("World"));
+            });
         }
 
         [Test]
@@ -127,7 +130,7 @@
             });
 
             ConsumeContext<A> result = await handler;
-            Assert.AreEqual(expected, result.Message.Name);
+            Assert.That(result.Message.Name, Is.EqualTo(expected));
         }
 
         public Specifying_an_event_reschedule_if_exists()

--- a/tests/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
@@ -24,7 +24,7 @@
             await _done;
 
             var countBeforeCancel = _count;
-            Assert.AreEqual(8, _count, "Expected to see 8 interval messages");
+            Assert.That(_count, Is.EqualTo(8), "Expected to see 8 interval messages");
 
             await Bus.CancelScheduledRecurringSend(scheduledRecurringMessage);
 
@@ -32,7 +32,7 @@
 
             await _doneAgain;
 
-            Assert.AreEqual(countBeforeCancel, _count, "Expected to see the count matches.");
+            Assert.That(_count, Is.EqualTo(countBeforeCancel), "Expected to see the count matches.");
         }
 
         [Test]
@@ -66,13 +66,16 @@
 
             await _done;
 
-            Assert.Greater(_count, 0, "Expected to see at least one interval");
+            Assert.Multiple(() =>
+            {
+                Assert.That(_count, Is.GreaterThan(0), "Expected to see at least one interval");
 
 
-            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.Scheduled));
-            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.Sent));
-            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.NextScheduled));
-            Assert.IsNotNull(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.PreviousSent));
+                Assert.That(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.Scheduled), Is.Not.Null);
+                Assert.That(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.Sent), Is.Not.Null);
+                Assert.That(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.NextScheduled), Is.Not.Null);
+                Assert.That(_lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.PreviousSent), Is.Not.Null);
+            });
 
             Console.WriteLine("{0}", _lastInterval.Headers.Get<DateTimeOffset>(MessageHeaders.Quartz.NextScheduled));
         }
@@ -87,7 +90,7 @@
 
             await _done;
 
-            Assert.AreEqual(8, _count, "Expected to see 8 interval messages");
+            Assert.That(_count, Is.EqualTo(8), "Expected to see 8 interval messages");
         }
 
         [Test]
@@ -103,7 +106,7 @@
             await _done;
 
             var countBeforeCancel = _count;
-            Assert.AreEqual(8, _count, "Expected to see 8 interval messages");
+            Assert.That(_count, Is.EqualTo(8), "Expected to see 8 interval messages");
 
             await Bus.PauseScheduledRecurringSend(scheduledRecurringMessage);
 
@@ -111,7 +114,7 @@
 
             await _doneAgain;
 
-            Assert.AreEqual(countBeforeCancel, _count, "Expected to see the count matches.");
+            Assert.That(_count, Is.EqualTo(countBeforeCancel), "Expected to see the count matches.");
         }
 
         Task<ConsumeContext<Done>> _done;

--- a/tests/MassTransit.QuartzIntegration.Tests/Reschedule_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Reschedule_Specs.cs
@@ -25,15 +25,18 @@
 
                 var sagaInstance = _repository[correlationId].Instance;
 
-                Assert.NotNull(rescheduledEvent.Message.NewScheduleTokenId);
-                Assert.AreEqual(sagaInstance.CorrelationId, rescheduledEvent.Message.CorrelationId);
-                Assert.AreEqual(sagaInstance.ScheduleId, rescheduledEvent.Message.NewScheduleTokenId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.Not.Null);
+                    Assert.That(rescheduledEvent.Message.CorrelationId, Is.EqualTo(sagaInstance.CorrelationId));
+                });
+                Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.EqualTo(sagaInstance.ScheduleId));
 
                 await InputQueueSendEndpoint.Send(new StopCommand(correlationId));
 
                 Guid? saga = await LoadSagaRepository.ShouldNotContainSaga(correlationId, TestTimeout);
 
-                Assert.IsNull(saga);
+                Assert.That(saga, Is.Null);
             }
 
             InMemorySagaRepository<TestState> _repository;

--- a/tests/MassTransit.QuartzIntegration.Tests/Reschedule_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Reschedule_Specs.cs
@@ -29,8 +29,8 @@
                 {
                     Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.Not.Null);
                     Assert.That(rescheduledEvent.Message.CorrelationId, Is.EqualTo(sagaInstance.CorrelationId));
+                    Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.EqualTo(sagaInstance.ScheduleId));
                 });
-                Assert.That(rescheduledEvent.Message.NewScheduleTokenId, Is.EqualTo(sagaInstance.ScheduleId));
 
                 await InputQueueSendEndpoint.Send(new StopCommand(correlationId));
 

--- a/tests/MassTransit.QuartzIntegration.Tests/SchedulerLoadInMemory_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/SchedulerLoadInMemory_Specs.cs
@@ -29,7 +29,7 @@
 
             await Task.Delay(1000);
 
-            Assert.AreEqual(0, _repository.Count);
+            Assert.That(_repository.Count, Is.EqualTo(0));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ConcurrencyFilter_Specs.cs
@@ -28,7 +28,7 @@
 
             await _complete.Task;
 
-            Assert.AreEqual(2, _consumer.MaxDeliveryCount);
+            Assert.That(_consumer.MaxDeliveryCount, Is.EqualTo(2));
         }
 
         Consumer _consumer;
@@ -93,6 +93,7 @@
         }
     }
 
+
     [TestFixture]
     [Category("Flaky")]
     public class Using_a_consumer_concurrency_limit_set_to_1 :
@@ -112,8 +113,11 @@
 
             await _complete.Task;
 
-            Assert.AreEqual(1, _consumer.MaxDeliveryCount);
-            Assert.AreEqual(true, _consumer.CompletedConsumingSequentially);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_consumer.MaxDeliveryCount, Is.EqualTo(1));
+                Assert.That(_consumer.CompletedConsumingSequentially, Is.EqualTo(true));
+            });
         }
 
         Consumer _consumer;
@@ -134,11 +138,11 @@
             IConsumer<A>,
             IConsumer<B>
         {
+            bool _completedConsumingSequentially = true;
             int _currentPendingDeliveryCount;
             long _deliveryCount;
             int _maxPendingDeliveryCount;
             int _previousSequenceIndex;
-            bool _completedConsumingSequentially = true;
 
             public int MaxDeliveryCount => _maxPendingDeliveryCount;
             public bool CompletedConsumingSequentially => _completedConsumingSequentially;

--- a/tests/MassTransit.RabbitMqTransport.Tests/Encrypted_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/Encrypted_Specs.cs
@@ -18,7 +18,7 @@
 
             ConsumeContext<PingMessage> received = await _handler;
 
-            Assert.AreEqual(EncryptedMessageSerializerV2.EncryptedContentType, received.ReceiveContext.ContentType);
+            Assert.That(received.ReceiveContext.ContentType, Is.EqualTo(EncryptedMessageSerializerV2.EncryptedContentType));
         }
 
         Task<ConsumeContext<PingMessage>> _handler;
@@ -84,7 +84,7 @@
 
             ConsumeContext<PingMessage> received = await _handler;
 
-            Assert.AreEqual(EncryptedMessageSerializer.EncryptedContentType, received.ReceiveContext.ContentType);
+            Assert.That(received.ReceiveContext.ContentType, Is.EqualTo(EncryptedMessageSerializer.EncryptedContentType));
         }
 
         Task<ConsumeContext<PingMessage>> _handler;

--- a/tests/MassTransit.RabbitMqTransport.Tests/HeaderObject_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/HeaderObject_Specs.cs
@@ -47,10 +47,13 @@
 
             var identity = await _header.Task;
 
-            Assert.AreEqual(27, identity.IdentityId);
-            Assert.AreEqual("AAD:Claims", identity.IdentityType);
-            Assert.AreEqual(3, identity.Claims.Length);
-            Assert.AreEqual("Azure", identity.Claims[0].Issuer);
+            Assert.Multiple(() =>
+            {
+                Assert.That(identity.IdentityId, Is.EqualTo(27));
+                Assert.That(identity.IdentityType, Is.EqualTo("AAD:Claims"));
+                Assert.That(identity.Claims, Has.Length.EqualTo(3));
+            });
+            Assert.That(identity.Claims[0].Issuer, Is.EqualTo("Azure"));
         }
 
         Task<ConsumeContext<PingMessage>> _handled;
@@ -127,11 +130,14 @@
 
             ConsumeContext<PingMessage> context = await _handled;
 
-            Assert.AreEqual(_now, context.Headers.Get("Now", default(DateTime?)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Headers.Get("Now", default(DateTime?)), Is.EqualTo(_now));
 
-            Assert.AreEqual(_later, context.Headers.Get("Later", default(DateTimeOffset?)));
+                Assert.That(context.Headers.Get("Later", default(DateTimeOffset?)), Is.EqualTo(_later));
 
-            Assert.AreEqual(_sometime, context.Headers.Get("Sometime", default(DateTime?)));
+                Assert.That(context.Headers.Get("Sometime", default(DateTime?)), Is.EqualTo(_sometime));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;

--- a/tests/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
+++ b/tests/MassTransit.RabbitMqTransport.Tests/MassTransit.RabbitMqTransport.Tests.csproj
@@ -11,6 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
     <PackageReference Include="Shouldly" />

--- a/tests/MassTransit.RabbitMqTransport.Tests/Publish_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/Publish_Specs.cs
@@ -1,22 +1,16 @@
 ﻿namespace MassTransit.RabbitMqTransport.Tests
 {
-    using System;
-    using System.Threading.Tasks;
-    using NUnit.Framework;
-    using Shouldly;
-
-
     namespace Send_Specs
     {
         using System;
         using System.Linq;
         using System.Threading.Tasks;
-        using MassTransit.Testing;
         using NUnit.Framework;
         using RabbitMQ.Client;
         using Serialization;
         using Shouldly;
         using TestFramework;
+        using Testing;
 
 
         [TestFixture]
@@ -33,7 +27,7 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
             }
 
             Task<ConsumeContext<A>> _receivedA;
@@ -65,7 +59,7 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
             }
 
             Task<ConsumeContext<A>> _receivedA;
@@ -93,7 +87,7 @@
 
                 ConsumeContext<A> received = await receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
             }
         }
 
@@ -112,9 +106,12 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(received.Message.Id, Is.EqualTo(message.Id));
 
-                Assert.AreEqual(EncryptedMessageSerializer.EncryptedContentType, received.ReceiveContext.ContentType);
+                    Assert.That(received.ReceiveContext.ContentType, Is.EqualTo(EncryptedMessageSerializer.EncryptedContentType));
+                });
             }
 
             Task<ConsumeContext<A>> _receivedA;
@@ -149,7 +146,7 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
             }
 
             Task<ConsumeContext<A>> _receivedA;
@@ -176,7 +173,7 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
             }
 
             [Test]
@@ -211,7 +208,7 @@
 
                 ConsumeContext<Fault<A>> received = await _faultA;
 
-                Assert.AreEqual(message.Id, received.Message.Message.Id);
+                Assert.That(received.Message.Message.Id, Is.EqualTo(message.Id));
             }
 
             [Test]
@@ -305,7 +302,7 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
 
                 ConsumeContext<GotA> consumeContext = await _receivedGotA;
 
@@ -360,7 +357,7 @@
 
                 IReceivedMessage<B> receivedMessage = _consumer.Received.Select<B>().First();
 
-                Assert.AreEqual(message.Id, receivedMessage.Context.Message.Id);
+                Assert.That(receivedMessage.Context.Message.Id, Is.EqualTo(message.Id));
             }
 
             MultiTestConsumer _consumer;
@@ -455,7 +452,7 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
             }
 
             Task<ConsumeContext<A>> _receivedA;
@@ -496,7 +493,7 @@
 
                 ConsumeContext<A> received = await _receivedA;
 
-                Assert.AreEqual(message.Id, received.Message.Id);
+                Assert.That(received.Message.Id, Is.EqualTo(message.Id));
             }
 
             Task<ConsumeContext<A>> _receivedA;

--- a/tests/MassTransit.RabbitMqTransport.Tests/RabbitMqAddress_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/RabbitMqAddress_Specs.cs
@@ -526,7 +526,7 @@ namespace MassTransit.RabbitMqTransport.Tests
         public void TheQueueName()
         {
             var guid = new Guid(_receiveSettings.QueueName);
-            Assert.AreNotEqual(Guid.Empty, guid);
+            Assert.That(guid, Is.Not.EqualTo(Guid.Empty));
         }
 
         readonly Uri _uri = new Uri("rabbitmq://localhost/mttest/*?temporary=true");

--- a/tests/MassTransit.RabbitMqTransport.Tests/RawJson_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/RawJson_Specs.cs
@@ -32,9 +32,12 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<RawContract> received = await _receivedA;
 
-            Assert.AreEqual(message.Name, received.Message.Name);
-            Assert.AreEqual(message.Value, received.Message.Value);
-            Assert.AreEqual(message.Timestamp, received.Message.Timestamp);
+            Assert.Multiple(() =>
+            {
+                Assert.That(received.Message.Name, Is.EqualTo(message.Name));
+                Assert.That(received.Message.Value, Is.EqualTo(message.Value));
+                Assert.That(received.Message.Timestamp, Is.EqualTo(message.Timestamp));
+            });
         }
 
         Task<ConsumeContext<RawContract>> _receivedA;
@@ -106,9 +109,12 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<RawContract> received = await _receivedA;
 
-            Assert.AreEqual(message.Name, received.Message.Name);
-            Assert.AreEqual(message.Value, received.Message.Value);
-            Assert.AreEqual(message.Timestamp, received.Message.Timestamp);
+            Assert.Multiple(() =>
+            {
+                Assert.That(received.Message.Name, Is.EqualTo(message.Name));
+                Assert.That(received.Message.Value, Is.EqualTo(message.Value));
+                Assert.That(received.Message.Timestamp, Is.EqualTo(message.Timestamp));
+            });
         }
 
         Task<ConsumeContext<RawContract>> _receivedA;

--- a/tests/MassTransit.RabbitMqTransport.Tests/TwoActivityCourier_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/TwoActivityCourier_Specs.cs
@@ -6,9 +6,9 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Courier.Contracts;
-    using MassTransit.Testing;
     using NUnit.Framework;
     using TestFramework.Courier;
+    using Testing;
 
 
     [TestFixture]
@@ -45,7 +45,7 @@
         {
             var activityCompleted = (await _firstActivityCompleted);
 
-            Assert.AreEqual("Hello", activityCompleted.GetResult<string>("OriginalValue"));
+            Assert.That(activityCompleted.GetResult<string>("OriginalValue"), Is.EqualTo("Hello"));
         }
 
         [Test]
@@ -54,7 +54,7 @@
         {
             var completed = await _completed;
 
-            Assert.AreEqual("Hello, World!", completed.GetVariable<string>("Value"));
+            Assert.That(completed.GetVariable<string>("Value"), Is.EqualTo("Hello, World!"));
         }
 
         [Test]
@@ -63,7 +63,7 @@
         {
             var completed = (await _completed).Message;
 
-            Assert.AreEqual("Knife", completed.Variables["Variable"]);
+            Assert.That(completed.Variables["Variable"], Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -72,7 +72,7 @@
         {
             var activityCompleted = (await _firstActivityCompleted).Message;
 
-            Assert.AreEqual("Knife", activityCompleted.Variables["Variable"]);
+            Assert.That(activityCompleted.Variables["Variable"], Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -81,7 +81,7 @@
         {
             var activityCompleted = (await _firstActivityCompleted).Message;
 
-            Assert.AreEqual(_routingSlip.TrackingNumber, activityCompleted.TrackingNumber);
+            Assert.That(activityCompleted.TrackingNumber, Is.EqualTo(_routingSlip.TrackingNumber));
         }
 
         [Test]
@@ -90,7 +90,7 @@
         {
             var completed = (await _completed).Message;
 
-            Assert.AreEqual(_routingSlip.TrackingNumber, completed.TrackingNumber);
+            Assert.That(completed.TrackingNumber, Is.EqualTo(_routingSlip.TrackingNumber));
         }
 
         [Test]
@@ -99,7 +99,7 @@
         {
             var activityCompleted = (await _secondActivityCompleted).Message;
 
-            Assert.AreEqual(_routingSlip.TrackingNumber, activityCompleted.TrackingNumber);
+            Assert.That(activityCompleted.TrackingNumber, Is.EqualTo(_routingSlip.TrackingNumber));
         }
 
         [Test]
@@ -165,7 +165,7 @@
 
             var completed = (await _completed).Message;
 
-            Assert.AreEqual(_routingSlip.TrackingNumber, completed.TrackingNumber);
+            Assert.That(completed.TrackingNumber, Is.EqualTo(_routingSlip.TrackingNumber));
         }
 
         public Executing_with_no_observers()

--- a/tests/MassTransit.RabbitMqTransport.Tests/UsingCluster_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/UsingCluster_Specs.cs
@@ -19,9 +19,12 @@
 
             ConsumeContext<PingMessage> received = await _receivedA;
 
-            Assert.AreEqual(message.CorrelationId, received.Message.CorrelationId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(received.Message.CorrelationId, Is.EqualTo(message.CorrelationId));
 
-            Assert.AreEqual(_logicalHostAddress.Host, received.DestinationAddress.Host);
+                Assert.That(received.DestinationAddress.Host, Is.EqualTo(_logicalHostAddress.Host));
+            });
         }
 
         public When_clustering_nodes_into_a_logical_broker()

--- a/tests/MassTransit.RedisIntegration.Tests/MassTransit.RedisIntegration.Tests.csproj
+++ b/tests/MassTransit.RedisIntegration.Tests/MassTransit.RedisIntegration.Tests.csproj
@@ -7,6 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <ProjectReference Include="..\..\src\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />

--- a/tests/MassTransit.SignalR.Tests/HubLifeTimeManagerTests.cs
+++ b/tests/MassTransit.SignalR.Tests/HubLifeTimeManagerTests.cs
@@ -14,10 +14,13 @@
         async Task AssertMessageAsync(TestClient client)
         {
             var message = await client.ReadAsync().OrTimeout() as InvocationMessage;
-            Assert.NotNull(message);
-            Assert.AreEqual("Hello", message.Target);
-            Assert.AreEqual(1, message.Arguments.Length);
-            Assert.AreEqual("World", message.Arguments[0].ToString());
+            Assert.That(message, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Target, Is.EqualTo("Hello"));
+                Assert.That(message.Arguments.Length, Is.EqualTo(1));
+            });
+            Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
         }
 
         static async Task AssertNoMessageAsync(TestClient client, int milliseconds = 1000)
@@ -39,21 +42,27 @@
                 await manager.OnConnectedAsync(connection1).OrTimeout(Harness.TestTimeout);
                 await manager.OnConnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
 
-                await manager.SendAllAsync("Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendAllAsync("Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(BackplaneHarness.All.Consumed.Select<All<MyHub>>().Any());
+                Assert.That(BackplaneHarness.All.Consumed.Select<All<MyHub>>().Any(), Is.True);
 
                 var message = client1.TryRead() as InvocationMessage;
-                Assert.NotNull(message);
-                Assert.AreEqual("Hello", message.Target);
-                Assert.AreEqual(1, message.Arguments.Length);
-                Assert.AreEqual("World", message.Arguments[0].ToString());
+                Assert.That(message, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(message.Target, Is.EqualTo("Hello"));
+                    Assert.That(message.Arguments.Length, Is.EqualTo(1));
+                });
+                Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
 
                 message = client2.TryRead() as InvocationMessage;
-                Assert.NotNull(message);
-                Assert.AreEqual("Hello", message.Target);
-                Assert.AreEqual(1, message.Arguments.Length);
-                Assert.AreEqual("World", message.Arguments[0].ToString());
+                Assert.That(message, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(message.Target, Is.EqualTo("Hello"));
+                    Assert.That(message.Arguments.Length, Is.EqualTo(1));
+                });
+                Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
             }
         }
 
@@ -73,17 +82,23 @@
 
                 await manager.OnDisconnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
 
-                await manager.SendAllAsync("Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendAllAsync("Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(BackplaneHarness.All.Consumed.Select<All<MyHub>>().Any());
+                Assert.That(BackplaneHarness.All.Consumed.Select<All<MyHub>>().Any(), Is.True);
 
                 var message = client1.TryRead() as InvocationMessage;
-                Assert.NotNull(message);
-                Assert.AreEqual("Hello", message.Target);
-                Assert.AreEqual(1, message.Arguments.Length);
-                Assert.AreEqual("World", message.Arguments[0].ToString());
+                Assert.That(message, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(message.Target, Is.EqualTo("Hello"));
+                    Assert.That(message.Arguments, Has.Length.EqualTo(1));
+                });
+                Assert.Multiple(() =>
+                {
+                    Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
 
-                Assert.Null(client2.TryRead());
+                    Assert.That(client2.TryRead(), Is.Null);
+                });
             }
         }
 
@@ -106,17 +121,23 @@
                 // Because connection is local, should not have any GroupManagement
                 //Assert.IsFalse(backplaneConsumers.GroupManagementConsumer.Consumed.Select<GroupManagement<MyHub>>().Any());
 
-                await manager.SendGroupAsync("group", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendGroupAsync("group", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 Assert.IsTrue(BackplaneHarness.Group.Consumed.Select<Group<MyHub>>().Any());
 
                 var message = client1.TryRead() as InvocationMessage;
-                Assert.NotNull(message);
-                Assert.AreEqual("Hello", message.Target);
-                Assert.AreEqual(1, message.Arguments.Length);
-                Assert.AreEqual("World", message.Arguments[0].ToString());
+                Assert.That(message, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(message.Target, Is.EqualTo("Hello"));
+                    Assert.That(message.Arguments, Has.Length.EqualTo(1));
+                });
+                Assert.Multiple(() =>
+                {
+                    Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
 
-                Assert.Null(client2.TryRead());
+                    Assert.That(client2.TryRead(), Is.Null);
+                });
             }
         }
 
@@ -141,7 +162,7 @@
 
                 await Task.Delay(2000);
 
-                await manager.SendGroupAsync("name", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 await Task.Delay(2000);
 
@@ -181,7 +202,7 @@
                 await manager.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
                 await manager.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                await manager.SendGroupAsync("name", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 await AssertMessageAsync(client);
                 Assert.Null(client.TryRead());
@@ -207,13 +228,13 @@
                 await manager.OnConnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
                 await manager.AddToGroupAsync(connection2.ConnectionId, "group").OrTimeout(Harness.TestTimeout);
 
-                await manager.SendGroupAsync("group", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendGroupAsync("group", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
                 // connection1 will throw when receiving a group message, we are making sure other connections
                 // are not affected by another connection throwing
                 await AssertMessageAsync(client2);
 
                 // Repeat to check that group can still be sent to
-                await manager.SendGroupAsync("group", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendGroupAsync("group", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
                 await AssertMessageAsync(client2);
             }
         }
@@ -235,7 +256,7 @@
                 await manager.OnConnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
                 await manager.OnConnectedAsync(connection3).OrTimeout(Harness.TestTimeout);
 
-                await manager.SendUserAsync("userA", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendUserAsync("userA", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
                 await AssertMessageAsync(client1);
                 await AssertMessageAsync(client2);
             }
@@ -335,7 +356,8 @@
 
             await manager.AddToGroupAsync(connection.ConnectionId, groupName).OrTimeout(Harness.TestTimeout);
 
-            await manager.SendGroupExceptAsync(groupName, "Hello", new object[] { "World" }, new[] { connection.ConnectionId.ToUpper() }).OrTimeout(Harness.TestTimeout);
+            await manager.SendGroupExceptAsync(groupName, "Hello", new object[] { "World" }, new[] { connection.ConnectionId.ToUpper() })
+                .OrTimeout(Harness.TestTimeout);
             await AssertMessageAsync(client);
         }
 
@@ -356,13 +378,13 @@
                 await manager.OnConnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
                 await manager.OnConnectedAsync(connection3).OrTimeout(Harness.TestTimeout);
 
-                await manager.SendUserAsync("userA", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendUserAsync("userA", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
                 await AssertMessageAsync(client1);
                 await AssertMessageAsync(client2);
 
                 // Disconnect one connection for the user
                 await manager.OnDisconnectedAsync(connection1).OrTimeout(Harness.TestTimeout);
-                await manager.SendUserAsync("userA", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager.SendUserAsync("userA", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
                 await AssertMessageAsync(client2);
             }
         }

--- a/tests/MassTransit.SignalR.Tests/MassTransit.SignalR.Tests.csproj
+++ b/tests/MassTransit.SignalR.Tests/MassTransit.SignalR.Tests.csproj
@@ -8,6 +8,10 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Shouldly" />
     <ProjectReference Include="..\..\src\MassTransit.SignalR\MassTransit.SignalR.csproj" />

--- a/tests/MassTransit.SignalR.Tests/MassTransitHubLifetimeManagerTests.cs
+++ b/tests/MassTransit.SignalR.Tests/MassTransitHubLifetimeManagerTests.cs
@@ -45,20 +45,21 @@
                     await manager1.OnConnectedAsync(connection1).OrTimeout(Harness.TestTimeout);
                     await manager2.OnConnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
 
-                    await manager1.SendAllAsync("Hello", new object[] {new TestObject {TestProperty = "Foo"}}).OrTimeout(Harness.TestTimeout);
+                    await manager1.SendAllAsync("Hello", new object[] { new TestObject { TestProperty = "Foo" } }).OrTimeout(Harness.TestTimeout);
 
-                    Assert.IsTrue(backplane2Harness.All.Consumed.Select<All<MyHub>>().Any());
+                    Assert.That(backplane2Harness.All.Consumed.Select<All<MyHub>>().Any(), Is.True);
 
                     var message = await client2.ReadAsync().OrTimeout() as InvocationMessage;
-                    Assert.NotNull(message);
-                    Assert.AreEqual("Hello", message.Target);
-                    CollectionAssert.AllItemsAreInstancesOfType(message.Arguments, typeof(JsonElement));
+                    Assert.That(message, Is.Not.Null);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(message.Target, Is.EqualTo("Hello"));
+                        Assert.That(message.Arguments, Is.All.InstanceOf(typeof(JsonElement)));
+                    });
                     var jsonElement = message.Arguments[0] as JsonElement?;
-                    Assert.NotNull(jsonElement);
-                    Assert.NotNull(jsonElement.Value);
+                    Assert.That(jsonElement, Is.Not.Null);
                     var testProperty = jsonElement.Value.GetProperty("testProperty");
-                    Assert.NotNull(testProperty);;
-                    Assert.AreEqual("Foo", testProperty.GetString());
+                    Assert.That(testProperty.GetString(), Is.EqualTo("Foo"));
                 }
             }
             finally

--- a/tests/MassTransit.SignalR.Tests/ScaleoutHubLifetimeManagerTests.cs
+++ b/tests/MassTransit.SignalR.Tests/ScaleoutHubLifetimeManagerTests.cs
@@ -19,7 +19,7 @@
             Assert.Multiple(() =>
             {
                 Assert.That(message.Target, Is.EqualTo("Hello"));
-                Assert.That(message.Arguments.Length, Is.EqualTo(1));
+                Assert.That(message.Arguments, Has.Length.EqualTo(1));
             });
             Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
         }

--- a/tests/MassTransit.SignalR.Tests/ScaleoutHubLifetimeManagerTests.cs
+++ b/tests/MassTransit.SignalR.Tests/ScaleoutHubLifetimeManagerTests.cs
@@ -15,10 +15,13 @@
         async Task AssertMessageAsync(TestClient client)
         {
             var message = await client.ReadAsync().OrTimeout() as InvocationMessage;
-            Assert.NotNull(message);
-            Assert.AreEqual("Hello", message.Target);
-            Assert.AreEqual(1, message.Arguments.Length);
-            Assert.AreEqual("World", message.Arguments[0].ToString());
+            Assert.That(message, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Target, Is.EqualTo("Hello"));
+                Assert.That(message.Arguments.Length, Is.EqualTo(1));
+            });
+            Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
         }
 
         [Test]
@@ -36,7 +39,7 @@
                 await manager1.OnConnectedAsync(connection1).OrTimeout(Harness.TestTimeout);
                 await manager2.OnConnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
 
-                await manager1.SendAllAsync("Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager1.SendAllAsync("Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 Assert.IsTrue(Backplane1Harness.All.Consumed.Select<All<MyHub>>().Any());
                 Assert.IsTrue(Backplane2Harness.All.Consumed.Select<All<MyHub>>().Any());
@@ -63,7 +66,7 @@
 
                 await manager2.OnDisconnectedAsync(connection2).OrTimeout(Harness.TestTimeout);
 
-                await manager2.SendAllAsync("Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager2.SendAllAsync("Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 await AssertMessageAsync(client1);
 
@@ -83,7 +86,7 @@
 
                 await manager1.OnConnectedAsync(connection).OrTimeout(Harness.TestTimeout);
 
-                await manager2.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager2.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 Assert.IsTrue(Backplane1Harness.Connection.Consumed.Select<Connection<MyHub>>().Any());
 
@@ -105,7 +108,7 @@
 
                 await manager1.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                await manager2.SendGroupAsync("name", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 Assert.IsTrue(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any());
 
@@ -129,11 +132,11 @@
 
                 await manager2.RemoveFromGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any());
+                Assert.That(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any(), Is.True);
 
                 ConsumeContext<Ack<MyHub>> responseContext = await ackHandler;
 
-                Assert.AreEqual(manager1.ServerName, responseContext.Message.ServerName);
+                Assert.That(responseContext.Message.ServerName, Is.EqualTo(manager1.ServerName));
             }
         }
 
@@ -153,13 +156,13 @@
 
                 await manager2.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any());
+                Assert.That(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any(), Is.True);
 
                 ConsumeContext<Ack<MyHub>> responseContext = await ackHandler;
 
-                Assert.AreEqual(manager1.ServerName, responseContext.Message.ServerName);
+                Assert.That(responseContext.Message.ServerName, Is.EqualTo(manager1.ServerName));
 
-                await manager2.SendGroupAsync("name", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 Assert.IsTrue(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any());
 
@@ -184,18 +187,18 @@
                 await manager1.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
                 await manager2.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any());
+                Assert.That(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any(), Is.True);
 
                 ConsumeContext<Ack<MyHub>> responseContext = await ackHandler;
 
-                Assert.AreEqual(manager1.ServerName, responseContext.Message.ServerName);
+                Assert.That(responseContext.Message.ServerName, Is.EqualTo(manager1.ServerName));
 
-                await manager2.SendGroupAsync("name", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any());
+                Assert.That(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any(), Is.True);
 
                 await AssertMessageAsync(client);
-                Assert.Null(client.TryRead());
+                Assert.That(client.TryRead(), Is.Null);
             }
         }
 
@@ -215,7 +218,7 @@
 
                 await manager1.AddToGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                await manager2.SendGroupAsync("name", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 IReceivedMessage<Group<MyHub>> firstMessage = Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().FirstOrDefault();
 
@@ -225,19 +228,22 @@
 
                 await manager2.RemoveFromGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any());
+                Assert.That(Backplane1Harness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>().Any(), Is.True);
 
                 ConsumeContext<Ack<MyHub>> responseContext = await ackHandler;
 
-                Assert.AreEqual(manager1.ServerName, responseContext.Message.ServerName);
+                Assert.That(responseContext.Message.ServerName, Is.EqualTo(manager1.ServerName));
 
-                await manager2.SendGroupAsync("name", "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 IReceivedMessage<Group<MyHub>> secondMessage = Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Skip(1).FirstOrDefault();
 
-                Assert.NotNull(secondMessage);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(secondMessage, Is.Not.Null);
 
-                Assert.Null(client.TryRead());
+                    Assert.That(client.TryRead(), Is.Null);
+                });
             }
         }
 
@@ -255,13 +261,16 @@
                 await manager1.OnConnectedAsync(connection).OrTimeout(Harness.TestTimeout);
                 await manager2.OnConnectedAsync(connection).OrTimeout(Harness.TestTimeout);
 
-                await manager1.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager1.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsFalse(Backplane1Harness.Connection.Consumed.Select<Connection<MyHub>>().Any());
-                Assert.IsFalse(Backplane2Harness.Connection.Consumed.Select<Connection<MyHub>>().Any());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(Backplane1Harness.Connection.Consumed.Select<Connection<MyHub>>().Any(), Is.False);
+                    Assert.That(Backplane2Harness.Connection.Consumed.Select<Connection<MyHub>>().Any(), Is.False);
+                });
 
                 await AssertMessageAsync(client);
-                Assert.Null(client.TryRead());
+                Assert.That(client.TryRead(), Is.Null);
             }
         }
 
@@ -280,7 +289,7 @@
 
                 // This doesn't throw because there is no connection.ConnectionId on this server so it has to publish to the backplane.
                 // And once that happens there is no way to know if the invocation was successful or not.
-                await manager1.SendConnectionAsync(connectionMock.ConnectionId, "Hello", new object[] {"World"}).OrTimeout(Harness.TestTimeout);
+                await manager1.SendConnectionAsync(connectionMock.ConnectionId, "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 Assert.IsTrue(Backplane2Harness.Connection.Consumed.Select<Connection<MyHub>>().Any());
             }

--- a/tests/MassTransit.SqlTransport.Tests/Address_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/Address_Specs.cs
@@ -8,42 +8,19 @@ namespace MassTransit.DbTransport.Tests
     public class Specifying_a_host_address
     {
         [Test]
-        public void Should_support_the_simplest_use_case()
-        {
-            var uri = new Uri("db://localhost");
-            var address = new SqlHostAddress(uri);
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("/", address.VirtualHost);
-
-            Assert.AreEqual(uri, (Uri)address);
-        }
-
-        [Test]
-        public void Should_support_the_simplest_use_case_option_2()
-        {
-            var uri = new Uri("db://localhost/");
-            var address = new SqlHostAddress(uri);
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("/", address.VirtualHost);
-
-            Assert.AreEqual(uri, (Uri)address);
-        }
-
-        [Test]
         public void Should_support_a_virtual_host()
         {
             var uri = new Uri("db://localhost/customer_a");
             var address = new SqlHostAddress(uri);
 
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
 
-            Assert.AreEqual(uri, (Uri)address);
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
         }
 
         [Test]
@@ -52,12 +29,15 @@ namespace MassTransit.DbTransport.Tests
             var uri = new Uri("db://localhost/customer_a.billing");
             var address = new SqlHostAddress(uri);
 
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("billing", address.Area);
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.EqualTo("billing"));
 
-            Assert.AreEqual(uri, (Uri)address);
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
         }
 
         [Test]
@@ -66,12 +46,15 @@ namespace MassTransit.DbTransport.Tests
             var uri = new Uri("db://localhost/customer_a.billing/");
             var address = new SqlHostAddress(uri);
 
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("billing", address.Area);
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.EqualTo("billing"));
 
-            Assert.AreEqual(new Uri("db://localhost/customer_a.billing"), (Uri)address);
+                Assert.That((Uri)address, Is.EqualTo(new Uri("db://localhost/customer_a.billing")));
+            });
         }
 
         [Test]
@@ -81,18 +64,47 @@ namespace MassTransit.DbTransport.Tests
 
             var address = new SqlHostAddress(uri);
 
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("billing", address.Area);
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.EqualTo("billing"));
 
-            Assert.AreEqual(new Uri("db://localhost/customer_a.billing"), (Uri)address);
+                Assert.That((Uri)address, Is.EqualTo(new Uri("db://localhost/customer_a.billing")));
+            });
         }
 
         [Test]
-        public void Should_throw_on_invalid_virtual_host()
+        public void Should_support_the_simplest_use_case()
         {
-            Assert.That(() => new SqlHostAddress(new Uri("db://localhost/customer-a.billing/input-queue")), Throws.InstanceOf<SqlEndpointAddressException>());
+            var uri = new Uri("db://localhost");
+            var address = new SqlHostAddress(uri);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("/"));
+
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
+        }
+
+        [Test]
+        public void Should_support_the_simplest_use_case_option_2()
+        {
+            var uri = new Uri("db://localhost/");
+            var address = new SqlHostAddress(uri);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("/"));
+
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
         }
 
         [Test]
@@ -100,12 +112,142 @@ namespace MassTransit.DbTransport.Tests
         {
             Assert.That(() => new SqlHostAddress(new Uri("db://localhost/customer.16/input-queue")), Throws.InstanceOf<SqlEndpointAddressException>());
         }
+
+        [Test]
+        public void Should_throw_on_invalid_virtual_host()
+        {
+            Assert.That(() => new SqlHostAddress(new Uri("db://localhost/customer-a.billing/input-queue")), Throws.InstanceOf<SqlEndpointAddressException>());
+        }
     }
 
 
     [TestFixture]
     public class Specifying_an_endpoint_address
     {
+        [Test]
+        public void Should_parse_the_instance_name_from_url()
+        {
+            var address = new SqlHostAddress(new Uri("db://localhost/customer_a?instance=instance"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.InstanceName, Is.EqualTo("instance"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+
+                Assert.That((Uri)address, Is.EqualTo(new Uri("db://localhost/customer_a?instance=instance")));
+            });
+        }
+
+        [Test]
+        public void Should_support_a_virtual_host()
+        {
+            var uri = new Uri("db://localhost/customer_a/input-queue");
+            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a")), uri);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
+        }
+
+        [Test]
+        public void Should_support_a_virtual_host_and_scope()
+        {
+            var uri = new Uri("db://localhost/customer_a.billing/input-queue");
+            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing")), uri);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.EqualTo("billing"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
+        }
+
+        [Test]
+        public void Should_support_a_virtual_host_and_scope_option_2()
+        {
+            var uri = new Uri("db://localhost/customer_a.billing/input-queue");
+            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing/")), uri);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.EqualTo("billing"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
+        }
+
+        [Test]
+        public void Should_support_a_virtual_host_and_scope_with_queue()
+        {
+            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing/")),
+                new Uri("queue:input-queue"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.EqualTo("billing"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+
+                Assert.That((Uri)address, Is.EqualTo(new Uri("db://localhost/customer_a.billing/input-queue")));
+            });
+        }
+
+        [Test]
+        public void Should_support_a_virtual_host_and_scope_with_topic()
+        {
+            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing/")),
+                new Uri("topic:namespace:type"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.Null);
+                Assert.That(address.Name, Is.EqualTo("namespace:type"));
+
+                Assert.That((Uri)address, Is.EqualTo(new Uri("db://localhost/customer_a/namespace:type?type=topic")));
+            });
+        }
+
+        [Test]
+        public void Should_support_the_backslash_in_sql_host_names()
+        {
+            var hostAddress = new SqlHostAddress("localhost", "instance", default, "customer_a", "billing");
+            var address = new SqlEndpointAddress(hostAddress, new Uri("queue:input-queue"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.InstanceName, Is.EqualTo("instance"));
+                Assert.That(address.VirtualHost, Is.EqualTo("customer_a"));
+                Assert.That(address.Area, Is.EqualTo("billing"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+
+                Assert.That((Uri)address, Is.EqualTo(new Uri("db://localhost/customer_a.billing/input-queue?instance=instance")));
+            });
+        }
+
         [Test]
         public void Should_support_the_simplest_use_case()
         {
@@ -119,122 +261,15 @@ namespace MassTransit.DbTransport.Tests
             var uri = new Uri("db://localhost/input-queue");
             var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost")), uri);
 
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("/", address.VirtualHost);
-            Assert.AreEqual("input-queue", address.Name);
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scheme, Is.EqualTo("db"));
+                Assert.That(address.Host, Is.EqualTo("localhost"));
+                Assert.That(address.VirtualHost, Is.EqualTo("/"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
 
-            Assert.AreEqual(uri, (Uri)address);
-        }
-
-        [Test]
-        public void Should_support_a_virtual_host()
-        {
-            var uri = new Uri("db://localhost/customer_a/input-queue");
-            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a")), uri);
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("input-queue", address.Name);
-
-            Assert.AreEqual(uri, (Uri)address);
-        }
-
-        [Test]
-        public void Should_support_a_virtual_host_and_scope()
-        {
-            var uri = new Uri("db://localhost/customer_a.billing/input-queue");
-            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing")), uri);
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("billing", address.Area);
-            Assert.AreEqual("input-queue", address.Name);
-
-            Assert.AreEqual(uri, (Uri)address);
-        }
-
-        [Test]
-        public void Should_support_a_virtual_host_and_scope_option_2()
-        {
-            var uri = new Uri("db://localhost/customer_a.billing/input-queue");
-            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing/")), uri);
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("billing", address.Area);
-            Assert.AreEqual("input-queue", address.Name);
-
-            Assert.AreEqual(uri, (Uri)address);
-        }
-
-        [Test]
-        public void Should_support_a_virtual_host_and_scope_with_queue()
-        {
-            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing/")),
-                new Uri("queue:input-queue"));
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("billing", address.Area);
-            Assert.AreEqual("input-queue", address.Name);
-
-            Assert.AreEqual(new Uri("db://localhost/customer_a.billing/input-queue"), (Uri)address);
-        }
-
-        [Test]
-        public void Should_support_the_backslash_in_sql_host_names()
-        {
-            var hostAddress = new SqlHostAddress("localhost", "instance", default, "customer_a", "billing");
-            var address = new SqlEndpointAddress(hostAddress, new Uri("queue:input-queue"));
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("instance", address.InstanceName);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.AreEqual("billing", address.Area);
-            Assert.AreEqual("input-queue", address.Name);
-
-            Assert.AreEqual(new Uri("db://localhost/customer_a.billing/input-queue?instance=instance"), (Uri)address);
-        }
-
-        [Test]
-        public void Should_parse_the_instance_name_from_url()
-        {
-            var address = new SqlHostAddress(new Uri("db://localhost/customer_a?instance=instance"));
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("instance", address.InstanceName);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-
-            Assert.AreEqual(new Uri("db://localhost/customer_a?instance=instance"), (Uri)address);
-        }
-
-        [Test]
-        public void Should_support_a_virtual_host_and_scope_with_topic()
-        {
-            var address = new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer_a.billing/")),
-                new Uri("topic:namespace:type"));
-
-            Assert.AreEqual("db", address.Scheme);
-            Assert.AreEqual("localhost", address.Host);
-            Assert.AreEqual("customer_a", address.VirtualHost);
-            Assert.IsNull(address.Area);
-            Assert.AreEqual("namespace:type", address.Name);
-
-            Assert.AreEqual(new Uri("db://localhost/customer_a/namespace:type?type=topic"), (Uri)address);
-        }
-
-        [Test]
-        public void Should_throw_on_invalid_virtual_host()
-        {
-            Assert.That(() => new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer-a.billing")),
-                new Uri("db://localhost/customer-a.billing/input-queue")), Throws.InstanceOf<SqlEndpointAddressException>());
+                Assert.That((Uri)address, Is.EqualTo(uri));
+            });
         }
 
         [Test]
@@ -242,6 +277,13 @@ namespace MassTransit.DbTransport.Tests
         {
             Assert.That(() => new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer.16")),
                 new Uri("db://localhost/customer.16/input-queue")), Throws.InstanceOf<SqlEndpointAddressException>());
+        }
+
+        [Test]
+        public void Should_throw_on_invalid_virtual_host()
+        {
+            Assert.That(() => new SqlEndpointAddress(new SqlHostAddress(new Uri("db://localhost/customer-a.billing")),
+                new Uri("db://localhost/customer-a.billing/input-queue")), Throws.InstanceOf<SqlEndpointAddressException>());
         }
     }
 }

--- a/tests/MassTransit.SqlTransport.Tests/MassTransit.SqlTransport.Tests.csproj
+++ b/tests/MassTransit.SqlTransport.Tests/MassTransit.SqlTransport.Tests.csproj
@@ -18,6 +18,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NUnit" />
+      <PackageReference Include="NUnit.Analyzers">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
         <ProjectReference Include="..\..\src\MassTransit.TestFramework\MassTransit.TestFramework.csproj" />

--- a/tests/MassTransit.Tests/ConcurrencyLimit_Specs.cs
+++ b/tests/MassTransit.Tests/ConcurrencyLimit_Specs.cs
@@ -33,7 +33,7 @@ namespace MassTransit.Tests
 
             await _complete.Task;
 
-            Assert.AreEqual(2, _consumer.MaxDeliveryCount);
+            Assert.That(_consumer.MaxDeliveryCount, Is.EqualTo(2));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -119,7 +119,7 @@ namespace MassTransit.Tests
 
             await _complete.Task;
 
-            Assert.AreEqual(2, ConsumerSaga.MaxDeliveryCount);
+            Assert.That(ConsumerSaga.MaxDeliveryCount, Is.EqualTo(2));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_Consumer.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_Consumer.cs
@@ -837,10 +837,10 @@
             var scope = consumerContext.GetPayload<IServiceScope>();
 
             ConsumerConsumeContext<EasyConsumer, EasyMessage> consumerMessageContext = await _consumerMessageCompletion.Task;
-            Assert.AreEqual(scope, consumerMessageContext.GetPayload<IServiceScope>());
+            Assert.That(consumerMessageContext.GetPayload<IServiceScope>(), Is.EqualTo(scope));
 
             ConsumeContext<EasyMessage> messageContext = await MessageCompletion.Task;
-            Assert.AreEqual(scope, messageContext.GetPayload<IServiceScope>());
+            Assert.That(messageContext.GetPayload<IServiceScope>(), Is.EqualTo(scope));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopePublish.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopePublish.cs
@@ -30,9 +30,12 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var published = await _taskCompletionSource.Task;
 
-            Assert.IsTrue(published.TryGetPayload<IServiceProvider>(out var serviceProvider));
+            Assert.Multiple(() =>
+            {
+                Assert.That(published.TryGetPayload<IServiceProvider>(out var serviceProvider), Is.True);
 
-            Assert.AreEqual(serviceProvider, ServiceScope.ServiceProvider);
+                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(serviceProvider));
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -66,9 +69,12 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var published = await _taskCompletionSource.Task;
 
-            Assert.IsTrue(published.TryGetPayload<IServiceProvider>(out var serviceProvider));
+            Assert.Multiple(() =>
+            {
+                Assert.That(published.TryGetPayload<IServiceProvider>(out var serviceProvider), Is.True);
 
-            Assert.AreEqual(serviceProvider, ServiceScope.ServiceProvider);
+                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(serviceProvider));
+            });
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -131,7 +137,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await PublishEndpoint.Publish<SimpleMessageInterface>(new { Name = "test" });
 
             var result = await TaskCompletionSource.Task;
-            Assert.AreEqual(MyId, result);
+            Assert.That(result, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -179,7 +185,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await PublishEndpoint.Publish<SimpleMessageInterface>(new { Name = "test" });
 
             var result = await TaskCompletionSource.Task;
-            Assert.AreEqual(MyId, result);
+            Assert.That(result, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -249,7 +255,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var consumer = await ConsumerSource.Task.OrCanceled(InMemoryTestHarness.InactivityToken);
 
-            Assert.AreEqual(myId, consumer.MyId);
+            Assert.That(consumer.MyId, Is.EqualTo(myId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopeRequestClient.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopeRequestClient.cs
@@ -27,9 +27,12 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var sent = await _taskCompletionSource.Task;
 
-            Assert.IsTrue(sent.TryGetPayload<IServiceProvider>(out var serviceProvider));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sent.TryGetPayload<IServiceProvider>(out var serviceProvider), Is.True);
 
-            Assert.AreEqual(serviceProvider, ServiceScope.ServiceProvider);
+                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(serviceProvider));
+            });
         }
 
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
@@ -68,9 +71,12 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var sent = await _taskCompletionSource.Task;
 
-            Assert.IsTrue(sent.TryGetPayload<IServiceProvider>(out var serviceProvider));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sent.TryGetPayload<IServiceProvider>(out var serviceProvider), Is.True);
 
-            Assert.AreEqual(serviceProvider, ServiceScope.ServiceProvider);
+                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(serviceProvider));
+            });
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -121,9 +127,9 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var sent = await _taskCompletionSource.Task;
 
-            Assert.IsTrue(sent.TryGetPayload<IServiceProvider>(out var serviceProvider));
+            Assert.That(sent.TryGetPayload<IServiceProvider>(out var serviceProvider), Is.True);
 
-            Assert.AreEqual(serviceProvider, ServiceScope.ServiceProvider);
+            Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(serviceProvider));
         }
 
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopeSend.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopeSend.cs
@@ -33,7 +33,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             {
                 Assert.That(sent.TryGetPayload<IServiceScope>(out var scope), Is.True);
 
-                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(scope.ServiceProvider));
+                Assert.That(scope.ServiceProvider, Is.EqualTo(ServiceScope.ServiceProvider));
             });
         }
 
@@ -72,7 +72,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             {
                 Assert.That(sent.TryGetPayload<IServiceScope>(out var scope), Is.True);
 
-                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(scope.ServiceProvider));
+                Assert.That(scope.ServiceProvider, Is.EqualTo(ServiceScope.ServiceProvider));
             });
         }
 

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopeSend.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopeSend.cs
@@ -29,9 +29,12 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var sent = await _taskCompletionSource.Task;
 
-            Assert.IsTrue(sent.TryGetPayload<IServiceScope>(out var scope));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sent.TryGetPayload<IServiceScope>(out var scope), Is.True);
 
-            Assert.AreEqual(scope.ServiceProvider, ServiceScope.ServiceProvider);
+                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(scope.ServiceProvider));
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -65,9 +68,12 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             var sent = await _taskCompletionSource.Task;
 
-            Assert.IsTrue(sent.TryGetPayload<IServiceScope>(out var scope));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sent.TryGetPayload<IServiceScope>(out var scope), Is.True);
 
-            Assert.AreEqual(scope.ServiceProvider, ServiceScope.ServiceProvider);
+                Assert.That(ServiceScope.ServiceProvider, Is.EqualTo(scope.ServiceProvider));
+            });
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -131,7 +137,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await endpoint.Send<SimpleMessageInterface>(new { Name = "test" });
 
             var result = await _taskCompletionSource.Task;
-            Assert.AreEqual(MyId, result);
+            Assert.That(result, Is.EqualTo(MyId));
         }
 
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
@@ -179,7 +185,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await SendEndpoint.Send<SimpleMessageInterface>(new { Name = "test" });
 
             var result = await _taskCompletionSource.Task;
-            Assert.AreEqual(MyId, result);
+            Assert.That(result, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopedMediator.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopedMediator.cs
@@ -29,7 +29,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await Mediator.Send<SimpleMessageInterface>(new { Name = "test" });
 
             var result = await _taskCompletionSource.Task;
-            Assert.AreEqual(MyId, result);
+            Assert.That(result, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -71,7 +71,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await Mediator.Publish<SimpleMessageInterface>(new { Name = "test" });
 
             var result = await _taskCompletionSource.Task;
-            Assert.AreEqual(MyId, result);
+            Assert.That(result, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -116,10 +116,10 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await Mediator.Send<SimplePublishedInterface>(new { Name = "test" });
 
             var myOtherId = await _otherTaskCompletionSource.Task;
-            Assert.AreEqual(MyOtherId, myOtherId);
+            Assert.That(myOtherId, Is.EqualTo(MyOtherId));
 
             var myId = await _taskCompletionSource.Task;
-            Assert.AreEqual(MyId, myId);
+            Assert.That(myId, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -167,10 +167,10 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await Mediator.Publish<SimplePublishedInterface>(new { Name = "test" });
 
             var myOtherId = await _otherTaskCompletionSource.Task;
-            Assert.AreEqual(MyOtherId, myOtherId);
+            Assert.That(myOtherId, Is.EqualTo(MyOtherId));
 
             var myId = await _taskCompletionSource.Task;
-            Assert.AreEqual(MyId, myId);
+            Assert.That(myId, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -214,7 +214,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await client.GetResponse<ISimpleMessageResponse>(new { Name = "test" });
 
             var result = await _taskCompletionSource.Task;
-            Assert.AreEqual(MyId, result);
+            Assert.That(result, Is.EqualTo(MyId));
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/MultiBus_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/MultiBus_Specs.cs
@@ -221,9 +221,12 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
         [Test]
         public async Task Should_configure_endpoints_correctly()
         {
-            Assert.AreEqual(1, _busOneConfigured);
-            Assert.AreEqual(1, _busTwoConfigured);
-            Assert.AreEqual(2, _globalConfigured);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_busOneConfigured, Is.EqualTo(1));
+                Assert.That(_busTwoConfigured, Is.EqualTo(1));
+                Assert.That(_globalConfigured, Is.EqualTo(2));
+            });
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -259,6 +262,18 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             });
         }
 
+        [OneTimeSetUp]
+        public async Task Setup()
+        {
+            await Task.WhenAll(HostedServices.Select(x => x.StartAsync(InMemoryTestHarness.TestCancellationToken)));
+        }
+
+        [OneTimeTearDown]
+        public async Task TearDown()
+        {
+            await Task.WhenAll(HostedServices.Select(x => x.StopAsync(InMemoryTestHarness.TestCancellationToken)));
+        }
+
 
         class GlobalConfigureReceiveEndpoint :
             IConfigureReceiveEndpoint
@@ -274,19 +289,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             {
                 _action();
             }
-        }
-
-
-        [OneTimeSetUp]
-        public async Task Setup()
-        {
-            await Task.WhenAll(HostedServices.Select(x => x.StartAsync(InMemoryTestHarness.TestCancellationToken)));
-        }
-
-        [OneTimeTearDown]
-        public async Task TearDown()
-        {
-            await Task.WhenAll(HostedServices.Select(x => x.StopAsync(InMemoryTestHarness.TestCancellationToken)));
         }
 
 

--- a/tests/MassTransit.Tests/Courier/ArgumentOverload_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/ArgumentOverload_Specs.cs
@@ -18,9 +18,9 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.AreEqual("Used", context.GetVariable<string>("Test"));
+            Assert.That(context.GetVariable<string>("Test"), Is.EqualTo("Used"));
         }
 
         [Test]
@@ -28,7 +28,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;
@@ -75,7 +75,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -83,9 +83,12 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.AreEqual("Used", context.GetVariable<string>("Test"));
+                Assert.That(context.GetVariable<string>("Test"), Is.EqualTo("Used"));
+            });
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;
@@ -128,7 +131,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -136,9 +139,12 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.AreEqual("Used", context.GetVariable<string>("Test"));
+                Assert.That(context.GetVariable<string>("Test"), Is.EqualTo("Used"));
+            });
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;
@@ -185,9 +191,12 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.That(context.GetArgument<Guid>("GuidValue"), Is.EqualTo(_trackingNumber));
+                Assert.That(context.GetArgument<Guid>("GuidValue"), Is.EqualTo(_trackingNumber));
+            });
         }
 
         [Test]
@@ -195,9 +204,12 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.AreEqual("Used", context.GetVariable<string>("Test"));
+                Assert.That(context.GetVariable<string>("Test"), Is.EqualTo("Used"));
+            });
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;

--- a/tests/MassTransit.Tests/Courier/FaultActivityEvent_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/FaultActivityEvent_Specs.cs
@@ -19,7 +19,7 @@
             ConsumeContext<RoutingSlipActivityCompensated> compensated = await _activityCompensated;
             ConsumeContext<RoutingSlipActivityCompleted> completed = await _activityCompleted;
 
-            Assert.AreEqual(completed.Message.TrackingNumber, compensated.Message.TrackingNumber);
+            Assert.That(compensated.Message.TrackingNumber, Is.EqualTo(completed.Message.TrackingNumber));
         }
 
         [Test]
@@ -27,7 +27,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompensated> context = await _activityCompensated;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -35,7 +35,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual("Hello", context.GetResult<string>("OriginalValue"));
+            Assert.That(context.GetResult<string>("OriginalValue"), Is.EqualTo("Hello"));
         }
 
         [Test]
@@ -43,7 +43,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -51,7 +51,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _secondActivityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -59,7 +59,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual("Knife", context.GetVariable<string>("Variable"));
+            Assert.That(context.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -67,7 +67,7 @@
         {
             ConsumeContext<RoutingSlipActivityFaulted> context = await _activityFaulted;
 
-            Assert.AreEqual("Knife", context.GetVariable<string>("Variable"));
+            Assert.That(context.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -75,7 +75,7 @@
         {
             ConsumeContext<RoutingSlipActivityFaulted> context = await _activityFaulted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -83,7 +83,7 @@
         {
             ConsumeContext<RoutingSlipFaulted> context = await _faulted;
 
-            Assert.AreEqual("Knife", context.GetVariable<string>("Variable"));
+            Assert.That(context.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         Task<ConsumeContext<RoutingSlipFaulted>> _faulted;

--- a/tests/MassTransit.Tests/Courier/Fault_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/Fault_Specs.cs
@@ -153,7 +153,7 @@
 
             ConsumeContext<RoutingSlipFaulted> context = await handled;
 
-            Assert.AreEqual("Data", context.GetVariable<string>("Test"));
+            Assert.That(context.GetVariable<string>("Test"), Is.EqualTo("Data"));
         }
 
         protected override void SetupActivities(BusTestHarness testHarness)

--- a/tests/MassTransit.Tests/Courier/FaultyRedeliveredActivityWithVariable_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/FaultyRedeliveredActivityWithVariable_Specs.cs
@@ -12,20 +12,6 @@ namespace MassTransit.Tests.Courier
     public class FaultyRedeliveredActivityVariables_Specs :
         InMemoryActivityTestFixture
     {
-        class MessageVariables
-        {
-            public string Test { get; set; }
-        }
-
-
-        class MessageWithVariables
-        {
-            public MessageVariables Variables { get; set; }
-        }
-
-
-        TaskCompletionSource<ConsumeContext<MessageWithVariables>> _received;
-
         [Test]
         public async Task Should_publish_the_completed_event_and_redeliver()
         {
@@ -43,8 +29,23 @@ namespace MassTransit.Tests.Courier
             await completed;
 
             var message = (await _received.Task).Message;
-            Assert.AreEqual("Data", message.Variables.Test);
+            Assert.That(message.Variables.Test, Is.EqualTo("Data"));
         }
+
+
+        class MessageVariables
+        {
+            public string Test { get; set; }
+        }
+
+
+        class MessageWithVariables
+        {
+            public MessageVariables Variables { get; set; }
+        }
+
+
+        TaskCompletionSource<ConsumeContext<MessageWithVariables>> _received;
 
         protected override void SetupActivities(BusTestHarness testHarness)
         {

--- a/tests/MassTransit.Tests/Courier/FaultyRetriedActivityWithVariable_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/FaultyRetriedActivityWithVariable_Specs.cs
@@ -12,20 +12,6 @@ namespace MassTransit.Tests.Courier
     public class FaultyRetriedActivityVariables_Specs :
         InMemoryActivityTestFixture
     {
-        class MessageVariables
-        {
-            public string Test { get; set; }
-        }
-
-
-        class MessageWithVariables
-        {
-            public MessageVariables Variables { get; set; }
-        }
-
-
-        TaskCompletionSource<ConsumeContext<MessageWithVariables>> _received;
-
         [Test]
         public async Task Should_publish_the_completed_event_and_redeliver()
         {
@@ -43,8 +29,23 @@ namespace MassTransit.Tests.Courier
             await completed;
 
             var message = (await _received.Task).Message;
-            Assert.AreEqual("Data", message.Variables.Test);
+            Assert.That(message.Variables.Test, Is.EqualTo("Data"));
         }
+
+
+        class MessageVariables
+        {
+            public string Test { get; set; }
+        }
+
+
+        class MessageWithVariables
+        {
+            public MessageVariables Variables { get; set; }
+        }
+
+
+        TaskCompletionSource<ConsumeContext<MessageWithVariables>> _received;
 
         protected override void SetupActivities(BusTestHarness testHarness)
         {

--- a/tests/MassTransit.Tests/Courier/MessageDataArguments_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/MessageDataArguments_Specs.cs
@@ -20,9 +20,9 @@ namespace MassTransit.Tests.Courier
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.AreEqual("Frank", context.GetVariable<string>("Name"));
+            Assert.That(context.GetVariable<string>("Name"), Is.EqualTo("Frank"));
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace MassTransit.Tests.Courier
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         public Using_message_data_arguments()

--- a/tests/MassTransit.Tests/Courier/ObjectGraph_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/ObjectGraph_Specs.cs
@@ -52,10 +52,8 @@
 
             if (faulted.Status == TaskStatus.RanToCompletion)
             {
-                Assert.Fail("Failed due to exception {0}", faulted.Result.Message.ActivityExceptions.Any()
-                    ? faulted.Result.Message.ActivityExceptions.First()
-                        .ExceptionInfo.Message
-                    : "VisitUnknownFilter");
+                Assert.Fail(
+                    $"Failed due to exception {(faulted.Result.Message.ActivityExceptions.Any() ? faulted.Result.Message.ActivityExceptions.First().ExceptionInfo.Message : "VisitUnknownFilter")}");
             }
 
             Assert.That(completed.Status, Is.EqualTo(TaskStatus.RanToCompletion));
@@ -97,10 +95,8 @@
 
             if (faulted.Status == TaskStatus.RanToCompletion)
             {
-                Assert.Fail("Failed due to exception {0}", faulted.Result.Message.ActivityExceptions.Any()
-                    ? faulted.Result.Message.ActivityExceptions.First()
-                        .ExceptionInfo.Message
-                    : "VisitUnknownFilter");
+                Assert.Fail(
+                    $"Failed due to exception {(faulted.Result.Message.ActivityExceptions.Any() ? faulted.Result.Message.ActivityExceptions.First().ExceptionInfo.Message : "VisitUnknownFilter")}");
             }
 
             Assert.That(completed.Status, Is.EqualTo(TaskStatus.RanToCompletion));

--- a/tests/MassTransit.Tests/Courier/ReviseItinerary_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/ReviseItinerary_Specs.cs
@@ -43,7 +43,7 @@
             await reviseActivityCompleted;
 
             ConsumeContext<RoutingSlipRevised> revisions = await revised;
-            Assert.AreEqual(0, revisions.Message.DiscardedItinerary.Length);
+            Assert.That(revisions.Message.DiscardedItinerary, Is.Empty);
         }
 
         [Test]
@@ -105,10 +105,13 @@
             await reviseActivityCompleted;
 
             ConsumeContext<RoutingSlipRevised> revisions = await revised;
-            Assert.AreEqual(1, revisions.Message.DiscardedItinerary.Length);
-            Assert.AreEqual(0, revisions.Message.Itinerary.Length);
+            Assert.Multiple(() =>
+            {
+                Assert.That(revisions.Message.DiscardedItinerary, Has.Length.EqualTo(1));
+                Assert.That(revisions.Message.Itinerary, Is.Empty);
 
-            Assert.That(testActivityCompleted.Wait(TimeSpan.FromSeconds(3)), Is.False);
+                Assert.That(testActivityCompleted.Wait(TimeSpan.FromSeconds(3)), Is.False);
+            });
         }
 
         protected override void SetupActivities(BusTestHarness testHarness)

--- a/tests/MassTransit.Tests/Courier/SingleActivityEvent_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/SingleActivityEvent_Specs.cs
@@ -18,7 +18,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -26,7 +26,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_originalValue, context.GetResult<string>("OriginalValue"));
+            Assert.That(context.GetResult<string>("OriginalValue"), Is.EqualTo(_originalValue));
         }
 
         [Test]
@@ -34,7 +34,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual("Knife", context.GetVariable<string>("Variable"));
+            Assert.That(context.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -42,7 +42,7 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -51,7 +51,7 @@
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
             ConsumeContext<RoutingSlipCompleted> completeContext = await _completed;
 
-            Assert.AreEqual(completeContext.Message.Timestamp, context.Message.Timestamp + context.Message.Duration);
+            Assert.That(context.Message.Timestamp + context.Message.Duration, Is.EqualTo(completeContext.Message.Timestamp));
 
             Console.WriteLine("Duration: {0}", context.Message.Duration);
         }
@@ -61,7 +61,7 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual("Knife", context.GetVariable<string>("Variable"));
+            Assert.That(context.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;
@@ -106,7 +106,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -114,7 +114,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual("Hello", context.GetResult<string>("OriginalValue"));
+            Assert.That(context.GetResult<string>("OriginalValue"), Is.EqualTo("Hello"));
         }
 
         [Test]
@@ -122,7 +122,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual("Knife", context.GetVariable<string>("Variable"));
+            Assert.That(context.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -130,7 +130,7 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -139,7 +139,7 @@
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
             ConsumeContext<RoutingSlipCompleted> completeContext = await _completed;
 
-            Assert.AreEqual(completeContext.Message.Timestamp, context.Message.Timestamp + context.Message.Duration);
+            Assert.That(context.Message.Timestamp + context.Message.Duration, Is.EqualTo(completeContext.Message.Timestamp));
 
             Console.WriteLine("Duration: {0}", context.Message.Duration);
         }
@@ -149,7 +149,7 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.AreEqual("Knife", context.GetVariable<string>("Variable"));
+            Assert.That(context.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;

--- a/tests/MassTransit.Tests/Courier/Subscription_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/Subscription_Specs.cs
@@ -1,7 +1,6 @@
 ﻿namespace MassTransit.Tests.Courier
 {
     using System;
-    using System.Linq;
     using System.Text.Json;
     using System.Threading.Tasks;
     using MassTransit.Courier.Contracts;
@@ -45,7 +44,7 @@
 
             var loaded = TestExtensionsForJson.GetRoutingSlip(jsonString);
 
-            Assert.AreEqual(RoutingSlipEvents.Completed | RoutingSlipEvents.Faulted, loaded.Subscriptions[0].Events);
+            Assert.That(loaded.Subscriptions[0].Events, Is.EqualTo(RoutingSlipEvents.Completed | RoutingSlipEvents.Faulted));
         }
     }
 
@@ -59,7 +58,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.IsFalse(context.Message.Data.ContainsKey("OriginalValue"));
+            Assert.That(context.Message.Data.ContainsKey("OriginalValue"), Is.False);
         }
 
         [Test]
@@ -67,7 +66,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.IsFalse(context.Message.Variables.ContainsKey("Variable"));
+            Assert.That(context.Message.Variables.ContainsKey("Variable"), Is.False);
         }
 
         [Test]
@@ -75,7 +74,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> context = await _activityCompleted;
 
-            Assert.AreEqual(_trackingNumber, context.Message.TrackingNumber);
+            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
         }
 
         [Test]
@@ -92,7 +91,7 @@
 
             var loaded = TestExtensionsForJson.GetRoutingSlip(jsonString);
 
-            Assert.AreEqual(RoutingSlipEvents.Completed | RoutingSlipEvents.Faulted, loaded.Subscriptions[0].Events);
+            Assert.That(loaded.Subscriptions[0].Events, Is.EqualTo(RoutingSlipEvents.Completed | RoutingSlipEvents.Faulted));
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;
@@ -124,7 +123,6 @@
     }
 
 
-
     [TestFixture(typeof(Json))]
     [TestFixture(typeof(RawJson))]
     [TestFixture(typeof(NewtonsoftJson))]
@@ -132,13 +130,6 @@
     public class Adding_a_custom_routing_slip_event_subscription<T>
         where T : new()
     {
-        readonly ITestBusConfiguration _configuration;
-
-        public Adding_a_custom_routing_slip_event_subscription()
-        {
-            _configuration = new T() as ITestBusConfiguration;
-        }
-
         [Test]
         public async Task Should_be_sent()
         {
@@ -173,6 +164,13 @@
             Assert.That(completed, Is.Not.Null);
 
             Assert.That(completed.Context.Message.Value, Is.EqualTo("Secret Value"));
+        }
+
+        readonly ITestBusConfiguration _configuration;
+
+        public Adding_a_custom_routing_slip_event_subscription()
+        {
+            _configuration = new T() as ITestBusConfiguration;
         }
 
 

--- a/tests/MassTransit.Tests/Courier/TwoActivityEvent_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/TwoActivityEvent_Specs.cs
@@ -18,7 +18,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> activityCompleted = await _firstActivityCompleted;
 
-            Assert.AreEqual("Hello", activityCompleted.GetResult<string>("OriginalValue"));
+            Assert.That(activityCompleted.GetResult<string>("OriginalValue"), Is.EqualTo("Hello"));
         }
 
         [Test]
@@ -26,7 +26,7 @@
         {
             ConsumeContext<RoutingSlipCompleted> completed = await _completed;
 
-            Assert.AreEqual("Hello, World!", completed.GetVariable<string>("Value"));
+            Assert.That(completed.GetVariable<string>("Value"), Is.EqualTo("Hello, World!"));
         }
 
         [Test]
@@ -34,7 +34,7 @@
         {
             ConsumeContext<RoutingSlipCompleted> completed = await _completed;
 
-            Assert.AreEqual("Knife", completed.GetVariable<string>("Variable"));
+            Assert.That(completed.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -42,7 +42,7 @@
         {
             ConsumeContext<RoutingSlipActivityCompleted> activityCompleted = await _firstActivityCompleted;
 
-            Assert.AreEqual("Knife", activityCompleted.GetVariable<string>("Variable"));
+            Assert.That(activityCompleted.GetVariable<string>("Variable"), Is.EqualTo("Knife"));
         }
 
         [Test]
@@ -50,7 +50,7 @@
         {
             var activityCompleted = (await _firstActivityCompleted).Message;
 
-            Assert.AreEqual(_routingSlip.TrackingNumber, activityCompleted.TrackingNumber);
+            Assert.That(activityCompleted.TrackingNumber, Is.EqualTo(_routingSlip.TrackingNumber));
         }
 
         [Test]
@@ -58,11 +58,11 @@
         {
             var completed = (await _completed).Message;
 
-            Assert.AreEqual(_routingSlip.TrackingNumber, completed.TrackingNumber);
+            Assert.That(completed.TrackingNumber, Is.EqualTo(_routingSlip.TrackingNumber));
 
             Console.WriteLine("Duration: {0}", completed.Duration);
 
-            Assert.IsFalse(completed.Variables.ContainsKey("ToBeRemoved"));
+            Assert.That(completed.Variables.ContainsKey("ToBeRemoved"), Is.False);
         }
 
         [Test]
@@ -70,7 +70,7 @@
         {
             var activityCompleted = (await _secondActivityCompleted).Message;
 
-            Assert.AreEqual(_routingSlip.TrackingNumber, activityCompleted.TrackingNumber);
+            Assert.That(activityCompleted.TrackingNumber, Is.EqualTo(_routingSlip.TrackingNumber));
         }
 
         Task<ConsumeContext<RoutingSlipCompleted>> _completed;

--- a/tests/MassTransit.Tests/Courier/UriArgument_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/UriArgument_Specs.cs
@@ -34,11 +34,11 @@
 
             ConsumeContext<RoutingSlipActivityCompleted> consumeContext = await activity;
 
-            Assert.AreEqual(new Uri("http://google.com/"), consumeContext.GetResult<string>("UsedAddress"));
+            Assert.That(consumeContext.GetResult<string>("UsedAddress"), Is.EqualTo("http://google.com/"));
 
             ConsumeContext<RoutingSlipActivityCompensated> context = await activityCompensated;
 
-            Assert.AreEqual(new Uri("http://google.com/"), context.GetResult<string>("UsedAddress"));
+            Assert.That(context.GetResult<string>("UsedAddress"), Is.EqualTo("http://google.com/"));
         }
 
         [Test]
@@ -61,7 +61,7 @@
 
             ConsumeContext<RoutingSlipActivityCompleted> consumeContext = await activity;
 
-            Assert.AreEqual(new Uri("http://google.com/"), consumeContext.GetResult<string>("UsedAddress"));
+            Assert.That(consumeContext.GetResult<string>("UsedAddress"), Is.EqualTo("http://google.com/"));
         }
 
         protected override void SetupActivities(BusTestHarness testHarness)

--- a/tests/MassTransit.Tests/Encryption/EncryptedFallbackDeserializerTests.cs
+++ b/tests/MassTransit.Tests/Encryption/EncryptedFallbackDeserializerTests.cs
@@ -41,7 +41,7 @@ namespace MassTransit.Tests.Encryption
 
             // Assert
 
-            Assert.AreNotEqual(inputMessage, encryptedMessage);
+            Assert.That(encryptedMessage, Is.Not.EqualTo(inputMessage));
             Assert.Throws<SerializationException>(DeserializeAction);
         }
 
@@ -66,10 +66,13 @@ namespace MassTransit.Tests.Encryption
             var deserializerContext = deserializer.Deserialize(messageBody, EmptyHeaders.Instance);
             var canDecryptMessage = deserializerContext.TryGetMessage(out TestMessage? decryptedReceivedTestEvent);
 
-            // Assert
-            Assert.AreNotEqual(inputMessage, encryptedMessage);
-            Assert.IsTrue(canDecryptMessage);
-            Assert.AreEqual(inputTestEvent, decryptedReceivedTestEvent);
+            Assert.Multiple(() =>
+            {
+                // Assert
+                Assert.That(encryptedMessage, Is.Not.EqualTo(inputMessage));
+                Assert.That(canDecryptMessage, Is.True);
+                Assert.That(decryptedReceivedTestEvent, Is.EqualTo(inputTestEvent));
+            });
         }
 
         [Test]
@@ -98,10 +101,13 @@ namespace MassTransit.Tests.Encryption
             var deserializerContext = secondDeserializer.Deserialize(messageBody, EmptyHeaders.Instance);
             var canDecryptMessage = deserializerContext.TryGetMessage(out TestMessage? decryptedReceivedTestEvent);
 
-            // Assert
-            Assert.AreNotEqual(inputMessage, encryptedMessage);
-            Assert.IsTrue(canDecryptMessage);
-            Assert.AreEqual(inputTestEvent, decryptedReceivedTestEvent);
+            Assert.Multiple(() =>
+            {
+                // Assert
+                Assert.That(encryptedMessage, Is.Not.EqualTo(inputMessage));
+                Assert.That(canDecryptMessage, Is.True);
+                Assert.That(decryptedReceivedTestEvent, Is.EqualTo(inputTestEvent));
+            });
         }
 
         static string CreateTestMessage(out TestMessage inputTestEvent)

--- a/tests/MassTransit.Tests/ExcessiveAsyncFault_Specs.cs
+++ b/tests/MassTransit.Tests/ExcessiveAsyncFault_Specs.cs
@@ -25,10 +25,10 @@
 
                 IReceivedMessage<Fault<PingMessage>>[] messages = _consumer.Received.Select<Fault<PingMessage>>().Take(limit).ToArray();
 
-                Assert.AreEqual(limit, messages.Length);
+                Assert.That(messages.Length, Is.EqualTo(limit));
 
-                Assert.AreEqual(limit,
-                    messages.Select(x => x.Context.Message.Exceptions[0].ExceptionType == TypeCache<IntentionalTestException>.ShortName).Count());
+                Assert.That(messages.Select(x => x.Context.Message.Exceptions[0].ExceptionType == TypeCache<IntentionalTestException>.ShortName).Count(),
+                    Is.EqualTo(limit));
             }
 
             PingConsumer _consumer;

--- a/tests/MassTransit.Tests/FastProperty_Specs.cs
+++ b/tests/MassTransit.Tests/FastProperty_Specs.cs
@@ -25,7 +25,7 @@ namespace MassTransit.Tests
             const string expectedValue = "Chris";
             fastProperty.Set(instance, expectedValue);
 
-            Assert.AreEqual(expectedValue, fastProperty.Get(instance));
+            Assert.That(fastProperty.Get(instance), Is.EqualTo(expectedValue));
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace MassTransit.Tests
             const string expectedValue = "Chris";
             cache["Name"].Set(instance, expectedValue);
 
-            Assert.AreEqual(expectedValue, instance.Name);
+            Assert.That(instance.Name, Is.EqualTo(expectedValue));
         }
 
 

--- a/tests/MassTransit.Tests/FaultPoly_Specs.cs
+++ b/tests/MassTransit.Tests/FaultPoly_Specs.cs
@@ -12,26 +12,29 @@ namespace MassTransit.Tests
         [Test]
         public void Should_have_the_fault_base_message_class_type()
         {
-            Assert.That(MessageTypeCache<Fault<MemberAddressUpdated>>.MessageTypeNames, Contains.Item(MessageUrn.ForType(typeof(Fault<MemberUpdateEvent>))));
+            Assert.That(MessageTypeCache<Fault<MemberAddressUpdated>>.MessageTypeNames,
+                Contains.Item(MessageUrn.ForTypeString(typeof(Fault<MemberUpdateEvent>))));
         }
 
         [Test]
         public void Should_have_the_fault_base_message_type()
         {
-            Assert.That(MessageTypeCache<Fault<UpdateMemberAddress>>.MessageTypeNames, Contains.Item(MessageUrn.ForType(typeof(Fault<MemberUpdateCommand>))));
+            Assert.That(MessageTypeCache<Fault<UpdateMemberAddress>>.MessageTypeNames,
+                Contains.Item(MessageUrn.ForTypeString(typeof(Fault<MemberUpdateCommand>))));
         }
 
         [Test]
         public void Should_have_the_fault_message_class_type()
         {
             Assert.That(MessageTypeCache<Fault<MemberAddressUpdated>>.MessageTypeNames,
-                Contains.Item(MessageUrn.ForType(typeof(Fault<MemberAddressUpdated>))));
+                Contains.Item(MessageUrn.ForTypeString(typeof(Fault<MemberAddressUpdated>))));
         }
 
         [Test]
         public void Should_have_the_fault_message_type()
         {
-            Assert.That(MessageTypeCache<Fault<UpdateMemberAddress>>.MessageTypeNames, Contains.Item(MessageUrn.ForType(typeof(Fault<UpdateMemberAddress>))));
+            Assert.That(MessageTypeCache<Fault<UpdateMemberAddress>>.MessageTypeNames,
+                Contains.Item(MessageUrn.ForTypeString(typeof(Fault<UpdateMemberAddress>))));
         }
     }
 
@@ -56,7 +59,7 @@ namespace MassTransit.Tests
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
         {
-            configurator.Handler<UpdateMemberAddress>(async context => throw new IntentionalTestException());
+            configurator.Handler<UpdateMemberAddress>(async _ => throw new IntentionalTestException());
         }
     }
 

--- a/tests/MassTransit.Tests/Groups/Group_Specs.cs
+++ b/tests/MassTransit.Tests/Groups/Group_Specs.cs
@@ -19,7 +19,7 @@ namespace MassTransit.Tests.Groups
 
             CorrelatedMessageGroup<Guid> messageGroup = createOrder.CombineWith(orderItemList.ToArray());
 
-            Assert.AreEqual(1, messageGroup.Count());
+            Assert.That(messageGroup.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -35,7 +35,7 @@ namespace MassTransit.Tests.Groups
 
             CorrelatedMessageGroup<Guid> messageGroup = createOrder.CombineWith(orderItemList.ToArray());
 
-            Assert.AreEqual(3, messageGroup.Count());
+            Assert.That(messageGroup.Count(), Is.EqualTo(3));
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace MassTransit.Tests.Groups
 
             messageGroup.CombineWith(secondGroup);
 
-            Assert.AreEqual(5, messageGroup.Count());
+            Assert.That(messageGroup.Count(), Is.EqualTo(5));
         }
 
         [SetUp]
@@ -73,7 +73,7 @@ namespace MassTransit.Tests.Groups
         public static CorrelatedMessageGroup<TKey> CombineWith<TMessage, TKey>(this CorrelatedBy<TKey> message, params TMessage[] messages)
             where TMessage : CorrelatedBy<TKey>
         {
-            var group = new CorrelatedMessageGroup<TKey> {message};
+            var group = new CorrelatedMessageGroup<TKey> { message };
 
             group.AddRange(messages);
 

--- a/tests/MassTransit.Tests/HeaderObject_Specs.cs
+++ b/tests/MassTransit.Tests/HeaderObject_Specs.cs
@@ -27,8 +27,11 @@
 
             var identity = await _header.Task;
 
-            Assert.AreEqual(27, identity.IdentityId);
-            Assert.AreEqual("AAD:Claims", identity.IdentityType);
+            Assert.Multiple(() =>
+            {
+                Assert.That(identity.IdentityId, Is.EqualTo(27));
+                Assert.That(identity.IdentityType, Is.EqualTo("AAD:Claims"));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;

--- a/tests/MassTransit.Tests/HostInfo_Specs.cs
+++ b/tests/MassTransit.Tests/HostInfo_Specs.cs
@@ -18,16 +18,19 @@
 
             ConsumeContext<PingMessage> context = await _handled;
 
-            Assert.IsNotNull(context.Host);
+            Assert.That(context.Host, Is.Not.Null);
 
-            Assert.AreEqual(HostMetadataCache.Host.MachineName, context.Host.MachineName);
-            Assert.AreEqual(HostMetadataCache.Host.Assembly, context.Host.Assembly);
-            Assert.AreEqual(HostMetadataCache.Host.AssemblyVersion, context.Host.AssemblyVersion);
-            Assert.AreEqual(HostMetadataCache.Host.FrameworkVersion, context.Host.FrameworkVersion);
-            Assert.AreEqual(HostMetadataCache.Host.MassTransitVersion, context.Host.MassTransitVersion);
-            Assert.AreEqual(HostMetadataCache.Host.OperatingSystemVersion, context.Host.OperatingSystemVersion);
-            Assert.AreEqual(HostMetadataCache.Host.ProcessName, context.Host.ProcessName);
-            Assert.AreEqual(HostMetadataCache.Host.ProcessId, context.Host.ProcessId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Host.MachineName, Is.EqualTo(HostMetadataCache.Host.MachineName));
+                Assert.That(context.Host.Assembly, Is.EqualTo(HostMetadataCache.Host.Assembly));
+                Assert.That(context.Host.AssemblyVersion, Is.EqualTo(HostMetadataCache.Host.AssemblyVersion));
+                Assert.That(context.Host.FrameworkVersion, Is.EqualTo(HostMetadataCache.Host.FrameworkVersion));
+                Assert.That(context.Host.MassTransitVersion, Is.EqualTo(HostMetadataCache.Host.MassTransitVersion));
+                Assert.That(context.Host.OperatingSystemVersion, Is.EqualTo(HostMetadataCache.Host.OperatingSystemVersion));
+                Assert.That(context.Host.ProcessName, Is.EqualTo(HostMetadataCache.Host.ProcessName));
+                Assert.That(context.Host.ProcessId, Is.EqualTo(HostMetadataCache.Host.ProcessId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;

--- a/tests/MassTransit.Tests/JsonToken_Specs.cs
+++ b/tests/MassTransit.Tests/JsonToken_Specs.cs
@@ -17,7 +17,7 @@
             {
                 var value = NewtonsoftJsonMessageSerializer.Deserializer.Deserialize<int>(jsonReader);
 
-                Assert.AreEqual(27, value);
+                Assert.That(value, Is.EqualTo(27));
             }
         }
     }

--- a/tests/MassTransit.Tests/MassTransit.Tests.csproj
+++ b/tests/MassTransit.Tests/MassTransit.Tests.csproj
@@ -29,6 +29,10 @@
     <PackageReference Include="MathNet.Numerics" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
     <ProjectReference Include="..\..\src\MassTransit.Interop.NServiceBus\MassTransit.Interop.NServiceBus.csproj" />
     <ProjectReference Include="..\..\src\MassTransit.Newtonsoft\MassTransit.Newtonsoft.csproj" />

--- a/tests/MassTransit.Tests/MessageUrnSpecs.cs
+++ b/tests/MassTransit.Tests/MessageUrnSpecs.cs
@@ -9,18 +9,86 @@ namespace MassTransit.Tests
     public class MessageUrnSpecs
     {
         [Test]
+        public void AttributedMessage()
+        {
+            var urn = MessageUrn.ForType(typeof(Attributed));
+            Assert.That(urn.AbsolutePath, Is.EqualTo("message:MyCustomName"));
+        }
+
+        [Test]
+        public void AttributedMessage_with_default_prefix_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedKnownPrefix)),
+                Throws.TypeOf<TypeInitializationException>()
+                    .And.InnerException.TypeOf<ArgumentException>()
+                    .And.InnerException.Message.StartsWith("Value should not contain the default prefix 'urn:message:'."));
+        }
+
+        [Test]
+        public void AttributedMessage_with_empty_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedEmpty)),
+                Throws.TypeOf<TypeInitializationException>()
+                    .And.InnerException.TypeOf<ArgumentException>()
+                    .And.InnerException.Message.StartsWith("Value cannot be empty or whitespace only string."));
+        }
+
+        [Test]
+        public void AttributedMessage_with_null_throws_error()
+        {
+            Assert.That(
+                () => MessageUrn.ForType(typeof(AttributedNull)),
+                Throws.TypeOf<TypeInitializationException>()
+                    .And.InnerException.TypeOf<ArgumentNullException>()
+                    .And.InnerException.Message.StartsWith("Value cannot be null."));
+        }
+
+        [Test]
+        public void AttributedMessage_with_symbols()
+        {
+            var urn = MessageUrn.ForType(typeof(AttributedSymbols));
+            Assert.That(urn, Is.EqualTo(new Uri("urn:message:\\|,./<>?;'#:@~[]{}�!\"�$%25^&*()_+`��")));
+            // Assert.That(urn, Is.EqualTo("urn:message:\\|,./<>?;'#:@~[]{}�!\"�$%25^&*()_+`��"));
+        }
+
+        [Test]
+        public void AttributedMessage_with_whitespace_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedWhitespace)),
+                Throws.TypeOf<TypeInitializationException>()
+                    .And.InnerException.TypeOf<ArgumentException>()
+                    .And.InnerException.Message.StartsWith("Value cannot be empty or whitespace only string."));
+        }
+
+        [Test]
+        public void AttributedMessage_without_default_prefix()
+        {
+            var urn = MessageUrn.ForTypeString(typeof(AttributedNoDefaults));
+            Assert.That(urn, Is.EqualTo("scheme:identifier"));
+        }
+
+        [Test]
+        public void AttributedMessage_without_default_prefix_and_invalid_urn_throws_error()
+        {
+            Assert.That(() => MessageUrn.ForType(typeof(AttributedNoDefaultsInvalidUrn)),
+                Throws.TypeOf<TypeInitializationException>()
+                    .And.InnerException.TypeOf<UriFormatException>()
+                    .And.InnerException.Message.EqualTo("Invalid URN: scheme"));
+        }
+
+        [Test]
         public void ClosedGenericMessage()
         {
             var urn = MessageUrn.ForType(typeof(G<PingMessage>));
             var expected = new Uri("urn:message:MassTransit.Tests:G[[MassTransit.TestFramework.Messages:PingMessage]]");
-            Assert.AreEqual(expected.AbsolutePath, urn.AbsolutePath);
+            Assert.That(urn.AbsolutePath, Is.EqualTo(expected.AbsolutePath));
         }
 
         [Test]
         public void NestedMessage()
         {
             var urn = MessageUrn.ForType(typeof(X));
-            Assert.AreEqual(urn.AbsolutePath, "message:MassTransit.Tests:MessageUrnSpecs+X");
+            Assert.That(urn.AbsolutePath, Is.EqualTo("message:MassTransit.Tests:MessageUrnSpecs+X"));
         }
 
         [Test]
@@ -33,75 +101,9 @@ namespace MassTransit.Tests
         public void SimpleMessage()
         {
             var urn = MessageUrn.ForType(typeof(PingMessage));
-            Assert.AreEqual(urn.AbsolutePath, "message:MassTransit.TestFramework.Messages:PingMessage");
+            Assert.That(urn.AbsolutePath, Is.EqualTo("message:MassTransit.TestFramework.Messages:PingMessage"));
         }
 
-        [Test]
-        public void AttributedMessage()
-        {
-            var urn = MessageUrn.ForType(typeof(Attributed));
-            Assert.AreEqual(urn.AbsolutePath, "message:MyCustomName");
-        }
-
-        [Test]
-        public void AttributedMessage_with_symbols()
-        {
-            var urn = MessageUrn.ForType(typeof(AttributedSymbols));
-            Assert.AreEqual(urn, "urn:message:\\|,./<>?;'#:@~[]{}�!\"�$%25^&*()_+`��");
-        }
-
-        [Test]
-        public void AttributedMessage_with_null_throws_error()
-        {
-            Assert.That(
-                () => MessageUrn.ForType(typeof(AttributedNull)),
-                Throws.TypeOf<TypeInitializationException>()
-                .And.InnerException.TypeOf<ArgumentNullException>()
-                .And.InnerException.Message.StartsWith("Value cannot be null."));
-        }
-
-        [Test]
-        public void AttributedMessage_with_empty_throws_error()
-        {
-            Assert.That(() => MessageUrn.ForType(typeof(AttributedEmpty)),
-                Throws.TypeOf<TypeInitializationException>()
-                .And.InnerException.TypeOf<ArgumentException>()
-                .And.InnerException.Message.StartsWith("Value cannot be empty or whitespace only string."));
-        }
-
-        [Test]
-        public void AttributedMessage_with_whitespace_throws_error()
-        {
-            Assert.That(() => MessageUrn.ForType(typeof(AttributedWhitespace)),
-                Throws.TypeOf<TypeInitializationException>()
-                .And.InnerException.TypeOf<ArgumentException>()
-                .And.InnerException.Message.StartsWith("Value cannot be empty or whitespace only string."));
-        }
-
-        [Test]
-        public void AttributedMessage_with_default_prefix_throws_error()
-        {
-            Assert.That(() => MessageUrn.ForType(typeof(AttributedKnownPrefix)),
-                Throws.TypeOf<TypeInitializationException>()
-                .And.InnerException.TypeOf<ArgumentException>()
-                .And.InnerException.Message.StartsWith("Value should not contain the default prefix 'urn:message:'."));
-        }
-
-        [Test]
-        public void AttributedMessage_without_default_prefix()
-        {
-            var urn = MessageUrn.ForType(typeof(AttributedNoDefaults));
-            Assert.AreEqual(urn, "scheme:identifier");
-        }
-
-        [Test]
-        public void AttributedMessage_without_default_prefix_and_invalid_urn_throws_error()
-        {
-            Assert.That(() => MessageUrn.ForType(typeof(AttributedNoDefaultsInvalidUrn)),
-                Throws.TypeOf<TypeInitializationException>()
-                .And.InnerException.TypeOf<UriFormatException>()
-                .And.InnerException.Message.EqualTo("Invalid URN: scheme"));
-        }
 
         class X
         {
@@ -113,51 +115,51 @@ namespace MassTransit.Tests
     {
     }
 
+
     [MessageUrn("MyCustomName")]
     public class Attributed
     {
-
     }
+
 
     [MessageUrn(null)]
     public class AttributedNull
     {
-
     }
+
 
     [MessageUrn("")]
     public class AttributedEmpty
     {
-
     }
+
 
     [MessageUrn("\t\t   ")]
     public class AttributedWhitespace
     {
-
     }
+
 
     [MessageUrn("urn:message:MyCustomName")]
     public class AttributedKnownPrefix
     {
-
     }
+
 
     [MessageUrn("\\|,./<>?;'#:@~[]{}�!\"�$%^&*()_+`��")]
     public class AttributedSymbols
     {
-
     }
+
 
     [MessageUrn("scheme:identifier", useDefaultPrefix: false)]
     public class AttributedNoDefaults
     {
-
     }
+
 
     [MessageUrn("scheme", useDefaultPrefix: false)]
     public class AttributedNoDefaultsInvalidUrn
     {
-
     }
 }

--- a/tests/MassTransit.Tests/Middleware/Internals/FastProperty_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Internals/FastProperty_Specs.cs
@@ -25,7 +25,7 @@ namespace MassTransit.Tests.Middleware.Internals
             const string expectedValue = "Chris";
             fastProperty.Set(instance, expectedValue);
 
-            Assert.AreEqual(expectedValue, fastProperty.Get(instance));
+            Assert.That(fastProperty.Get(instance), Is.EqualTo(expectedValue));
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace MassTransit.Tests.Middleware.Internals
             const string expectedValue = "Chris";
             cache["Name"].Set(instance, expectedValue);
 
-            Assert.AreEqual(expectedValue, instance.Name);
+            Assert.That(instance.Name, Is.EqualTo(expectedValue));
         }
 
 

--- a/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionGeneric_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionGeneric_Specs.cs
@@ -39,43 +39,55 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             IEnumerable<Type> types = typeof(SuperGenericBaseClass<>).GetClosingArguments(typeof(IGeneric<>));
 
-            Assert.AreEqual(0, types.Count());
+            Assert.That(types.Count(), Is.EqualTo(0));
         }
 
         [Test]
         public void Should_return_the_appropriate_generic_type()
         {
-            IEnumerable<Type> types = typeof(GenericClass).GetClosingArguments(typeof(IGeneric<>));
+            IEnumerable<Type> types = typeof(GenericClass).GetClosingArguments(typeof(IGeneric<>)).ToArray();
 
-            Assert.AreEqual(1, types.Count());
-            Assert.AreEqual(typeof(int), types.First());
+            Assert.Multiple(() =>
+            {
+                Assert.That(types.Count(), Is.EqualTo(1));
+                Assert.That(types.First(), Is.EqualTo(typeof(int)));
+            });
         }
 
         [Test]
         public void Should_return_the_appropriate_generic_type_for_a_subclass_non_generic()
         {
-            IEnumerable<Type> types = typeof(SubClass).GetClosingArguments(typeof(IGeneric<>));
+            IEnumerable<Type> types = typeof(SubClass).GetClosingArguments(typeof(IGeneric<>)).ToArray();
 
-            Assert.AreEqual(1, types.Count());
-            Assert.AreEqual(typeof(int), types.First());
+            Assert.Multiple(() =>
+            {
+                Assert.That(types.Count(), Is.EqualTo(1));
+                Assert.That(types.First(), Is.EqualTo(typeof(int)));
+            });
         }
 
         [Test]
         public void Should_return_the_appropriate_generic_type_with_a_generic_base_class()
         {
-            IEnumerable<Type> types = typeof(NonGenericSubClass).GetClosingArguments(typeof(IGeneric<>));
+            IEnumerable<Type> types = typeof(NonGenericSubClass).GetClosingArguments(typeof(IGeneric<>)).ToArray();
 
-            Assert.AreEqual(1, types.Count());
-            Assert.AreEqual(typeof(int), types.First());
+            Assert.Multiple(() =>
+            {
+                Assert.That(types.Count(), Is.EqualTo(1));
+                Assert.That(types.First(), Is.EqualTo(typeof(int)));
+            });
         }
 
         [Test]
         public void Should_return_the_generic_type_from_a_class()
         {
-            IEnumerable<Type> types = typeof(NonGenericSubClass).GetClosingArguments(typeof(GenericBaseClass<>));
+            IEnumerable<Type> types = typeof(NonGenericSubClass).GetClosingArguments(typeof(GenericBaseClass<>)).ToArray();
 
-            Assert.AreEqual(1, types.Count());
-            Assert.AreEqual(typeof(int), types.First());
+            Assert.Multiple(() =>
+            {
+                Assert.That(types.Count(), Is.EqualTo(1));
+                Assert.That(types.First(), Is.EqualTo(typeof(int)));
+            });
         }
 
 

--- a/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionMoreGeneric_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionMoreGeneric_Specs.cs
@@ -21,9 +21,12 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(NestedDoubleGenericInterface).GetClosingArguments(typeof(INestedDoubleGeneric<,>)).ToArray();
 
-            Assert.AreEqual(2, types.Length);
-            Assert.AreEqual(typeof(SingleGenericInterface), types[0]);
-            Assert.AreEqual(typeof(int), types[1]);
+            Assert.That(types, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(types[0], Is.EqualTo(typeof(SingleGenericInterface)));
+                Assert.That(types[1], Is.EqualTo(typeof(int)));
+            });
         }
 
         [Test]
@@ -31,9 +34,12 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(DeepDoubleNestedGeneric).GetClosingArguments(typeof(Dictionary<,>)).ToArray();
 
-            Assert.AreEqual(2, types.Length);
-            Assert.AreEqual(typeof(int), types[0]);
-            Assert.AreEqual(typeof(string), types[1]);
+            Assert.That(types, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(types[0], Is.EqualTo(typeof(int)));
+                Assert.That(types[1], Is.EqualTo(typeof(string)));
+            });
         }
 
         [Test]
@@ -41,8 +47,8 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(DeepSingleNestedGeneric).GetClosingArguments(typeof(List<>)).ToArray();
 
-            Assert.AreEqual(1, types.Length);
-            Assert.AreEqual(typeof(string), types[0]);
+            Assert.That(types, Has.Length.EqualTo(1));
+            Assert.That(types[0], Is.EqualTo(typeof(string)));
         }
 
         [Test]
@@ -50,9 +56,12 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(DoubleGenericInterface).GetClosingArguments(typeof(IDoubleGeneric<,>)).ToArray();
 
-            Assert.AreEqual(2, types.Length);
-            Assert.AreEqual(typeof(int), types[0]);
-            Assert.AreEqual(typeof(string), types[1]);
+            Assert.That(types, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(types[0], Is.EqualTo(typeof(int)));
+                Assert.That(types[1], Is.EqualTo(typeof(string)));
+            });
         }
 
         [Test]
@@ -60,9 +69,12 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(Dictionary<int, string>).GetClosingArguments(typeof(Dictionary<,>)).ToArray();
 
-            Assert.AreEqual(2, types.Length);
-            Assert.AreEqual(typeof(int), types[0]);
-            Assert.AreEqual(typeof(string), types[1]);
+            Assert.That(types, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(types[0], Is.EqualTo(typeof(int)));
+                Assert.That(types[1], Is.EqualTo(typeof(string)));
+            });
         }
 
         [Test]
@@ -70,9 +82,12 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(DoubleNestedGeneric).GetClosingArguments(typeof(Dictionary<,>)).ToArray();
 
-            Assert.AreEqual(2, types.Length);
-            Assert.AreEqual(typeof(int), types[0]);
-            Assert.AreEqual(typeof(string), types[1]);
+            Assert.That(types, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(types[0], Is.EqualTo(typeof(int)));
+                Assert.That(types[1], Is.EqualTo(typeof(string)));
+            });
         }
 
         [Test]
@@ -80,8 +95,8 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(SingleGenericInterface).GetClosingArguments(typeof(ISingleGeneric<>)).ToArray();
 
-            Assert.AreEqual(1, types.Length);
-            Assert.AreEqual(typeof(int), types[0]);
+            Assert.That(types, Has.Length.EqualTo(1));
+            Assert.That(types[0], Is.EqualTo(typeof(int)));
         }
 
         [Test]
@@ -89,8 +104,8 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(List<string>).GetClosingArguments(typeof(List<>)).ToArray();
 
-            Assert.AreEqual(1, types.Length);
-            Assert.AreEqual(typeof(string), types[0]);
+            Assert.That(types, Has.Length.EqualTo(1));
+            Assert.That(types[0], Is.EqualTo(typeof(string)));
         }
 
         [Test]
@@ -98,8 +113,8 @@ namespace MassTransit.Tests.Middleware.Internals
         {
             Type[] types = typeof(SingleNestedGeneric).GetClosingArguments(typeof(List<>)).ToArray();
 
-            Assert.AreEqual(1, types.Length);
-            Assert.AreEqual(typeof(string), types[0]);
+            Assert.That(types, Has.Length.EqualTo(1));
+            Assert.That(types[0], Is.EqualTo(typeof(string)));
         }
 
 

--- a/tests/MassTransit.Tests/Middleware/Internals/TypeProperty_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Internals/TypeProperty_Specs.cs
@@ -15,7 +15,7 @@
         {
             IEnumerable<PropertyInfo> properties = typeof(B).GetAllProperties();
 
-            Assert.AreEqual(3, properties.Count());
+            Assert.That(properties.Count(), Is.EqualTo(3));
         }
 
         [Test]
@@ -23,7 +23,7 @@
         {
             IEnumerable<PropertyInfo> properties = typeof(C).GetAllProperties();
 
-            Assert.AreEqual(2, properties.Count());
+            Assert.That(properties.Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -31,7 +31,7 @@
         {
             IEnumerable<PropertyInfo> properties = typeof(D).GetAllProperties();
 
-            Assert.AreEqual(4, properties.Count());
+            Assert.That(properties.Count(), Is.EqualTo(4));
         }
 
         [Test]
@@ -39,7 +39,7 @@
         {
             IEnumerable<PropertyInfo> properties = typeof(ID).GetAllProperties();
 
-            Assert.AreEqual(4, properties.Count());
+            Assert.That(properties.Count(), Is.EqualTo(4));
         }
 
         [Test]
@@ -47,7 +47,7 @@
         {
             IEnumerable<PropertyInfo> properties = typeof(A).GetAllStaticProperties();
 
-            Assert.AreEqual(1, properties.Count());
+            Assert.That(properties.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -55,7 +55,7 @@
         {
             IEnumerable<PropertyInfo> properties = typeof(B).GetAllStaticProperties();
 
-            Assert.AreEqual(1, properties.Count());
+            Assert.That(properties.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -63,7 +63,7 @@
         {
             IEnumerable<PropertyInfo> properties = typeof(A).GetAllProperties();
 
-            Assert.AreEqual(2, properties.Count());
+            Assert.That(properties.Count(), Is.EqualTo(2));
         }
 
 

--- a/tests/MassTransit.Tests/Middleware/PartitionByKey_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/PartitionByKey_Specs.cs
@@ -30,7 +30,7 @@
 
             await completed.Task;
 
-            Assert.AreEqual(Limit, count);
+            Assert.That(count, Is.EqualTo(Limit));
 
             Console.WriteLine("Processed: {0}", count);
         }

--- a/tests/MassTransit.Tests/Pipeline/PartitionByKey_Specs.cs
+++ b/tests/MassTransit.Tests/Pipeline/PartitionByKey_Specs.cs
@@ -19,7 +19,7 @@
 
             var count = await _completed.Task;
 
-            Assert.AreEqual(Limit, count);
+            Assert.That(count, Is.EqualTo(Limit));
 
             Console.WriteLine("Processed: {0}", count);
         }
@@ -81,7 +81,7 @@
 
             var count = await _completed.Task;
 
-            Assert.AreEqual(Limit, count);
+            Assert.That(count, Is.EqualTo(Limit));
 
             Console.WriteLine("Processed: {0}", count);
         }

--- a/tests/MassTransit.Tests/ReceiveObserver_Specs.cs
+++ b/tests/MassTransit.Tests/ReceiveObserver_Specs.cs
@@ -24,7 +24,7 @@
 
                     Tuple<ConsumeContext, string> context = await observer.PostConsumed;
 
-                    Assert.AreEqual(TypeCache<MessageHandler<PingMessage>>.ShortName, context.Item2);
+                    Assert.That(context.Item2, Is.EqualTo(TypeCache<MessageHandler<PingMessage>>.ShortName));
                 }
             }
 
@@ -80,7 +80,7 @@
 
                     Tuple<ConsumeContext, string> context = await observer.PostConsumed;
 
-                    Assert.AreEqual(TypeCache<PingConsumerDude>.ShortName, context.Item2);
+                    Assert.That(context.Item2, Is.EqualTo(TypeCache<PingConsumerDude>.ShortName));
                 }
             }
 

--- a/tests/MassTransit.Tests/Saga/InitiateSaga_Specs.cs
+++ b/tests/MassTransit.Tests/Saga/InitiateSaga_Specs.cs
@@ -192,7 +192,7 @@ namespace MassTransit.Tests.Saga
             }
             catch (SagaException sex)
             {
-                Assert.That(typeof(InitiateSimpleSaga), Is.EqualTo(sex.MessageType));
+                Assert.That(sex.MessageType, Is.EqualTo(typeof(InitiateSimpleSaga)));
             }
         }
 

--- a/tests/MassTransit.Tests/Saga/InitiateSaga_Specs.cs
+++ b/tests/MassTransit.Tests/Saga/InitiateSaga_Specs.cs
@@ -192,7 +192,7 @@ namespace MassTransit.Tests.Saga
             }
             catch (SagaException sex)
             {
-                Assert.AreEqual(sex.MessageType, typeof(InitiateSimpleSaga));
+                Assert.That(typeof(InitiateSimpleSaga), Is.EqualTo(sex.MessageType));
             }
         }
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Activity_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Activity_Specs.cs
@@ -10,7 +10,7 @@
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(_machine.Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Running));
         }
 
         Instance _instance;
@@ -60,7 +60,7 @@
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(_machine.Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Running));
         }
 
         Instance _instance;
@@ -107,13 +107,13 @@
         [Test]
         public void Should_have_called_the_finally_activity()
         {
-            Assert.AreEqual(InstanceStateMachine.Finalized, _instance.Value);
+            Assert.That(_instance.Value, Is.EqualTo(InstanceStateMachine.Finalized));
         }
 
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(_machine.Final, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Final));
         }
 
         Instance _instance;
@@ -166,25 +166,25 @@
         [Test]
         public void Should_call_the_activity()
         {
-            Assert.AreEqual(_machine.Final, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Final));
         }
 
         [Test]
         public void Should_have_trigger_the_final_before_enter_event()
         {
-            Assert.AreEqual(_machine.Running, _instance.FinalState);
+            Assert.That(_instance.FinalState, Is.EqualTo(_machine.Running));
         }
 
         [Test]
         public void Should_have_triggered_the_after_leave_event()
         {
-            Assert.AreEqual(_machine.Initial, _instance.LeftState);
+            Assert.That(_instance.LeftState, Is.EqualTo(_machine.Initial));
         }
 
         [Test]
         public void Should_have_triggered_the_before_enter_event()
         {
-            Assert.AreEqual(_machine.Initializing, _instance.EnteredState);
+            Assert.That(_instance.EnteredState, Is.EqualTo(_machine.Initializing));
         }
 
         Instance _instance;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/AnyStateTransition_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/AnyStateTransition_Specs.cs
@@ -10,19 +10,19 @@
         [Test]
         public void Should_be_running()
         {
-            Assert.AreEqual(_machine.Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Running));
         }
 
         [Test]
         public void Should_have_entered_running()
         {
-            Assert.AreEqual(_machine.Running, _instance.LastEntered);
+            Assert.That(_instance.LastEntered, Is.EqualTo(_machine.Running));
         }
 
         [Test]
         public void Should_have_left_initial()
         {
-            Assert.AreEqual(_machine.Initial, _instance.LastLeft);
+            Assert.That(_instance.LastLeft, Is.EqualTo(_machine.Initial));
         }
 
         Instance _instance;
@@ -40,13 +40,13 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
 
             public State LastEntered { get; set; }
             public State LastLeft { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Anytime_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Anytime_Specs.cs
@@ -16,8 +16,8 @@
             await _machine.RaiseEvent(instance, x => x.Init);
             await _machine.RaiseEvent(instance, x => x.Hello);
 
-            Assert.IsTrue(instance.HelloCalled);
-            Assert.AreEqual(_machine.Final, instance.CurrentState);
+            Assert.That(instance.HelloCalled, Is.True);
+            Assert.That(instance.CurrentState, Is.EqualTo(_machine.Final));
         }
 
         [Test]
@@ -26,13 +26,10 @@
             var instance = new Instance();
 
             await _machine.RaiseEvent(instance, x => x.Init);
-            await _machine.RaiseEvent(instance, x => x.EventA, new A
-            {
-                Value = "Test"
-            });
+            await _machine.RaiseEvent(instance, x => x.EventA, new A { Value = "Test" });
 
-            Assert.AreEqual("Test", instance.AValue);
-            Assert.AreEqual(_machine.Final, instance.CurrentState);
+            Assert.That(instance.AValue, Is.EqualTo("Test"));
+            Assert.That(instance.CurrentState, Is.EqualTo(_machine.Final));
         }
 
         [Test]
@@ -42,8 +39,11 @@
 
             Assert.That(async () => await _machine.RaiseEvent(instance, x => x.Hello), Throws.TypeOf<UnhandledEventException>());
 
-            Assert.IsFalse(instance.HelloCalled);
-            Assert.AreEqual(_machine.Initial, instance.CurrentState);
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.HelloCalled, Is.False);
+                Assert.That(instance.CurrentState, Is.EqualTo(_machine.Initial));
+            });
         }
 
         TestStateMachine _machine;
@@ -62,12 +62,12 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public bool HelloCalled { get; set; }
             public string AValue { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/AsyncActivity_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/AsyncActivity_Specs.cs
@@ -16,16 +16,16 @@
 
             await machine.RaiseEvent(claim, machine.Create, new CreateInstance());
 
-            Assert.AreEqual("ExecuteAsync", claim.Value);
+            Assert.That(claim.Value, Is.EqualTo("ExecuteAsync"));
         }
 
 
         class TestInstance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public string Value { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -38,7 +38,8 @@
                 context.Instance.Value = "ExecuteAsync";
             }
 
-            Task IStateMachineActivity<TestInstance, CreateInstance>.Faulted<TException>(BehaviorExceptionContext<TestInstance, CreateInstance, TException> context,
+            Task IStateMachineActivity<TestInstance, CreateInstance>.Faulted<TException>(
+                BehaviorExceptionContext<TestInstance, CreateInstance, TException> context,
                 IBehavior<TestInstance, CreateInstance> next)
             {
                 return next.Faulted(context);
@@ -56,11 +57,11 @@
 
 
         class CreateInstance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public int X { get; set; }
             public int Y { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/DataActivity_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/DataActivity_Specs.cs
@@ -10,13 +10,13 @@
         [Test]
         public void Should_have_the_proper_value()
         {
-            Assert.AreEqual("Hello", _instance.Value);
+            Assert.That(_instance.Value, Is.EqualTo("Hello"));
         }
 
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(_machine.Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Running));
         }
 
         Instance _instance;
@@ -33,7 +33,7 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
             public string Value { get; set; }
             public int OtherValue { get; set; }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Declarative_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Declarative_Specs.cs
@@ -10,8 +10,11 @@
         [Test]
         public void Should_handle_both_states()
         {
-            Assert.AreEqual(_top.Greeted, _instance.Top);
-            Assert.AreEqual(_bottom.Ignored, _instance.Bottom);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.Top, Is.EqualTo(_top.Greeted));
+                Assert.That(_instance.Bottom, Is.EqualTo(_bottom.Ignored));
+            });
         }
 
         MyState _instance;
@@ -26,24 +29,18 @@
             _top = new TopInstanceStateMachine();
             _bottom = new BottomInstanceStateMachine();
 
-            _top.RaiseEvent(_instance, _top.Initialized, new Init
-            {
-                Value = "Hello"
-            }).Wait();
+            _top.RaiseEvent(_instance, _top.Initialized, new Init { Value = "Hello" }).Wait();
 
-            _bottom.RaiseEvent(_instance, _bottom.Initialized, new Init
-            {
-                Value = "Goodbye"
-            }).Wait();
+            _bottom.RaiseEvent(_instance, _bottom.Initialized, new Init { Value = "Goodbye" }).Wait();
         }
 
 
         class MyState :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State Top { get; set; }
             public State Bottom { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Dependency_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Dependency_Specs.cs
@@ -12,7 +12,7 @@
         [Test]
         public void Should_capture_the_value()
         {
-            Assert.AreEqual("79", _claim.Value);
+            Assert.That(_claim.Value, Is.EqualTo("79"));
         }
 
         ClaimAdjustmentInstance _claim;
@@ -37,11 +37,11 @@
 
         class ClaimAdjustmentInstance :
             ClaimAdjustment,
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public string Value { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/EventObservable_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/EventObservable_Specs.cs
@@ -10,13 +10,13 @@
         [Test]
         public void Should_have_raised_the_initialized_event()
         {
-            Assert.AreEqual(_machine.Initialized, _observer.Events[0].Event);
+            Assert.That(_observer.Events[0].Event, Is.EqualTo(_machine.Initialized));
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(1, _observer.Events.Count);
+            Assert.That(_observer.Events.Count, Is.EqualTo(1));
         }
 
         Instance _instance;
@@ -36,10 +36,10 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Event_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Event_Specs.cs
@@ -11,25 +11,25 @@
         [Test]
         public void It_should_capture_a_simple_event_name()
         {
-            Assert.AreEqual("Hello", _machine.Hello.Name);
+            Assert.That(_machine.Hello.Name, Is.EqualTo("Hello"));
         }
 
         [Test]
         public void It_should_capture_the_data_event_name()
         {
-            Assert.AreEqual("EventA", _machine.EventA.Name);
+            Assert.That(_machine.EventA.Name, Is.EqualTo("EventA"));
         }
 
         [Test]
         public void It_should_create_the_proper_event_type_for_data_events()
         {
-            Assert.IsInstanceOf<MessageEvent<A>>(_machine.EventA);
+            Assert.That(_machine.EventA, Is.InstanceOf<MessageEvent<A>>());
         }
 
         [Test]
         public void It_should_create_the_proper_event_type_for_simple_events()
         {
-            Assert.IsInstanceOf<TriggerEvent>(_machine.Hello);
+            Assert.That(_machine.Hello, Is.InstanceOf<TriggerEvent>());
         }
 
         TestStateMachine _machine;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Exception_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Exception_Specs.cs
@@ -11,13 +11,13 @@
         [Test]
         public void Should_capture_the_exception_message()
         {
-            Assert.AreEqual("Boom!", _instance.ExceptionMessage);
+            Assert.That(_instance.ExceptionMessage, Is.EqualTo("Boom!"));
         }
 
         [Test]
         public void Should_capture_the_exception_type()
         {
-            Assert.AreEqual(typeof(ApplicationException), _instance.ExceptionType);
+            Assert.That(_instance.ExceptionType, Is.EqualTo(typeof(ApplicationException)));
         }
 
         [Test]
@@ -35,7 +35,7 @@
         [Test]
         public void Should_have_called_the_exception_handler()
         {
-            Assert.AreEqual(_machine.Failed, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Failed));
         }
 
         [Test]
@@ -184,31 +184,31 @@
         [Test]
         public void Should_capture_the_exception_message()
         {
-            Assert.AreEqual("Boom!", _instance.ExceptionMessage);
+            Assert.That(_instance.ExceptionMessage, Is.EqualTo("Boom!"));
         }
 
         [Test]
         public void Should_capture_the_exception_type()
         {
-            Assert.AreEqual(typeof(ApplicationException), _instance.ExceptionType);
+            Assert.That(_instance.ExceptionType, Is.EqualTo(typeof(ApplicationException)));
         }
 
         [Test]
         public void Should_have_called_the_exception_handler()
         {
-            Assert.AreEqual(_machine.Failed, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Failed));
         }
 
         [Test]
         public void Should_have_called_the_first_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
         public void Should_not_have_called_the_second_action()
         {
-            Assert.IsTrue(_instance.NotCalled);
+            Assert.That(_instance.NotCalled, Is.True);
         }
 
         Instance _instance;
@@ -329,7 +329,7 @@
         [Test]
         public void Should_have_called_the_subsequent_action()
         {
-            Assert.AreEqual(_instance.CurrentState, _machine.Failed);
+            Assert.That(_machine.Failed, Is.EqualTo(_instance.CurrentState));
         }
 
         Instance _instance;
@@ -386,67 +386,67 @@
         [Test]
         public void Should_capture_the_exception_message()
         {
-            Assert.AreEqual("Boom!", _instance.ExceptionMessage);
+            Assert.That(_instance.ExceptionMessage, Is.EqualTo("Boom!"));
         }
 
         [Test]
         public void Should_capture_the_exception_type()
         {
-            Assert.AreEqual(typeof(ApplicationException), _instance.ExceptionType);
+            Assert.That(_instance.ExceptionType, Is.EqualTo(typeof(ApplicationException)));
         }
 
         [Test]
         public void Should_have_called_the_async_if_block()
         {
-            Assert.IsTrue(_instance.CalledSecondThenClause);
+            Assert.That(_instance.CalledSecondThenClause, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_exception_handler()
         {
-            Assert.AreEqual(_machine.Failed, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Failed));
         }
 
         [Test]
         public void Should_have_called_the_false_async_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseAsyncShouldBeCalled);
+            Assert.That(_instance.ElseAsyncShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_false_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseShouldBeCalled);
+            Assert.That(_instance.ElseShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_if_block()
         {
-            Assert.IsTrue(_instance.CalledThenClause);
+            Assert.That(_instance.CalledThenClause, Is.True);
         }
 
         [Test]
         public void Should_not_have_called_the_false_async_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenAsyncShouldNotBeCalled);
+            Assert.That(_instance.ThenAsyncShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_false_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenShouldNotBeCalled);
+            Assert.That(_instance.ThenShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_second_action()
         {
-            Assert.IsTrue(_instance.NotCalled);
+            Assert.That(_instance.NotCalled, Is.True);
         }
 
         Instance _instance;
@@ -540,7 +540,7 @@
         [Test]
         public void Should_finalize_in_catch_block()
         {
-            Assert.AreEqual(_machine.Final, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Final));
         }
 
         Instance _instance;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Faulted_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Faulted_Specs.cs
@@ -20,7 +20,7 @@ namespace MassTransit.Tests.SagaStateMachineTests.Automatonymous
 
             Assert.That(async () => await _machine.RaiseEvent(_claim, _machine.Create, data), Throws.TypeOf<EventExecutionException>());
 
-            Assert.AreEqual(default, _claim.Value);
+            Assert.That(_claim.Value, Is.EqualTo(default));
         }
 
         ClaimAdjustmentInstance _claim;
@@ -36,11 +36,11 @@ namespace MassTransit.Tests.SagaStateMachineTests.Automatonymous
 
         class ClaimAdjustmentInstance :
             ClaimAdjustment,
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public string Value { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/FilterExpression_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/FilterExpression_Specs.cs
@@ -14,22 +14,22 @@
             var instance = new Instance();
             var machine = new InstanceStateMachine();
 
-            await machine.RaiseEvent(instance, machine.Thing, new Data {Condition = true});
-            Assert.AreEqual(machine.True, instance.CurrentState);
+            await machine.RaiseEvent(instance, machine.Thing, new Data { Condition = true });
+            Assert.That(instance.CurrentState, Is.EqualTo(machine.True));
 
             // reset
             instance.CurrentState = machine.Initial;
 
-            await machine.RaiseEvent(instance, machine.Thing, new Data {Condition = false});
-            Assert.AreEqual(machine.False, instance.CurrentState);
+            await machine.RaiseEvent(instance, machine.Thing, new Data { Condition = false });
+            Assert.That(instance.CurrentState, Is.EqualTo(machine.False));
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Group_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Group_Specs.cs
@@ -15,8 +15,11 @@
         [Test]
         public void Should_have_captured_initial_data()
         {
-            Assert.AreEqual("Audi", _instance.VehicleMake);
-            Assert.AreEqual("A6", _instance.VehicleModel);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.VehicleMake, Is.EqualTo("Audi"));
+                Assert.That(_instance.VehicleModel, Is.EqualTo("A6"));
+            });
         }
 
         PitStop _machine;
@@ -39,9 +42,8 @@
 
 
         class PitStopInstance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State OverallState { get; private set; }
             public State FuelState { get; private set; }
             public State OilState { get; private set; }
@@ -56,6 +58,7 @@ SagaStateMachineInstance
             public decimal OilQuarts { get; set; }
             public decimal OilPricePerQuart { get; set; }
             public decimal OilCost { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -74,12 +77,12 @@ SagaStateMachineInstance
                             context.Instance.VehicleModel = context.Data.Model;
                         })
                         .TransitionTo(BeingServiced)
-//                        .RunParallel(p =>
-//                            {
-//                                p.Start<FillTank>(x => x.BeginFilling);
-//                                p.Start<CheckOil>(x => x.BeginChecking);
-//                            }))
-                    );
+                    //                        .RunParallel(p =>
+                    //                            {
+                    //                                p.Start<FillTank>(x => x.BeginFilling);
+                    //                                p.Start<CheckOil>(x => x.BeginChecking);
+                    //                            }))
+                );
             }
 
             public State BeingServiced { get; private set; }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Introspection_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Introspection_Specs.cs
@@ -13,7 +13,7 @@ namespace MassTransit.Tests.SagaStateMachineTests.Automatonymous
         [Test]
         public void The_machine_shoud_report_its_instance_type()
         {
-            Assert.AreEqual(typeof(Instance), ((StateMachine<Instance>)_machine).InstanceType);
+            Assert.That(((StateMachine<Instance>)_machine).InstanceType, Is.EqualTo(typeof(Instance)));
         }
 
         [Test]
@@ -21,29 +21,32 @@ namespace MassTransit.Tests.SagaStateMachineTests.Automatonymous
         {
             List<Event> events = _machine.Events.ToList();
 
-            Assert.AreEqual(4, events.Count);
-            Assert.Contains(_machine.Ignored, events);
-            Assert.Contains(_machine.Handshake, events);
-            Assert.Contains(_machine.Hello, events);
-            Assert.Contains(_machine.YelledAt, events);
+            Assert.That(events, Has.Count.EqualTo(4));
+            Assert.That(events, Does.Contain(_machine.Ignored));
+            Assert.That(events, Does.Contain(_machine.Handshake));
+            Assert.That(events, Does.Contain(_machine.Hello));
+            Assert.That(events, Does.Contain(_machine.YelledAt));
         }
 
         [Test]
         public void The_machine_should_expose_all_states()
         {
-            Assert.AreEqual(5, ((StateMachine)_machine).States.Count());
-            Assert.Contains(_machine.Initial, _machine.States.ToList());
-            Assert.Contains(_machine.Final, _machine.States.ToList());
-            Assert.Contains(_machine.Greeted, _machine.States.ToList());
-            Assert.Contains(_machine.Loved, _machine.States.ToList());
-            Assert.Contains(_machine.Pissed, _machine.States.ToList());
+            Assert.Multiple(() =>
+            {
+                Assert.That(((StateMachine)_machine).States.Count(), Is.EqualTo(5));
+                Assert.That(_machine.States.ToList(), Does.Contain(_machine.Initial));
+            });
+            Assert.That(_machine.States.ToList(), Does.Contain(_machine.Final));
+            Assert.That(_machine.States.ToList(), Does.Contain(_machine.Greeted));
+            Assert.That(_machine.States.ToList(), Does.Contain(_machine.Loved));
+            Assert.That(_machine.States.ToList(), Does.Contain(_machine.Pissed));
         }
 
         [Test]
         public async Task The_next_events_should_be_known()
         {
             List<Event> events = (await _machine.NextEvents(_instance)).ToList();
-            Assert.AreEqual(3, events.Count);
+            Assert.That(events, Has.Count.EqualTo(3));
         }
 
         Instance _instance;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Observable_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Observable_Specs.cs
@@ -10,21 +10,27 @@
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_second_switched_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(_machine.Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(_machine.Running));
+            });
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(3, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(3));
         }
 
         Instance _instance;
@@ -49,8 +55,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -81,53 +87,65 @@
         [Test]
         public void Should_have_all_events()
         {
-            Assert.AreEqual(2, _eventObserver.Events.Count);
+            Assert.That(_eventObserver.Events.Count, Is.EqualTo(2));
         }
 
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_fourth_switched_to_finished()
         {
-            Assert.AreEqual(_machine.Resting, _observer.Events[3].Previous);
-            Assert.AreEqual(_machine.Final, _observer.Events[3].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[3].Previous, Is.EqualTo(_machine.Resting));
+                Assert.That(_observer.Events[3].Current, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
         public void Should_have_second_switched_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(_machine.Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(_machine.Running));
+            });
         }
 
         [Test]
         public void Should_have_third_switched_to_resting()
         {
-            Assert.AreEqual(_machine.Running, _observer.Events[2].Previous);
-            Assert.AreEqual(_machine.Resting, _observer.Events[2].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[2].Previous, Is.EqualTo(_machine.Running));
+                Assert.That(_observer.Events[2].Current, Is.EqualTo(_machine.Resting));
+            });
         }
 
         [Test]
         public void Should_have_transition_1()
         {
-            Assert.AreEqual("Initialized", _eventObserver.Events[0].Event.Name);
+            Assert.That(_eventObserver.Events[0].Event.Name, Is.EqualTo("Initialized"));
         }
 
         [Test]
         public void Should_have_transition_2()
         {
-            Assert.AreEqual("LegCramped", _eventObserver.Events[1].Event.Name);
+            Assert.That(_eventObserver.Events[1].Event.Name, Is.EqualTo("LegCramped"));
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(4, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(4));
         }
 
         Instance _instance;
@@ -157,8 +175,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -208,60 +226,75 @@
         [Test]
         public void Should_have_all_events()
         {
-            Assert.AreEqual(2, _eventObserver.Events.Count);
+            Assert.That(_eventObserver.Events, Has.Count.EqualTo(2));
         }
 
         [Test]
         public void Should_have_fifth_switched_to_finished()
         {
-            Assert.AreEqual(_machine.Running, _observer.Events[4].Previous);
-            Assert.AreEqual(_machine.Final, _observer.Events[4].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[4].Previous, Is.EqualTo(_machine.Running));
+                Assert.That(_observer.Events[4].Current, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_fourth_switched_to_finished()
         {
-            Assert.AreEqual(_machine.Resting, _observer.Events[3].Previous);
-            Assert.AreEqual(_machine.Running, _observer.Events[3].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[3].Previous, Is.EqualTo(_machine.Resting));
+                Assert.That(_observer.Events[3].Current, Is.EqualTo(_machine.Running));
+            });
         }
 
         [Test]
         public void Should_have_second_switched_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(_machine.Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(_machine.Running));
+            });
         }
 
         [Test]
         public void Should_have_third_switched_to_resting()
         {
-            Assert.AreEqual(_machine.Running, _observer.Events[2].Previous);
-            Assert.AreEqual(_machine.Resting, _observer.Events[2].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[2].Previous, Is.EqualTo(_machine.Running));
+                Assert.That(_observer.Events[2].Current, Is.EqualTo(_machine.Resting));
+            });
         }
 
         [Test]
         public void Should_have_transition_1()
         {
-            Assert.AreEqual("Running.BeforeEnter", _eventObserver.Events[0].Event.Name);
+            Assert.That(_eventObserver.Events[0].Event.Name, Is.EqualTo("Running.BeforeEnter"));
         }
 
         [Test]
         public void Should_have_transition_2()
         {
-            Assert.AreEqual("Running.AfterLeave", _eventObserver.Events[1].Event.Name);
+            Assert.That(_eventObserver.Events[1].Event.Name, Is.EqualTo("Running.AfterLeave"));
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(5, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(5));
         }
 
         Instance _instance;
@@ -292,8 +325,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/RaiseEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/RaiseEvent_Specs.cs
@@ -14,21 +14,21 @@
             var instance = new Instance();
             var machine = new InstanceStateMachine();
 
-            await machine.RaiseEvent(instance, machine.Thing, new Data
+            await machine.RaiseEvent(instance, machine.Thing, new Data { Condition = true });
+            Assert.Multiple(() =>
             {
-                Condition = true
+                Assert.That(instance.CurrentState, Is.EqualTo(machine.True));
+                Assert.That(instance.Initialized.HasValue, Is.True);
             });
-            Assert.AreEqual(machine.True, instance.CurrentState);
-            Assert.IsTrue(instance.Initialized.HasValue);
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public DateTime? Initialized { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/SerializeState_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/SerializeState_Specs.cs
@@ -14,11 +14,8 @@
             var instance = new Instance();
             var machine = new InstanceStateMachine();
 
-            await machine.RaiseEvent(instance, machine.Thing, new Data
-            {
-                Condition = true
-            });
-            Assert.AreEqual(machine.True, instance.CurrentState);
+            await machine.RaiseEvent(instance, machine.Thing, new Data { Condition = true });
+            Assert.That(instance.CurrentState, Is.EqualTo(machine.True));
 
             var serializer = new JsonStateSerializer<InstanceStateMachine, Instance>(machine);
 
@@ -27,15 +24,15 @@
             Console.WriteLine("Body: {0}", body);
             var reInstance = serializer.Deserialize<Instance>(body);
 
-            Assert.AreEqual(machine.True, reInstance.CurrentState);
+            Assert.That(reInstance.CurrentState, Is.EqualTo(machine.True));
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/State_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/State_Specs.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using NUnit.Framework;
-    using SagaStateMachine;
 
 
     [TestFixture]
@@ -11,33 +10,33 @@
         [Test]
         public void It_should_capture_the_name_of_final()
         {
-            Assert.AreEqual("Final", _machine.Final.Name);
+            Assert.That(_machine.Final.Name, Is.EqualTo("Final"));
         }
 
         [Test]
         public void It_should_capture_the_name_of_initial()
         {
-            Assert.AreEqual("Initial", _machine.Initial.Name);
+            Assert.That(_machine.Initial.Name, Is.EqualTo("Initial"));
         }
 
         [Test]
         public void It_should_capture_the_name_of_running()
         {
-            Assert.AreEqual("Running", _machine.Running.Name);
+            Assert.That(_machine.Running.Name, Is.EqualTo("Running"));
         }
 
         [Test]
         public void Should_be_an_instance_of_the_proper_type()
         {
-            Assert.IsInstanceOf<MassTransitStateMachine<Instance>.StateMachineState>(_machine.Initial);
+            Assert.That(_machine.Initial, Is.InstanceOf<MassTransitStateMachine<Instance>.StateMachineState>());
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -69,7 +68,7 @@ SagaStateMachineInstance
         [Test]
         public void It_should_get_the_name_right()
         {
-            Assert.AreEqual("Running", _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo("Running"));
         }
 
         TestStateMachine _machine;
@@ -93,13 +92,14 @@ SagaStateMachineInstance
         /// an ORM that doesn't support user types (cough, EF, cough).
         /// </summary>
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             /// <summary>
             /// The CurrentState is exposed as a string for the ORM
             /// </summary>
             public string CurrentState { get; private set; }
+
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -127,7 +127,7 @@ SagaStateMachineInstance
         [Test]
         public void It_should_get_the_name_right()
         {
-            Assert.AreEqual(_machine.Running, _machine.GetState(_instance).Result);
+            Assert.That(_machine.GetState(_instance).Result, Is.EqualTo(_machine.Running));
         }
 
         TestStateMachine _machine;
@@ -151,13 +151,14 @@ SagaStateMachineInstance
         /// an ORM that doesn't support user types (cough, EF, cough).
         /// </summary>
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             /// <summary>
             /// The CurrentState is exposed as a string for the ORM
             /// </summary>
             public int CurrentState { get; private set; }
+
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Telephone_Sample.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Telephone_Sample.cs
@@ -26,8 +26,11 @@
 
                 await _machine.RaiseEvent(phone, x => x.HungUp);
 
-                Assert.AreEqual(_machine.OffHook.Name, phone.CurrentState);
-                Assert.GreaterOrEqual(phone.CallTimer.ElapsedMilliseconds, 45);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(phone.CurrentState, Is.EqualTo(_machine.OffHook.Name));
+                    Assert.That(phone.CallTimer.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(45));
+                });
             }
 
             PhoneStateMachine _machine;
@@ -74,8 +77,11 @@
                 await _machine.RaiseEvent(phone, x => x.TakenOffHold);
                 await _machine.RaiseEvent(phone, x => x.HungUp);
 
-                Assert.AreEqual(_machine.OffHook.Name, phone.CurrentState);
-                Assert.GreaterOrEqual(phone.CallTimer.ElapsedMilliseconds, 45);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(phone.CurrentState, Is.EqualTo(_machine.OffHook.Name));
+                    Assert.That(phone.CallTimer.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(45));
+                });
             }
 
             PhoneStateMachine _machine;
@@ -105,8 +111,11 @@
 
                 await _machine.RaiseEvent(phone, x => x.HungUp);
 
-                Assert.AreEqual(_machine.OffHook.Name, phone.CurrentState);
-                Assert.GreaterOrEqual(phone.CallTimer.ElapsedMilliseconds, 45);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(phone.CurrentState, Is.EqualTo(_machine.OffHook.Name));
+                    Assert.That(phone.CallTimer.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(45));
+                });
             }
 
             PhoneStateMachine _machine;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Transition_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Transition_Specs.cs
@@ -16,21 +16,27 @@
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_second_moved_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(_machine.Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(_machine.Running));
+            });
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(2, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(2));
         }
 
         Instance _instance;
@@ -53,11 +59,11 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public bool EnterCalled { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -91,40 +97,49 @@ SagaStateMachineInstance
         [Test]
         public void Should_call_the_enter_event()
         {
-            Assert.IsTrue(_instance.EnterCalled);
+            Assert.That(_instance.EnterCalled, Is.True);
         }
 
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_invoked_final_entered()
         {
-            Assert.IsTrue(_instance.FinalEntered);
+            Assert.That(_instance.FinalEntered, Is.True);
         }
 
         [Test]
         public void Should_have_second_moved_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(_machine.Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(_machine.Running));
+            });
         }
 
         [Test]
         public void Should_have_third_moved_to_final()
         {
-            Assert.AreEqual(_machine.Running, _observer.Events[2].Previous);
-            Assert.AreEqual(_machine.Final, _observer.Events[2].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[2].Previous, Is.EqualTo(_machine.Running));
+                Assert.That(_observer.Events[2].Current, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(3, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(3));
         }
 
         Instance _instance;
@@ -148,13 +163,13 @@ SagaStateMachineInstance
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public bool EnterCalled { get; set; }
 
             public bool FinalEntered { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/UnobservedEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/UnobservedEvent_Specs.cs
@@ -127,7 +127,7 @@
 
             await _machine.RaiseEvent(instance, x => x.Charge, new A { Volts = 12 });
 
-            Assert.AreEqual(0, instance.Volts);
+            Assert.That(instance.Volts, Is.EqualTo(0));
         }
 
         [Test]
@@ -137,11 +137,11 @@
 
             await _machine.RaiseEvent(instance, x => x.Start);
 
-            Assert.AreEqual(_machine.Running, await _machine.GetState(instance));
+            Assert.That(await _machine.GetState(instance), Is.EqualTo(_machine.Running));
 
             var nextEvents = await _machine.NextEvents(instance);
 
-            Assert.IsTrue(nextEvents.Any(x => x.Name.Equals("Charge")));
+            Assert.That(nextEvents.Any(x => x.Name.Equals("Charge")), Is.True);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Visualizer_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Visualizer_Specs.cs
@@ -16,20 +16,6 @@
         }
 
         [Test]
-        public void Should_show_the_goods()
-        {
-            var generator = new StateMachineGraphvizGenerator(_graph);
-
-            string dots = generator.CreateDotFile();
-
-            Console.WriteLine(dots);
-
-            var expected = Expected.Replace("\r", "").Replace("\n", Environment.NewLine);
-
-            Assert.AreEqual(expected, dots);
-        }
-
-        [Test]
         public void Should_show_the_differences()
         {
             var dotsAssigned = new StateMachineGraphvizGenerator(new TestStateMachine().GetGraph()).CreateDotFile();
@@ -39,8 +25,22 @@
             var expectedAssigned = ExpectedAssigned.Replace("\r", "").Replace("\n", Environment.NewLine);
             var expectedNotAssigned = ExpectedNotAssigned.Replace("\r", "").Replace("\n", Environment.NewLine);
 
-            Assert.AreEqual(expectedAssigned, dotsAssigned);
-            Assert.AreNotEqual(expectedNotAssigned, dotsAssigned);
+            Assert.That(dotsAssigned, Is.EqualTo(expectedAssigned));
+            Assert.That(dotsAssigned, Is.Not.EqualTo(expectedNotAssigned));
+        }
+
+        [Test]
+        public void Should_show_the_goods()
+        {
+            var generator = new StateMachineGraphvizGenerator(_graph);
+
+            var dots = generator.CreateDotFile();
+
+            Console.WriteLine(dots);
+
+            var expected = Expected.Replace("\r", "").Replace("\n", Environment.NewLine);
+
+            Assert.That(dots, Is.EqualTo(expected));
         }
 
         InstanceStateMachine _machine;
@@ -116,11 +116,12 @@
 6 -> 5;
 }";
 
+
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -168,10 +169,10 @@
             public string Name { get; set; }
         }
 
+
         class CompositeInstance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public CompositeEventStatus CompositeStatus { get; set; }
             public bool Called { get; set; }
             public bool CalledAfterAll { get; set; }
@@ -179,6 +180,7 @@
             public bool SecondFirst { get; set; }
             public bool First { get; set; }
             public bool Second { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/CatchFault_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/CatchFault_Specs.cs
@@ -95,13 +95,16 @@
 
             Response<StartFaulted> startFaulted = await Bus.Request<Start, StartFaulted>(InputQueueAddress, message, TestCancellationToken, TestTimeout);
 
-            Assert.AreEqual(message.CorrelationId, startFaulted.CorrelationId);
+            Assert.That(startFaulted.CorrelationId, Is.EqualTo(message.CorrelationId));
 
             ConsumeContext<ServiceFaulted> context = await serviceFaulted;
 
-            Assert.AreEqual(message.CorrelationId, context.CorrelationId);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(context.CorrelationId, Is.EqualTo(message.CorrelationId));
 
-            Assert.That(await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.FailedToStart, TestTimeout), Is.Not.Null);
+                Assert.That(await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.FailedToStart, TestTimeout), Is.Not.Null);
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -172,13 +175,16 @@
 
             Response<StartFaulted> startFaulted = await Bus.Request<Start, StartFaulted>(InputQueueAddress, message, TestCancellationToken, TestTimeout);
 
-            Assert.AreEqual(message.CorrelationId, startFaulted.CorrelationId);
+            Assert.That(startFaulted.CorrelationId, Is.EqualTo(message.CorrelationId));
 
             ConsumeContext<ServiceFaulted> context = await serviceFaulted;
 
-            Assert.AreEqual(message.CorrelationId, context.CorrelationId);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(context.CorrelationId, Is.EqualTo(message.CorrelationId));
 
-            Assert.That(await LoadSagaRepository.ShouldNotContainSaga(message.CorrelationId, TestTimeout), Is.Null);
+                Assert.That(await LoadSagaRepository.ShouldNotContainSaga(message.CorrelationId, TestTimeout), Is.Null);
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/CompositeEventUpgrade_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/CompositeEventUpgrade_Specs.cs
@@ -27,11 +27,14 @@ namespace MassTransit.Tests.SagaStateMachineTests
                 });
                 ConsumeContext<MemberRegistered> registered = await handler;
                 Guid? saga = await _repository.ShouldContainSagaInState(memberId, _machine, x => x.Rejected, TestTimeout);
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
                 var sagaInstance = _repository[saga.Value].Instance;
-                Assert.AreEqual("Invalid ID", sagaInstance.Result);
-                Assert.AreEqual("REJECTED!", sagaInstance.Name);
-                Assert.AreEqual("REJECTED!", sagaInstance.Surname);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sagaInstance.Result, Is.EqualTo("Invalid ID"));
+                    Assert.That(sagaInstance.Name, Is.EqualTo("REJECTED!"));
+                    Assert.That(sagaInstance.Surname, Is.EqualTo("REJECTED!"));
+                });
             }
 
             [Test]
@@ -47,11 +50,14 @@ namespace MassTransit.Tests.SagaStateMachineTests
                 });
                 ConsumeContext<MemberRegistered> registered = await handler;
                 Guid? saga = await _repository.ShouldContainSagaInState(memberId, _machine, x => x.Registered, TestInactivityTimeout);
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
                 var sagaInstance = _repository[saga.Value].Instance;
-                Assert.AreEqual("Success", sagaInstance.Result);
-                Assert.AreEqual("Frank", sagaInstance.Name);
-                Assert.AreEqual("Castle", sagaInstance.Surname);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sagaInstance.Result, Is.EqualTo("Success"));
+                    Assert.That(sagaInstance.Name, Is.EqualTo("Frank"));
+                    Assert.That(sagaInstance.Surname, Is.EqualTo("Castle"));
+                });
             }
 
             [Test]
@@ -67,11 +73,14 @@ namespace MassTransit.Tests.SagaStateMachineTests
                 });
                 ConsumeContext<MemberRegistered> registered = await handler;
                 Guid? saga = await _repository.ShouldContainSagaInState(memberId, _machine, x => x.Rejected, TestTimeout);
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
                 var sagaInstance = _repository[saga.Value].Instance;
-                Assert.AreEqual("Invalid Name", sagaInstance.Result);
-                Assert.AreEqual("REJECTED!", sagaInstance.Name);
-                Assert.AreEqual("Kent", sagaInstance.Surname);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sagaInstance.Result, Is.EqualTo("Invalid Name"));
+                    Assert.That(sagaInstance.Name, Is.EqualTo("REJECTED!"));
+                    Assert.That(sagaInstance.Surname, Is.EqualTo("Kent"));
+                });
             }
 
             [Test]
@@ -95,11 +104,14 @@ namespace MassTransit.Tests.SagaStateMachineTests
                 });
                 ConsumeContext<MemberRegistered> registered = await handler;
                 Guid? saga = await _repository.ShouldContainSagaInState(memberId, _machine, x => x.Rejected, TestTimeout);
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
                 var sagaInstance = _repository[saga.Value].Instance;
-                Assert.AreEqual("Invalid Surname", sagaInstance.Result);
-                Assert.AreEqual("Peter", sagaInstance.Name);
-                Assert.AreEqual("REJECTED!", sagaInstance.Surname);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sagaInstance.Result, Is.EqualTo("Invalid Surname"));
+                    Assert.That(sagaInstance.Name, Is.EqualTo("Peter"));
+                    Assert.That(sagaInstance.Surname, Is.EqualTo("REJECTED!"));
+                });
             }
 
             InMemorySagaRepository<TestState> _repository;
@@ -257,7 +269,6 @@ namespace MassTransit.Tests.SagaStateMachineTests
                         })
                         .PublishAsync(context => context.Init<MemberRegistered>(context.Instance))
                         .TransitionTo(Registered)
-
                     ,
 
                     //--

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Activity_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Activity_Specs.cs
@@ -10,7 +10,7 @@
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(Running));
         }
 
         State Running;
@@ -29,7 +29,7 @@
                     .Event("Initialized", out Initialized)
                     .InstanceState(b => b.CurrentState)
                     .During(builder.Initial)
-                        .When(Initialized, b => b.TransitionTo(Running))
+                    .When(Initialized, b => b.TransitionTo(Running))
                 );
 
             _machine.RaiseEvent(_instance, Initialized)
@@ -38,10 +38,10 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -52,7 +52,7 @@ SagaStateMachineInstance
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(Running));
         }
 
         State Running;
@@ -71,7 +71,7 @@ SagaStateMachineInstance
                     .Event("Initialized", out Initialized)
                     .InstanceState(b => b.CurrentState)
                     .During(builder.Initial)
-                        .When(Initialized, b => b.TransitionTo(Running))
+                    .When(Initialized, b => b.TransitionTo(Running))
                 );
 
             _machine.RaiseEvent(_instance, Initialized);
@@ -79,10 +79,10 @@ SagaStateMachineInstance
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -109,13 +109,13 @@ SagaStateMachineInstance
         [Test]
         public void Should_have_called_the_finally_activity()
         {
-            Assert.AreEqual(Finalized, _instance.Value);
+            Assert.That(_instance.Value, Is.EqualTo(Finalized));
         }
 
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(_machine.Final, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Final));
         }
 
         const string Finalized = "Finalized";
@@ -138,7 +138,7 @@ SagaStateMachineInstance
                     .Event("Initialized", out Initialized)
                     .InstanceState(b => b.CurrentState)
                     .During(builder.Initial)
-                        .When(Initialized, b => b.Finalize())
+                    .When(Initialized, b => b.Finalize())
                     .Finally(b => b.Then(context => context.Instance.Value = Finalized))
                 );
 
@@ -148,11 +148,11 @@ SagaStateMachineInstance
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public string Value { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -163,25 +163,25 @@ SagaStateMachineInstance
         [Test]
         public void Should_call_the_activity()
         {
-            Assert.AreEqual(_machine.Final, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Final));
         }
 
         [Test]
         public void Should_have_trigger_the_final_before_enter_event()
         {
-            Assert.AreEqual(Running, _instance.FinalState);
+            Assert.That(_instance.FinalState, Is.EqualTo(Running));
         }
 
         [Test]
         public void Should_have_triggered_the_after_leave_event()
         {
-            Assert.AreEqual(_machine.Initial, _instance.LeftState);
+            Assert.That(_instance.LeftState, Is.EqualTo(_machine.Initial));
         }
 
         [Test]
         public void Should_have_triggered_the_before_enter_event()
         {
-            Assert.AreEqual(Initializing, _instance.EnteredState);
+            Assert.That(_instance.EnteredState, Is.EqualTo(Initializing));
         }
 
         State Running;
@@ -202,27 +202,28 @@ SagaStateMachineInstance
                     .Event("Initialized", out Initialized)
                     .InstanceState(b => b.CurrentState)
                     .During(Initializing)
-                        .When(Initialized, b => b.TransitionTo(Running))
+                    .When(Initialized, b => b.TransitionTo(Running))
                     .DuringAny()
-                        .When(builder.Initial.Enter, b => b.TransitionTo(Initializing))
-                        .When(builder.Initial.AfterLeave, b => b.Then(context => context.Instance.LeftState = context.Data))
-                        .When(Initializing.BeforeEnter, b => b.Then(context => context.Instance.EnteredState = context.Data))
-                        .When(Running.Enter, b => b.Finalize())
-                        .When(builder.Final.BeforeEnter, b => b.Then(context => context.Instance.FinalState = context.Instance.CurrentState))
+                    .When(builder.Initial.Enter, b => b.TransitionTo(Initializing))
+                    .When(builder.Initial.AfterLeave, b => b.Then(context => context.Instance.LeftState = context.Data))
+                    .When(Initializing.BeforeEnter, b => b.Then(context => context.Instance.EnteredState = context.Data))
+                    .When(Running.Enter, b => b.Finalize())
+                    .When(builder.Final.BeforeEnter, b => b.Then(context => context.Instance.FinalState = context.Instance.CurrentState))
                 );
 
             _machine.RaiseEvent(_instance, Initialized)
                 .Wait();
         }
 
+
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public State EnteredState { get; set; }
             public State LeftState { get; set; }
             public State FinalState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/AnyStateTransition_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/AnyStateTransition_Specs.cs
@@ -10,19 +10,19 @@
         [Test]
         public void Should_be_running()
         {
-            Assert.AreEqual(Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(Running));
         }
 
         [Test]
         public void Should_have_entered_running()
         {
-            Assert.AreEqual(Running, _instance.LastEntered);
+            Assert.That(_instance.LastEntered, Is.EqualTo(Running));
         }
 
         [Test]
         public void Should_have_left_initial()
         {
-            Assert.AreEqual(_machine.Initial, _instance.LastLeft);
+            Assert.That(_instance.LastLeft, Is.EqualTo(_machine.Initial));
         }
 
         State Running;
@@ -43,9 +43,9 @@
                     .Event("Finish", out Finish)
                     .InstanceState(b => b.CurrentState)
                     .During(builder.Initial)
-                        .When(Initialized, b => b.TransitionTo(Running))
+                    .When(Initialized, b => b.TransitionTo(Running))
                     .During(Running)
-                        .When(Finish, b => b.Finalize())
+                    .When(Finish, b => b.Finalize())
                     .BeforeEnterAny(b => b.Then(context => context.Instance.LastEntered = context.Data))
                     .AfterLeaveAny(b => b.Then(context => context.Instance.LastLeft = context.Data))
                 );
@@ -56,13 +56,13 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
 
             public State LastEntered { get; set; }
             public State LastLeft { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Anytime_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Anytime_Specs.cs
@@ -16,8 +16,11 @@
             await _machine.RaiseEvent(instance, Init);
             await _machine.RaiseEvent(instance, Hello);
 
-            Assert.IsTrue(instance.HelloCalled);
-            Assert.AreEqual(_machine.Final, instance.CurrentState);
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.HelloCalled, Is.True);
+                Assert.That(instance.CurrentState, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
@@ -26,13 +29,13 @@
             var instance = new Instance();
 
             await _machine.RaiseEvent(instance, Init);
-            await _machine.RaiseEvent(instance, EventA, new A
-            {
-                Value = "Test"
-            });
+            await _machine.RaiseEvent(instance, EventA, new A { Value = "Test" });
 
-            Assert.AreEqual("Test", instance.AValue);
-            Assert.AreEqual(_machine.Final, instance.CurrentState);
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.AValue, Is.EqualTo("Test"));
+                Assert.That(instance.CurrentState, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
@@ -42,8 +45,11 @@
 
             Assert.That(async () => await _machine.RaiseEvent(instance, Hello), Throws.TypeOf<UnhandledEventException>());
 
-            Assert.IsFalse(instance.HelloCalled);
-            Assert.AreEqual(_machine.Initial, instance.CurrentState);
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.HelloCalled, Is.False);
+                Assert.That(instance.CurrentState, Is.EqualTo(_machine.Initial));
+            });
         }
 
         State Ready;
@@ -63,31 +69,33 @@
                     .Event("Hello", out Hello)
                     .Event("EventA", out EventA)
                     .Initially()
-                        .When(Init, b => b.TransitionTo(Ready))
+                    .When(Init, b => b.TransitionTo(Ready))
                     .DuringAny()
-                        .When(Hello, b => b
-                            .Then(context => context.Instance.HelloCalled = true)
-                            .Finalize()
-                        )
-                        .When(EventA, b => b
-                            .Then(context => context.Instance.AValue = context.Data.Value)
-                            .Finalize()
-                        )
+                    .When(Hello, b => b
+                        .Then(context => context.Instance.HelloCalled = true)
+                        .Finalize()
+                    )
+                    .When(EventA, b => b
+                        .Then(context => context.Instance.AValue = context.Data.Value)
+                        .Finalize()
+                    )
                 );
         }
+
 
         class A
         {
             public string Value { get; set; }
         }
 
+
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public bool HelloCalled { get; set; }
             public string AValue { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/AsyncActivity_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/AsyncActivity_Specs.cs
@@ -28,12 +28,12 @@
 
             await machine.RaiseEvent(claim, Create, new CreateInstance());
 
-            Assert.AreEqual("ExecuteAsync", claim.Value);
+            Assert.That(claim.Value, Is.EqualTo("ExecuteAsync"));
         }
 
 
         class TestInstance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
             public State CurrentState { get; set; }
             public string Value { get; set; }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Combine_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Combine_Specs.cs
@@ -56,13 +56,14 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public CompositeEventStatus CompositeStatus { get; set; }
             public bool Called { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
+
 
         private StateMachine<Instance> CreateStateMachine()
         {
@@ -74,12 +75,12 @@ SagaStateMachineInstance
                     .Event("Second", out Second)
                     .CompositeEvent("Third", out Third, b => b.CompositeStatus, First, Second)
                     .Initially()
-                        .When(Start, b => b.TransitionTo(Waiting))
+                    .When(Start, b => b.TransitionTo(Waiting))
                     .During(Waiting)
-                        .When(Third, b => b
-                            .Then(context => context.Instance.Called = true)
-                            .Finalize()
-                        )
+                    .When(Third, b => b
+                        .Then(context => context.Instance.Called = true)
+                        .Finalize()
+                    )
                 );
         }
     }
@@ -95,14 +96,17 @@ SagaStateMachineInstance
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, Start);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
 
             await _machine.RaiseEvent(_instance, First);
             await _machine.RaiseEvent(_instance, Second);
 
-            Assert.IsTrue(_instance.Called);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.Called, Is.True);
 
-            Assert.AreEqual(2, _instance.CurrentState);
+                Assert.That(_instance.CurrentState, Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -112,7 +116,7 @@ SagaStateMachineInstance
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, Start);
 
-            Assert.AreEqual(3, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(3));
         }
 
         [Test]
@@ -124,7 +128,7 @@ SagaStateMachineInstance
 
             await _machine.RaiseEvent(_instance, First);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         [Test]
@@ -150,13 +154,14 @@ SagaStateMachineInstance
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public int CompositeStatus { get; set; }
             public bool Called { get; set; }
             public int CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
+
 
         private StateMachine<Instance> CreateStateMachine()
         {
@@ -168,13 +173,13 @@ SagaStateMachineInstance
                     .Event("Second", out Second)
                     .InstanceState(b => b.CurrentState)
                     .Initially()
-                        .When(Start, b => b.TransitionTo(Waiting))
+                    .When(Start, b => b.TransitionTo(Waiting))
                     .CompositeEvent("Third", out Third, b => b.CompositeStatus, First, Second)
                     .During(Waiting)
-                        .When(Third, b => b
-                            .Then(context => context.Instance.Called = true)
-                            .Finalize()
-                        )
+                    .When(Third, b => b
+                        .Then(context => context.Instance.Called = true)
+                        .Finalize()
+                    )
                 );
         }
     }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/DataActivity_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/DataActivity_Specs.cs
@@ -10,13 +10,13 @@
         [Test]
         public void Should_have_the_proper_value()
         {
-            Assert.AreEqual("Hello", _instance.Value);
+            Assert.That(_instance.Value, Is.EqualTo("Hello"));
         }
 
         [Test]
         public void Should_transition_to_the_proper_state()
         {
-            Assert.AreEqual(Running, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(Running));
         }
 
         State Running;
@@ -45,12 +45,12 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public string Value { get; set; }
             public int OtherValue { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Declarative_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Declarative_Specs.cs
@@ -10,8 +10,11 @@
         [Test]
         public void Should_handle_both_states()
         {
-            Assert.AreEqual(TopGreeted, _instance.Top);
-            Assert.AreEqual(BottomIgnored, _instance.Bottom);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.Top, Is.EqualTo(TopGreeted));
+                Assert.That(_instance.Bottom, Is.EqualTo(BottomIgnored));
+            });
         }
 
         State TopGreeted;
@@ -34,7 +37,7 @@
                     .Event("Initialized", out TopInitialized)
                     .InstanceState(b => b.Top)
                     .During(builder.Initial)
-                        .When(TopInitialized, b => b.TransitionTo(TopGreeted))
+                    .When(TopInitialized, b => b.TransitionTo(TopGreeted))
                 );
             _bottom = MassTransitStateMachine<MyState>
                 .New(builder => builder
@@ -42,27 +45,23 @@
                     .Event("Initialized", out BottomInitialized)
                     .InstanceState(b => b.Bottom)
                     .During(builder.Initial)
-                        .When(BottomInitialized, b => b.TransitionTo(BottomIgnored))
+                    .When(BottomInitialized, b => b.TransitionTo(BottomIgnored))
                 );
 
-            _top.RaiseEvent(_instance, TopInitialized, new Init
-            {
-                Value = "Hello"
-            }).Wait();
+            _top.RaiseEvent(_instance, TopInitialized, new Init { Value = "Hello" }).Wait();
 
-            _bottom.RaiseEvent(_instance, BottomInitialized, new Init
-            {
-                Value = "Goodbye"
-            }).Wait();
+            _bottom.RaiseEvent(_instance, BottomInitialized, new Init { Value = "Goodbye" }).Wait();
         }
+
 
         class MyState :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State Top { get; set; }
             public State Bottom { get; set; }
+            public Guid CorrelationId { get; set; }
         }
+
 
         class Init
         {

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Dependency_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Dependency_Specs.cs
@@ -12,7 +12,7 @@
         [Test]
         public void Should_capture_the_value()
         {
-            Assert.AreEqual("79", _claim.Value);
+            Assert.That(_claim.Value, Is.EqualTo("79"));
         }
 
         State Running;
@@ -52,11 +52,11 @@
 
         class ClaimAdjustmentInstance :
             ClaimAdjustment,
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public string Value { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/EventObservable_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/EventObservable_Specs.cs
@@ -11,13 +11,13 @@
         [Test]
         public void Should_have_raised_the_initialized_event()
         {
-            Assert.AreEqual(Initialized, _observer.Events[0].Event);
+            Assert.That(_observer.Events[0].Event, Is.EqualTo(Initialized));
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(1, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(1));
         }
 
         State Running;
@@ -35,7 +35,7 @@
                     .Event("Initialized", out Initialized)
                     .State("Running", out Running)
                     .During(builder.Initial)
-                        .When(Initialized, b => b.TransitionTo(Running))
+                    .When(Initialized, b => b.TransitionTo(Running))
                 );
             _observer = new EventRaisedObserver<Instance>();
 
@@ -43,11 +43,12 @@
                 _machine.RaiseEvent(_instance, Initialized).Wait();
         }
 
+
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Event_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Event_Specs.cs
@@ -11,13 +11,13 @@
         [Test]
         public void It_should_capture_a_simple_event_name()
         {
-            Assert.AreEqual("Hello", _hello.Name);
+            Assert.That(_hello.Name, Is.EqualTo("Hello"));
         }
 
         [Test]
         public void It_should_capture_the_data_event_name()
         {
-            Assert.AreEqual("EventA", _eventA.Name);
+            Assert.That(_eventA.Name, Is.EqualTo("EventA"));
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Exception_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Exception_Specs.cs
@@ -11,79 +11,79 @@
         [Test]
         public void Should_capture_the_exception_message()
         {
-            Assert.AreEqual("Boom!", _instance.ExceptionMessage);
+            Assert.That(_instance.ExceptionMessage, Is.EqualTo("Boom!"));
         }
 
         [Test]
         public void Should_capture_the_exception_type()
         {
-            Assert.AreEqual(typeof(ApplicationException), _instance.ExceptionType);
+            Assert.That(_instance.ExceptionType, Is.EqualTo(typeof(ApplicationException)));
         }
 
         [Test]
         public void Should_have_called_the_async_if_block()
         {
-            Assert.IsTrue(_instance.CalledThenClauseAsync);
+            Assert.That(_instance.CalledThenClauseAsync, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_async_then_block()
         {
-            Assert.IsTrue(_instance.ThenAsyncShouldBeCalled);
+            Assert.That(_instance.ThenAsyncShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_exception_handler()
         {
-            Assert.AreEqual(Failed, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(Failed));
         }
 
         [Test]
         public void Should_have_called_the_false_async_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseAsyncShouldBeCalled);
+            Assert.That(_instance.ElseAsyncShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_false_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseShouldBeCalled);
+            Assert.That(_instance.ElseShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_if_block()
         {
-            Assert.IsTrue(_instance.CalledThenClause);
+            Assert.That(_instance.CalledThenClause, Is.True);
         }
 
         [Test]
         public void Should_not_have_called_the_false_async_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenAsyncShouldNotBeCalled);
+            Assert.That(_instance.ThenAsyncShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_false_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenShouldNotBeCalled);
+            Assert.That(_instance.ThenShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_regular_exception()
         {
-            Assert.IsFalse(_instance.ShouldNotBeCalled);
+            Assert.That(_instance.ShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_second_action()
         {
-            Assert.IsTrue(_instance.NotCalled);
+            Assert.That(_instance.NotCalled, Is.True);
         }
 
         State Failed;
@@ -147,8 +147,6 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
-
             public Instance()
             {
                 NotCalled = true;
@@ -171,6 +169,7 @@
             public bool ElseAsyncShouldBeCalled { get; set; }
 
             public bool ThenAsyncShouldBeCalled { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -181,31 +180,31 @@
         [Test]
         public void Should_capture_the_exception_message()
         {
-            Assert.AreEqual("Boom!", _instance.ExceptionMessage);
+            Assert.That(_instance.ExceptionMessage, Is.EqualTo("Boom!"));
         }
 
         [Test]
         public void Should_capture_the_exception_type()
         {
-            Assert.AreEqual(typeof(ApplicationException), _instance.ExceptionType);
+            Assert.That(_instance.ExceptionType, Is.EqualTo(typeof(ApplicationException)));
         }
 
         [Test]
         public void Should_have_called_the_exception_handler()
         {
-            Assert.AreEqual(Failed, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(Failed));
         }
 
         [Test]
         public void Should_have_called_the_first_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
         public void Should_not_have_called_the_second_action()
         {
-            Assert.IsTrue(_instance.NotCalled);
+            Assert.That(_instance.NotCalled, Is.True);
         }
 
         State Failed;
@@ -248,8 +247,6 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
-
             public Instance()
             {
                 NotCalled = true;
@@ -260,6 +257,7 @@
             public Type ExceptionType { get; set; }
             public string ExceptionMessage { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -270,7 +268,7 @@
         [Test]
         public void Should_have_called_the_subsequent_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         Instance _instance;
@@ -305,9 +303,9 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public bool Called { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -318,67 +316,67 @@
         [Test]
         public void Should_capture_the_exception_message()
         {
-            Assert.AreEqual("Boom!", _instance.ExceptionMessage);
+            Assert.That(_instance.ExceptionMessage, Is.EqualTo("Boom!"));
         }
 
         [Test]
         public void Should_capture_the_exception_type()
         {
-            Assert.AreEqual(typeof(ApplicationException), _instance.ExceptionType);
+            Assert.That(_instance.ExceptionType, Is.EqualTo(typeof(ApplicationException)));
         }
 
         [Test]
         public void Should_have_called_the_async_if_block()
         {
-            Assert.IsTrue(_instance.CalledSecondThenClause);
+            Assert.That(_instance.CalledSecondThenClause, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_exception_handler()
         {
-            Assert.AreEqual(Failed, _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo(Failed));
         }
 
         [Test]
         public void Should_have_called_the_false_async_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseAsyncShouldBeCalled);
+            Assert.That(_instance.ElseAsyncShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_false_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseShouldBeCalled);
+            Assert.That(_instance.ElseShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_if_block()
         {
-            Assert.IsTrue(_instance.CalledThenClause);
+            Assert.That(_instance.CalledThenClause, Is.True);
         }
 
         [Test]
         public void Should_not_have_called_the_false_async_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenAsyncShouldNotBeCalled);
+            Assert.That(_instance.ThenAsyncShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_false_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenShouldNotBeCalled);
+            Assert.That(_instance.ThenShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_second_action()
         {
-            Assert.IsTrue(_instance.NotCalled);
+            Assert.That(_instance.NotCalled, Is.True);
         }
 
         State Failed;
@@ -435,8 +433,6 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
-
             public Instance()
             {
                 NotCalled = true;
@@ -455,6 +451,7 @@
             public bool ElseShouldBeCalled { get; set; }
             public bool ThenAsyncShouldNotBeCalled { get; set; }
             public bool ElseAsyncShouldBeCalled { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Faulted_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Faulted_Specs.cs
@@ -20,7 +20,7 @@ namespace MassTransit.Tests.SagaStateMachineTests.Dynamic_Modify
 
             Assert.That(async () => await _machine.RaiseEvent(_claim, Create, data), Throws.TypeOf<EventExecutionException>());
 
-            Assert.AreEqual(default, _claim.Value);
+            Assert.That(_claim.Value, Is.EqualTo(default));
         }
 
         Event<CreateClaim> Create;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/FilterExpression_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/FilterExpression_Specs.cs
@@ -23,26 +23,26 @@
                     .Event("Thing", out Thing)
                     .InstanceState(b => b.CurrentState)
                     .During(builder.Initial)
-                        .When(Thing, context => context.Data.Condition, b => b.TransitionTo(True))
-                        .When(Thing, context => !context.Data.Condition, b => b.TransitionTo(False))
+                    .When(Thing, context => context.Data.Condition, b => b.TransitionTo(True))
+                    .When(Thing, context => !context.Data.Condition, b => b.TransitionTo(False))
                 );
 
-            await machine.RaiseEvent(instance, Thing, new Data {Condition = true});
-            Assert.AreEqual(True, instance.CurrentState);
+            await machine.RaiseEvent(instance, Thing, new Data { Condition = true });
+            Assert.That(instance.CurrentState, Is.EqualTo(True));
 
             // reset
             instance.CurrentState = machine.Initial;
 
-            await machine.RaiseEvent(instance, Thing, new Data {Condition = false});
-            Assert.AreEqual(False, instance.CurrentState);
+            await machine.RaiseEvent(instance, Thing, new Data { Condition = false });
+            Assert.That(instance.CurrentState, Is.EqualTo(False));
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Group_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Group_Specs.cs
@@ -16,8 +16,8 @@
         [Test]
         public void Should_have_captured_initial_data()
         {
-            Assert.AreEqual("Audi", _instance.VehicleMake);
-            Assert.AreEqual("A6", _instance.VehicleModel);
+            Assert.That(_instance.VehicleMake, Is.EqualTo("Audi"));
+            Assert.That(_instance.VehicleModel, Is.EqualTo("A6"));
         }
 
         State BeingServiced;
@@ -36,13 +36,13 @@
                     .Event("VehicleArrived", out VehicleArrived)
                     .InstanceState(b => b.OverallState)
                     .During(builder.Initial)
-                        .When(VehicleArrived, b => b
-                            .Then(context =>
-                            {
-                                context.Instance.VehicleMake = context.Data.Make;
-                                context.Instance.VehicleModel = context.Data.Model;
-                            })
-                            .TransitionTo(BeingServiced))
+                    .When(VehicleArrived, b => b
+                        .Then(context =>
+                        {
+                            context.Instance.VehicleMake = context.Data.Make;
+                            context.Instance.VehicleModel = context.Data.Model;
+                        })
+                        .TransitionTo(BeingServiced))
                 );
 
             var vehicle = new Vehicle
@@ -56,9 +56,8 @@
 
 
         class PitStopInstance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State OverallState { get; private set; }
             public State FuelState { get; private set; }
             public State OilState { get; private set; }
@@ -73,36 +72,38 @@ SagaStateMachineInstance
             public decimal OilQuarts { get; set; }
             public decimal OilPricePerQuart { get; set; }
             public decimal OilCost { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
+
         // NOTE: Left in place due to the incompleteness of this test.
-//        class PitStop :
-//            MassTransitStateMachine<PitStopInstance>
-//        {
-//            public PitStop()
-//            {
-//                InstanceState(x => x.OverallState);
+        //        class PitStop :
+        //            MassTransitStateMachine<PitStopInstance>
+        //        {
+        //            public PitStop()
+        //            {
+        //                InstanceState(x => x.OverallState);
 
-//                During(Initial,
-//                    When(VehicleArrived)
-//                        .Then(context =>
-//                        {
-//                            context.Instance.VehicleMake = context.Data.Make;
-//                            context.Instance.VehicleModel = context.Data.Model;
-//                        })
-//                        .TransitionTo(BeingServiced)
-////                        .RunParallel(p =>
-////                            {
-////                                p.Start<FillTank>(x => x.BeginFilling);
-////                                p.Start<CheckOil>(x => x.BeginChecking);
-////                            }))
-//                    );
-//            }
+        //                During(Initial,
+        //                    When(VehicleArrived)
+        //                        .Then(context =>
+        //                        {
+        //                            context.Instance.VehicleMake = context.Data.Make;
+        //                            context.Instance.VehicleModel = context.Data.Model;
+        //                        })
+        //                        .TransitionTo(BeingServiced)
+        ////                        .RunParallel(p =>
+        ////                            {
+        ////                                p.Start<FillTank>(x => x.BeginFilling);
+        ////                                p.Start<CheckOil>(x => x.BeginChecking);
+        ////                            }))
+        //                    );
+        //            }
 
-//            public State BeingServiced { get; private set; }
+        //            public State BeingServiced { get; private set; }
 
-//            public Event<Vehicle> VehicleArrived { get; private set; }
-//        }
+        //            public Event<Vehicle> VehicleArrived { get; private set; }
+        //        }
 
 
         class FillTank :

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Introspection_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Introspection_Specs.cs
@@ -15,35 +15,38 @@ namespace MassTransit.Tests.SagaStateMachineTests.Dynamic_Modify
         {
             List<Event> events = _machine.Events.ToList();
 
-            Assert.AreEqual(4, events.Count);
-            Assert.Contains(Ignored, events);
-            Assert.Contains(Handshake, events);
-            Assert.Contains(Hello, events);
-            Assert.Contains(YelledAt, events);
+            Assert.That(events.Count, Is.EqualTo(4));
+            Assert.That(events, Does.Contain(Ignored));
+            Assert.That(events, Does.Contain(Handshake));
+            Assert.That(events, Does.Contain(Hello));
+            Assert.That(events, Does.Contain(YelledAt));
         }
 
         [Test]
         public void The_machine_should_expose_all_states()
         {
-            Assert.AreEqual(5, _machine.States.Count());
-            Assert.Contains(_machine.Initial, _machine.States.ToList());
-            Assert.Contains(_machine.Final, _machine.States.ToList());
-            Assert.Contains(Greeted, _machine.States.ToList());
-            Assert.Contains(Loved, _machine.States.ToList());
-            Assert.Contains(Pissed, _machine.States.ToList());
+            Assert.Multiple(() =>
+            {
+                Assert.That(_machine.States.Count(), Is.EqualTo(5));
+                Assert.That(_machine.States.ToList(), Does.Contain(_machine.Initial));
+            });
+            Assert.That(_machine.States.ToList(), Does.Contain(_machine.Final));
+            Assert.That(_machine.States.ToList(), Does.Contain(Greeted));
+            Assert.That(_machine.States.ToList(), Does.Contain(Loved));
+            Assert.That(_machine.States.ToList(), Does.Contain(Pissed));
         }
 
         [Test]
         public void The_machine_should_report_its_instance_type()
         {
-            Assert.AreEqual(typeof(Instance), _machine.InstanceType);
+            Assert.That(_machine.InstanceType, Is.EqualTo(typeof(Instance)));
         }
 
         [Test]
         public async Task The_next_events_should_be_known()
         {
             List<Event> events = (await _machine.NextEvents(_instance)).ToList();
-            Assert.AreEqual(3, events.Count);
+            Assert.That(events, Has.Count.EqualTo(3));
         }
 
         Event<B> Ignored;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Observable_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Observable_Specs.cs
@@ -11,21 +11,27 @@
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_second_switched_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(Running));
+            });
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(3, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(3));
         }
 
         State Running;
@@ -63,8 +69,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -75,53 +81,65 @@
         [Test]
         public void Should_have_all_events()
         {
-            Assert.AreEqual(2, _eventObserver.Events.Count);
+            Assert.That(_eventObserver.Events, Has.Count.EqualTo(2));
         }
 
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_fourth_switched_to_finished()
         {
-            Assert.AreEqual(Resting, _observer.Events[3].Previous);
-            Assert.AreEqual(_machine.Final, _observer.Events[3].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[3].Previous, Is.EqualTo(Resting));
+                Assert.That(_observer.Events[3].Current, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
         public void Should_have_second_switched_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(Running));
+            });
         }
 
         [Test]
         public void Should_have_third_switched_to_resting()
         {
-            Assert.AreEqual(Running, _observer.Events[2].Previous);
-            Assert.AreEqual(Resting, _observer.Events[2].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[2].Previous, Is.EqualTo(Running));
+                Assert.That(_observer.Events[2].Current, Is.EqualTo(Resting));
+            });
         }
 
         [Test]
         public void Should_have_transition_1()
         {
-            Assert.AreEqual("Initialized", _eventObserver.Events[0].Event.Name);
+            Assert.That(_eventObserver.Events[0].Event.Name, Is.EqualTo("Initialized"));
         }
 
         [Test]
         public void Should_have_transition_2()
         {
-            Assert.AreEqual("LegCramped", _eventObserver.Events[1].Event.Name);
+            Assert.That(_eventObserver.Events[1].Event.Name, Is.EqualTo("LegCramped"));
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(4, _observer.Events.Count);
+            Assert.That(_observer.Events.Count, Is.EqualTo(4));
         }
 
         State<Instance> Resting;
@@ -181,8 +199,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -232,60 +250,75 @@
         [Test]
         public void Should_have_all_events()
         {
-            Assert.AreEqual(2, _eventObserver.Events.Count);
+            Assert.That(_eventObserver.Events, Has.Count.EqualTo(2));
         }
 
         [Test]
         public void Should_have_fifth_switched_to_finished()
         {
-            Assert.AreEqual(Running, _observer.Events[4].Previous);
-            Assert.AreEqual(_machine.Final, _observer.Events[4].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[4].Previous, Is.EqualTo(Running));
+                Assert.That(_observer.Events[4].Current, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_fourth_switched_to_finished()
         {
-            Assert.AreEqual(Resting, _observer.Events[3].Previous);
-            Assert.AreEqual(Running, _observer.Events[3].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[3].Previous, Is.EqualTo(Resting));
+                Assert.That(_observer.Events[3].Current, Is.EqualTo(Running));
+            });
         }
 
         [Test]
         public void Should_have_second_switched_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(Running));
+            });
         }
 
         [Test]
         public void Should_have_third_switched_to_resting()
         {
-            Assert.AreEqual(Running, _observer.Events[2].Previous);
-            Assert.AreEqual(Resting, _observer.Events[2].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[2].Previous, Is.EqualTo(Running));
+                Assert.That(_observer.Events[2].Current, Is.EqualTo(Resting));
+            });
         }
 
         [Test]
         public void Should_have_transition_1()
         {
-            Assert.AreEqual("Running.BeforeEnter", _eventObserver.Events[0].Event.Name);
+            Assert.That(_eventObserver.Events[0].Event.Name, Is.EqualTo("Running.BeforeEnter"));
         }
 
         [Test]
         public void Should_have_transition_2()
         {
-            Assert.AreEqual("Running.AfterLeave", _eventObserver.Events[1].Event.Name);
+            Assert.That(_eventObserver.Events[1].Event.Name, Is.EqualTo("Running.AfterLeave"));
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(5, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(5));
         }
 
         State<Instance> Resting;
@@ -350,8 +383,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/RaiseEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/RaiseEvent_Specs.cs
@@ -22,31 +22,28 @@
                     .Event("Thing", out Thing)
                     .Event("Initialize", out Event Initialize)
                     .During(builder.Initial)
-                        .When(Thing, context => context.Data.Condition, b => b
-                            .TransitionTo(True)
-                            .Then(context => context.Raise(Initialize)))
-                        .When(Thing, context => !context.Data.Condition, b => b
-                            .TransitionTo(False))
+                    .When(Thing, context => context.Data.Condition, b => b
+                        .TransitionTo(True)
+                        .Then(context => context.Raise(Initialize)))
+                    .When(Thing, context => !context.Data.Condition, b => b
+                        .TransitionTo(False))
                     .DuringAny()
-                        .When(Initialize, b => b
-                            .Then(context => context.Instance.Initialized = DateTime.Now))
+                    .When(Initialize, b => b
+                        .Then(context => context.Instance.Initialized = DateTime.Now))
                 );
 
-            await machine.RaiseEvent(instance, Thing, new Data
-            {
-                Condition = true
-            });
-            Assert.AreEqual(True, instance.CurrentState);
-            Assert.IsTrue(instance.Initialized.HasValue);
+            await machine.RaiseEvent(instance, Thing, new Data { Condition = true });
+            Assert.That(instance.CurrentState, Is.EqualTo(True));
+            Assert.That(instance.Initialized.HasValue, Is.True);
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public DateTime? Initialized { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/SerializeState_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/SerializeState_Specs.cs
@@ -23,15 +23,12 @@
                     .State("False", out False)
                     .Event("Thing", out Thing)
                     .During(builder.Initial)
-                        .When(Thing, context => context.Data.Condition, b => b.TransitionTo(True))
-                        .When(Thing, context => !context.Data.Condition, b => b.TransitionTo(False))
+                    .When(Thing, context => context.Data.Condition, b => b.TransitionTo(True))
+                    .When(Thing, context => !context.Data.Condition, b => b.TransitionTo(False))
                 );
 
-            await machine.RaiseEvent(instance, Thing, new Data
-            {
-                Condition = true
-            });
-            Assert.AreEqual(True, instance.CurrentState);
+            await machine.RaiseEvent(instance, Thing, new Data { Condition = true });
+            Assert.That(instance.CurrentState, Is.EqualTo(True));
 
             var serializer = new JsonStateSerializer<StateMachine<Instance>, Instance>(machine);
 
@@ -40,15 +37,15 @@
             Console.WriteLine("Body: {0}", body);
             var reInstance = serializer.Deserialize<Instance>(body);
 
-            Assert.AreEqual(True, reInstance.CurrentState);
+            Assert.That(reInstance.CurrentState, Is.EqualTo(True));
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/State_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/State_Specs.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using NUnit.Framework;
-    using SagaStateMachine;
 
 
     [TestFixture(Category = "Dynamic Modify")]
@@ -11,34 +10,35 @@
         [Test]
         public void It_should_capture_the_name_of_final()
         {
-            Assert.AreEqual("Final", _machine.Final.Name);
+            Assert.That(_machine.Final.Name, Is.EqualTo("Final"));
         }
 
         [Test]
         public void It_should_capture_the_name_of_initial()
         {
-            Assert.AreEqual("Initial", _machine.Initial.Name);
+            Assert.That(_machine.Initial.Name, Is.EqualTo("Initial"));
         }
 
         [Test]
         public void It_should_capture_the_name_of_running()
         {
-            Assert.AreEqual("Running", Running.Name);
+            Assert.That(Running.Name, Is.EqualTo("Running"));
         }
 
         [Test]
         public void Should_be_an_instance_of_the_proper_type()
         {
-            Assert.IsInstanceOf<MassTransitStateMachine<Instance>.StateMachineState>(_machine.Initial);
+            Assert.That(_machine.Initial, Is.InstanceOf<MassTransitStateMachine<Instance>.StateMachineState>());
         }
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
+
 
         State Running;
         StateMachine<Instance> _machine;
@@ -61,7 +61,7 @@ SagaStateMachineInstance
         [Test]
         public void It_should_get_the_name_right()
         {
-            Assert.AreEqual("Running", _instance.CurrentState);
+            Assert.That(_instance.CurrentState, Is.EqualTo("Running"));
         }
 
         Event Started;
@@ -77,7 +77,7 @@ SagaStateMachineInstance
                     .State("Running", out State Running)
                     .InstanceState(x => x.CurrentState)
                     .Initially()
-                        .When(Started, b => b.TransitionTo(Running))
+                    .When(Started, b => b.TransitionTo(Running))
                 );
             _instance = new Instance();
 
@@ -93,13 +93,14 @@ SagaStateMachineInstance
         /// an ORM that doesn't support user types (cough, EF, cough).
         /// </summary>
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             /// <summary>
             /// The CurrentState is exposed as a string for the ORM
             /// </summary>
             public string CurrentState { get; private set; }
+
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -110,7 +111,7 @@ SagaStateMachineInstance
         [Test]
         public void It_should_get_the_name_right()
         {
-            Assert.AreEqual(Running, _machine.GetState(_instance).Result);
+            Assert.That(_machine.GetState(_instance).Result, Is.EqualTo(Running));
         }
 
         State Running;
@@ -127,7 +128,7 @@ SagaStateMachineInstance
                     .Event("Started", out Started)
                     .InstanceState(x => x.CurrentState, Running)
                     .Initially()
-                        .When(Started, b => b.TransitionTo(Running))
+                    .When(Started, b => b.TransitionTo(Running))
                 );
             _instance = new Instance();
 
@@ -143,13 +144,14 @@ SagaStateMachineInstance
         /// an ORM that doesn't support user types (cough, EF, cough).
         /// </summary>
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             /// <summary>
             /// The CurrentState is exposed as a string for the ORM
             /// </summary>
             public int CurrentState { get; private set; }
+
+            public Guid CorrelationId { get; set; }
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Telephone_Sample.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Telephone_Sample.cs
@@ -26,8 +26,11 @@
 
                 await _machine.RaiseEvent(phone, _model.HungUp);
 
-                Assert.AreEqual(_model.OffHook.Name, phone.CurrentState);
-                Assert.GreaterOrEqual(phone.CallTimer.ElapsedMilliseconds, 45);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(phone.CurrentState, Is.EqualTo(_model.OffHook.Name));
+                    Assert.That(phone.CallTimer.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(45));
+                });
             }
 
             PhoneServiceStateModel _model;
@@ -86,8 +89,11 @@
                 await _machine.RaiseEvent(phone, _model.TakenOffHold);
                 await _machine.RaiseEvent(phone, _model.HungUp);
 
-                Assert.AreEqual(_model.OffHook.Name, phone.CurrentState);
-                Assert.GreaterOrEqual(phone.CallTimer.ElapsedMilliseconds, 45);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(phone.CurrentState, Is.EqualTo(_model.OffHook.Name));
+                    Assert.That(phone.CallTimer.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(45));
+                });
             }
 
             PhoneServiceStateModel _model;
@@ -119,8 +125,11 @@
 
                 await _machine.RaiseEvent(phone, _model.HungUp);
 
-                Assert.AreEqual(_model.OffHook.Name, phone.CurrentState);
-                Assert.GreaterOrEqual(phone.CallTimer.ElapsedMilliseconds, 45);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(phone.CurrentState, Is.EqualTo(_model.OffHook.Name));
+                    Assert.That(phone.CallTimer.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(45));
+                });
             }
 
             PhoneServiceStateModel _model;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Transition_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Transition_Specs.cs
@@ -11,27 +11,33 @@
         [Test]
         public void Should_call_the_enter_event()
         {
-            Assert.IsTrue(_instance.EnterCalled);
+            Assert.That(_instance.EnterCalled, Is.True);
         }
 
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_second_moved_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(Running));
+            });
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(2, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(2));
         }
 
         State Running;
@@ -49,9 +55,9 @@
                     .Event("Initialized", out Event Initialized)
                     .Event("Finish", out Event Finish)
                     .During(builder.Initial)
-                        .When(Initialized, b => b.TransitionTo(Running))
+                    .When(Initialized, b => b.TransitionTo(Running))
                     .During(Running)
-                        .When(Finish, b => b.Finalize())
+                    .When(Finish, b => b.Finalize())
                     .WhenEnter(Running, x => x.Then(context => context.Instance.EnterCalled = true))
                 );
             _observer = new StateChangeObserver<Instance>();
@@ -65,11 +71,11 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public bool EnterCalled { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 
@@ -80,40 +86,49 @@ SagaStateMachineInstance
         [Test]
         public void Should_call_the_enter_event()
         {
-            Assert.IsTrue(_instance.EnterCalled);
+            Assert.That(_instance.EnterCalled, Is.True);
         }
 
         [Test]
         public void Should_have_first_moved_to_initial()
         {
-            Assert.AreEqual(null, _observer.Events[0].Previous);
-            Assert.AreEqual(_machine.Initial, _observer.Events[0].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[0].Previous, Is.EqualTo(null));
+                Assert.That(_observer.Events[0].Current, Is.EqualTo(_machine.Initial));
+            });
         }
 
         [Test]
         public void Should_have_invoked_final_entered()
         {
-            Assert.IsTrue(_instance.FinalEntered);
+            Assert.That(_instance.FinalEntered, Is.True);
         }
 
         [Test]
         public void Should_have_second_moved_to_running()
         {
-            Assert.AreEqual(_machine.Initial, _observer.Events[1].Previous);
-            Assert.AreEqual(Running, _observer.Events[1].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[1].Previous, Is.EqualTo(_machine.Initial));
+                Assert.That(_observer.Events[1].Current, Is.EqualTo(Running));
+            });
         }
 
         [Test]
         public void Should_have_third_moved_to_final()
         {
-            Assert.AreEqual(Running, _observer.Events[2].Previous);
-            Assert.AreEqual(_machine.Final, _observer.Events[2].Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_observer.Events[2].Previous, Is.EqualTo(Running));
+                Assert.That(_observer.Events[2].Current, Is.EqualTo(_machine.Final));
+            });
         }
 
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.AreEqual(3, _observer.Events.Count);
+            Assert.That(_observer.Events, Has.Count.EqualTo(3));
         }
 
         State Running;
@@ -133,9 +148,9 @@ SagaStateMachineInstance
                     .Event("Initialized", out Initialized)
                     .Event("Finish", out Finish)
                     .During(builder.Initial)
-                        .When(Initialized, b => b.TransitionTo(Running))
+                    .When(Initialized, b => b.TransitionTo(Running))
                     .During(Running)
-                        .When(Finish, b => b.Finalize())
+                    .When(Finish, b => b.Finalize())
                     .BeforeEnter(builder.Final, x => x.Then(context => context.Instance.FinalEntered = true))
                     .WhenEnter(Running, x => x.Then(context => context.Instance.EnterCalled = true))
                 );
@@ -151,13 +166,13 @@ SagaStateMachineInstance
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public bool EnterCalled { get; set; }
 
             public bool FinalEntered { get; set; }
+            public Guid CorrelationId { get; set; }
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/UnobservedEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/UnobservedEvent_Specs.cs
@@ -26,8 +26,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -67,9 +67,9 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public int Volts { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -109,7 +109,7 @@
 
             await _machine.RaiseEvent(instance, Charge, new A { Volts = 12 });
 
-            Assert.AreEqual(0, instance.Volts);
+            Assert.That(instance.Volts, Is.EqualTo(0));
         }
 
         [Test]
@@ -119,7 +119,7 @@
 
             await _machine.RaiseEvent(instance, Start);
 
-            Assert.AreEqual(Running, await _machine.GetState(instance));
+            Assert.That(await _machine.GetState(instance), Is.EqualTo(Running));
 
             var nextEvents = await _machine.NextEvents(instance);
 
@@ -145,9 +145,9 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
             public int Volts { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -195,8 +195,8 @@
         class Instance :
             SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
@@ -1,9 +1,9 @@
 ﻿namespace MassTransit.Tests.SagaStateMachineTests.Dynamic_Modify
 {
     using System;
-    using Visualizer;
     using NUnit.Framework;
     using SagaStateMachine;
+    using Visualizer;
 
 
     [TestFixture(Category = "Dynamic Modify")]
@@ -26,7 +26,7 @@
 
             var expected = ExpectedGraphvizFile.Replace("\r", "").Replace("\n", Environment.NewLine);
 
-            Assert.AreEqual(expected, output);
+            Assert.That(output, Is.EqualTo(expected));
         }
 
         [Test]
@@ -40,7 +40,7 @@
 
             var expected = ExpectedMermaidFile.Replace("\r", "").Replace("\n", Environment.NewLine);
 
-            Assert.AreEqual(expected, output);
+            Assert.That(output, Is.EqualTo(expected));
         }
 
         StateMachine<Instance> _machine;
@@ -60,18 +60,18 @@
                     .Event("Finished", out Event Finished)
                     .Event<RestartData>("Restart", out Event<RestartData> Restart)
                     .During(b.Initial)
-                        .When(Initialized, (binder) => binder
-                            .TransitionTo(Running)
-                            .Catch<Exception>(h => h.TransitionTo(Failed))
-                        )
+                    .When(Initialized, (binder) => binder
+                        .TransitionTo(Running)
+                        .Catch<Exception>(h => h.TransitionTo(Failed))
+                    )
                     .During(Running)
-                        .When(Finished, (binder) => binder.TransitionTo(b.Final))
-                        .When(Suspend, (binder) => binder.TransitionTo(Suspended))
-                        .Ignore(Resume)
+                    .When(Finished, (binder) => binder.TransitionTo(b.Final))
+                    .When(Suspend, (binder) => binder.TransitionTo(Suspended))
+                    .Ignore(Resume)
                     .During(Suspended)
-                        .When(Resume, b => b.TransitionTo(Running))
+                    .When(Resume, b => b.TransitionTo(Running))
                     .During(Failed)
-                        .When(Restart, context => context.Data.Name != null, b => b.TransitionTo(Running))
+                    .When(Restart, context => context.Data.Name != null, b => b.TransitionTo(Running))
                 );
 
             _graph = _machine.GetGraph();
@@ -119,10 +119,10 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/EnterEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/EnterEvent_Specs.cs
@@ -16,12 +16,15 @@
         {
             var sagaId = Guid.NewGuid();
 
-            await InputQueueSendEndpoint.Send(new Start {CorrelationId = sagaId});
+            await InputQueueSendEndpoint.Send(new Start { CorrelationId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSagaInState(sagaId, _machine, _machine.RunningFaster, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(saga.HasValue, Is.True);
 
-            Assert.AreEqual(1, _repository[saga.Value].Instance.OnEnter);
+                Assert.That(_repository[saga.Value].Instance.OnEnter, Is.EqualTo(1));
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Fault_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Fault_Specs.cs
@@ -39,7 +39,7 @@
 
             ConsumeContext<Fault<Start>> fault = await faultReceived;
 
-            Assert.AreEqual(message.CorrelationId, fault.Message.Message.CorrelationId);
+            Assert.That(fault.Message.Message.CorrelationId, Is.EqualTo(message.CorrelationId));
         }
 
         [Test]
@@ -58,7 +58,7 @@
 
             ConsumeContext<Fault<Start>> fault = await faultReceived;
 
-            Assert.AreEqual(message.CorrelationId, fault.Message.Message.CorrelationId);
+            Assert.That(fault.Message.Message.CorrelationId, Is.EqualTo(message.CorrelationId));
 
             saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.FailedToStart, TestTimeout);
 
@@ -77,7 +77,7 @@
 
             ConsumeContext<Fault<Stop>> fault = await faultReceived;
 
-            Assert.AreEqual(message.CorrelationId, fault.Message.Message.CorrelationId);
+            Assert.That(fault.Message.Message.CorrelationId, Is.EqualTo(message.CorrelationId));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Initiator_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Initiator_Specs.cs
@@ -29,9 +29,9 @@
 
                 Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
+                Assert.That(received.InitiatorId.Value, Is.EqualTo(message.CorrelationId), "The initiator should be the saga CorrelationId");
 
-                Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                Assert.That(received.SourceAddress, Is.EqualTo(InputQueueAddress), "The published message should have the input queue source address");
             });
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Initiator_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Initiator_Specs.cs
@@ -23,17 +23,20 @@
 
             ConsumeContext<StartupComplete> received = await messageReceived;
 
-            Assert.That(received.Message.TransactionId, Is.EqualTo(message.CorrelationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(received.Message.TransactionId, Is.EqualTo(message.CorrelationId));
 
-            Assert.IsTrue(received.InitiatorId.HasValue, "The initiator should be copied from the CorrelationId");
+                Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-            Assert.AreEqual(received.InitiatorId.Value, message.CorrelationId, "The initiator should be the saga CorrelationId");
+                Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
 
-            Assert.AreEqual(received.SourceAddress, InputQueueAddress, "The published message should have the input queue source address");
+                Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+            });
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/MissingInstance_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/MissingInstance_Specs.cs
@@ -21,7 +21,7 @@
 
             await notFound;
 
-            Assert.AreEqual("A", notFound.Result.Message.ServiceName);
+            Assert.That(notFound.Result.Message.ServiceName, Is.EqualTo("A"));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Publish_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Publish_Specs.cs
@@ -28,9 +28,9 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
                 Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-                Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
+                Assert.That(received.InitiatorId.Value, Is.EqualTo(message.CorrelationId), "The initiator should be the saga CorrelationId");
 
-                Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+                Assert.That(received.SourceAddress, Is.EqualTo(InputQueueAddress), "The published message should have the input queue source address");
             });
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Publish_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Publish_Specs.cs
@@ -22,17 +22,20 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             ConsumeContext<StartupComplete> received = await messageReceived;
 
-            Assert.AreEqual(message.CorrelationId, received.Message.TransactionId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(received.Message.TransactionId, Is.EqualTo(message.CorrelationId));
 
-            Assert.IsTrue(received.InitiatorId.HasValue, "The initiator should be copied from the CorrelationId");
+                Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-            Assert.AreEqual(received.InitiatorId.Value, message.CorrelationId, "The initiator should be the saga CorrelationId");
+                Assert.That(message.CorrelationId, Is.EqualTo(received.InitiatorId.Value), "The initiator should be the saga CorrelationId");
 
-            Assert.AreEqual(received.SourceAddress, InputQueueAddress, "The published message should have the input queue source address");
+                Assert.That(InputQueueAddress, Is.EqualTo(received.SourceAddress), "The published message should have the input queue source address");
+            });
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/RemoveWhen_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/RemoveWhen_Specs.cs
@@ -122,9 +122,12 @@ namespace MassTransit.Tests.SagaStateMachineTests
             await Task.Delay(50);
 
             Guid? saga = await _repository.ShouldNotContainSaga(sagaId, TestTimeout);
-            Assert.IsFalse(saga.HasValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(saga.HasValue, Is.False);
 
-            Assert.AreEqual(sagaId, response.CorrelationId);
+                Assert.That(response.CorrelationId, Is.EqualTo(sagaId));
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Send_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Send_Specs.cs
@@ -20,17 +20,20 @@
 
             ConsumeContext<StartupComplete> received = await _handled;
 
-            Assert.AreEqual(message.CorrelationId, received.Message.TransactionId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(received.Message.TransactionId, Is.EqualTo(message.CorrelationId));
 
-            Assert.IsTrue(received.InitiatorId.HasValue, "The initiator should be copied from the CorrelationId");
+                Assert.That(received.InitiatorId.HasValue, Is.True, "The initiator should be copied from the CorrelationId");
 
-            Assert.AreEqual(message.CorrelationId, received.InitiatorId.Value, "The initiator should be the saga CorrelationId");
+                Assert.That(received.InitiatorId.Value, Is.EqualTo(message.CorrelationId), "The initiator should be the saga CorrelationId");
 
-            Assert.AreEqual(InputQueueAddress, received.SourceAddress, "The published message should have the input queue source address");
+                Assert.That(received.SourceAddress, Is.EqualTo(InputQueueAddress), "The published message should have the input queue source address");
+            });
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, _machine.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/UncorrelatedMessage_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/UncorrelatedMessage_Specs.cs
@@ -20,7 +20,7 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             Response<Status> status = await statusTask;
 
-            Assert.AreEqual("A", status.Message.ServiceName);
+            Assert.That(status.Message.ServiceName, Is.EqualTo("A"));
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             Response<Status> status = await Bus.Request<CheckStatus, Status>(InputQueueAddress, new CheckStatus("A"), TestCancellationToken);
 
-            Assert.AreEqual("A", status.Message.ServiceName);
+            Assert.That(status.Message.ServiceName, Is.EqualTo("A"));
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             Response<Status> status = await Bus.Request<CheckStatus, Status>(InputQueueAddress, new CheckStatus("B"), TestCancellationToken);
 
-            Assert.AreEqual("B", status.Message.ServiceName);
+            Assert.That(status.Message.ServiceName, Is.EqualTo("B"));
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/StaticProperty_Specs.cs
+++ b/tests/MassTransit.Tests/StaticProperty_Specs.cs
@@ -41,45 +41,54 @@
         [Test]
         public void Can_get_even_with_private_getter()
         {
-            IEnumerable<PropertyInfo> props = typeof(StaticsNoGetter).GetAllStaticProperties();
+            IEnumerable<PropertyInfo> props = typeof(StaticsNoGetter).GetAllStaticProperties().ToArray();
             Assert.That(props.Count(), Is.EqualTo(2));
-            IEnumerable<string> names = props.Select(x => x.Name);
-            CollectionAssert.Contains(names, "ZupMan");
-            CollectionAssert.Contains(names, "StaticProp");
+            IEnumerable<string> names = props.Select(x => x.Name).ToArray();
+            Assert.That(names, Has.Member("ZupMan"));
+            Assert.That(names, Has.Member("StaticProp"));
         }
 
         [Test]
         public void Can_get_private_static_properties()
         {
-            IEnumerable<PropertyInfo> props = typeof(PrivateStatics).GetAllStaticProperties();
+            IEnumerable<PropertyInfo> props = typeof(PrivateStatics).GetAllStaticProperties().ToArray();
             Assert.That(props.Count(), Is.EqualTo(2));
-            IEnumerable<string> names = props.Select(x => x.Name);
-            CollectionAssert.Contains(names, "CanWeGetPrivates");
-            CollectionAssert.Contains(names, "StaticProp");
+            IEnumerable<string> names = props.Select(x => x.Name).ToArray();
+            Assert.That(names, Has.Member("CanWeGetPrivates"));
+            Assert.That(names, Has.Member("StaticProp"));
         }
 
         [Test]
         public void Can_get_property_on_stand_alone_class()
         {
-            IEnumerable<PropertyInfo> props = typeof(SuperTarget).GetAllStaticProperties();
-            Assert.That(props.Count(), Is.EqualTo(1));
-            Assert.That(props.First().Name, Is.EqualTo("StaticProp"));
+            IEnumerable<PropertyInfo> props = typeof(SuperTarget).GetAllStaticProperties().ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(props.Count(), Is.EqualTo(1));
+                Assert.That(props.First().Name, Is.EqualTo("StaticProp"));
+            });
         }
 
         [Test]
         public void Can_get_single_property_on_super_from_sub()
         {
-            IEnumerable<PropertyInfo> props = typeof(SubTarget).GetAllStaticProperties();
-            Assert.That(props.Count(), Is.EqualTo(1));
-            Assert.That(props.First().Name, Is.EqualTo("StaticProp"));
+            IEnumerable<PropertyInfo> props = typeof(SubTarget).GetAllStaticProperties().ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(props.Count(), Is.EqualTo(1));
+                Assert.That(props.First().Name, Is.EqualTo("StaticProp"));
+            });
         }
 
         [Test]
         public void Can_get_with_no_hierarchy()
         {
-            IEnumerable<PropertyInfo> props = typeof(StaticsNoGetter).GetStaticProperties();
-            Assert.That(props.Count(), Is.EqualTo(1));
-            Assert.That(props.First().Name, Is.EqualTo("ZupMan"));
+            IEnumerable<PropertyInfo> props = typeof(StaticsNoGetter).GetStaticProperties().ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(props.Count(), Is.EqualTo(1));
+                Assert.That(props.First().Name, Is.EqualTo("ZupMan"));
+            });
         }
     }
 }


### PR DESCRIPTION
Seems like NUnit 4.x was already released: https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
In order to migrate we have to fix a lot of stuff and `NUnit.Analyzer ` can help with that + keep the best practices
