### PR TITLE
Added duplicate check to group headers by Key before group into dicti…

### DIFF
--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Serializers/DictionaryHeadersSerialize.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Serializers/DictionaryHeadersSerialize.cs
@@ -29,11 +29,14 @@ namespace MassTransit.KafkaIntegration.Serializers
         {
             public IHeaderProvider Deserialize(Headers headers)
             {
-                return new DictionaryHeaderProvider(headers.ToDictionary(x => x.Key, x =>
-                {
-                    var valueBytes = x.GetValueBytes();
-                    return valueBytes != null ? (object)Encoding.UTF8.GetString(valueBytes) : null;
-                }));
+                var dictionary = headers.GroupBy(header => header.Key)
+                                 .ToDictionary(group => group.Key, group =>
+                                 {
+                                     var valueBytes = group.First().GetValueBytes();
+                                     return valueBytes != null ? (object)Encoding.UTF8.GetString(valueBytes) : null;
+                                 });
+
+                return new DictionaryHeaderProvider(dictionary);
             }
         }
 

--- a/tests/MassTransit.KafkaIntegration.Tests/DictionaryHeadersDeserializerTests.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/DictionaryHeadersDeserializerTests.cs
@@ -19,6 +19,16 @@
         }
 
         [Test]
+        public async Task Should_Deserialize_with_duplicate_header_value()
+        {
+            var headers = new Headers { new Header("TestValue", null), new Header("TestValue", null) };
+
+            var result = DictionaryHeadersSerialize.Deserializer.Deserialize(headers);
+            Assert.IsTrue(result.TryGetHeader("TestValue", out var emptyValue));
+            Assert.IsNull(emptyValue);
+        }
+
+        [Test]
         public async Task Should_not_throw_when_header_in_different_encoding()
         {
             var bytes = Encoding.Unicode.GetBytes("test");


### PR DESCRIPTION
This PR aims to resolve an issue with Kafka header serializers.

When Kafka messages arrive with multiple duplicated headers, which can occur when working with external services (like NewRelic, etc.), MassTransit was throwing a "duplicate key entry" exception when attempting to insert these into a dictionary.