### PR TITLE
Set DeadLetterReason and DeadLetterErrorDescription when natively dead-lettering messages in Azure Service Bus

### DIFF
--- a/src/MassTransit.Abstractions/Util/ExceptionUtil.cs
+++ b/src/MassTransit.Abstractions/Util/ExceptionUtil.cs
@@ -39,7 +39,7 @@ namespace MassTransit.Util
             return _cleanup.Replace(stackTrace, "");
         }
 
-        public static IDictionary<string, object> GetExceptionHeaderDictionary(Exception exception)
+        public static Dictionary<string, object> GetExceptionHeaderDictionary(Exception exception)
         {
             exception = exception.GetBaseException() ?? exception;
 

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusSessionMessageLockContext.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusSessionMessageLockContext.cs
@@ -36,16 +36,21 @@ namespace MassTransit.AzureServiceBusTransport
 
         public async Task DeadLetter()
         {
-            var headers = new Dictionary<string, object> { { MessageHeaders.Reason, "dead-letter" } };
+            const string deadLetterReason = "dead-letter";
+            var headers = new Dictionary<string, object> { { MessageHeaders.Reason, deadLetterReason } };
 
-            await _session.DeadLetterMessageAsync(_message, headers).ConfigureAwait(false);
+            await _session.DeadLetterMessageAsync(_message, headers, deadLetterReason).ConfigureAwait(false);
 
             _deadLettered = true;
         }
 
         public async Task DeadLetter(Exception exception)
         {
-            await _session.DeadLetterMessageAsync(_message, ExceptionUtil.GetExceptionHeaderDictionary(exception)).ConfigureAwait(false);
+            Dictionary<string, object> exceptionHeaderDictionary = ExceptionUtil.GetExceptionHeaderDictionary(exception);
+            var deadLetterReason = (string)exceptionHeaderDictionary[MessageHeaders.Reason];
+            var deadLetterErrorDescription = (string)exceptionHeaderDictionary[MessageHeaders.FaultMessage];
+
+            await _session.DeadLetterMessageAsync(_message, exceptionHeaderDictionary, deadLetterReason, deadLetterErrorDescription).ConfigureAwait(false);
 
             _deadLettered = true;
         }


### PR DESCRIPTION
Fixes #5107.

I'm unsure about exactly how this should be tested within the Mass Transit codebase. The [existing tests](https://github.com/MassTransit/MassTransit/blob/develop/tests/MassTransit.Azure.ServiceBus.Core.Tests/DeadLetter_Specs.cs) of Azure Service Bus just test that the messages are consumed, not that they are successfully moved to the native dead-letter queue. I'm happy to write test cases that peek at or consume them from that queue, however.