### PR TITLE
Ignore case for anonymous type exception test

### DIFF
--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/PublishDynamicType_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/PublishDynamicType_Specs.cs
@@ -13,7 +13,7 @@
         [Test]
         public async Task Should_throw_a_proper_exception()
         {
-            Assert.That(async () => await Bus.Publish(new {Value = "Name"}), Throws.TypeOf<ArgumentException>().With.Message.Contain("anonymous"));
+            Assert.That(async () => await Bus.Publish(new { Value = "Name" }), Throws.TypeOf<ArgumentException>().With.Message.Contain("anonymous").IgnoreCase);
         }
 
         Task<ConsumeContext<PingMessage>> _handler;


### PR DESCRIPTION
When running this test on Windows 11 with .NET 8, it fails because the anonymous type is named `<>f__AnonymousType0`, which doesn't match the expected casing. Doing a case insensitive match ensures the test works regardless of how exactly .NET cases the generated anonymous type.