### PR TITLE
Migrate to NUnit 4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,8 +73,8 @@
     <PackageVersion Include="NHibernate" Version="5.5.1" />
     <PackageVersion Include="Npgsql" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageVersion Include="NUnit" Version="3.14.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageVersion Include="NUnit" Version="4.1.0"/>
+    <PackageVersion Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/src/MassTransit.TestFramework/ForkJoint/Tests/BurgerFuture_Specs.cs
+++ b/src/MassTransit.TestFramework/ForkJoint/Tests/BurgerFuture_Specs.cs
@@ -36,10 +36,13 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
                 }
             });
 
-            Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
-            Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
-            Assert.That(response.Message.Burger.Cheese, Is.True);
-            Assert.That(response.Message.Burger.Weight, Is.EqualTo(1.0m));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
+                Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
+                Assert.That(response.Message.Burger.Cheese, Is.True);
+                Assert.That(response.Message.Burger.Weight, Is.EqualTo(1.0m));
+            });
         }
 
         [Test]
@@ -71,9 +74,12 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
             }
             catch (RequestFaultException exception)
             {
-                Assert.That(exception.Fault.Host, Is.Not.Null);
-                Assert.That(exception.Fault.Exceptions, Is.Not.Null.Or.Empty);
-                Assert.That(exception.Message, Contains.Substring("lettuce"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(exception.Fault.Host, Is.Not.Null);
+                    Assert.That(exception.Fault.Exceptions, Is.Not.Null.Or.Empty);
+                    Assert.That(exception.Message, Contains.Substring("lettuce"));
+                });
             }
         }
 

--- a/src/MassTransit.TestFramework/ForkJoint/Tests/CalculateFuture_Specs.cs
+++ b/src/MassTransit.TestFramework/ForkJoint/Tests/CalculateFuture_Specs.cs
@@ -33,12 +33,15 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
                 Number = 5
             }, timeout: RequestTimeout.After(s: 5));
 
-            Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
-            Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
-            Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
-            Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
+                Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
+                Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
+                Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
 
-            Assert.That(response.Message.Description, Contains.Substring("Fries"));
+                Assert.That(response.Message.Description, Contains.Substring("Fries"));
+            });
             Assert.That(response.Message.Description, Contains.Substring("Delicious"));
         }
 

--- a/src/MassTransit.TestFramework/ForkJoint/Tests/ComboFuture_Specs.cs
+++ b/src/MassTransit.TestFramework/ForkJoint/Tests/ComboFuture_Specs.cs
@@ -33,12 +33,15 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
                 Number = 5
             }, timeout: RequestTimeout.After(s: 5));
 
-            Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
-            Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
-            Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
-            Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
+                Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
+                Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
+                Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
 
-            Assert.That(response.Message.Description, Contains.Substring("Fries"));
+                Assert.That(response.Message.Description, Contains.Substring("Fries"));
+            });
             Assert.That(response.Message.Description, Contains.Substring("Shake"));
         }
 

--- a/src/MassTransit.TestFramework/ForkJoint/Tests/FryFuture_Specs.cs
+++ b/src/MassTransit.TestFramework/ForkJoint/Tests/FryFuture_Specs.cs
@@ -13,6 +13,11 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
     public class FryFuture_Specs :
         FutureTestFixture
     {
+        public FryFuture_Specs(IFutureTestFixtureConfigurator testFixtureConfigurator)
+            : base(testFixtureConfigurator)
+        {
+        }
+
         [Test]
         public async Task Should_complete()
         {
@@ -32,11 +37,14 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
                 Size = Size.Medium
             });
 
-            Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
-            Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
-            Assert.That(response.Message.Size, Is.EqualTo(Size.Medium));
-            Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
-            Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
+                Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
+                Assert.That(response.Message.Size, Is.EqualTo(Size.Medium));
+                Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
+                Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
+            });
         }
 
         protected override void ConfigureServices(IServiceCollection collection)
@@ -48,11 +56,6 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
         {
             configurator.AddConsumer<CookFryConsumer, CookFryConsumerDefinition>();
             configurator.AddFuture<FryFuture>();
-        }
-
-        public FryFuture_Specs(IFutureTestFixtureConfigurator testFixtureConfigurator)
-            : base(testFixtureConfigurator)
-        {
         }
     }
 }

--- a/src/MassTransit.TestFramework/ForkJoint/Tests/FryShakeFuture_Specs.cs
+++ b/src/MassTransit.TestFramework/ForkJoint/Tests/FryShakeFuture_Specs.cs
@@ -34,12 +34,15 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
                 Size = Size.Medium
             });
 
-            Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
-            Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
-            Assert.That(response.Message.Size, Is.EqualTo(Size.Medium));
-            Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
-            Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
-            Assert.That(response.Message.Description, Contains.Substring("FryShake(2)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
+                Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
+                Assert.That(response.Message.Size, Is.EqualTo(Size.Medium));
+                Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
+                Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
+                Assert.That(response.Message.Description, Contains.Substring("FryShake(2)"));
+            });
         }
 
         [Test]
@@ -66,8 +69,11 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
             }
             catch (RequestFaultException exception)
             {
-                Assert.That(exception.Fault.Host, Is.Not.Null);
-                Assert.That(exception.Message, Contains.Substring("Strawberry is not available"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(exception.Fault.Host, Is.Not.Null);
+                    Assert.That(exception.Message, Contains.Substring("Strawberry is not available"));
+                });
             }
         }
 

--- a/src/MassTransit.TestFramework/ForkJoint/Tests/OrderFuture_Specs.cs
+++ b/src/MassTransit.TestFramework/ForkJoint/Tests/OrderFuture_Specs.cs
@@ -52,10 +52,13 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
                 FryShakes = default(FryShake[])
             }, timeout: RequestTimeout.After(s: 5));
 
-            Assert.That(response.Is(out Response<OrderCompleted> completed), "Order did not complete");
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Is(out Response<OrderCompleted> completed), "Order did not complete");
 
-            Assert.That(completed.Message.OrderId, Is.EqualTo(orderId));
-            Assert.That(completed.Message.LinesCompleted.Count, Is.EqualTo(2));
+                Assert.That(completed.Message.OrderId, Is.EqualTo(orderId));
+                Assert.That(completed.Message.LinesCompleted, Has.Count.EqualTo(2));
+            });
         }
 
         [Test]

--- a/src/MassTransit.TestFramework/ForkJoint/Tests/ShakeFuture_Specs.cs
+++ b/src/MassTransit.TestFramework/ForkJoint/Tests/ShakeFuture_Specs.cs
@@ -34,11 +34,14 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
                 Size = Size.Medium
             });
 
-            Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
-            Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
-            Assert.That(response.Message.Size, Is.EqualTo(Size.Medium));
-            Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
-            Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.OrderId, Is.EqualTo(orderId));
+                Assert.That(response.Message.OrderLineId, Is.EqualTo(orderLineId));
+                Assert.That(response.Message.Size, Is.EqualTo(Size.Medium));
+                Assert.That(response.Message.Created, Is.GreaterThanOrEqualTo(startedAt));
+                Assert.That(response.Message.Completed, Is.GreaterThanOrEqualTo(response.Message.Created));
+            });
         }
 
         [Test]
@@ -65,8 +68,11 @@ namespace MassTransit.TestFramework.ForkJoint.Tests
             }
             catch (RequestFaultException exception)
             {
-                Assert.That(exception.Fault.Host, Is.Not.Null);
-                Assert.That(exception.Message, Contains.Substring("Strawberry is not available"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(exception.Fault.Host, Is.Not.Null);
+                    Assert.That(exception.Message, Contains.Substring("Strawberry is not available"));
+                });
             }
         }
 

--- a/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
+++ b/src/MassTransit.TestFramework/MassTransit.TestFramework.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../signing.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsWindows)' == 'true' ">

--- a/tests/MassTransit.Abstractions.Tests/NewId/GuidInterop_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/GuidInterop_Specs.cs
@@ -115,8 +115,11 @@
             var gsn = Guid.Parse(ns);
             var g = n.ToSequentialGuid();
 
-            Assert.That(gsn, Is.EqualTo(g));
-            Assert.That(n.ToGuid(), Is.Not.EqualTo(gsn));
+            Assert.Multiple(() =>
+            {
+                Assert.That(gsn, Is.EqualTo(g));
+                Assert.That(n.ToGuid(), Is.Not.EqualTo(gsn));
+            });
         }
 
         [Test]
@@ -216,7 +219,7 @@
             Assert.That(ng, Is.EqualTo(n));
 
             // Also checks to see if this would throw
-            Assert.IsTrue(ng.Timestamp != default);
+            Assert.That(ng.Timestamp, Is.Not.EqualTo(default));
         }
 
         [Test]

--- a/tests/MassTransit.Abstractions.Tests/NewId/NewId_Specs.cs
+++ b/tests/MassTransit.Abstractions.Tests/NewId/NewId_Specs.cs
@@ -17,7 +17,7 @@
             var id1 = new NewId("fc070000-9565-3668-e000-08d5893343c6");
             var id2 = new NewId("fc070000-9565-3668-e000-08d5893343c6");
 
-            Assert.IsTrue(id1 == id2);
+            Assert.That(id1, Is.EqualTo(id2));
         }
 
         [Test]
@@ -26,7 +26,7 @@
             var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
             var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");
 
-            Assert.IsTrue(lowerId < greaterId);
+            Assert.That(lowerId, Is.LessThan(greaterId));
         }
 
         [Test]
@@ -35,7 +35,7 @@
             var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
             var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");
 
-            Assert.IsFalse(lowerId > greaterId);
+            Assert.That(lowerId, Is.LessThanOrEqualTo(greaterId));
         }
 
         [Test]
@@ -53,7 +53,7 @@
             if (difference < TimeSpan.Zero)
                 difference = difference.Negate();
 
-            Assert.LessOrEqual(difference, TimeSpan.FromMinutes(1));
+            Assert.That(difference, Is.LessThanOrEqualTo(TimeSpan.FromMinutes(1)));
         }
 
         [Test]
@@ -72,7 +72,7 @@
             if (difference < TimeSpan.Zero)
                 difference = difference.Negate();
 
-            Assert.LessOrEqual(difference, TimeSpan.FromMinutes(1));
+            Assert.That(difference, Is.LessThanOrEqualTo(TimeSpan.FromMinutes(1)));
         }
 
         [Test]

--- a/tests/MassTransit.ActiveMqTransport.Tests/DelayRetry_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/DelayRetry_Specs.cs
@@ -21,7 +21,7 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;
@@ -156,8 +156,11 @@
             ConsumeContext<Fault<OneMessage>> pingFaultContext = await pingFault;
             ConsumeContext<Fault<TwoMessage>> pongFaultContext = await pongFault;
 
-            Assert.That(_consumer.PingCount, Is.EqualTo(3));
-            Assert.That(_consumer.PongCount, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_consumer.PingCount, Is.EqualTo(3));
+                Assert.That(_consumer.PongCount, Is.EqualTo(3));
+            });
         }
 
         Consumer _consumer;
@@ -212,8 +215,6 @@
     [TestFixture]
     public class Delayed_redelivery
     {
-        Consumer _consumer;
-
         [Test]
         [Category("Flaky")]
         [TestCase("activemq")]
@@ -275,11 +276,16 @@
             ConsumeContext<Fault<OneMessage>> pingFaultContext = await pingFault;
             ConsumeContext<Fault<TwoMessage>> pongFaultContext = await pongFault;
 
-            Assert.That(_consumer.PingCount, Is.EqualTo(3));
-            Assert.That(_consumer.PongCount, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_consumer.PingCount, Is.EqualTo(3));
+                Assert.That(_consumer.PongCount, Is.EqualTo(3));
+            });
 
             await busControl.StopAsync();
         }
+
+        Consumer _consumer;
 
         public Task<ConsumeContext<T>> SubscribeHandler<T>(IBus bus, Func<ConsumeContext<T>, bool> filter)
             where T : class
@@ -438,7 +444,7 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;
@@ -490,8 +496,11 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
-            Assert.IsTrue(_hit);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
+                Assert.That(_hit, Is.True);
+            });
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;

--- a/tests/MassTransit.ActiveMqTransport.Tests/EndpointConfiguration_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/EndpointConfiguration_Specs.cs
@@ -42,9 +42,12 @@ namespace MassTransit.ActiveMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -73,9 +76,12 @@ namespace MassTransit.ActiveMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -104,9 +110,12 @@ namespace MassTransit.ActiveMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -135,8 +144,11 @@ namespace MassTransit.ActiveMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -157,8 +169,11 @@ namespace MassTransit.ActiveMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
         }
 
         [Test]
@@ -190,8 +205,11 @@ namespace MassTransit.ActiveMqTransport.Tests
 
             var probe = JObject.Parse(busControl.GetProbeResult().ToJsonString());
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
         }
 
 

--- a/tests/MassTransit.ActiveMqTransport.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/JobConsumer_Specs.cs
@@ -66,12 +66,15 @@ namespace MassTransit.ActiveMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -100,12 +103,15 @@ namespace MassTransit.ActiveMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             IRequestClient<GetJobState> stateClient = harness.GetRequestClient<GetJobState>();
 
@@ -115,8 +121,11 @@ namespace MassTransit.ActiveMqTransport.Tests
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
-            Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
-            Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            });
 
             jobState = await stateClient.GetResponse<JobState>(new { JobId = jobId });
 
@@ -145,21 +154,30 @@ namespace MassTransit.ActiveMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
-            Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
-            Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            });
 
             await harness.Bus.Publish<RetryJob>(new { JobId = jobId });
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             await harness.Stop();
         }
@@ -194,11 +212,14 @@ namespace MassTransit.ActiveMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(x => x.Context.Message.JobId == jobId), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobSubmitted>(x => x.Context.Message.JobId == jobId), Is.True);
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Sent.Any<JobSlotWaitElapsed>(x => x.Context.Message.JobId == jobId), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotWaitElapsed>(x => x.Context.Message.JobId == jobId), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -230,15 +251,18 @@ namespace MassTransit.ActiveMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(1) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             await harness.Stop();
         }
@@ -255,13 +279,16 @@ namespace MassTransit.ActiveMqTransport.Tests
 
             await harness.Bus.Publish<OddJob>(new { Duration = TimeSpan.FromSeconds(1) });
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             IPublishedMessage<JobCompleted> publishedMessage = await harness.Published.SelectAsync<JobCompleted>().First();
             Assert.That(publishedMessage.Context.Message.JobId, Is.Not.EqualTo(Guid.Empty));

--- a/tests/MassTransit.ActiveMqTransport.Tests/KillSwitch_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/KillSwitch_Specs.cs
@@ -20,11 +20,14 @@ namespace MassTransit.ActiveMqTransport.Tests
 
             await Task.WhenAll(Enumerable.Range(0, 11).Select(x => Bus.Publish(new BadMessage())));
 
-            Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Degraded, TimeSpan.FromSeconds(15)), Is.EqualTo(BusHealthStatus.Degraded));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Degraded, TimeSpan.FromSeconds(15)), Is.EqualTo(BusHealthStatus.Degraded));
 
-            Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Healthy, TimeSpan.FromSeconds(10)), Is.EqualTo(BusHealthStatus.Healthy));
+                Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Healthy, TimeSpan.FromSeconds(10)), Is.EqualTo(BusHealthStatus.Healthy));
 
-            Assert.That(await ActiveMqTestHarness.Consumed.SelectAsync<BadMessage>().Take(11).Count(), Is.EqualTo(11));
+                Assert.That(await ActiveMqTestHarness.Consumed.SelectAsync<BadMessage>().Take(11).Count(), Is.EqualTo(11));
+            });
 
             await Task.WhenAll(Enumerable.Range(0, 20).Select(x => Bus.Publish(new GoodMessage())));
 

--- a/tests/MassTransit.ActiveMqTransport.Tests/OpenTelemetry_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/OpenTelemetry_Specs.cs
@@ -1,6 +1,5 @@
 namespace MassTransit.ActiveMqTransport.Tests
 {
-    using System;
     using System.Diagnostics;
     using System.Threading.Tasks;
     using HarnessContracts;
@@ -14,6 +13,9 @@ namespace MassTransit.ActiveMqTransport.Tests
 
     namespace HarnessContracts
     {
+        using System;
+
+
         public interface SubmitOrder
         {
             Guid OrderId { get; }
@@ -87,9 +89,12 @@ namespace MassTransit.ActiveMqTransport.Tests
                 OrderNumber = "123"
             });
 
-            Assert.IsTrue(await harness.Sent.Any<OrderSubmitted>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Sent.Any<OrderSubmitted>(), Is.True);
 
-            Assert.IsTrue(await harness.Consumed.Any<SubmitOrder>());
+                Assert.That(await harness.Consumed.Any<SubmitOrder>(), Is.True);
+            });
         }
 
 

--- a/tests/MassTransit.ActiveMqTransport.Tests/Reconnecting_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/Reconnecting_Specs.cs
@@ -3,9 +3,9 @@ namespace MassTransit.ActiveMqTransport.Tests
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using MassTransit.Testing;
     using NUnit.Framework;
     using TestFramework.Messages;
+    using Testing;
     using Transports;
 
 
@@ -20,7 +20,7 @@ namespace MassTransit.ActiveMqTransport.Tests
             await Bus.Publish(new ReconnectMessage { Value = "Before" });
 
             var beforeFound = await Task.Run(() => _consumer.Received.Select<ReconnectMessage>(x => x.Context.Message.Value == "Before").Any());
-            Assert.IsTrue(beforeFound);
+            Assert.That(beforeFound, Is.True);
 
             Console.WriteLine("Okay, restart ActiveMQ");
 
@@ -46,7 +46,7 @@ namespace MassTransit.ActiveMqTransport.Tests
             await Bus.Publish(new ReconnectMessage { Value = "After" });
 
             var afterFound = await Task.Run(() => _consumer.Received.Select<ReconnectMessage>(x => x.Context.Message.Value == "After").Any());
-            Assert.IsTrue(afterFound);
+            Assert.That(afterFound, Is.True);
         }
 
         public Reconnecting_Specs()

--- a/tests/MassTransit.ActiveMqTransport.Tests/RequestReply_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/RequestReply_Specs.cs
@@ -21,9 +21,13 @@
 
             TestExecutionContext.CurrentContext.OutWriter.Flush();
 
-            Assert.IsNotNull(response);
-            Assert.NotNull(_replyToAddress);
-            Assert.IsTrue(_replyAddressPattern.IsMatch(_replyToAddress?.ToString()), "Reply address '{0}' does not match desired pattern", _replyToAddress);
+            Assert.Multiple(() =>
+            {
+                Assert.That(response, Is.Not.Null);
+                Assert.That(_replyToAddress, Is.Not.Null);
+                Assert.That(_replyAddressPattern.IsMatch(_replyToAddress?.ToString()), Is.True,
+                    $"Reply address '{_replyToAddress}' does not match desired pattern");
+            });
         }
 
         Uri _replyToAddress;
@@ -62,9 +66,13 @@
             RequestHandle<PingMessage> request = clientFactory.CreateRequest(new PingMessage(_pingId));
             Response<PongMessage> response = await request.GetResponse<PongMessage>();
 
-            Assert.IsNotNull(response);
-            Assert.NotNull(_replyToAddress);
-            Assert.IsTrue(_replyAddressPattern.IsMatch(_replyToAddress?.ToString()), "Reply address '{0}' does not match desired pattern", _replyToAddress);
+            Assert.Multiple(() =>
+            {
+                Assert.That(response, Is.Not.Null);
+                Assert.That(_replyToAddress, Is.Not.Null);
+                Assert.That(_replyAddressPattern.IsMatch(_replyToAddress?.ToString()), Is.True,
+                    $"Reply address '{_replyToAddress}' does not match desired pattern");
+            });
         }
 
         Uri _replyToAddress;

--- a/tests/MassTransit.AmazonSqsTransport.Tests/AmazonSqsAddress_Specs.cs
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/AmazonSqsAddress_Specs.cs
@@ -13,8 +13,11 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var host = new Uri("amazonsqs://remote-host");
             var address = new AmazonSqsHostAddress(host);
 
-            Assert.That(address.Scope, Is.EqualTo("/"));
-            Assert.That(address.Host, Is.EqualTo("remote-host"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scope, Is.EqualTo("/"));
+                Assert.That(address.Host, Is.EqualTo("remote-host"));
+            });
 
             Uri uri = address;
 
@@ -27,8 +30,11 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var host = new Uri("amazonsqs://remote-host/production");
             var address = new AmazonSqsHostAddress(host);
 
-            Assert.That(address.Scope, Is.EqualTo("production"));
-            Assert.That(address.Host, Is.EqualTo("remote-host"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scope, Is.EqualTo("production"));
+                Assert.That(address.Host, Is.EqualTo("remote-host"));
+            });
 
             Uri uri = address;
 
@@ -47,8 +53,11 @@ namespace MassTransit.AmazonSqsTransport.Tests
 
             var address = new AmazonSqsEndpointAddress(hostAddress, new Uri("amazonsqs://remote-host/input-queue"));
 
-            Assert.That(address.Scope, Is.EqualTo("/"));
-            Assert.That(address.Name, Is.EqualTo("input-queue"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scope, Is.EqualTo("/"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+            });
 
             Uri uri = address;
 
@@ -62,8 +71,11 @@ namespace MassTransit.AmazonSqsTransport.Tests
 
             var address = new AmazonSqsEndpointAddress(hostAddress, new Uri("amazonsqs://remote-host/production/input-queue"));
 
-            Assert.That(address.Scope, Is.EqualTo("production"));
-            Assert.That(address.Name, Is.EqualTo("input-queue"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.Scope, Is.EqualTo("production"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+            });
 
             Uri uri = address;
 
@@ -107,8 +119,11 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var hostAddress = new Uri("amazonsqs://localhost/test");
             var address = new AmazonSqsEndpointAddress(hostAddress, new Uri($"topic:input?temporary={isTemporary}"));
 
-            Assert.That(address.AutoDelete, Is.EqualTo(isTemporary));
-            Assert.That(address.Durable, Is.Not.EqualTo(isTemporary));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.AutoDelete, Is.EqualTo(isTemporary));
+                Assert.That(address.Durable, Is.Not.EqualTo(isTemporary));
+            });
         }
 
         [Theory]

--- a/tests/MassTransit.AmazonSqsTransport.Tests/DelayedRedelivery_Specs.cs
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/DelayedRedelivery_Specs.cs
@@ -26,13 +26,16 @@ namespace MassTransit.AmazonSqsTransport.Tests
 
             ConsumeContext<Fault<PingMessage>> handled = await handler;
 
-            Assert.That(handled.Headers.Get<int>(MessageHeaders.FaultRedeliveryCount), Is.EqualTo(_limit));
+            Assert.Multiple(() =>
+            {
+                Assert.That(handled.Headers.Get<int>(MessageHeaders.FaultRedeliveryCount), Is.EqualTo(_limit));
 
-            Assert.That(handled.Headers.Get<int>(MessageHeaders.FaultRetryCount), Is.EqualTo(1));
+                Assert.That(handled.Headers.Get<int>(MessageHeaders.FaultRetryCount), Is.EqualTo(1));
+            });
 
             await InactivityTask;
 
-            Assert.LessOrEqual(_attempts[pingId], (_limit + 1) * 2);
+            Assert.That(_attempts[pingId], Is.LessThanOrEqualTo((_limit + 1) * 2));
         }
 
         readonly int _limit;

--- a/tests/MassTransit.AmazonSqsTransport.Tests/EndpointConfiguration_Specs.cs
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/EndpointConfiguration_Specs.cs
@@ -5,7 +5,6 @@ namespace MassTransit.AmazonSqsTransport.Tests
     using System.Threading.Tasks;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
-    using MassTransit.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;
@@ -13,6 +12,7 @@ namespace MassTransit.AmazonSqsTransport.Tests
     using NUnit.Framework;
     using TestFramework;
     using TestFramework.Messages;
+    using Testing;
 
 
     [TestFixture]
@@ -46,9 +46,12 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -79,23 +82,14 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
-        }
-
-        static void ConfigureHost(IAmazonSqsBusFactoryConfigurator cfg)
-        {
-            cfg.Host(new Uri("amazonsqs://localhost:4576"), h =>
-            {
-                h.AccessKey("admin");
-                h.SecretKey("admin");
-
-                h.Config(new AmazonSQSConfig {ServiceURL = "http://localhost:4566"});
-                h.Config(new AmazonSimpleNotificationServiceConfig {ServiceURL = "http://localhost:4566"});
-            });
         }
 
         [Test]
@@ -124,9 +118,12 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -157,8 +154,11 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -181,8 +181,11 @@ namespace MassTransit.AmazonSqsTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
         }
 
         [Test]
@@ -218,8 +221,23 @@ namespace MassTransit.AmazonSqsTransport.Tests
 
             var probe = JObject.Parse(busControl.GetProbeResult().ToJsonString());
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
+        }
+
+        static void ConfigureHost(IAmazonSqsBusFactoryConfigurator cfg)
+        {
+            cfg.Host(new Uri("amazonsqs://localhost:4576"), h =>
+            {
+                h.AccessKey("admin");
+                h.SecretKey("admin");
+
+                h.Config(new AmazonSQSConfig { ServiceURL = "http://localhost:4566" });
+                h.Config(new AmazonSimpleNotificationServiceConfig { ServiceURL = "http://localhost:4566" });
+            });
         }
 
 

--- a/tests/MassTransit.AmazonSqsTransport.Tests/OpenTelemetry_Specs.cs
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/OpenTelemetry_Specs.cs
@@ -91,9 +91,12 @@ namespace MassTransit.AmazonSqsTransport.Tests
                 OrderNumber = "123"
             });
 
-            Assert.IsTrue(await harness.Sent.Any<OrderSubmitted>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Sent.Any<OrderSubmitted>(), Is.True);
 
-            Assert.IsTrue(await harness.Consumed.Any<SubmitOrder>());
+                Assert.That(await harness.Consumed.Any<SubmitOrder>(), Is.True);
+            });
         }
 
 

--- a/tests/MassTransit.AmazonSqsTransport.Tests/RawJson_Specs.cs
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/RawJson_Specs.cs
@@ -58,20 +58,23 @@ namespace MassTransit.AmazonSqsTransport.Tests
 
             ConsumeContext<Command> context = await _handled;
 
-            Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonRawMessageSerializer.JsonContentType),
-                $"unexpected content-type {context.ReceiveContext.ContentType}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonRawMessageSerializer.JsonContentType),
+                    $"unexpected content-type {context.ReceiveContext.ContentType}");
 
-            Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
-            Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+                Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
+                Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
 
-            Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(headerValue));
+                Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(headerValue));
 
-            Assert.IsTrue(context.MessageId.HasValue);
-            Assert.IsTrue(context.ConversationId.HasValue);
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.IsTrue(context.SentTime.HasValue);
-            Assert.IsNotNull(context.DestinationAddress);
-            Assert.That(context.SupportedMessageTypes.Count(), Is.EqualTo(1));
+                Assert.That(context.MessageId.HasValue, Is.True);
+                Assert.That(context.ConversationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.SentTime.HasValue, Is.True);
+                Assert.That(context.DestinationAddress, Is.Not.Null);
+                Assert.That(context.SupportedMessageTypes.Count(), Is.EqualTo(1));
+            });
         }
 
         Task<ConsumeContext<Command>> _handled;
@@ -118,12 +121,15 @@ namespace MassTransit.AmazonSqsTransport.Tests
 
             ConsumeContext<CrapConsumed> context = await _handled;
 
-            Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonMessageSerializer.JsonContentType),
-                $"unexpected content-type {context.ReceiveContext.ContentType}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonMessageSerializer.JsonContentType),
+                    $"unexpected content-type {context.ReceiveContext.ContentType}");
 
-            Assert.That(context.Message.CorrelationId, Is.EqualTo(message.CommandId));
+                Assert.That(context.Message.CorrelationId, Is.EqualTo(message.CommandId));
 
-            Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(default));
+                Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(default));
+            });
         }
 
         Task<ConsumeContext<CrapConsumed>> _handled;
@@ -192,12 +198,15 @@ namespace MassTransit.AmazonSqsTransport.Tests
 
             ConsumeContext<CrapConsumed> context = await _handled;
 
-            Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonMessageSerializer.JsonContentType),
-                $"unexpected content-type {context.ReceiveContext.ContentType}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonMessageSerializer.JsonContentType),
+                    $"unexpected content-type {context.ReceiveContext.ContentType}");
 
-            Assert.That(context.Message.CorrelationId, Is.EqualTo(message.CommandId));
+                Assert.That(context.Message.CorrelationId, Is.EqualTo(message.CommandId));
 
-            Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(headerValue));
+                Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(headerValue));
+            });
         }
 
         Task<ConsumeContext<CrapConsumed>> _handled;

--- a/tests/MassTransit.AmazonSqsTransport.Tests/SentTime_Specs.cs
+++ b/tests/MassTransit.AmazonSqsTransport.Tests/SentTime_Specs.cs
@@ -69,10 +69,13 @@ namespace MassTransit.AmazonSqsTransport.Tests
             IReceivedMessage<PongMessage> consumed = await harness.Consumed.SelectAsync<PongMessage>().FirstOrDefault();
             Assert.That(consumed, Is.Not.Null);
 
-            Assert.That(consumed.Context.SentTime.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
-            Assert.That(consumed.Context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonRawMessageSerializer.JsonContentType));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consumed.Context.SentTime.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+                Assert.That(consumed.Context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonRawMessageSerializer.JsonContentType));
 
-            Assert.That(consumed.Context.ReceiveContext.GetSentTime(), Is.GreaterThanOrEqualTo(consumed.Context.SentTime - TimeSpan.FromSeconds(30)));
+                Assert.That(consumed.Context.ReceiveContext.GetSentTime(), Is.GreaterThanOrEqualTo(consumed.Context.SentTime - TimeSpan.FromSeconds(30)));
+            });
             Assert.That(consumed.Context.ReceiveContext.GetSentTime(), Is.LessThanOrEqualTo(consumed.Context.SentTime + TimeSpan.FromSeconds(30)));
         }
     }

--- a/tests/MassTransit.Analyzers.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/tests/MassTransit.Analyzers.Tests/Verifiers/DiagnosticVerifier.cs
@@ -39,7 +39,7 @@ namespace MassTransit.Analyzers.Tests
                             builder.AppendFormat("GetGlobalResult({0}.{1})", analyzerType.Name, rule.Id);
                         else
                         {
-                            Assert.IsTrue(location.IsInSource,
+                            Assert.That(location.IsInSource, Is.True,
                                 $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
 
                             var resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
@@ -89,7 +89,7 @@ namespace MassTransit.Analyzers.Tests
         /// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
         protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
         {
-            VerifyDiagnostics(new[] {source}, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
+            VerifyDiagnostics(new[] { source }, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace MassTransit.Analyzers.Tests
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the source</param>
         protected void VerifyBasicDiagnostic(string source, params DiagnosticResult[] expected)
         {
-            VerifyDiagnostics(new[] {source}, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
+            VerifyDiagnostics(new[] { source }, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
         }
 
         /// <summary>
@@ -128,7 +128,8 @@ namespace MassTransit.Analyzers.Tests
         protected void VerifyCSharpDiagnosticWithoutMassTransit(string source, params DiagnosticResult[] expected)
         {
             var analyzer = GetCSharpDiagnosticAnalyzer();
-            Diagnostic[] diagnostics = GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(new []{ source }, LanguageNames.CSharp, includeMassTransit: false));
+            Diagnostic[] diagnostics =
+                GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(new[] { source }, LanguageNames.CSharp, includeMassTransit: false));
             VerifyDiagnosticResults(diagnostics, analyzer, expected);
         }
 
@@ -164,9 +165,8 @@ namespace MassTransit.Analyzers.Tests
             {
                 var diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, actualResults.ToArray()) : "    NONE.";
 
-                Assert.IsTrue(false,
-                    string.Format("Mismatch between number of diagnostics returned, expected \"{0}\" actual \"{1}\"\r\n\r\nDiagnostics:\r\n{2}\r\n",
-                        expectedCount, actualCount, diagnosticsOutput));
+                Assert.Fail(
+                    $"Mismatch between number of diagnostics returned, expected \"{expectedCount}\" actual \"{actualCount}\"\r\n\r\nDiagnostics:\r\n{diagnosticsOutput}\r\n");
             }
 
             for (var i = 0; i < expectedResults.Length; i++)
@@ -178,9 +178,8 @@ namespace MassTransit.Analyzers.Tests
                 {
                     if (actual.Location != Location.None)
                     {
-                        Assert.IsTrue(false,
-                            string.Format("Expected:\nA project diagnostic with No location\nActual:\n{0}",
-                                FormatDiagnostics(analyzer, actual)));
+                        Assert.Fail(
+                            $"Expected:\nA project diagnostic with No location\nActual:\n{FormatDiagnostics(analyzer, actual)}");
                     }
                 }
                 else
@@ -190,10 +189,8 @@ namespace MassTransit.Analyzers.Tests
 
                     if (additionalLocations.Length != expected.Locations.Length - 1)
                     {
-                        Assert.IsTrue(false,
-                            string.Format("Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
-                                expected.Locations.Length - 1, additionalLocations.Length,
-                                FormatDiagnostics(analyzer, actual)));
+                        Assert.Fail(
+                            $"Expected {expected.Locations.Length - 1} additional locations but got {additionalLocations.Length} for Diagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
                     }
 
                     for (var j = 0; j < additionalLocations.Length; ++j)
@@ -202,23 +199,20 @@ namespace MassTransit.Analyzers.Tests
 
                 if (actual.Id != expected.Id)
                 {
-                    Assert.IsTrue(false,
-                        string.Format("Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Id, actual.Id, FormatDiagnostics(analyzer, actual)));
+                    Assert.Fail(
+                        $"Expected diagnostic id to be \"{expected.Id}\" was \"{actual.Id}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
                 }
 
                 if (actual.Severity != expected.Severity)
                 {
-                    Assert.IsTrue(false,
-                        string.Format("Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
+                    Assert.Fail(
+                        $"Expected diagnostic severity to be \"{expected.Severity}\" was \"{actual.Severity}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
                 }
 
                 if (actual.GetMessage() != expected.Message)
                 {
-                    Assert.IsTrue(false,
-                        string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Message, actual.GetMessage(), FormatDiagnostics(analyzer, actual)));
+                    Assert.Fail(
+                        $"Expected diagnostic message to be \"{expected.Message}\" was \"{actual.GetMessage()}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, actual)}\r\n");
                 }
             }
         }
@@ -234,9 +228,9 @@ namespace MassTransit.Analyzers.Tests
         {
             var actualSpan = actual.GetLineSpan();
 
-            Assert.IsTrue(actualSpan.Path == expected.Path || actualSpan.Path != null && actualSpan.Path.Contains("Test0.") && expected.Path.Contains("Test."),
-                string.Format("Expected diagnostic to be in file \"{0}\" was actually in file \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                    expected.Path, actualSpan.Path, FormatDiagnostics(analyzer, diagnostic)));
+            Assert.That(actualSpan.Path == expected.Path || actualSpan.Path != null && actualSpan.Path.Contains("Test0.") && expected.Path.Contains("Test."),
+                Is.True,
+                $"Expected diagnostic to be in file \"{expected.Path}\" was actually in file \"{actualSpan.Path}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, diagnostic)}\r\n");
 
             var actualLinePosition = actualSpan.StartLinePosition;
 
@@ -245,9 +239,8 @@ namespace MassTransit.Analyzers.Tests
             {
                 if (actualLinePosition.Line + 1 != expected.Line)
                 {
-                    Assert.IsTrue(false,
-                        string.Format("Expected diagnostic to be on line \"{0}\" was actually on line \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Line, actualLinePosition.Line + 1, FormatDiagnostics(analyzer, diagnostic)));
+                    Assert.Fail(
+                        $"Expected diagnostic to be on line \"{expected.Line}\" was actually on line \"{actualLinePosition.Line + 1}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, diagnostic)}\r\n");
                 }
             }
 
@@ -256,9 +249,8 @@ namespace MassTransit.Analyzers.Tests
             {
                 if (actualLinePosition.Character + 1 != expected.Column)
                 {
-                    Assert.IsTrue(false,
-                        string.Format("Expected diagnostic to start at column \"{0}\" was actually at column \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Column, actualLinePosition.Character + 1, FormatDiagnostics(analyzer, diagnostic)));
+                    Assert.Fail(
+                        $"Expected diagnostic to start at column \"{expected.Column}\" was actually at column \"{actualLinePosition.Character + 1}\"\r\n\r\nDiagnostic:\r\n    {FormatDiagnostics(analyzer, diagnostic)}\r\n");
                 }
             }
         }

--- a/tests/MassTransit.Azure.Cosmos.Tests/Container_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/Container_Specs.cs
@@ -108,10 +108,10 @@ namespace MassTransit.Azure.Cosmos.Tests
                     TestKey = "Unique"
                 });
 
-                Assert.IsTrue(await harness.Published.Any<TestStarted>(x => x.Context.Message.CorrelationId == correlationId));
+                Assert.That(await harness.Published.Any<TestStarted>(x => x.Context.Message.CorrelationId == correlationId), Is.True);
 
                 // For some reason, the LINQ provider for Cosmos does not properly resolve this query.
-                 var sagaHarness = harness.GetSagaStateMachineHarness<TestStateMachineSaga, TestInstance>();
+                var sagaHarness = harness.GetSagaStateMachineHarness<TestStateMachineSaga, TestInstance>();
                 // Assert.IsNotNull(await sagaHarness.Exists(correlationId, x => x.Active));
 
                 await harness.Bus.Publish(new UpdateTest
@@ -120,7 +120,7 @@ namespace MassTransit.Azure.Cosmos.Tests
                     TestKey = "Unique"
                 });
 
-                Assert.IsTrue(await harness.Published.Any<TestUpdated>(x => x.Context.Message.CorrelationId == correlationId));
+                Assert.That(await harness.Published.Any<TestUpdated>(x => x.Context.Message.CorrelationId == correlationId), Is.True);
             }
         }
 

--- a/tests/MassTransit.Azure.Cosmos.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/JobConsumer_Specs.cs
@@ -116,15 +116,18 @@ namespace MassTransit.Azure.Cosmos.Tests
                     Job = new { Duration = TimeSpan.FromSeconds(1) }
                 });
 
-                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                });
             }
             finally
             {

--- a/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyNoRetry_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyNoRetry_Specs.cs
@@ -25,7 +25,7 @@
 
             var saga = await GetSagaRetry(correlationId, TestTimeout);
 
-            Assert.IsNotNull(saga);
+            Assert.That(saga, Is.Not.Null);
 
             await Task.WhenAll(
                 InputQueueSendEndpoint.Send(new Bass
@@ -53,7 +53,7 @@
             // Because concurrency exception's happened without retry middleware configured, we aren't in our final state/
             var instance = await GetSaga(correlationId);
 
-            Assert.IsTrue(!instance.CurrentState.Equals("Harmony"));
+            Assert.That(instance.CurrentState, Is.Not.EqualTo("Harmony"));
         }
 
         [Test]
@@ -74,7 +74,7 @@
             for (var i = 0; i < 20; i++)
             {
                 var saga = await GetSagaRetry(sagaIds[i], TestTimeout);
-                Assert.IsNotNull(saga);
+                Assert.That(saga, Is.Not.Null);
             }
 
             for (var i = 0; i < 20; i++)
@@ -116,7 +116,7 @@
                     break;
             }
 
-            Assert.IsTrue(someNotInFinalState);
+            Assert.That(someNotInFinalState, Is.True);
         }
 
         ChoirStateMachine _machine;

--- a/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyOptimistic_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmosConcurrencyOptimistic_Specs.cs
@@ -36,7 +36,7 @@
             for (var i = 0; i < 20; i++)
             {
                 var saga = await GetSagaRetry(sagaIds[i], TestTimeout);
-                Assert.IsNotNull(saga);
+                Assert.That(saga, Is.Not.Null);
             }
 
             for (var i = 0; i < 20; i++)
@@ -72,8 +72,8 @@
             {
                 var instance = await GetSagaRetry(sid, TestTimeout, x => x.CurrentState == _machine.Harmony.Name);
 
-                Assert.IsNotNull(instance);
-                Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
+                Assert.That(instance, Is.Not.Null);
+                Assert.That(instance.CurrentState, Is.EqualTo("Harmony"));
             }
         }
 
@@ -87,7 +87,7 @@
 
             var saga = await GetSagaRetry(correlationId, TestTimeout);
 
-            Assert.IsNotNull(saga);
+            Assert.That(saga, Is.Not.Null);
 
             await Task.WhenAll(
                 InputQueueSendEndpoint.Send(new Bass
@@ -114,12 +114,12 @@
 
             saga = await GetSagaRetry(correlationId, TestTimeout, x => x.CurrentState == _machine.Harmony.Name);
 
-            Assert.IsNotNull(saga);
-            Assert.IsTrue(saga.CurrentState == _machine.Harmony.Name);
+            Assert.That(saga, Is.Not.Null);
+            Assert.That(saga.CurrentState, Is.EqualTo(_machine.Harmony.Name));
 
             var instance = await GetSaga(correlationId);
 
-            Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
+            Assert.That(instance.CurrentState, Is.EqualTo("Harmony"));
         }
 
         ChoirStateMachine _machine;

--- a/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmos_Specs.cs
+++ b/tests/MassTransit.Azure.Cosmos.Tests/UsingCosmos_Specs.cs
@@ -23,12 +23,12 @@
             await InputQueueSendEndpoint.Send(new GirlfriendYelling { CorrelationId = correlationId });
 
             var saga = await GetSagaRetry(correlationId, TestTimeout);
-            Assert.IsNotNull(saga);
+            Assert.That(saga, Is.Not.Null);
 
             await InputQueueSendEndpoint.Send(new SodOff { CorrelationId = correlationId });
 
             saga = await GetNoSagaRetry(correlationId, TestTimeout);
-            Assert.IsNull(saga);
+            Assert.That(saga, Is.Null);
         }
 
         [Test]
@@ -40,18 +40,18 @@
 
             var saga = await GetSagaRetry(correlationId, TestTimeout);
 
-            Assert.IsNotNull(saga);
+            Assert.That(saga, Is.Not.Null);
 
             await InputQueueSendEndpoint.Send(new GotHitByACar { CorrelationId = correlationId });
 
             saga = await GetSagaRetry(correlationId, TestTimeout, x => x.CurrentState == _machine.Dead.Name);
 
-            Assert.IsNotNull(saga);
-            Assert.IsTrue(saga.CurrentState == _machine.Dead.Name);
+            Assert.That(saga, Is.Not.Null);
+            Assert.That(saga.CurrentState, Is.EqualTo(_machine.Dead.Name));
 
             var instance = await GetSaga(correlationId);
 
-            Assert.IsTrue(instance.Screwed);
+            Assert.That(instance.Screwed, Is.True);
         }
 
         SuperShopper _machine;

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Address_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Address_Specs.cs
@@ -18,26 +18,35 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             Assert.That(address.Type, Is.EqualTo(ServiceBusEndpointAddress.AddressType.Topic));
 
             Uri uri = address;
-            Assert.That(uri.TryGetValueFromQueryString("type", out var type), Is.True);
-            Assert.That(type, Is.EqualTo("topic"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(uri.TryGetValueFromQueryString("type", out var type), Is.True);
+                Assert.That(type, Is.EqualTo("topic"));
 
-            Assert.That(uri.AbsolutePath, Is.EqualTo("/private-topic"));
+                Assert.That(uri.AbsolutePath, Is.EqualTo("/private-topic"));
+            });
         }
 
         [Test]
         public void Should_handle_address_loopback()
         {
-            Assert.IsTrue(Bus.Topology.TryGetPublishAddress<PingMessage>(out var address));
+            Assert.Multiple(() =>
+            {
+                Assert.That(Bus.Topology.TryGetPublishAddress<PingMessage>(out var address), Is.True);
 
-            Assert.That(address.TryGetValueFromQueryString("type", out var type), Is.True);
-            Assert.That(type, Is.EqualTo("topic"));
+                Assert.That(address.TryGetValueFromQueryString("type", out var type), Is.True);
+                Assert.That(type, Is.EqualTo("topic"));
 
-            Uri normalizedAddress = new ServiceBusEndpointAddress(AzureServiceBusTestHarness.HostAddress, address);
+                Uri normalizedAddress = new ServiceBusEndpointAddress(AzureServiceBusTestHarness.HostAddress, address);
 
-            Assert.That(normalizedAddress.TryGetValueFromQueryString("type", out type), Is.True);
-            Assert.That(type, Is.EqualTo("topic"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(normalizedAddress.TryGetValueFromQueryString("type", out type), Is.True);
+                    Assert.That(type, Is.EqualTo("topic"));
 
-            Assert.That(normalizedAddress.AbsolutePath, Is.EqualTo(address.AbsolutePath));
+                    Assert.That(normalizedAddress.AbsolutePath, Is.EqualTo(address.AbsolutePath));
+                });
+            });
         }
 
         [Test]
@@ -45,12 +54,15 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             var address = new ServiceBusEndpointAddress(HostAddress, "input_queue");
 
-            Assert.That((Uri)address, Is.EqualTo(InputQueueAddress));
+            Assert.Multiple(() =>
+            {
+                Assert.That((Uri)address, Is.EqualTo(InputQueueAddress));
 
-            Assert.That(address.Name, Is.EqualTo("input_queue"));
-            Assert.That(address.Scope, Is.EqualTo(typeof(An_address).Namespace));
+                Assert.That(address.Name, Is.EqualTo("input_queue"));
+                Assert.That(address.Scope, Is.EqualTo(typeof(An_address).Namespace));
 
-            Assert.That(address.Path, Is.EqualTo(InputQueueAddress.AbsolutePath.Substring(1)));
+                Assert.That(address.Path, Is.EqualTo(InputQueueAddress.AbsolutePath.Substring(1)));
+            });
         }
     }
 }

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/BuildTopology_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/BuildTopology_Specs.cs
@@ -50,8 +50,8 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         [Test]
         public async Task Should_be_received()
         {
-            await Bus.Publish<ThirdInterface>(new {Value = "A"});
-            await Bus.Publish<AnotherThirdInterface>(new {Value = "B"});
+            await Bus.Publish<ThirdInterface>(new { Value = "A" });
+            await Bus.Publish<AnotherThirdInterface>(new { Value = "B" });
 
             ConsumeContext<FirstInterface> received = await _receivedA;
 
@@ -119,17 +119,25 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.True);
-            Assert.That(
-                topology.QueueSubscriptions.Any(x => x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateQueueOptions.Name == _inputQueueName),
-                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.True);
+                Assert.That(
+                    topology.QueueSubscriptions.Any(x =>
+                        x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateQueueOptions.Name == _inputQueueName),
+                    Is.True);
+            });
 
             interfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.False);
-            Assert.That(
-                topology.QueueSubscriptions.Any(x => x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateQueueOptions.Name == _inputQueueName),
-                Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.False);
+                Assert.That(
+                    topology.QueueSubscriptions.Any(x =>
+                        x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateQueueOptions.Name == _inputQueueName),
+                    Is.False);
+            });
         }
 
         [Test]
@@ -144,11 +152,14 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
-            Assert.That(
-                topology.QueueSubscriptions.Any(x =>
-                    x.Source.CreateTopicOptions.Name == singleInterfaceName && x.Destination.CreateQueueOptions.Name == _inputQueueName),
-                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+                Assert.That(
+                    topology.QueueSubscriptions.Any(x =>
+                        x.Source.CreateTopicOptions.Name == singleInterfaceName && x.Destination.CreateQueueOptions.Name == _inputQueueName),
+                    Is.True);
+            });
         }
 
         [SetUp]
@@ -186,14 +197,20 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var singleInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface)).ToString();
             var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.True);
-            Assert.That(topology.Topics.Length, Is.EqualTo(2));
-            Assert.That(topology.TopicSubscriptions.Length, Is.EqualTo(1));
-            Assert.That(
-                topology.TopicSubscriptions.Any(x =>
-                    x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.True);
+                Assert.That(topology.Topics, Has.Length.EqualTo(2));
+                Assert.That(topology.TopicSubscriptions, Has.Length.EqualTo(1));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    topology.TopicSubscriptions.Any(x =>
+                        x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateTopicOptions.Name == singleInterfaceName), Is.True);
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+            });
         }
 
         [Test]
@@ -206,9 +223,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
-            Assert.That(topology.Topics.Length, Is.EqualTo(1));
-            Assert.That(topology.TopicSubscriptions.Length, Is.EqualTo(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+                Assert.That(topology.Topics, Has.Length.EqualTo(1));
+                Assert.That(topology.TopicSubscriptions, Is.Empty);
+            });
         }
 
         [SetUp]
@@ -243,14 +263,20 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var singleInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface)).ToString();
             var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.True);
-            Assert.That(topology.Topics.Length, Is.EqualTo(2));
-            Assert.That(topology.TopicSubscriptions.Length, Is.EqualTo(1));
-            Assert.That(
-                topology.TopicSubscriptions.Any(x =>
-                    x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == interfaceName), Is.True);
+                Assert.That(topology.Topics, Has.Length.EqualTo(2));
+                Assert.That(topology.TopicSubscriptions, Has.Length.EqualTo(1));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    topology.TopicSubscriptions.Any(x =>
+                        x.Source.CreateTopicOptions.Name == interfaceName && x.Destination.CreateTopicOptions.Name == singleInterfaceName), Is.True);
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+            });
         }
 
         [Test]
@@ -264,9 +290,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
-            Assert.That(topology.Topics.Length, Is.EqualTo(1));
-            Assert.That(topology.TopicSubscriptions.Length, Is.EqualTo(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == singleInterfaceName), Is.True);
+                Assert.That(topology.Topics, Has.Length.EqualTo(1));
+                Assert.That(topology.TopicSubscriptions, Is.Empty);
+            });
         }
 
         [Test]
@@ -282,20 +311,26 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var secondInterfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
             var thirdInterfaceName = _nameFormatter.GetMessageName(typeof(ThirdInterface)).ToString();
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == secondInterfaceName), Is.True);
-            Assert.That(topology.Topics.Length, Is.EqualTo(3));
-            Assert.That(topology.TopicSubscriptions.Length, Is.EqualTo(2));
-            Assert.That(
-                topology.TopicSubscriptions.Any(x =>
-                    x.Source.CreateTopicOptions.Name == secondInterfaceName && x.Destination.CreateTopicOptions.Name == firstInterfaceName),
-                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == secondInterfaceName), Is.True);
+                Assert.That(topology.Topics, Has.Length.EqualTo(3));
+                Assert.That(topology.TopicSubscriptions, Has.Length.EqualTo(2));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    topology.TopicSubscriptions.Any(x =>
+                        x.Source.CreateTopicOptions.Name == secondInterfaceName && x.Destination.CreateTopicOptions.Name == firstInterfaceName),
+                    Is.True);
 
-            Assert.That(
-                topology.TopicSubscriptions.Any(x =>
-                    x.Source.CreateTopicOptions.Name == thirdInterfaceName && x.Destination.CreateTopicOptions.Name == secondInterfaceName),
-                Is.True);
+                Assert.That(
+                    topology.TopicSubscriptions.Any(x =>
+                        x.Source.CreateTopicOptions.Name == thirdInterfaceName && x.Destination.CreateTopicOptions.Name == secondInterfaceName),
+                    Is.True);
 
-            Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == firstInterfaceName), Is.True);
+                Assert.That(topology.Topics.Any(x => x.CreateTopicOptions.Name == firstInterfaceName), Is.True);
+            });
         }
 
         [SetUp]

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/EndpointConfiguration_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/EndpointConfiguration_Specs.cs
@@ -3,7 +3,6 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using MassTransit.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;
@@ -11,6 +10,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
     using NUnit.Framework;
     using TestFramework;
     using TestFramework.Messages;
+    using Testing;
 
 
     [TestFixture]
@@ -42,9 +42,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -73,9 +76,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -104,9 +110,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -135,8 +144,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -157,8 +169,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
         }
 
         [Test]
@@ -190,8 +205,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             var probe = JObject.Parse(busControl.GetProbeResult().ToJsonString());
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
         }
 
 

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/ExistingSubscription_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/ExistingSubscription_Specs.cs
@@ -55,10 +55,13 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             Response<SubscriptionProperties> response = await managementClient.GetSubscriptionAsync(topicName, subscriptionName);
 
-            Assert.That(response?.Value, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(response?.Value, Is.Not.Null);
 
-            Assert.That(Uri.IsWellFormedUriString(response.Value.ForwardTo, UriKind.Absolute));
-            Assert.That(new Uri(response.Value.ForwardTo).AbsolutePath.TrimStart('/'), Is.EqualTo(queueName));
+                Assert.That(Uri.IsWellFormedUriString(response.Value.ForwardTo, UriKind.Absolute));
+                Assert.That(new Uri(response.Value.ForwardTo).AbsolutePath.TrimStart('/'), Is.EqualTo(queueName));
+            });
 
             bus = Bus.Factory.CreateUsingAzureServiceBus(x =>
             {
@@ -82,10 +85,13 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             await managementClient.GetSubscriptionAsync(topicName, subscriptionName);
 
-            Assert.That(response?.Value, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(response?.Value, Is.Not.Null);
 
-            Assert.That(Uri.IsWellFormedUriString(response.Value.ForwardTo, UriKind.Absolute));
-            Assert.That(new Uri(response.Value.ForwardTo).AbsolutePath.TrimStart('/'), Is.EqualTo(queueName));
+                Assert.That(Uri.IsWellFormedUriString(response.Value.ForwardTo, UriKind.Absolute));
+                Assert.That(new Uri(response.Value.ForwardTo).AbsolutePath.TrimStart('/'), Is.EqualTo(queueName));
+            });
         }
 
         public Specifying_an_existing_subscription()

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
@@ -25,9 +25,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             ConsumeContext<DataMessage> consumeContext = await _handler;
 
-            Assert.That(consumeContext.Message.Data.HasValue, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(consumeContext.Message.Data.HasValue, Is.True);
 
-            Assert.That(_data, Is.EqualTo(data));
+                Assert.That(_data, Is.EqualTo(data));
+            });
         }
 
         Task<ConsumeContext<DataMessage>> _handler;
@@ -80,8 +83,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             ConsumeContext<DataMessage> consumeContext = await _handler;
 
-            Assert.That(consumeContext.Message.Dictionary.HasValue, Is.True);
-            Assert.That(_data.Values, Is.EqualTo(dataDictionary.Values));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consumeContext.Message.Dictionary.HasValue, Is.True);
+                Assert.That(_data.Values, Is.EqualTo(dataDictionary.Values));
+            });
         }
 
         Task<ConsumeContext<DataMessage>> _handler;
@@ -138,8 +144,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             ConsumeContext<DataMessage> consumeContext = await _handler;
 
-            Assert.That(consumeContext.Message.Dictionary.HasValue, Is.True);
-            Assert.That(_data.Values, Is.EqualTo(dataDictionary.Values));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consumeContext.Message.Dictionary.HasValue, Is.True);
+                Assert.That(_data.Values, Is.EqualTo(dataDictionary.Values));
+            });
         }
 
         Task<ConsumeContext<DataMessage>> _handler;

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Receiver_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Receiver_Specs.cs
@@ -35,9 +35,12 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             IConsumerTestHarness<FaultyFunctionConsumer> consumerHarness = harness.GetConsumerHarness<FaultyFunctionConsumer>();
 
-            Assert.That(await consumerHarness.Consumed.Any<FunctionMessage>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await consumerHarness.Consumed.Any<FunctionMessage>(), Is.True);
 
-            Assert.That(await harness.Published.Any<Fault<FunctionMessage>>(), Is.True);
+                Assert.That(await harness.Published.Any<Fault<FunctionMessage>>(), Is.True);
+            });
         }
     }
 

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/ScheduleTimeout_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/ScheduleTimeout_Specs.cs
@@ -24,7 +24,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, _machine.Active, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 await InputQueueSendEndpoint.Send<OrderSubmitted>(new { MemberNumber = memberNumber });
 
@@ -54,7 +54,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, _machine.Active, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 await InputQueueSendEndpoint.Send<CartItemAdded>(new { MemberNumber = memberNumber });
 

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Send_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Send_Specs.cs
@@ -14,7 +14,7 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             ConsumeContext<PingMessage> context = await _handler;
 
-            Assert.IsFalse(context.ReceiveContext.Redelivered);
+            Assert.That(context.ReceiveContext.Redelivered, Is.False);
         }
 
         [Test]

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Session_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Session_Specs.cs
@@ -15,7 +15,7 @@
         {
             ConsumeContext<PingMessage> context = await _handler;
 
-            Assert.IsFalse(context.ReceiveContext.Redelivered);
+            Assert.That(context.ReceiveContext.Redelivered, Is.False);
         }
 
         [Test]

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Stopping_the_bus.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Stopping_the_bus.cs
@@ -69,7 +69,6 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
                         options.StopTimeout = TimeSpan.FromSeconds(30);
                         options.ConsumerStopTimeout = TimeSpan.FromSeconds(10);
                     });
-
                 })
                 .BuildServiceProvider(true);
 
@@ -85,8 +84,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
 
             await harness.Stop();
 
-            Assert.That(await harness.Consumed.Any<SloMessage>(), Is.True);
-            Assert.That(await harness.Published.Any<SloResult>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.Any<SloMessage>(), Is.True);
+                Assert.That(await harness.Published.Any<SloResult>(), Is.True);
+            });
         }
 
 

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/TopologyCorrelationId_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/TopologyCorrelationId_Specs.cs
@@ -14,12 +14,15 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             var transactionId = NewId.NextGuid();
 
-            await InputQueueSendEndpoint.Send<INewUserEvent>(new {TransactionId = transactionId});
+            await InputQueueSendEndpoint.Send<INewUserEvent>(new { TransactionId = transactionId });
 
             ConsumeContext<INewUserEvent> context = await _handled;
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
         }
 
         [Test]
@@ -27,12 +30,15 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             var transactionId = NewId.NextGuid();
 
-            await InputQueueSendEndpoint.Send<LegacyMessage>(new {TransactionId = transactionId});
+            await InputQueueSendEndpoint.Send<LegacyMessage>(new { TransactionId = transactionId });
 
             ConsumeContext<LegacyMessage> legacyContext = await _legacyHandled;
 
-            Assert.IsTrue(legacyContext.CorrelationId.HasValue);
-            Assert.That(legacyContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(legacyContext.CorrelationId.HasValue, Is.True);
+                Assert.That(legacyContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
         }
 
         [Test]
@@ -40,12 +46,15 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             var transactionId = NewId.NextGuid();
 
-            await InputQueueSendEndpoint.Send<OtherMessage>(new {CorrelationId = transactionId});
+            await InputQueueSendEndpoint.Send<OtherMessage>(new { CorrelationId = transactionId });
 
             ConsumeContext<OtherMessage> otherContext = await _otherHandled;
 
-            Assert.IsTrue(otherContext.CorrelationId.HasValue);
-            Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(otherContext.CorrelationId.HasValue, Is.True);
+                Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
         }
 
         Task<ConsumeContext<INewUserEvent>> _handled;
@@ -104,12 +113,15 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             var transactionId = NewId.NextGuid();
 
-            await Bus.Publish<PartitionedMessage>(new {CorrelationId = transactionId});
+            await Bus.Publish<PartitionedMessage>(new { CorrelationId = transactionId });
 
             ConsumeContext<PartitionedMessage> otherContext = await _otherHandled;
 
-            Assert.IsTrue(otherContext.CorrelationId.HasValue);
-            Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(otherContext.CorrelationId.HasValue, Is.True);
+                Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
         }
 
         Task<ConsumeContext<PartitionedMessage>> _otherHandled;
@@ -155,12 +167,15 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         {
             var transactionId = NewId.NextGuid();
 
-            await Bus.Publish<PartitionedMessage>(new {CorrelationId = transactionId});
+            await Bus.Publish<PartitionedMessage>(new { CorrelationId = transactionId });
 
             ConsumeContext<PartitionedMessage> otherContext = await _otherHandled;
 
-            Assert.IsTrue(otherContext.CorrelationId.HasValue);
-            Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(otherContext.CorrelationId.HasValue, Is.True);
+                Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
         }
 
         Task<ConsumeContext<PartitionedMessage>> _otherHandled;

--- a/tests/MassTransit.Azure.Table.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.Azure.Table.Tests/JobConsumer_Specs.cs
@@ -116,15 +116,18 @@ namespace MassTransit.Azure.Table.Tests
                     Job = new { Duration = TimeSpan.FromSeconds(1) }
                 });
 
-                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                });
             }
             finally
             {

--- a/tests/MassTransit.DapperIntegration.Tests/SqlExpressionVisitorTests.cs
+++ b/tests/MassTransit.DapperIntegration.Tests/SqlExpressionVisitorTests.cs
@@ -19,9 +19,12 @@
             // Act
             var result = SqlExpressionVisitor.CreateFromExpression(filter).Single();
 
-            // Assert
-            Assert.That(result.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelateBySomething)));
-            Assert.That(result.Item2, Is.EqualTo("Fiskbullar"));
+            Assert.Multiple(() =>
+            {
+                // Assert
+                Assert.That(result.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelateBySomething)));
+                Assert.That(result.Item2, Is.EqualTo("Fiskbullar"));
+            });
         }
 
         [Test]
@@ -33,9 +36,12 @@
             // Act
             var result = SqlExpressionVisitor.CreateFromExpression(filter).Single();
 
-            // Assert
-            Assert.That(result.Item1, Is.EqualTo(nameof(SimpleSaga.Completed)));
-            Assert.That(result.Item2, Is.True);
+            Assert.Multiple(() =>
+            {
+                // Assert
+                Assert.That(result.Item1, Is.EqualTo(nameof(SimpleSaga.Completed)));
+                Assert.That(result.Item2, Is.True);
+            });
         }
 
         [Test]
@@ -48,9 +54,12 @@
             // Act
             var result = SqlExpressionVisitor.CreateFromExpression(filter).Single();
 
-            // Assert
-            Assert.That(result.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelationId)));
-            Assert.That(result.Item2, Is.EqualTo(sagaId));
+            Assert.Multiple(() =>
+            {
+                // Assert
+                Assert.That(result.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelationId)));
+                Assert.That(result.Item2, Is.EqualTo(sagaId));
+            });
         }
 
         [Test]
@@ -64,15 +73,21 @@
             List<(string, object)> result = SqlExpressionVisitor.CreateFromExpression(filter);
 
             // Assert
-            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result, Has.Count.EqualTo(2));
 
             var first = result.First();
-            Assert.That(first.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelationId)));
-            Assert.That(first.Item2, Is.EqualTo(sagaId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelationId)));
+                Assert.That(first.Item2, Is.EqualTo(sagaId));
+            });
 
             var last = result.Last();
-            Assert.That(last.Item1, Is.EqualTo(nameof(SimpleSaga.Completed)));
-            Assert.That(last.Item2, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(last.Item1, Is.EqualTo(nameof(SimpleSaga.Completed)));
+                Assert.That(last.Item2, Is.True);
+            });
         }
 
         [Test]
@@ -86,19 +101,28 @@
             List<(string, object)> result = SqlExpressionVisitor.CreateFromExpression(filter);
 
             // Assert
-            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result, Has.Count.EqualTo(3));
 
             var first = result[0];
-            Assert.That(first.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelationId)));
-            Assert.That(first.Item2, Is.EqualTo(sagaId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelationId)));
+                Assert.That(first.Item2, Is.EqualTo(sagaId));
+            });
 
             var second = result[1];
-            Assert.That(second.Item1, Is.EqualTo(nameof(SimpleSaga.Completed)));
-            Assert.That(second.Item2, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.Item1, Is.EqualTo(nameof(SimpleSaga.Completed)));
+                Assert.That(second.Item2, Is.True);
+            });
 
             var third = result[2];
-            Assert.That(third.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelateBySomething)));
-            Assert.That(third.Item2, Is.EqualTo("Kebabsvarv"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(third.Item1, Is.EqualTo(nameof(SimpleSaga.CorrelateBySomething)));
+                Assert.That(third.Item2, Is.EqualTo("Kebabsvarv"));
+            });
         }
     }
 }

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/JobConsumer_Specs.cs
@@ -107,15 +107,18 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests
                     Job = new { Duration = TimeSpan.FromSeconds(1) }
                 });
 
-                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                });
             }
             finally
             {

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/BusOutbox_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/BusOutbox_Specs.cs
@@ -72,10 +72,13 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
 
                 IReceivedMessage<PingMessage> context = harness.Consumed.Select<PingMessage>().Single();
 
-                Assert.That(context.Context.MessageId, Is.Not.Null);
-                Assert.That(context.Context.ConversationId, Is.Not.Null);
-                Assert.That(context.Context.DestinationAddress, Is.Not.Null);
-                Assert.That(context.Context.SourceAddress, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.Context.MessageId, Is.Not.Null);
+                    Assert.That(context.Context.ConversationId, Is.Not.Null);
+                    Assert.That(context.Context.DestinationAddress, Is.Not.Null);
+                    Assert.That(context.Context.SourceAddress, Is.Not.Null);
+                });
             }
             finally
             {
@@ -142,14 +145,17 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
 
                 IReceivedMessage<PingMessage> context = await consumerHarness.Consumed.SelectAsync<PingMessage>().FirstOrDefault();
 
-                Assert.That(context.Context.Headers.TryGetHeader("Test-Header", out var header), Is.True);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.Context.Headers.TryGetHeader("Test-Header", out var header), Is.True);
 
-                Assert.That(header, Is.EqualTo("Test-Value"));
+                    Assert.That(header, Is.EqualTo("Test-Value"));
 
-                Assert.That(context.Context.MessageId, Is.Not.Null);
-                Assert.That(context.Context.ConversationId, Is.Not.Null);
-                Assert.That(context.Context.DestinationAddress, Is.Not.Null);
-                Assert.That(context.Context.SourceAddress, Is.Not.Null);
+                    Assert.That(context.Context.MessageId, Is.Not.Null);
+                    Assert.That(context.Context.ConversationId, Is.Not.Null);
+                    Assert.That(context.Context.DestinationAddress, Is.Not.Null);
+                    Assert.That(context.Context.SourceAddress, Is.Not.Null);
+                });
             }
             finally
             {

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/InboxLock_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/InboxLock_Specs.cs
@@ -47,7 +47,7 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
 
             var events = provider.GetRequiredService<IList<Event>>();
 
-            Assert.That(events.Count, Is.EqualTo(100));
+            Assert.That(events, Has.Count.EqualTo(100));
         }
     }
 

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/QuartzOutbox_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/QuartzOutbox_Specs.cs
@@ -56,9 +56,12 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
             {
                 await harness.Bus.Publish<FirstMessage>(new { });
 
-                Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
 
-                Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+                    Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+                });
 
                 await adjustment.AdvanceTime(TimeSpan.FromSeconds(10));
 

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/Reliable_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/Reliable_Specs.cs
@@ -109,9 +109,12 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
                 ISagaStateMachineTestHarness<ReliableStateMachine, ReliableState>? sagaHarness =
                     harness.GetSagaStateMachineHarness<ReliableStateMachine, ReliableState>();
 
-                Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
 
-                Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                    Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                });
             }
             finally
             {
@@ -145,9 +148,12 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
                 ISagaStateMachineTestHarness<ReliableStateMachine, ReliableState>? sagaHarness =
                     harness.GetSagaStateMachineHarness<ReliableStateMachine, ReliableState>();
 
-                Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
 
-                Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                    Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                });
             }
             finally
             {
@@ -181,9 +187,12 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
                 ISagaStateMachineTestHarness<ReliableStateMachine, ReliableState>? sagaHarness =
                     harness.GetSagaStateMachineHarness<ReliableStateMachine, ReliableState>();
 
-                Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
 
-                Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                    Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                });
             }
             finally
             {

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/TransactionalBusOutbox_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/TransactionalBusOutbox_Specs.cs
@@ -41,7 +41,7 @@
 
             await using (var dbContext = GetDbContext())
             {
-                Assert.IsFalse(await dbContext.Products.AnyAsync(x => x.Id == product.Id));
+                Assert.That(await dbContext.Products.AnyAsync(x => x.Id == product.Id), Is.False);
             }
         }
 
@@ -71,7 +71,7 @@
 
             await using (var dbContext = GetDbContext())
             {
-                Assert.IsTrue(await dbContext.Products.AnyAsync(x => x.Id == product.Id));
+                Assert.That(await dbContext.Products.AnyAsync(x => x.Id == product.Id), Is.True);
             }
         }
 
@@ -101,7 +101,7 @@
 
             await using (var dbContext = GetDbContext())
             {
-                Assert.IsTrue(await dbContext.Products.AnyAsync(x => x.Id == product.Id));
+                Assert.That(await dbContext.Products.AnyAsync(x => x.Id == product.Id), Is.True);
             }
         }
 

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/DiscardEvent_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/DiscardEvent_Specs.cs
@@ -31,14 +31,14 @@
 
             var wasDiscarded = await _discarded.Task;
 
-            Assert.IsTrue(wasDiscarded);
+            Assert.That(wasDiscarded, Is.True);
 
             using (var dbContext = _sagaDbContextFactory.Create())
             {
                 var result = dbContext.Set<SimpleState>().FirstOrDefault(x => x.CorrelationId == sagaId);
                 // THE PROBLEM : the missing instance is not discarded and is persisted to the repository
                 // This test fails
-                Assert.IsNull(result);
+                Assert.That(result, Is.Null);
             }
         }
 
@@ -62,7 +62,7 @@
             using (var dbContext = _sagaDbContextFactory.Create())
             {
                 var result = dbContext.Set<SimpleState>().FirstOrDefault(x => x.CorrelationId == sagaId);
-                Assert.IsNotNull(result);
+                Assert.That(result, Is.Not.Null);
             }
         }
 

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyFail_Specs.cs
@@ -35,7 +35,7 @@
             for (var i = 0; i < 20; i++)
             {
                 Guid? sagaId = await _repository.Value.ShouldContainSaga(sagaIds[i], TestTimeout);
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
             }
 
             for (var i = 0; i < 20; i++)
@@ -69,7 +69,7 @@
             {
                 Guid? sagaId = await _repository.Value.ShouldContainSagaInState(sid, _machine, _machine.Warmup, TestTimeout);
 
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
             }
         }
 
@@ -82,7 +82,7 @@
 
             Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             await Task.WhenAll(
                 InputQueueSendEndpoint.Send(new Bass
@@ -109,7 +109,7 @@
 
             sagaId = await _repository.Value.ShouldContainSagaInState(correlationId, _machine, _machine.Warmup, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
         }
 
         ChoirStateMachine _machine;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyOptimistic_Specs.cs
@@ -35,7 +35,7 @@
             for (var i = 0; i < 20; i++)
             {
                 Guid? sagaId = await _repository.Value.ShouldContainSaga(sagaIds[i], TestTimeout);
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
             }
 
             for (var i = 0; i < 20; i++)
@@ -69,7 +69,7 @@
             {
                 Guid? sagaId = await _repository.Value.ShouldContainSagaInState(sid, _machine, _machine.Harmony, TestTimeout);
 
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
             }
         }
 
@@ -82,7 +82,7 @@
 
             Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             await Task.WhenAll(
                 InputQueueSendEndpoint.Send(new Bass
@@ -109,11 +109,11 @@
 
             sagaId = await _repository.Value.ShouldContainSagaInState(correlationId, _machine, _machine.Harmony, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             var instance = await GetSaga(correlationId);
 
-            Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
+            Assert.That(instance.CurrentState, Is.EqualTo("Harmony"));
         }
 
         ChoirStateMachine _machine;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFrameworkConcurrencyPessimistic_Specs.cs
@@ -34,7 +34,7 @@
             for (var i = 0; i < 20; i++)
             {
                 Guid? sagaId = await _repository.Value.ShouldContainSaga(sagaIds[i], TestTimeout);
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
             }
 
             for (var i = 0; i < 20; i++)
@@ -68,7 +68,7 @@
             {
                 Guid? sagaId = await _repository.Value.ShouldContainSagaInState(sid, _machine, _machine.Harmony, TestTimeout);
 
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
             }
         }
 
@@ -81,7 +81,7 @@
 
             Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             await Task.WhenAll(
                 InputQueueSendEndpoint.Send(new Bass
@@ -108,11 +108,11 @@
 
             sagaId = await _repository.Value.ShouldContainSagaInState(correlationId, _machine, _machine.Harmony, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             var instance = await GetSaga(correlationId);
 
-            Assert.IsTrue(instance.CurrentState.Equals("Harmony"));
+            Assert.That(instance.CurrentState, Is.EqualTo("Harmony"));
         }
 
         ChoirStatePessimisticMachine _machine;

--- a/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFramework_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkIntegration.Tests/UsingEntityFramework_Specs.cs
@@ -40,7 +40,7 @@
             for (var i = 0; i < 200; i++)
             {
                 Guid? sagaId = await _repository.Value.ShouldContainSaga(sagaIds[i], TestTimeout);
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
             }
         }
 
@@ -52,12 +52,12 @@
             await InputQueueSendEndpoint.Send(new GirlfriendYelling { CorrelationId = correlationId });
 
             Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             await InputQueueSendEndpoint.Send(new SodOff { CorrelationId = correlationId });
 
             sagaId = await _repository.Value.ShouldNotContainSaga(correlationId, TestTimeout);
-            Assert.IsFalse(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.False);
         }
 
         [Test]
@@ -69,17 +69,17 @@
 
             Guid? sagaId = await _repository.Value.ShouldContainSaga(correlationId, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             await InputQueueSendEndpoint.Send(new GotHitByACar { CorrelationId = correlationId });
 
             sagaId = await _repository.Value.ShouldContainSagaInState(correlationId, _machine, _machine.Dead, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             var instance = await GetSaga(correlationId);
 
-            Assert.IsTrue(instance.Screwed);
+            Assert.That(instance.Screwed, Is.True);
         }
 
         SuperShopper _machine;

--- a/tests/MassTransit.EventHubIntegration.Tests/BatchProducer_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/BatchProducer_Specs.cs
@@ -78,13 +78,16 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
-                Assert.That(result.DestinationAddress,
-                    Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
-                Assert.That(result.MessageId, Is.EqualTo(messageId));
-                Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
-                Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
-                Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.SourceAddress, Is.EqualTo(new Uri("loopback://localhost/")));
+                    Assert.That(result.DestinationAddress,
+                        Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
+                    Assert.That(result.MessageId, Is.EqualTo(messageId));
+                    Assert.That(result.CorrelationId, Is.EqualTo(correlationId));
+                    Assert.That(result.InitiatorId, Is.EqualTo(initiatorId));
+                    Assert.That(result.ConversationId, Is.EqualTo(conversationId));
+                });
             }
             finally
             {

--- a/tests/MassTransit.EventHubIntegration.Tests/BatchReceive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/BatchReceive_Specs.cs
@@ -72,7 +72,7 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<Batch<BatchEventHubMessage>> result = await taskCompletionSource.Task;
 
-                Assert.That(result.Message.Length, Is.EqualTo(batchSize));
+                Assert.That(result.Message, Has.Length.EqualTo(batchSize));
 
                 for (var i = 0; i < batchSize; i++)
                     Assert.That(result.Message[i].Message.Index, Is.EqualTo(i));

--- a/tests/MassTransit.EventHubIntegration.Tests/Filter_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Filter_Specs.cs
@@ -58,9 +58,12 @@ namespace MassTransit.EventHubIntegration.Tests
 
             ConsumeContext<EventHubMessage> result = await provider.GetRequiredService<TaskCompletionSource<ConsumeContext<EventHubMessage>>>().Task;
 
-            Assert.That(_attempts, Is.EqualTo(4));
-            Assert.That(_lastCount, Is.EqualTo(2));
-            Assert.That(_lastAttempt, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_attempts, Is.EqualTo(4));
+                Assert.That(_lastCount, Is.EqualTo(2));
+                Assert.That(_lastAttempt, Is.EqualTo(3));
+            });
         }
 
 

--- a/tests/MassTransit.EventHubIntegration.Tests/Outbox_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Outbox_Specs.cs
@@ -67,8 +67,11 @@ namespace MassTransit.EventHubIntegration.Tests
 
             Assert.That(message, Is.Not.Null);
 
-            Assert.That(message.Context.Message.OriginalMessageId, Is.EqualTo(messageId));
-            Assert.That(message.Context.Message.OriginalCorrelationId, Is.EqualTo(correlationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Context.Message.OriginalMessageId, Is.EqualTo(messageId));
+                Assert.That(message.Context.Message.OriginalCorrelationId, Is.EqualTo(correlationId));
+            });
         }
 
 

--- a/tests/MassTransit.EventHubIntegration.Tests/ProducerPipe_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/ProducerPipe_Specs.cs
@@ -62,10 +62,13 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 var result = await sendFilterTaskCompletionSource.Task;
 
-                Assert.IsTrue(result.TryGetPayload<EventHubSendContext>(out _));
-                Assert.IsTrue(result.TryGetPayload<EventHubSendContext<EventHubMessage>>(out _));
-                Assert.That(result.DestinationAddress,
-                    Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.TryGetPayload<EventHubSendContext>(out _), Is.True);
+                    Assert.That(result.TryGetPayload<EventHubSendContext<EventHubMessage>>(out _), Is.True);
+                    Assert.That(result.DestinationAddress,
+                        Is.EqualTo(new Uri($"loopback://localhost/{EventHubEndpointAddress.PathPrefix}/{Configuration.EventHubName}")));
+                });
 
                 await taskCompletionSource.Task;
             }

--- a/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
+++ b/tests/MassTransit.EventHubIntegration.Tests/Receive_Specs.cs
@@ -153,7 +153,7 @@ namespace MassTransit.EventHubIntegration.Tests
 
                 ConsumeContext<EventHubMessage> result = await taskCompletionSource.Task;
 
-                Assert.IsTrue(result.TryGetPayload(out EventHubConsumeContext _));
+                Assert.That(result.TryGetPayload(out EventHubConsumeContext _), Is.True);
             }
             finally
             {

--- a/tests/MassTransit.HangfireIntegration.Tests/Cleanup_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/Cleanup_Specs.cs
@@ -33,7 +33,7 @@ namespace MassTransit.HangfireIntegration.Tests
 
             Dictionary<string, string> items = connection.GetAllEntriesFromHash(hashId);
 
-            Assert.Null(items);
+            Assert.That(items, Is.Null);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace MassTransit.HangfireIntegration.Tests
 
             Dictionary<string, string> items = connection.GetAllEntriesFromHash(hashId);
 
-            Assert.Null(items);
+            Assert.That(items, Is.Null);
         }
 
         Task<ConsumeContext<FirstMessage>> _first;

--- a/tests/MassTransit.HangfireIntegration.Tests/Container_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/Container_Specs.cs
@@ -54,11 +54,14 @@ namespace MassTransit.HangfireIntegration.Tests
 
             await harness.Bus.Publish<FirstMessage>(new { });
 
-            Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
 
-            Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+                Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
 
-            Assert.That(await harness.GetConsumerHarness<SecondMessageConsumer>().Consumed.Any<SecondMessage>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<SecondMessageConsumer>().Consumed.Any<SecondMessage>(), Is.True);
+            });
         }
 
         [Test]
@@ -96,18 +99,24 @@ namespace MassTransit.HangfireIntegration.Tests
 
             await harness.Bus.Publish<FirstMessage>(new { }, x => x.Headers.Set("SimpleHeader", "SimpleValue"));
 
-            Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
 
-            Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+                Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
 
-            Assert.That(await harness.GetConsumerHarness<SecondMessageConsumer>().Consumed.Any<SecondMessage>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<SecondMessageConsumer>().Consumed.Any<SecondMessage>(), Is.True);
+            });
 
             ConsumeContext<SecondMessage> context =
                 (await harness.GetConsumerHarness<SecondMessageConsumer>().Consumed.SelectAsync<SecondMessage>().First()).Context;
 
-            Assert.That(context.Headers.TryGetHeader("SimpleHeader", out var header), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Headers.TryGetHeader("SimpleHeader", out var header), Is.True);
 
-            Assert.That(header, Is.EqualTo("SimpleValue"));
+                Assert.That(header, Is.EqualTo("SimpleValue"));
+            });
         }
 
         readonly ITestBusConfiguration _configuration;

--- a/tests/MassTransit.HangfireIntegration.Tests/DelayRetry_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/DelayRetry_Specs.cs
@@ -19,7 +19,7 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;
@@ -74,7 +74,7 @@
 
             ConsumeContext<PingMessage> context = await _consumer.Received;
 
-            Assert.GreaterOrEqual(_consumer.ReceivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_consumer.ReceivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         MyConsumer _consumer;
@@ -102,7 +102,6 @@
         {
             readonly TaskCompletionSource<ConsumeContext<PingMessage>> _received;
             int _count;
-            TimeSpan _receivedTimeSpan;
             Stopwatch _timer;
 
             public MyConsumer(TaskCompletionSource<ConsumeContext<PingMessage>> taskCompletionSource)
@@ -112,7 +111,7 @@
 
             public Task<ConsumeContext<PingMessage>> Received => _received.Task;
 
-            public IComparable ReceivedTimeSpan => _receivedTimeSpan;
+            public TimeSpan ReceivedTimeSpan { get; private set; }
 
             public Task Consume(ConsumeContext<PingMessage> context)
             {
@@ -130,7 +129,7 @@
                 Console.WriteLine("{0} okay, now is good (retried {1} times)", DateTime.UtcNow, context.Headers.Get("MT-Redelivery-Count", default(int?)));
 
                 // okay, ready.
-                _receivedTimeSpan = _timer.Elapsed;
+                ReceivedTimeSpan = _timer.Elapsed;
                 _received.TrySetResult(context);
 
                 return Task.CompletedTask;

--- a/tests/MassTransit.HangfireIntegration.Tests/RequestTimeout_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/RequestTimeout_Specs.cs
@@ -25,7 +25,7 @@ namespace MassTransit.HangfireIntegration.Tests
 
             Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, x => x.AddressValidationTimeout,
                 TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         InMemorySagaRepository<TestState> _repository;

--- a/tests/MassTransit.HangfireIntegration.Tests/Request_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/Request_Specs.cs
@@ -3,7 +3,6 @@
     namespace Request_Specs
     {
         using System;
-        using System.Runtime.Intrinsics.Arm;
         using System.Threading.Tasks;
         using Contracts;
         using NUnit.Framework;
@@ -32,10 +31,10 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, x => x.Registered, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 var sagaInstance = _repository[saga.Value].Instance;
-                Assert.IsFalse(sagaInstance.ValidateAddressRequestId.HasValue);
+                Assert.That(sagaInstance.ValidateAddressRequestId.HasValue, Is.False);
             }
 
             static Sending_a_request_from_a_state_machine()

--- a/tests/MassTransit.HangfireIntegration.Tests/ScheduleMessage_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/ScheduleMessage_Specs.cs
@@ -20,7 +20,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -53,6 +53,7 @@
         }
     }
 
+
     [TestFixture]
     public class ScheduleMessageUsingJson_Specs :
         HangfireInMemoryTestFixture
@@ -67,7 +68,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -106,6 +107,7 @@
         }
     }
 
+
     [TestFixture]
     public class ScheduleMessageUsingNewtonsoftJson_Specs :
         HangfireInMemoryTestFixture
@@ -120,7 +122,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -174,7 +176,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -228,8 +230,11 @@
 
             ConsumeContext<SecondMessage> second = await _second;
 
-            Assert.That(second.ExpirationTime.HasValue, Is.True);
-            Assert.That(second.ExpirationTime.Value, Is.GreaterThan(DateTime.UtcNow + TimeSpan.FromSeconds(24)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.ExpirationTime.HasValue, Is.True);
+                Assert.That(second.ExpirationTime.Value, Is.GreaterThan(DateTime.UtcNow + TimeSpan.FromSeconds(24)));
+            });
         }
 
         Task<ConsumeContext<SecondMessage>> _second;

--- a/tests/MassTransit.HangfireIntegration.Tests/ScheduleTimeout_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/ScheduleTimeout_Specs.cs
@@ -23,7 +23,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, _machine.Active, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 await InputQueueSendEndpoint.Send<OrderSubmitted>(new { MemberNumber = memberNumber });
 
@@ -55,7 +55,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, _machine.Active, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 await InputQueueSendEndpoint.Send<CartItemAdded>(new { MemberNumber = memberNumber });
 

--- a/tests/MassTransit.HangfireIntegration.Tests/ScheduledRedelivery_Specs.cs
+++ b/tests/MassTransit.HangfireIntegration.Tests/ScheduledRedelivery_Specs.cs
@@ -19,9 +19,12 @@ namespace MassTransit.HangfireIntegration.Tests
 
             await Task.WhenAll(_received.Select(x => x.Task));
 
-            Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.8)));
-            Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.8)));
-            Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.8)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.8)));
+                Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.8)));
+                Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.8)));
+            });
 
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[1] - _timestamps[0]);
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[2] - _timestamps[1]);

--- a/tests/MassTransit.KafkaIntegration.Tests/Avro_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Avro_Specs.cs
@@ -165,8 +165,11 @@ namespace MassTransit.KafkaIntegration.Tests
 
             Assert.That(message, Is.Not.Null);
 
-            Assert.That(message.Context.Message.OriginalMessageId, Is.EqualTo(messageId));
-            Assert.That(message.Context.Message.OriginalCorrelationId, Is.EqualTo(correlationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Context.Message.OriginalMessageId, Is.EqualTo(messageId));
+                Assert.That(message.Context.Message.OriginalCorrelationId, Is.EqualTo(correlationId));
+            });
         }
 
 

--- a/tests/MassTransit.KafkaIntegration.Tests/ConfigureTopology_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/ConfigureTopology_Specs.cs
@@ -45,14 +45,14 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var meta = client.GetMetadata(topicName, TimeSpan.FromSeconds(10));
 
-            Assert.That(meta.Topics.Count, Is.EqualTo(1));
+            Assert.That(meta.Topics, Has.Count.EqualTo(1));
 
             foreach (var topic in meta.Topics)
             {
-                Assert.That(topic.Partitions.Count, Is.EqualTo(partitionCount));
+                Assert.That(topic.Partitions, Has.Count.EqualTo(partitionCount));
 
                 foreach (var partition in topic.Partitions)
-                    Assert.That(partition.Replicas.Length, Is.EqualTo(replicaCount));
+                    Assert.That(partition.Replicas, Has.Length.EqualTo(replicaCount));
             }
         }
 
@@ -103,7 +103,7 @@ namespace MassTransit.KafkaIntegration.Tests
 
             var result = await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.NotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
 

--- a/tests/MassTransit.KafkaIntegration.Tests/DictionaryHeadersDeserializerTests.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/DictionaryHeadersDeserializerTests.cs
@@ -14,18 +14,28 @@
         {
             var headers = new Headers { new Header("EmptyValue", null) };
             var result = DictionaryHeadersSerialize.Deserializer.Deserialize(headers);
-            Assert.IsTrue(result.TryGetHeader("EmptyValue", out var emptyValue));
-            Assert.IsNull(emptyValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.TryGetHeader("EmptyValue", out var emptyValue), Is.True);
+                Assert.That(emptyValue, Is.Null);
+            });
         }
 
         [Test]
         public async Task Should_Deserialize_with_duplicate_header_value()
         {
-            var headers = new Headers { new Header("TestValue", null), new Header("TestValue", null) };
+            var headers = new Headers
+            {
+                new Header("TestValue", null),
+                new Header("TestValue", null)
+            };
 
             var result = DictionaryHeadersSerialize.Deserializer.Deserialize(headers);
-            Assert.IsTrue(result.TryGetHeader("TestValue", out var emptyValue));
-            Assert.IsNull(emptyValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.TryGetHeader("TestValue", out var emptyValue), Is.True);
+                Assert.That(emptyValue, Is.Null);
+            });
         }
 
         [Test]
@@ -34,8 +44,11 @@
             var bytes = Encoding.Unicode.GetBytes("test");
             var headers = new Headers { new Header("BadValue", bytes) };
             var result = DictionaryHeadersSerialize.Deserializer.Deserialize(headers);
-            Assert.IsTrue(result.TryGetHeader("BadValue", out var value));
-            Assert.That(value, Is.EqualTo(Encoding.UTF8.GetString(bytes)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.TryGetHeader("BadValue", out var value), Is.True);
+                Assert.That(value, Is.EqualTo(Encoding.UTF8.GetString(bytes)));
+            });
         }
     }
 }

--- a/tests/MassTransit.KafkaIntegration.Tests/Filter_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Filter_Specs.cs
@@ -61,9 +61,12 @@ namespace MassTransit.KafkaIntegration.Tests
 
             await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
-            Assert.That(_attempts, Is.EqualTo(4));
-            Assert.That(_lastCount, Is.EqualTo(2));
-            Assert.That(_lastAttempt, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_attempts, Is.EqualTo(4));
+                Assert.That(_lastCount, Is.EqualTo(2));
+                Assert.That(_lastAttempt, Is.EqualTo(3));
+            });
         }
 
 

--- a/tests/MassTransit.KafkaIntegration.Tests/MultiBus_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/MultiBus_Specs.cs
@@ -259,7 +259,7 @@ namespace MassTransit.KafkaIntegration.Tests
                     groupInfo = adminClient.ListGroup(nameof(MultiBus_ReBalance_Specs), TimeSpan.FromSeconds(5));
                 }
 
-                Assert.That(groupInfo.Members.Count, Is.EqualTo(2)); // this fails, second instance consumer assigned to all partitions
+                Assert.That(groupInfo.Members, Has.Count.EqualTo(2)); // this fails, second instance consumer assigned to all partitions
 
                 await secondBus.BusControl.StopAsync(TestCancellationToken);
             }
@@ -402,7 +402,7 @@ namespace MassTransit.KafkaIntegration.Tests
                     groupInfo = adminClient.ListGroup(nameof(MultiBus_ConcurrentConsumers_ReBalance_Specs), TimeSpan.FromSeconds(5));
                 }
 
-                Assert.That(groupInfo.Members.Count, Is.EqualTo(6)); // this fails, second instance consumer assigned to all partitions
+                Assert.That(groupInfo.Members, Has.Count.EqualTo(6)); // this fails, second instance consumer assigned to all partitions
 
                 await secondBus.BusControl.StopAsync(TestCancellationToken);
             }

--- a/tests/MassTransit.KafkaIntegration.Tests/ProducerPipe_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/ProducerPipe_Specs.cs
@@ -152,7 +152,7 @@ namespace MassTransit.KafkaIntegration.Tests
                 context.ValueSerializer = new CustomSerializer<KafkaMessage>();
             }), harness.CancellationToken);
 
-            Assert.IsFalse(await harness.Consumed.Any<KafkaMessage>());
+            Assert.That(await harness.Consumed.Any<KafkaMessage>(), Is.False);
         }
 
 

--- a/tests/MassTransit.KafkaIntegration.Tests/Receive_Specs.cs
+++ b/tests/MassTransit.KafkaIntegration.Tests/Receive_Specs.cs
@@ -167,7 +167,7 @@ namespace MassTransit.KafkaIntegration.Tests
             await provider.GetTask<ConsumeContext<KafkaMessage>>();
 
             IList<IReceivedMessage<KafkaMessage>> receivedMessages = await harness.Consumed.SelectAsync<KafkaMessage>().ToListAsync();
-            Assert.That(receivedMessages.Count, Is.EqualTo(NumMessages));
+            Assert.That(receivedMessages, Has.Count.EqualTo(NumMessages));
             var result = new int[NumKeys];
 
             foreach (IReceivedMessage<KafkaMessage> receivedMessage in receivedMessages)

--- a/tests/MassTransit.MongoDbIntegration.Tests/Courier/RoutingSlipCompleted_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/Courier/RoutingSlipCompleted_Specs.cs
@@ -43,7 +43,7 @@
 
             Assert.That(routingSlip, Is.Not.Null);
             Assert.That(routingSlip.Events, Is.Not.Null);
-            Assert.That(routingSlip.Events.Length, Is.EqualTo(1));
+            Assert.That(routingSlip.Events, Has.Length.EqualTo(1));
 
             var completed = routingSlip.Events[0] as RoutingSlipCompletedDocument;
             Assert.That(completed, Is.Not.Null);

--- a/tests/MassTransit.MongoDbIntegration.Tests/InboxLock_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/InboxLock_Specs.cs
@@ -47,7 +47,7 @@ namespace MassTransit.MongoDbIntegration.Tests
 
             var events = provider.GetRequiredService<IList<Event>>();
 
-            Assert.That(events.Count, Is.EqualTo(100));
+            Assert.That(events, Has.Count.EqualTo(100));
         }
     }
 

--- a/tests/MassTransit.MongoDbIntegration.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/JobConsumer_Specs.cs
@@ -95,15 +95,18 @@ namespace MassTransit.MongoDbIntegration.Tests
                     Job = new { Duration = TimeSpan.FromSeconds(1) }
                 });
 
-                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                });
             }
             finally
             {

--- a/tests/MassTransit.NHibernateIntegration.Tests/Saving_using_no_custom_types.cs
+++ b/tests/MassTransit.NHibernateIntegration.Tests/Saving_using_no_custom_types.cs
@@ -22,7 +22,7 @@ namespace MassTransit.NHibernateIntegration.Tests
 
             var instance = await GetStateMachine(correlationId);
 
-            Assert.IsTrue(instance.Screwed);
+            Assert.That(instance.Screwed, Is.True);
         }
 
         SuperShopper _machine;

--- a/tests/MassTransit.NHibernateIntegration.Tests/UsingNHibernate_Specs.cs
+++ b/tests/MassTransit.NHibernateIntegration.Tests/UsingNHibernate_Specs.cs
@@ -20,12 +20,12 @@
             await InputQueueSendEndpoint.Send(new GirlfriendYelling { CorrelationId = correlationId });
 
             Guid? sagaId = await _repository.ShouldContainSaga(correlationId, TestTimeout);
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             await InputQueueSendEndpoint.Send(new SodOff { CorrelationId = correlationId });
 
             sagaId = await _repository.ShouldNotContainSaga(correlationId, TestTimeout);
-            Assert.IsFalse(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.False);
         }
 
         [Test]
@@ -37,17 +37,17 @@
 
             Guid? sagaId = await _repository.ShouldContainSaga(correlationId, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             await InputQueueSendEndpoint.Send(new GotHitByACar { CorrelationId = correlationId });
 
             sagaId = await _repository.ShouldContainSagaInState(correlationId, _machine, x => x.Dead, TestTimeout);
 
-            Assert.IsTrue(sagaId.HasValue);
+            Assert.That(sagaId.HasValue, Is.True);
 
             var instance = await GetSaga(correlationId);
 
-            Assert.IsTrue(instance.Screwed);
+            Assert.That(instance.Screwed, Is.True);
         }
 
         SuperShopper _machine;

--- a/tests/MassTransit.NHibernateIntegration.Tests/Vanilla_Specs.cs
+++ b/tests/MassTransit.NHibernateIntegration.Tests/Vanilla_Specs.cs
@@ -22,7 +22,7 @@
 
             var instance = await GetStateMachine(correlationId);
 
-            Assert.IsTrue(instance.Screwed);
+            Assert.That(instance.Screwed, Is.True);
         }
 
         SuperShopper _machine;

--- a/tests/MassTransit.QuartzIntegration.Tests/Container_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Container_Specs.cs
@@ -54,9 +54,12 @@ namespace MassTransit.QuartzIntegration.Tests
 
             await harness.Bus.Publish<FirstMessage>(new { });
 
-            Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
 
-            Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+                Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+            });
 
             await adjustment.AdvanceTime(TimeSpan.FromSeconds(10));
 
@@ -99,9 +102,12 @@ namespace MassTransit.QuartzIntegration.Tests
 
             await harness.Bus.Publish<FirstMessage>(new { }, x => x.Headers.Set("SimpleHeader", "SimpleValue"));
 
-            Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.GetConsumerHarness<FirstMessageConsumer>().Consumed.Any<FirstMessage>(), Is.True);
 
-            Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+                Assert.That(await harness.Consumed.Any<ScheduleMessage>(), Is.True);
+            });
 
             await adjustment.AdvanceTime(TimeSpan.FromSeconds(10));
 
@@ -110,9 +116,12 @@ namespace MassTransit.QuartzIntegration.Tests
             ConsumeContext<SecondMessage> context =
                 (await harness.GetConsumerHarness<SecondMessageConsumer>().Consumed.SelectAsync<SecondMessage>().First()).Context;
 
-            Assert.That(context.Headers.TryGetHeader("SimpleHeader", out var header), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Headers.TryGetHeader("SimpleHeader", out var header), Is.True);
 
-            Assert.That(header, Is.EqualTo("SimpleValue"));
+                Assert.That(header, Is.EqualTo("SimpleValue"));
+            });
         }
 
         readonly ITestBusConfiguration _configuration;

--- a/tests/MassTransit.QuartzIntegration.Tests/Courier_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Courier_Specs.cs
@@ -50,7 +50,7 @@ namespace MassTransit.QuartzIntegration.Tests
 
             await completed;
 
-            Assert.IsFalse(activityFaulted.IsCompleted);
+            Assert.That(activityFaulted.IsCompleted, Is.False);
         }
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)
@@ -111,7 +111,7 @@ namespace MassTransit.QuartzIntegration.Tests
 
             await completed;
 
-            Assert.IsFalse(activityFaulted.IsCompleted);
+            Assert.That(activityFaulted.IsCompleted, Is.False);
         }
 
         protected override void ConfigureInMemoryBus(IInMemoryBusFactoryConfigurator configurator)

--- a/tests/MassTransit.QuartzIntegration.Tests/DelayRetry_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/DelayRetry_Specs.cs
@@ -19,7 +19,7 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;
@@ -74,7 +74,7 @@
 
             ConsumeContext<PingMessage> context = await _consumer.Received;
 
-            Assert.GreaterOrEqual(_consumer.ReceivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_consumer.ReceivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         MyConsumer _consumer;
@@ -95,7 +95,6 @@
         {
             readonly TaskCompletionSource<ConsumeContext<PingMessage>> _received;
             int _count;
-            TimeSpan _receivedTimeSpan;
             Stopwatch _timer;
 
             public MyConsumer(TaskCompletionSource<ConsumeContext<PingMessage>> taskCompletionSource)
@@ -105,7 +104,7 @@
 
             public Task<ConsumeContext<PingMessage>> Received => _received.Task;
 
-            public IComparable ReceivedTimeSpan => _receivedTimeSpan;
+            public TimeSpan ReceivedTimeSpan { get; private set; }
 
             public Task Consume(ConsumeContext<PingMessage> context)
             {
@@ -123,7 +122,7 @@
                 Console.WriteLine("{0} okay, now is good (retried {1} times)", DateTime.UtcNow, context.Headers.Get("MT-Redelivery-Count", default(int?)));
 
                 // okay, ready.
-                _receivedTimeSpan = _timer.Elapsed;
+                ReceivedTimeSpan = _timer.Elapsed;
                 _received.TrySetResult(context);
 
                 return Task.CompletedTask;
@@ -143,9 +142,12 @@
 
             ConsumeContext<PingMessage> context = await _consumer.Received;
 
-            Assert.GreaterOrEqual(_consumer.ReceivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_consumer.ReceivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
 
-            Assert.That(_consumer.RedeliveryCount, Is.EqualTo(2));
+                Assert.That(_consumer.RedeliveryCount, Is.EqualTo(2));
+            });
         }
 
         MyConsumer _consumer;
@@ -164,7 +166,6 @@
         {
             readonly TaskCompletionSource<ConsumeContext<PingMessage>> _received;
             int _count;
-            TimeSpan _receivedTimeSpan;
             Stopwatch _timer;
 
             public MyConsumer(TaskCompletionSource<ConsumeContext<PingMessage>> taskCompletionSource)
@@ -174,7 +175,7 @@
 
             public Task<ConsumeContext<PingMessage>> Received => _received.Task;
 
-            public IComparable ReceivedTimeSpan => _receivedTimeSpan;
+            public TimeSpan ReceivedTimeSpan { get; private set; }
 
             public int RedeliveryCount { get; set; }
 
@@ -194,7 +195,7 @@
                 Console.WriteLine("{0} okay, now is good (retried {1} times)", DateTime.UtcNow, context.Headers.Get("MT-Redelivery-Count", default(int?)));
 
                 // okay, ready.
-                _receivedTimeSpan = _timer.Elapsed;
+                ReceivedTimeSpan = _timer.Elapsed;
                 RedeliveryCount = context.GetRedeliveryCount();
                 _received.TrySetResult(context);
 
@@ -215,10 +216,13 @@
 
             ConsumeContext<PingMessage> context = await _consumer.Received;
 
-            Assert.GreaterOrEqual(_consumer.ReceivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_consumer.ReceivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
 
-            Assert.That(_consumer.RedeliveryCount, Is.EqualTo(2));
-            Assert.That(context.GetRedeliveryCount(), Is.EqualTo(2));
+                Assert.That(_consumer.RedeliveryCount, Is.EqualTo(2));
+                Assert.That(context.GetRedeliveryCount(), Is.EqualTo(2));
+            });
         }
 
         MyConsumer _consumer;
@@ -243,7 +247,6 @@
         {
             readonly TaskCompletionSource<ConsumeContext<PingMessage>> _received;
             int _count;
-            TimeSpan _receivedTimeSpan;
             Stopwatch _timer;
 
             public MyConsumer(TaskCompletionSource<ConsumeContext<PingMessage>> taskCompletionSource)
@@ -253,7 +256,7 @@
 
             public Task<ConsumeContext<PingMessage>> Received => _received.Task;
 
-            public IComparable ReceivedTimeSpan => _receivedTimeSpan;
+            public TimeSpan ReceivedTimeSpan { get; private set; }
 
             public int RedeliveryCount { get; set; }
 
@@ -273,7 +276,7 @@
                 Console.WriteLine("{0} okay, now is good (retried {1} times)", DateTime.UtcNow, context.Headers.Get("MT-Redelivery-Count", default(int?)));
 
                 // okay, ready.
-                _receivedTimeSpan = _timer.Elapsed;
+                ReceivedTimeSpan = _timer.Elapsed;
                 RedeliveryCount = context.GetRedeliveryCount();
                 _received.TrySetResult(context);
 
@@ -294,7 +297,7 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;

--- a/tests/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Recurring_Specs.cs
@@ -47,11 +47,14 @@
 
             await _done;
 
-            Assert.Greater(_count, 0, "Expected to see at least one interval");
+            Assert.Multiple(() =>
+            {
+                Assert.That(_count, Is.GreaterThan(0), "Expected to see at least one interval");
 
 
-            Assert.IsNotNull(_lastInterval.Headers.Get<string>(MessageHeaders.Quartz.ScheduleId));
-            Assert.IsNotNull(_lastInterval.Headers.Get<string>(MessageHeaders.Quartz.ScheduleGroup));
+                Assert.That(_lastInterval.Headers.Get<string>(MessageHeaders.Quartz.ScheduleId), Is.Not.Null);
+                Assert.That(_lastInterval.Headers.Get<string>(MessageHeaders.Quartz.ScheduleGroup), Is.Not.Null);
+            });
         }
 
         [Test]

--- a/tests/MassTransit.QuartzIntegration.Tests/RequestTimeout_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/RequestTimeout_Specs.cs
@@ -25,7 +25,7 @@ namespace MassTransit.QuartzIntegration.Tests
 
             Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, x => x.AddressValidationTimeout,
                 TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         InMemorySagaRepository<TestState> _repository;

--- a/tests/MassTransit.QuartzIntegration.Tests/Request_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Request_Specs.cs
@@ -32,10 +32,10 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, x => x.Registered, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 var sagaInstance = _repository[saga.Value].Instance;
-                Assert.IsFalse(sagaInstance.ValidateAddressRequestId.HasValue);
+                Assert.That(sagaInstance.ValidateAddressRequestId.HasValue, Is.False);
             }
 
             static Sending_a_request_from_a_state_machine()

--- a/tests/MassTransit.QuartzIntegration.Tests/ScheduleMessage_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/ScheduleMessage_Specs.cs
@@ -24,7 +24,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -74,7 +74,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -113,6 +113,7 @@
         }
     }
 
+
     [TestFixture]
     public class ScheduleMessageUsingNewtonsoftRawJson_Specs :
         QuartzInMemoryTestFixture
@@ -129,7 +130,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -185,7 +186,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -242,7 +243,7 @@
             await _second;
 
             if (_secondActivityId != null && _firstActivityId != null)
-                Assert.That(_secondActivityId.StartsWith(_firstActivityId), Is.True);
+                Assert.That(_secondActivityId, Does.StartWith(_firstActivityId));
         }
 
         Task<ConsumeContext<SecondMessage>> _second;
@@ -303,8 +304,11 @@
 
             ConsumeContext<SecondMessage> second = await _second;
 
-            Assert.That(second.ExpirationTime.HasValue, Is.True);
-            Assert.That(second.ExpirationTime.Value, Is.GreaterThan(DateTime.UtcNow + TimeSpan.FromSeconds(20)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.ExpirationTime.HasValue, Is.True);
+                Assert.That(second.ExpirationTime.Value, Is.GreaterThan(DateTime.UtcNow + TimeSpan.FromSeconds(20)));
+            });
         }
 
         Task<ConsumeContext<SecondMessage>> _second;

--- a/tests/MassTransit.QuartzIntegration.Tests/ScheduleTimeout_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/ScheduleTimeout_Specs.cs
@@ -23,7 +23,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, _machine.Active, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 await InputQueueSendEndpoint.Send<OrderSubmitted>(new { MemberNumber = memberNumber });
 
@@ -55,7 +55,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(x => x.MemberNumber == memberNumber, _machine, _machine.Active, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 await InputQueueSendEndpoint.Send<CartItemAdded>(new { MemberNumber = memberNumber });
 

--- a/tests/MassTransit.QuartzIntegration.Tests/ScheduledRedelivery_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/ScheduledRedelivery_Specs.cs
@@ -19,9 +19,12 @@ namespace MassTransit.QuartzIntegration.Tests
 
             await Task.WhenAll(_received.Select(x => x.Task));
 
-            Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2)));
-            Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(3)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
+                Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2)));
+                Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(3)));
+            });
 
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[1] - _timestamps[0]);
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[2] - _timestamps[1]);

--- a/tests/MassTransit.QuartzIntegration.Tests/Service_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Service_Specs.cs
@@ -52,7 +52,7 @@
 
             ConsumeContext<IA> context = await handlerIA;
 
-            Assert.IsTrue(context.GetQuartzSent().HasValue);
+            Assert.That(context.GetQuartzSent().HasValue, Is.True);
         }
 
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/AlternateExchange_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/AlternateExchange_Specs.cs
@@ -2,11 +2,11 @@
 {
     using System;
     using System.Threading.Tasks;
-    using MassTransit.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
     using RabbitMQ.Client;
     using TestFramework.Messages;
+    using Testing;
 
 
     public class Using_alternate_exchange_with_the_outbox
@@ -46,7 +46,7 @@
                     {
                         if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
                         {
-                            if(name == alternateQueueName)
+                            if (name == alternateQueueName)
                             {
                                 rmq.Bind(alternateExchangeName);
                             }
@@ -114,11 +114,14 @@
         [Test]
         public async Task Should_have_the_proper_address()
         {
-            Assert.That(Bus.Topology.TryGetPublishAddress<TheWorldImploded>(out var address));
+            Assert.Multiple(() =>
+            {
+                Assert.That(Bus.Topology.TryGetPublishAddress<TheWorldImploded>(out var address));
 
-            Assert.That(address,
-                Is.EqualTo(new Uri(
-                    "rabbitmq://localhost/test/MassTransit.RabbitMqTransport.Tests:AlternateExchange_Specs-TheWorldImploded?alternateexchange=publish-not-delivered")));
+                Assert.That(address,
+                    Is.EqualTo(new Uri(
+                        "rabbitmq://localhost/test/MassTransit.RabbitMqTransport.Tests:AlternateExchange_Specs-TheWorldImploded?alternateexchange=publish-not-delivered")));
+            });
         }
 
         Task<ConsumeContext<TheWorldImploded>> _handled;

--- a/tests/MassTransit.RabbitMqTransport.Tests/Batching_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/Batching_Specs.cs
@@ -20,7 +20,7 @@ namespace MassTransit.RabbitMqTransport.Tests
 
                 Batch<PingMessage> batch = await _consumer[0];
 
-                Assert.That(batch.Length, Is.EqualTo(5));
+                Assert.That(batch, Has.Length.EqualTo(5));
                 Assert.That(batch.Mode, Is.EqualTo(BatchCompletionMode.Size));
             }
 
@@ -54,12 +54,12 @@ namespace MassTransit.RabbitMqTransport.Tests
 
                 Batch<PingMessage> batch = await _consumer[0];
 
-                Assert.That(batch.Length, Is.EqualTo(5));
+                Assert.That(batch, Has.Length.EqualTo(5));
                 Assert.That(batch.Mode, Is.EqualTo(BatchCompletionMode.Time));
 
                 batch = await _consumer[1];
 
-                Assert.That(batch.Length, Is.EqualTo(5));
+                Assert.That(batch, Has.Length.EqualTo(5));
                 Assert.That(batch.Mode, Is.EqualTo(BatchCompletionMode.Time));
             }
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/BuildTopology_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/BuildTopology_Specs.cs
@@ -109,15 +109,23 @@
 
             var topology = _builder.BuildBrokerTopology();
 
-            var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
+            var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.True);
-            Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == _inputQueueName), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.True);
+                Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == _inputQueueName),
+                    Is.True);
+            });
 
-            interfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface)).ToString();
+            interfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.False);
-            Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == _inputQueueName), Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.False);
+                Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == _inputQueueName),
+                    Is.False);
+            });
         }
 
         [Test]
@@ -130,11 +138,14 @@
 
             var topology = _builder.BuildBrokerTopology();
 
-            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface)).ToString();
+            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
-            Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == singleInterfaceName && x.Destination.ExchangeName == _inputQueueName),
-                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
+                Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == singleInterfaceName && x.Destination.ExchangeName == _inputQueueName),
+                    Is.True);
+            });
         }
 
         [SetUp]
@@ -171,16 +182,22 @@
 
             var topology = _builder.BuildBrokerTopology();
 
-            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface)).ToString();
-            var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
+            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface));
+            var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.True);
-            Assert.That(topology.Exchanges.Length, Is.EqualTo(2));
-            Assert.That(topology.ExchangeBindings.Length, Is.EqualTo(1));
-            Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == singleInterfaceName),
-                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.True);
+                Assert.That(topology.Exchanges, Has.Length.EqualTo(2));
+                Assert.That(topology.ExchangeBindings, Has.Length.EqualTo(1));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == singleInterfaceName),
+                    Is.True);
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
+            });
         }
 
         [Test]
@@ -191,11 +208,14 @@
 
             var topology = _builder.BuildBrokerTopology();
 
-            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface)).ToString();
+            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
-            Assert.That(topology.Exchanges.Length, Is.EqualTo(1));
-            Assert.That(topology.ExchangeBindings.Length, Is.EqualTo(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
+                Assert.That(topology.Exchanges, Has.Length.EqualTo(1));
+                Assert.That(topology.ExchangeBindings, Is.Empty);
+            });
         }
 
         [SetUp]
@@ -225,16 +245,22 @@
             var topology = _builder.BuildBrokerTopology();
             topology.LogResult();
 
-            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface)).ToString();
-            var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
+            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface));
+            var interfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.True);
-            Assert.That(topology.Exchanges.Length, Is.EqualTo(2));
-            Assert.That(topology.ExchangeBindings.Length, Is.EqualTo(1));
-            Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == singleInterfaceName),
-                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == interfaceName), Is.True);
+                Assert.That(topology.Exchanges, Has.Length.EqualTo(2));
+                Assert.That(topology.ExchangeBindings, Has.Length.EqualTo(1));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == interfaceName && x.Destination.ExchangeName == singleInterfaceName),
+                    Is.True);
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
+            });
         }
 
         [Test]
@@ -246,11 +272,14 @@
             var topology = _builder.BuildBrokerTopology();
             topology.LogResult();
 
-            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface)).ToString();
+            var singleInterfaceName = _nameFormatter.GetMessageName(typeof(SingleInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
-            Assert.That(topology.Exchanges.Length, Is.EqualTo(1));
-            Assert.That(topology.ExchangeBindings.Length, Is.EqualTo(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == singleInterfaceName), Is.True);
+                Assert.That(topology.Exchanges, Has.Length.EqualTo(1));
+                Assert.That(topology.ExchangeBindings, Is.Empty);
+            });
         }
 
         [Test]
@@ -262,20 +291,28 @@
             var topology = _builder.BuildBrokerTopology();
             topology.LogResult();
 
-            var firstInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface)).ToString();
-            var secondInterfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface)).ToString();
-            var thirdInterfaceName = _nameFormatter.GetMessageName(typeof(ThirdInterface)).ToString();
+            var firstInterfaceName = _nameFormatter.GetMessageName(typeof(FirstInterface));
+            var secondInterfaceName = _nameFormatter.GetMessageName(typeof(SecondInterface));
+            var thirdInterfaceName = _nameFormatter.GetMessageName(typeof(ThirdInterface));
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == secondInterfaceName), Is.True);
-            Assert.That(topology.Exchanges.Length, Is.EqualTo(3));
-            Assert.That(topology.ExchangeBindings.Length, Is.EqualTo(2));
-            Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == secondInterfaceName && x.Destination.ExchangeName == firstInterfaceName),
-                Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == secondInterfaceName), Is.True);
+                Assert.That(topology.Exchanges, Has.Length.EqualTo(3));
+                Assert.That(topology.ExchangeBindings, Has.Length.EqualTo(2));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    topology.ExchangeBindings.Any(x => x.Source.ExchangeName == secondInterfaceName && x.Destination.ExchangeName == firstInterfaceName),
+                    Is.True);
 
-            Assert.That(topology.ExchangeBindings.Any(x => x.Source.ExchangeName == thirdInterfaceName && x.Destination.ExchangeName == secondInterfaceName),
-                Is.True);
+                Assert.That(
+                    topology.ExchangeBindings.Any(x => x.Source.ExchangeName == thirdInterfaceName && x.Destination.ExchangeName == secondInterfaceName),
+                    Is.True);
 
-            Assert.That(topology.Exchanges.Any(x => x.ExchangeName == firstInterfaceName), Is.True);
+                Assert.That(topology.Exchanges.Any(x => x.ExchangeName == firstInterfaceName), Is.True);
+            });
         }
 
         [SetUp]

--- a/tests/MassTransit.RabbitMqTransport.Tests/ConsumerBind_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ConsumerBind_Specs.cs
@@ -171,7 +171,7 @@
             public async Task Should_receive_the_message_a()
             {
                 Guid? sagaId = await SagaRepository.ShouldContainSaga(_sagaId, TestTimeout);
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
 
                 var saga = _repository[sagaId.Value].Instance;
 
@@ -182,7 +182,7 @@
             public async Task Should_receive_the_message_b()
             {
                 Guid? sagaId = await SagaRepository.ShouldContainSaga(_sagaId, TestTimeout);
-                Assert.IsTrue(sagaId.HasValue);
+                Assert.That(sagaId.HasValue, Is.True);
 
                 var saga = _repository[sagaId.Value].Instance;
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/Container_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/Container_Specs.cs
@@ -2,9 +2,9 @@ namespace MassTransit.RabbitMqTransport.Tests
 {
     using System.Threading.Tasks;
     using HarnessContracts;
-    using MassTransit.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
+    using Testing;
 
 
     namespace HarnessContracts
@@ -67,9 +67,12 @@ namespace MassTransit.RabbitMqTransport.Tests
                 OrderNumber = "123"
             });
 
-            Assert.IsTrue(await harness.Sent.Any<OrderSubmitted>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Sent.Any<OrderSubmitted>(), Is.True);
 
-            Assert.IsTrue(await harness.Consumed.Any<SubmitOrder>());
+                Assert.That(await harness.Consumed.Any<SubmitOrder>(), Is.True);
+            });
         }
 
 
@@ -126,9 +129,12 @@ namespace MassTransit.RabbitMqTransport.Tests
                 OrderNumber = "123"
             });
 
-            Assert.IsTrue(await harness.Sent.Any<OrderSubmitted>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Sent.Any<OrderSubmitted>(), Is.True);
 
-            Assert.IsTrue(await harness.Consumed.Any<SubmitOrder>());
+                Assert.That(await harness.Consumed.Any<SubmitOrder>(), Is.True);
+            });
         }
 
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/DelayDirectExchange_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/DelayDirectExchange_Specs.cs
@@ -96,9 +96,12 @@ namespace MassTransit.RabbitMqTransport.Tests
                 Priority = "Low"
             });
 
-            Assert.That(await harness.Consumed.Any<TextMessage>(x => x.Context.Message.Text == "High Priority"), Is.True, "High");
-            Assert.That(await harness.Consumed.Any<TextMessage>(x => x.Context.Message.Text == "Low Priority 1"), Is.True, "Low 1");
-            Assert.That(await harness.Consumed.Any<TextMessage>(x => x.Context.Message.Text == "Low Priority 2"), Is.True, "Low 2");
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.Any<TextMessage>(x => x.Context.Message.Text == "High Priority"), Is.True, "High");
+                Assert.That(await harness.Consumed.Any<TextMessage>(x => x.Context.Message.Text == "Low Priority 1"), Is.True, "Low 1");
+                Assert.That(await harness.Consumed.Any<TextMessage>(x => x.Context.Message.Text == "Low Priority 2"), Is.True, "Low 2");
+            });
         }
     }
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/DelayRetry_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/DelayRetry_Specs.cs
@@ -21,7 +21,7 @@
 
             ConsumeContext<PingMessage> context = await _received.Task;
 
-            Assert.GreaterOrEqual(_receivedTimeSpan, TimeSpan.FromSeconds(1));
+            Assert.That(_receivedTimeSpan, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;
@@ -169,8 +169,11 @@
             ConsumeContext<Fault<PingMessage>> pingFaultContext = await pingFault;
             ConsumeContext<Fault<PongMessage>> pongFaultContext = await pongFault;
 
-            Assert.That(_consumer.PingCount, Is.EqualTo(3));
-            Assert.That(_consumer.PongCount, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_consumer.PingCount, Is.EqualTo(3));
+                Assert.That(_consumer.PongCount, Is.EqualTo(3));
+            });
         }
 
         Consumer _consumer;
@@ -375,7 +378,7 @@
 
             await _received.Task;
 
-            Assert.IsTrue(_hit);
+            Assert.That(_hit, Is.True);
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>> _received;

--- a/tests/MassTransit.RabbitMqTransport.Tests/EndpointConfiguration_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/EndpointConfiguration_Specs.cs
@@ -3,7 +3,6 @@ namespace MassTransit.RabbitMqTransport.Tests
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using MassTransit.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Logging;
@@ -11,6 +10,7 @@ namespace MassTransit.RabbitMqTransport.Tests
     using NUnit.Framework;
     using TestFramework;
     using TestFramework.Messages;
+    using Testing;
 
 
     [TestFixture]
@@ -42,9 +42,12 @@ namespace MassTransit.RabbitMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -73,9 +76,12 @@ namespace MassTransit.RabbitMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(120));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -104,9 +110,12 @@ namespace MassTransit.RabbitMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetConcurrentMessageLimit(probe, 0), Is.EqualTo(100));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -135,8 +144,11 @@ namespace MassTransit.RabbitMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
 
             await provider.DisposeAsync();
         }
@@ -157,8 +169,11 @@ namespace MassTransit.RabbitMqTransport.Tests
             var jsonString = busControl.GetProbeResult().ToJsonString();
             var probe = JObject.Parse(jsonString);
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(351));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
         }
 
         [Test]
@@ -190,8 +205,11 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             var probe = JObject.Parse(busControl.GetProbeResult().ToJsonString());
 
-            Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
-            Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPrefetchCount(probe, 0), Is.EqualTo(427));
+                Assert.That(GetPrefetchCount(probe, 1), Is.EqualTo(427));
+            });
         }
 
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/ExcludeTopology_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ExcludeTopology_Specs.cs
@@ -20,8 +20,11 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<TransactionEvent> context = await _handled;
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
 
             var settings = GetHostSettings();
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/JobConsumer_Specs.cs
@@ -66,12 +66,15 @@ namespace MassTransit.RabbitMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -100,12 +103,15 @@ namespace MassTransit.RabbitMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             IRequestClient<GetJobState> stateClient = harness.GetRequestClient<GetJobState>();
 
@@ -115,8 +121,11 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
-            Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
-            Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            });
 
             jobState = await stateClient.GetResponse<JobState>(new { JobId = jobId });
 
@@ -145,21 +154,30 @@ namespace MassTransit.RabbitMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
-            Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
-            Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            });
 
             await harness.Bus.Publish<RetryJob>(new { JobId = jobId });
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             await harness.Stop();
         }
@@ -194,11 +212,14 @@ namespace MassTransit.RabbitMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(x => x.Context.Message.JobId == jobId), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobSubmitted>(x => x.Context.Message.JobId == jobId), Is.True);
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Sent.Any<JobSlotWaitElapsed>(x => x.Context.Message.JobId == jobId), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotWaitElapsed>(x => x.Context.Message.JobId == jobId), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -230,15 +251,18 @@ namespace MassTransit.RabbitMqTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(1) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             await harness.Stop();
         }
@@ -255,13 +279,16 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await harness.Bus.Publish<OddJob>(new { Duration = TimeSpan.FromSeconds(1) });
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             IPublishedMessage<JobCompleted> publishedMessage = await harness.Published.SelectAsync<JobCompleted>().First();
             Assert.That(publishedMessage.Context.Message.JobId, Is.Not.EqualTo(Guid.Empty));

--- a/tests/MassTransit.RabbitMqTransport.Tests/KillSwitch_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/KillSwitch_Specs.cs
@@ -3,9 +3,9 @@ namespace MassTransit.RabbitMqTransport.Tests
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using MassTransit.Testing;
     using NUnit.Framework;
     using TestFramework;
+    using Testing;
 
 
     [Category("Flaky")]
@@ -20,11 +20,14 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await Task.WhenAll(Enumerable.Range(0, 11).Select(x => Bus.Publish(new BadMessage())));
 
-            Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Degraded, TimeSpan.FromSeconds(15)), Is.EqualTo(BusHealthStatus.Degraded));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Degraded, TimeSpan.FromSeconds(15)), Is.EqualTo(BusHealthStatus.Degraded));
 
-            Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Healthy, TimeSpan.FromSeconds(10)), Is.EqualTo(BusHealthStatus.Healthy));
+                Assert.That(await BusControl.WaitForHealthStatus(BusHealthStatus.Healthy, TimeSpan.FromSeconds(10)), Is.EqualTo(BusHealthStatus.Healthy));
 
-            Assert.That(await RabbitMqTestHarness.Consumed.SelectAsync<BadMessage>().Take(11).Count(), Is.EqualTo(11));
+                Assert.That(await RabbitMqTestHarness.Consumed.SelectAsync<BadMessage>().Take(11).Count(), Is.EqualTo(11));
+            });
 
             await Task.WhenAll(Enumerable.Range(0, 20).Select(x => Bus.Publish(new GoodMessage())));
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/PriorityQueue_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/PriorityQueue_Specs.cs
@@ -2,11 +2,11 @@
 {
     using System;
     using System.Threading.Tasks;
-    using MassTransit.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
     using RabbitMQ.Client;
     using TestFramework.Messages;
+    using Testing;
 
 
     [TestFixture]
@@ -118,8 +118,11 @@
 
             Assert.That(message, Is.Not.Null);
 
-            Assert.That(message.Context.TryGetPayload<RabbitMqBasicConsumeContext>(out var rmqContext), Is.True);
-            Assert.That(rmqContext.Properties.Priority, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Context.TryGetPayload<RabbitMqBasicConsumeContext>(out var rmqContext), Is.True);
+                Assert.That(rmqContext.Properties.Priority, Is.EqualTo(3));
+            });
         }
 
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/RabbitMqAddress_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/RabbitMqAddress_Specs.cs
@@ -221,8 +221,11 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             var address = new RabbitMqEndpointAddress(hostAddress, new Uri("rabbitmq://remote-host/production/client/input-queue"));
 
-            Assert.That(address.VirtualHost, Is.EqualTo("production/client"));
-            Assert.That(address.Name, Is.EqualTo("input-queue"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.VirtualHost, Is.EqualTo("production/client"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+            });
 
             Uri uri = address;
 
@@ -236,9 +239,12 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             var address = new RabbitMqEndpointAddress(hostAddress, new Uri("rabbitmq://remote-host/input-queue"));
 
-            Assert.That(address.VirtualHost, Is.EqualTo("/"));
-            Assert.That(address.Name, Is.EqualTo("input-queue"));
-            Assert.That(address.Port, Is.EqualTo(5672));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.VirtualHost, Is.EqualTo("/"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+                Assert.That(address.Port, Is.EqualTo(5672));
+            });
 
             Uri uri = address;
 
@@ -252,8 +258,11 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             var address = new RabbitMqEndpointAddress(hostAddress, new Uri("rabbitmq://remote-host/production%2Fclient/input-queue"));
 
-            Assert.That(address.VirtualHost, Is.EqualTo("production/client"));
-            Assert.That(address.Name, Is.EqualTo("input-queue"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.VirtualHost, Is.EqualTo("production/client"));
+                Assert.That(address.Name, Is.EqualTo("input-queue"));
+            });
 
             Uri uri = address;
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/RawJson_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/RawJson_Specs.cs
@@ -183,21 +183,24 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<Command> context = await _handled;
 
-            Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonRawMessageSerializer.JsonContentType),
-                $"unexpected content-type {context.ReceiveContext.ContentType}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(SystemTextJsonRawMessageSerializer.JsonContentType),
+                    $"unexpected content-type {context.ReceiveContext.ContentType}");
 
-            Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
-            Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+                Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
+                Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
 
-            Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(headerValue));
+                Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(headerValue));
 
-            Assert.IsTrue(context.MessageId.HasValue);
-            Assert.IsTrue(context.ConversationId.HasValue);
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.IsTrue(context.SentTime.HasValue);
-            Assert.IsNotNull(context.DestinationAddress);
-            Assert.IsNotNull(context.Host);
-            Assert.That(context.SupportedMessageTypes.Count(), Is.EqualTo(1));
+                Assert.That(context.MessageId.HasValue, Is.True);
+                Assert.That(context.ConversationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.SentTime.HasValue, Is.True);
+                Assert.That(context.DestinationAddress, Is.Not.Null);
+                Assert.That(context.Host, Is.Not.Null);
+                Assert.That(context.SupportedMessageTypes.Count(), Is.EqualTo(1));
+            });
         }
 
         Task<ConsumeContext<Command>> _handled;
@@ -257,12 +260,15 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<PingMessage> context = await _handled;
 
-            Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(NewtonsoftJsonMessageSerializer.JsonContentType),
-                $"unexpected content-type {context.ReceiveContext.ContentType}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(NewtonsoftJsonMessageSerializer.JsonContentType),
+                    $"unexpected content-type {context.ReceiveContext.ContentType}");
 
-            Assert.That(context.Message.CorrelationId, Is.EqualTo(message.CommandId));
+                Assert.That(context.Message.CorrelationId, Is.EqualTo(message.CommandId));
 
-            Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(default));
+                Assert.That(context.Headers.Get<string>(headerName), Is.EqualTo(default));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;

--- a/tests/MassTransit.RabbitMqTransport.Tests/Reconnecting_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/Reconnecting_Specs.cs
@@ -3,9 +3,9 @@
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using MassTransit.Testing;
     using NUnit.Framework;
     using TestFramework.Messages;
+    using Testing;
     using Transports;
 
 
@@ -20,7 +20,7 @@
             await Bus.Publish(new ReconnectMessage { Value = "Before" });
 
             var beforeFound = await Task.Run(() => _consumer.Received.Select<ReconnectMessage>(x => x.Context.Message.Value == "Before").Any());
-            Assert.IsTrue(beforeFound);
+            Assert.That(beforeFound, Is.True);
 
             Console.WriteLine("Okay, restart RabbitMQ");
 
@@ -51,7 +51,7 @@
             await Bus.Publish(new ReconnectMessage { Value = "After" });
 
             var afterFound = await Task.Run(() => _consumer.Received.Select<ReconnectMessage>(x => x.Context.Message.Value == "After").Any());
-            Assert.IsTrue(afterFound);
+            Assert.That(afterFound, Is.True);
         }
 
         public Reconnecting_Specs()

--- a/tests/MassTransit.RabbitMqTransport.Tests/Retry_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/Retry_Specs.cs
@@ -30,7 +30,7 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await InactivityTask;
 
-            Assert.LessOrEqual(_attempts[pingId], _limit + 1);
+            Assert.That(_attempts[pingId], Is.LessThanOrEqualTo(_limit + 1));
         }
 
         readonly int _limit;
@@ -92,7 +92,7 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await InactivityTask;
 
-            Assert.LessOrEqual(_attempts[pingId], _limit + 1);
+            Assert.That(_attempts[pingId], Is.LessThanOrEqualTo(_limit + 1));
         }
 
         readonly int _limit;
@@ -140,7 +140,7 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await InactivityTask;
 
-            Assert.LessOrEqual(_attempts[pingId], _limit + 1);
+            Assert.That(_attempts[pingId], Is.LessThanOrEqualTo(_limit + 1));
         }
 
         readonly int _limit;
@@ -188,7 +188,7 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await InactivityTask;
 
-            Assert.LessOrEqual(_attempts[pingId], _limit + 1);
+            Assert.That(_attempts[pingId], Is.LessThanOrEqualTo(_limit + 1));
         }
 
         readonly int _limit;
@@ -234,7 +234,7 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             await InactivityTask;
 
-            Assert.LessOrEqual(_attempts[pingId], _limit + 1);
+            Assert.That(_attempts[pingId], Is.LessThanOrEqualTo(_limit + 1));
         }
 
         readonly int _limit;

--- a/tests/MassTransit.RabbitMqTransport.Tests/ScheduleMessage_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ScheduleMessage_Specs.cs
@@ -3,9 +3,10 @@
     using System;
     using System.Diagnostics;
     using System.Threading.Tasks;
-    using MassTransit.Internals;
+    using Internals;
     using NUnit.Framework;
     using RabbitMQ.Client;
+
 
     public class ScheduleMessage_Specs :
         RabbitMqTestFixture
@@ -117,8 +118,11 @@
 
             ConsumeContext<SecondMessage> consumeContext = await _second;
 
-            Assert.That(consumeContext.Headers.TryGetHeader("Super-Fun", out var headerValue), Is.True);
-            Assert.That(headerValue, Is.EqualTo("Super Fun!"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consumeContext.Headers.TryGetHeader("Super-Fun", out var headerValue), Is.True);
+                Assert.That(headerValue, Is.EqualTo("Super Fun!"));
+            });
         }
 
         protected override void ConfigureRabbitMqBus(IRabbitMqBusFactoryConfigurator configurator)
@@ -191,6 +195,7 @@
         }
     }
 
+
     public class Should_schedule_in_direct_exchange_type :
         Should_schedule_in_any_exchange_type
     {
@@ -199,6 +204,7 @@
         {
         }
     }
+
 
     public class Should_schedule_in_fanout_exchange_type :
         Should_schedule_in_any_exchange_type
@@ -209,6 +215,7 @@
         }
     }
 
+
     public class Should_schedule_in_headers_exchange_type :
         Should_schedule_in_any_exchange_type
     {
@@ -217,6 +224,7 @@
         {
         }
     }
+
 
     public class Should_schedule_in_topic_exchange_type :
         Should_schedule_in_any_exchange_type
@@ -227,20 +235,21 @@
         }
     }
 
+
     public abstract class Should_schedule_in_any_exchange_type :
         RabbitMqTestFixture
     {
         private readonly string _exchangeType;
+
+        Task<ConsumeContext<FirstMessage>> _first;
+
+        Task<ConsumeContext<SecondMessage>> _second;
 
         protected Should_schedule_in_any_exchange_type(string exchangeType)
             : base(inputQueueName: $"input_queue_{exchangeType}")
         {
             _exchangeType = exchangeType;
         }
-
-        Task<ConsumeContext<FirstMessage>> _first;
-
-        Task<ConsumeContext<SecondMessage>> _second;
 
         [Test]
         public async Task Should_get_both_messages()
@@ -262,6 +271,7 @@
         {
             configurator.UseDelayedMessageScheduler();
         }
+
         protected override void ConfigureRabbitMqReceiveEndpoint(IRabbitMqReceiveEndpointConfigurator configurator)
         {
             configurator.ExchangeType = _exchangeType;

--- a/tests/MassTransit.RabbitMqTransport.Tests/SendObserver_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/SendObserver_Specs.cs
@@ -195,8 +195,11 @@
 
                     await observer.PreSent;
                     await observer.SendFaulted;
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    });
                 }
             }
 
@@ -211,8 +214,11 @@
                     await observer.PreSent;
                     await observer.PostSent;
 
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    });
                 }
             }
 
@@ -226,8 +232,11 @@
 
                     await observer.PreSent;
 
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    });
                 }
             }
 
@@ -244,9 +253,12 @@
 
                     observer.PostSent.Status.ShouldBe(TaskStatus.WaitingForActivation);
 
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.PostSentCount, Is.EqualTo(0));
-                    Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.PostSentCount, Is.EqualTo(0));
+                        Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    });
                 }
             }
         }

--- a/tests/MassTransit.RabbitMqTransport.Tests/TestHarnessOptions_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/TestHarnessOptions_Specs.cs
@@ -2,9 +2,9 @@ namespace MassTransit.RabbitMqTransport.Tests
 {
     using System.Threading.Tasks;
     using HarnessContracts;
-    using MassTransit.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
+    using Testing;
 
 
     [TestFixture]
@@ -42,9 +42,12 @@ namespace MassTransit.RabbitMqTransport.Tests
                 OrderNumber = "123"
             });
 
-            Assert.IsTrue(await harness.Sent.Any<OrderSubmitted>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Sent.Any<OrderSubmitted>(), Is.True);
 
-            Assert.IsTrue(await harness.Consumed.Any<SubmitOrder>());
+                Assert.That(await harness.Consumed.Any<SubmitOrder>(), Is.True);
+            });
 
             IReceivedMessage<SubmitOrder> message = await harness.Consumed.SelectAsync<SubmitOrder>().First();
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/TopologyCorrelationId_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/TopologyCorrelationId_Specs.cs
@@ -19,8 +19,11 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<OtherMessage> otherContext = await _otherHandled;
 
-            Assert.IsTrue(otherContext.CorrelationId.HasValue);
-            Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(otherContext.CorrelationId.HasValue, Is.True);
+                Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
         }
 
         Task<ConsumeContext<OtherMessage>> _otherHandled;
@@ -43,11 +46,6 @@ namespace MassTransit.RabbitMqTransport.Tests
     public class When_using_named_legacy_config :
         RabbitMqTestFixture
     {
-        public When_using_named_legacy_config()
-        {
-            MessageCorrelation.UseCorrelationId<LegacyMessage>(x => x.TransactionId);
-        }
-
         [Test]
         public async Task Should_handle_named_configured_legacy()
         {
@@ -57,8 +55,16 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<LegacyMessage> legacyContext = await _legacyHandled;
 
-            Assert.IsTrue(legacyContext.CorrelationId.HasValue);
-            Assert.That(legacyContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(legacyContext.CorrelationId.HasValue, Is.True);
+                Assert.That(legacyContext.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
+        }
+
+        public When_using_named_legacy_config()
+        {
+            MessageCorrelation.UseCorrelationId<LegacyMessage>(x => x.TransactionId);
         }
 
         Task<ConsumeContext<LegacyMessage>> _legacyHandled;
@@ -90,8 +96,11 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<INewUserEvent> context = await _handled;
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+            });
         }
 
         Task<ConsumeContext<INewUserEvent>> _handled;

--- a/tests/MassTransit.RabbitMqTransport.Tests/TopologyRoutingKey_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/TopologyRoutingKey_Specs.cs
@@ -18,11 +18,14 @@ namespace MassTransit.RabbitMqTransport.Tests
 
             ConsumeContext<IRoutedEvent> context = await _handled;
 
-            Assert.IsTrue(context.CorrelationId.HasValue);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
 
-            Assert.IsTrue(context.TryGetPayload<RabbitMqBasicConsumeContext>(out var basicConsumeContext));
-            Assert.That(basicConsumeContext.RoutingKey, Is.EqualTo(transactionId.ToString()));
+                Assert.That(context.TryGetPayload<RabbitMqBasicConsumeContext>(out var basicConsumeContext), Is.True);
+                Assert.That(basicConsumeContext.RoutingKey, Is.EqualTo(transactionId.ToString()));
+            });
         }
 
         Task<ConsumeContext<IRoutedEvent>> _handled;

--- a/tests/MassTransit.RedisIntegration.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.RedisIntegration.Tests/JobConsumer_Specs.cs
@@ -91,13 +91,16 @@ namespace MassTransit.RedisIntegration.Tests
                     Job = new { Duration = TimeSpan.FromSeconds(1) }
                 });
 
-                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.Multiple(async () =>
+                {
+                    Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
 
-                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                    Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                });
             }
             finally
             {

--- a/tests/MassTransit.SignalR.Tests/HubLifeTimeManagerTests.cs
+++ b/tests/MassTransit.SignalR.Tests/HubLifeTimeManagerTests.cs
@@ -18,7 +18,7 @@
             Assert.Multiple(() =>
             {
                 Assert.That(message.Target, Is.EqualTo("Hello"));
-                Assert.That(message.Arguments.Length, Is.EqualTo(1));
+                Assert.That(message.Arguments, Has.Length.EqualTo(1));
             });
             Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
         }
@@ -51,7 +51,7 @@
                 Assert.Multiple(() =>
                 {
                     Assert.That(message.Target, Is.EqualTo("Hello"));
-                    Assert.That(message.Arguments.Length, Is.EqualTo(1));
+                    Assert.That(message.Arguments, Has.Length.EqualTo(1));
                 });
                 Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
 
@@ -60,7 +60,7 @@
                 Assert.Multiple(() =>
                 {
                     Assert.That(message.Target, Is.EqualTo("Hello"));
-                    Assert.That(message.Arguments.Length, Is.EqualTo(1));
+                    Assert.That(message.Arguments, Has.Length.EqualTo(1));
                 });
                 Assert.That(message.Arguments[0].ToString(), Is.EqualTo("World"));
             }
@@ -123,7 +123,7 @@
 
                 await manager.SendGroupAsync("group", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(BackplaneHarness.Group.Consumed.Select<Group<MyHub>>().Any());
+                Assert.That(BackplaneHarness.Group.Consumed.Select<Group<MyHub>>().Any(), Is.True);
 
                 var message = client1.TryRead() as InvocationMessage;
                 Assert.That(message, Is.Not.Null);
@@ -166,7 +166,7 @@
 
                 await Task.Delay(2000);
 
-                Assert.Null(client.TryRead());
+                Assert.That(client.TryRead(), Is.Null);
             }
         }
 
@@ -183,8 +183,8 @@
 
                 await manager.RemoveFromGroupAsync(connection.ConnectionId, "name").OrTimeout(Harness.TestTimeout);
 
-                Assert.IsFalse(BackplaneHarness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>()
-                    .Any()); // Should not have published, because connection was local
+                Assert.That(BackplaneHarness.GroupManagement.Consumed.Select<GroupManagement<MyHub>>()
+                    .Any(), Is.False); // Should not have published, because connection was local
             }
         }
 
@@ -205,7 +205,7 @@
                 await manager.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
                 await AssertMessageAsync(client);
-                Assert.Null(client.TryRead());
+                Assert.That(client.TryRead(), Is.Null);
             }
         }
 

--- a/tests/MassTransit.SignalR.Tests/ScaleoutHubLifetimeManagerTests.cs
+++ b/tests/MassTransit.SignalR.Tests/ScaleoutHubLifetimeManagerTests.cs
@@ -41,8 +41,11 @@
 
                 await manager1.SendAllAsync("Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.All.Consumed.Select<All<MyHub>>().Any());
-                Assert.IsTrue(Backplane2Harness.All.Consumed.Select<All<MyHub>>().Any());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(Backplane1Harness.All.Consumed.Select<All<MyHub>>().Any(), Is.True);
+                    Assert.That(Backplane2Harness.All.Consumed.Select<All<MyHub>>().Any(), Is.True);
+                });
 
                 await AssertMessageAsync(client1);
                 await AssertMessageAsync(client2);
@@ -70,7 +73,7 @@
 
                 await AssertMessageAsync(client1);
 
-                Assert.Null(client2.TryRead());
+                Assert.That(client2.TryRead(), Is.Null);
             }
         }
 
@@ -88,7 +91,7 @@
 
                 await manager2.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.Connection.Consumed.Select<Connection<MyHub>>().Any());
+                Assert.That(Backplane1Harness.Connection.Consumed.Select<Connection<MyHub>>().Any(), Is.True);
 
                 await AssertMessageAsync(client);
             }
@@ -110,7 +113,7 @@
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any());
+                Assert.That(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any(), Is.True);
 
                 await AssertMessageAsync(client);
             }
@@ -164,7 +167,7 @@
 
                 await manager2.SendGroupAsync("name", "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any());
+                Assert.That(Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().Any(), Is.True);
 
                 await AssertMessageAsync(client);
             }
@@ -222,7 +225,7 @@
 
                 IReceivedMessage<Group<MyHub>> firstMessage = Backplane1Harness.Group.Consumed.Select<Group<MyHub>>().FirstOrDefault();
 
-                Assert.NotNull(firstMessage);
+                Assert.That(firstMessage, Is.Not.Null);
 
                 await AssertMessageAsync(client);
 
@@ -291,7 +294,7 @@
                 // And once that happens there is no way to know if the invocation was successful or not.
                 await manager1.SendConnectionAsync(connectionMock.ConnectionId, "Hello", new object[] { "World" }).OrTimeout(Harness.TestTimeout);
 
-                Assert.IsTrue(Backplane2Harness.Connection.Consumed.Select<Connection<MyHub>>().Any());
+                Assert.That(Backplane2Harness.Connection.Consumed.Select<Connection<MyHub>>().Any(), Is.True);
             }
         }
     }

--- a/tests/MassTransit.SqlTransport.Tests/BusOutbox_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/BusOutbox_Specs.cs
@@ -73,7 +73,7 @@ namespace MassTransit.DbTransport.Tests
                     Assert.That(await consumerHarness.Consumed.Any<PingMessage>(cts.Token), Is.False);
 
                     await dbContext.SaveChangesAsync(harness.CancellationToken);
-                    
+
                     await transaction.CommitAsync();
                 }
 
@@ -81,10 +81,13 @@ namespace MassTransit.DbTransport.Tests
 
                 IReceivedMessage<PingMessage> context = harness.Consumed.Select<PingMessage>().First();
 
-                Assert.That(context.Context.MessageId, Is.Not.Null);
-                Assert.That(context.Context.ConversationId, Is.Not.Null);
-                Assert.That(context.Context.DestinationAddress, Is.Not.Null);
-                Assert.That(context.Context.SourceAddress, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.Context.MessageId, Is.Not.Null);
+                    Assert.That(context.Context.ConversationId, Is.Not.Null);
+                    Assert.That(context.Context.DestinationAddress, Is.Not.Null);
+                    Assert.That(context.Context.SourceAddress, Is.Not.Null);
+                });
             }
             finally
             {
@@ -135,7 +138,7 @@ namespace MassTransit.DbTransport.Tests
 
             foreach (var entity in modelBuilder.Model.GetEntityTypes())
             {
-            #pragma warning disable EF1001
+                #pragma warning disable EF1001
                 if (entity is EntityType { IsImplicitlyCreatedJoinEntityType: true })
                     continue;
 

--- a/tests/MassTransit.SqlTransport.Tests/DelayedDelivery_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/DelayedDelivery_Specs.cs
@@ -44,7 +44,7 @@ public class Using_delayed_send<T>
 
         await endpoint.Send(testMessage, x => x.Delay = TimeSpan.FromSeconds(3));
 
-        Assert.IsTrue(await harness.Consumed.Any<TestMessage>(x => x.Context.Message.Id == testMessage.Id));
+        Assert.That(await harness.Consumed.Any<TestMessage>(x => x.Context.Message.Id == testMessage.Id), Is.True);
 
         var then = DateTime.UtcNow;
 
@@ -92,7 +92,7 @@ public class Using_delayed_publish<T>
 
         await harness.Bus.Publish(testMessage, x => x.Delay = TimeSpan.FromSeconds(3));
 
-        Assert.IsTrue(await harness.Consumed.Any<TestMessage>(x => x.Context.Message.Id == testMessage.Id));
+        Assert.That(await harness.Consumed.Any<TestMessage>(x => x.Context.Message.Id == testMessage.Id), Is.True);
 
         var then = DateTime.UtcNow;
 

--- a/tests/MassTransit.SqlTransport.Tests/Fault_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/Fault_Specs.cs
@@ -13,6 +13,35 @@ namespace MassTransit.DbTransport.Tests
     public class When_a_consumer_throws_an_exception
     {
         [Test, Explicit]
+        public async Task Should_dead_letter_skipped_messages()
+        {
+            await using var provider = new ServiceCollection()
+                .ConfigurePostgresTransport()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.UsingPostgres((context, cfg) =>
+                    {
+                        cfg.ReceiveEndpoint("input-queue", e =>
+                        {
+                            e.PollingInterval = TimeSpan.FromSeconds(.5);
+                            e.ConfigureConsumeTopology = false;
+                        });
+                    });
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+
+            await harness.Start();
+
+            var endpoint = await harness.Bus.GetSendEndpoint(new Uri("queue:input-queue"));
+
+            await endpoint.Send(new TestMessage("Hello, World!"));
+
+            await Task.Delay(2000);
+        }
+
+        [Test, Explicit]
         public async Task Should_publish_fault_and_move_to_the_error_queue()
         {
             await using var provider = new ServiceCollection()
@@ -41,7 +70,7 @@ namespace MassTransit.DbTransport.Tests
                 Address = "123 American Way"
             });
 
-            Assert.IsTrue(await harness.Consumed.Any<Fault<MemberUpdateCommand>>());
+            Assert.That(await harness.Consumed.Any<Fault<MemberUpdateCommand>>(), Is.True);
         }
 
         [Test, Explicit]
@@ -79,38 +108,9 @@ namespace MassTransit.DbTransport.Tests
                 Address = "123 American Way"
             });
 
-            Assert.IsTrue(await harness.Consumed.Any<Fault<MemberUpdateCommand>>());
-            
+            Assert.That(await harness.Consumed.Any<Fault<MemberUpdateCommand>>(), Is.True);
+
             await harness.Stop();
-        }
-
-        [Test, Explicit]
-        public async Task Should_dead_letter_skipped_messages()
-        {
-            await using var provider = new ServiceCollection()
-                .ConfigurePostgresTransport()
-                .AddMassTransitTestHarness(x =>
-                {
-                    x.UsingPostgres((context, cfg) =>
-                    {
-                        cfg.ReceiveEndpoint("input-queue", e =>
-                        {
-                            e.PollingInterval = TimeSpan.FromSeconds(.5);
-                            e.ConfigureConsumeTopology = false;
-                        });
-                    });
-                })
-                .BuildServiceProvider(true);
-
-            var harness = provider.GetTestHarness();
-
-            await harness.Start();
-
-            var endpoint = await harness.Bus.GetSendEndpoint(new Uri("queue:input-queue"));
-
-            await endpoint.Send(new TestMessage("Hello, World!"));
-
-            await Task.Delay(2000);
         }
     }
 

--- a/tests/MassTransit.SqlTransport.Tests/JobConsumer_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/JobConsumer_Specs.cs
@@ -70,12 +70,15 @@ namespace MassTransit.DbTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -104,12 +107,15 @@ namespace MassTransit.DbTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             IRequestClient<GetJobState> stateClient = harness.GetRequestClient<GetJobState>();
 
@@ -119,8 +125,11 @@ namespace MassTransit.DbTransport.Tests
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
-            Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
-            Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            });
 
             jobState = await stateClient.GetResponse<JobState>(new { JobId = jobId });
 
@@ -149,23 +158,32 @@ namespace MassTransit.DbTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
-            Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
-            Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCanceled>(), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotReleased>(), Is.True);
+            });
 
             await Task.Delay(500);
 
             await harness.Bus.Publish<RetryJob>(new { JobId = jobId });
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             await harness.Stop();
         }
@@ -200,11 +218,14 @@ namespace MassTransit.DbTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(10) }
             });
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(x => x.Context.Message.JobId == jobId), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobSubmitted>(x => x.Context.Message.JobId == jobId), Is.True);
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Sent.Any<JobSlotWaitElapsed>(x => x.Context.Message.JobId == jobId), Is.True);
+                Assert.That(await harness.Sent.Any<JobSlotWaitElapsed>(x => x.Context.Message.JobId == jobId), Is.True);
+            });
 
             await harness.Bus.Publish<CancelJob>(new { JobId = jobId });
 
@@ -236,15 +257,18 @@ namespace MassTransit.DbTransport.Tests
                 Job = new { Duration = TimeSpan.FromSeconds(1) }
             });
 
-            Assert.That(response.Message.JobId, Is.EqualTo(jobId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.JobId, Is.EqualTo(jobId));
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             await harness.Stop();
         }
@@ -261,13 +285,16 @@ namespace MassTransit.DbTransport.Tests
 
             await harness.Bus.Publish<OddJob>(new { Duration = TimeSpan.FromSeconds(1) });
 
-            Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.Any<JobSubmitted>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobStarted<OddJob>>(), Is.True);
 
-            Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
-            Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted>(), Is.True);
+                Assert.That(await harness.Published.Any<JobCompleted<OddJob>>(), Is.True);
+            });
 
             IPublishedMessage<JobCompleted> publishedMessage = await harness.Published.SelectAsync<JobCompleted>().First();
             Assert.That(publishedMessage.Context.Message.JobId, Is.Not.EqualTo(Guid.Empty));

--- a/tests/MassTransit.SqlTransport.Tests/PartitionKey_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/PartitionKey_Specs.cs
@@ -52,7 +52,7 @@ public class Using_partition_keys<T>
         await provider.GetTask<ConsumeContext<PartitionedTestMessage>>();
 
         IList<IReceivedMessage<PartitionedTestMessage>> receivedMessages = await harness.Consumed.SelectAsync<PartitionedTestMessage>().ToListAsync();
-        Assert.That(receivedMessages.Count, Is.EqualTo(MessageLimit));
+        Assert.That(receivedMessages, Has.Count.EqualTo(MessageLimit));
         var result = new int[NumKeys];
 
         foreach (IReceivedMessage<PartitionedTestMessage> receivedMessage in receivedMessages)

--- a/tests/MassTransit.SqlTransport.Tests/PgSql/PortAddress_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/PgSql/PortAddress_Specs.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using SqlTransport.PostgreSql;
 
+
 [TestFixture]
 public class PortAddress_Specs
 {
@@ -34,7 +35,7 @@ public class PortAddress_Specs
 
         var connection = PostgresSqlTransportConnection.GetDatabaseConnection(provider.GetRequiredService<IOptions<SqlTransportOptions>>().Value);
 
-        Assert.That(connection.Connection.ConnectionString.Contains("Port=5544"));
+        Assert.That(connection.Connection.ConnectionString, Does.Contain("Port=5544"));
     }
 
     [Test]
@@ -61,6 +62,6 @@ public class PortAddress_Specs
 
         var connection = PostgresSqlTransportConnection.GetDatabaseConnection(provider.GetRequiredService<IOptions<SqlTransportOptions>>().Value);
 
-        Assert.That(connection.Connection.ConnectionString.Contains("Port="), Is.False);
+        Assert.That(connection.Connection.ConnectionString, Does.Not.Contain("Port="));
     }
 }

--- a/tests/MassTransit.SqlTransport.Tests/RenewLock_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/RenewLock_Specs.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using Testing;
 using UnitTests;
 
+
 [Explicit]
 [TestFixture(typeof(PostgresDatabaseTestConfiguration))]
 [TestFixture(typeof(SqlServerDatabaseTestConfiguration))]
@@ -33,7 +34,7 @@ public class Using_a_slow_consumer<T>
 
         await harness.Bus.Publish(new SlowMessage());
 
-        Assert.IsTrue(await harness.Consumed.Any<SlowMessage>());
+        Assert.That(await harness.Consumed.Any<SlowMessage>(), Is.True);
     }
 
     readonly T _configuration;

--- a/tests/MassTransit.SqlTransport.Tests/SqlServer/InstanceName_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/SqlServer/InstanceName_Specs.cs
@@ -40,34 +40,6 @@ public class InstanceName_Specs
     }
 
     [Test]
-    public async Task Should_include_the_instance_name_and_start()
-    {
-        await using var provider = new ServiceCollection()
-            .AddMassTransitTestHarness(x =>
-            {
-                x.AddOptions<SqlTransportOptions>().Configure(options =>
-                {
-                    options.Host = "localhost\\instance";
-                    options.Database = "masstransit_transport_tests";
-                    options.Schema = "transport";
-                    options.Role = "transport";
-                    options.Username = "unit_tests";
-                    options.Password = "H4rd2Gu3ss!";
-                    options.AdminUsername = "sa";
-                    options.AdminPassword = "Password12!";
-                });
-
-                x.UsingSqlServer();
-            })
-            .BuildServiceProvider(true);
-
-        var harness = await provider.StartTestHarness();
-
-        Assert.That(harness.Bus.Address.GetLeftPart(UriPartial.Authority), Is.EqualTo("db://localhost"));
-        Assert.That(harness.Bus.Address.Query, Is.EqualTo("?autodelete=300&instance=instance"));
-    }
-
-    [Test]
     public async Task Should_include_the_instance_name_and_port_and_start()
     {
         await using var provider = new ServiceCollection()
@@ -92,12 +64,46 @@ public class InstanceName_Specs
 
         var harness = await provider.StartTestHarness();
 
-        Assert.That(harness.Bus.Address.Host, Is.EqualTo("localhost"));
-        Assert.That(harness.Bus.Address.Port, Is.EqualTo(3381));
-        Assert.That(harness.Bus.Address.Query, Is.EqualTo("?autodelete=300&instance=instance"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(harness.Bus.Address.Host, Is.EqualTo("localhost"));
+            Assert.That(harness.Bus.Address.Port, Is.EqualTo(3381));
+            Assert.That(harness.Bus.Address.Query, Is.EqualTo("?autodelete=300&instance=instance"));
+        });
 
         var connection = SqlServerSqlTransportConnection.GetDatabaseConnection(provider.GetRequiredService<IOptions<SqlTransportOptions>>().Value);
 
         Assert.That(connection.Connection.ConnectionString, Contains.Substring("Data Source=localhost\\instance,3381"));
+    }
+
+    [Test]
+    public async Task Should_include_the_instance_name_and_start()
+    {
+        await using var provider = new ServiceCollection()
+            .AddMassTransitTestHarness(x =>
+            {
+                x.AddOptions<SqlTransportOptions>().Configure(options =>
+                {
+                    options.Host = "localhost\\instance";
+                    options.Database = "masstransit_transport_tests";
+                    options.Schema = "transport";
+                    options.Role = "transport";
+                    options.Username = "unit_tests";
+                    options.Password = "H4rd2Gu3ss!";
+                    options.AdminUsername = "sa";
+                    options.AdminPassword = "Password12!";
+                });
+
+                x.UsingSqlServer();
+            })
+            .BuildServiceProvider(true);
+
+        var harness = await provider.StartTestHarness();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(harness.Bus.Address.GetLeftPart(UriPartial.Authority), Is.EqualTo("db://localhost"));
+            Assert.That(harness.Bus.Address.Query, Is.EqualTo("?autodelete=300&instance=instance"));
+        });
     }
 }

--- a/tests/MassTransit.SqlTransport.Tests/SqlServer/PortAddress_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/SqlServer/PortAddress_Specs.cs
@@ -34,7 +34,7 @@ public class PortAddress_Specs
 
         var connection = SqlServerSqlTransportConnection.GetDatabaseConnection(provider.GetRequiredService<IOptions<SqlTransportOptions>>().Value);
 
-        Assert.That(connection.Connection.ConnectionString.Contains("Data Source=localhost,8675"));
+        Assert.That(connection.Connection.ConnectionString, Does.Contain("Data Source=localhost,8675"));
     }
 
     [Test]
@@ -61,9 +61,12 @@ public class PortAddress_Specs
 
         var connection = SqlServerSqlTransportConnection.GetDatabaseConnection(provider.GetRequiredService<IOptions<SqlTransportOptions>>().Value);
 
-        Assert.That(connection.Connection.ConnectionString, Contains.Substring("Data Source=(LocalDb)"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(connection.Connection.ConnectionString, Contains.Substring("Data Source=(LocalDb)"));
 
-        Assert.That(provider.GetRequiredService<IBus>().Address.Host, Is.EqualTo("localdb"));
+            Assert.That(provider.GetRequiredService<IBus>().Address.Host, Is.EqualTo("localdb"));
+        });
     }
 
     [Test]
@@ -90,6 +93,6 @@ public class PortAddress_Specs
 
         var connection = SqlServerSqlTransportConnection.GetDatabaseConnection(provider.GetRequiredService<IOptions<SqlTransportOptions>>().Value);
 
-        Assert.That(connection.Connection.ConnectionString.Contains("Data Source=localhost;"));
+        Assert.That(connection.Connection.ConnectionString, Does.Contain("Data Source=localhost;"));
     }
 }

--- a/tests/MassTransit.SqlTransport.Tests/SubscriptionType_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/SubscriptionType_Specs.cs
@@ -52,8 +52,11 @@ public class When_routing_via_a_routing_key
         await harness.Bus.Publish(new CustomerUpdatedEvent(NewId.NextGuid(), "11223344"), x => x.SetRoutingKey("11223344"));
         await harness.Bus.Publish(new CustomerDeletedEvent(NewId.NextGuid(), "655321"), x => x.SetRoutingKey("655321"));
 
-        Assert.That(await harness.Consumed.Any<CustomerUpdatedEvent>(), Is.False);
-        Assert.That(await harness.Consumed.Any<CustomerDeletedEvent>(), Is.True);
+        Assert.Multiple(async () =>
+        {
+            Assert.That(await harness.Consumed.Any<CustomerUpdatedEvent>(), Is.False);
+            Assert.That(await harness.Consumed.Any<CustomerDeletedEvent>(), Is.True);
+        });
 
         await harness.Stop();
     }
@@ -63,12 +66,12 @@ public class When_routing_via_a_routing_key
         IConsumer<CustomerUpdatedEvent>,
         IConsumer<CustomerDeletedEvent>
     {
-        public Task Consume(ConsumeContext<CustomerUpdatedEvent> context)
+        public Task Consume(ConsumeContext<CustomerDeletedEvent> context)
         {
             return Task.CompletedTask;
         }
 
-        public Task Consume(ConsumeContext<CustomerDeletedEvent> context)
+        public Task Consume(ConsumeContext<CustomerUpdatedEvent> context)
         {
             return Task.CompletedTask;
         }
@@ -126,8 +129,11 @@ public class When_routing_using_a_pattern
         await harness.Bus.Publish(new ClientUpdatedEvent(NewId.NextGuid(), "11223344"), x => x.SetRoutingKey("11223344"));
         await harness.Bus.Publish(new ClientDeletedEvent(NewId.NextGuid(), "655321"), x => x.SetRoutingKey("655321"));
 
-        Assert.That(await harness.Consumed.Any<ClientUpdatedEvent>(), Is.False);
-        Assert.That(await harness.Consumed.Any<ClientDeletedEvent>(), Is.True);
+        Assert.Multiple(async () =>
+        {
+            Assert.That(await harness.Consumed.Any<ClientUpdatedEvent>(), Is.False);
+            Assert.That(await harness.Consumed.Any<ClientDeletedEvent>(), Is.True);
+        });
 
         await harness.Stop();
     }
@@ -137,12 +143,12 @@ public class When_routing_using_a_pattern
         IConsumer<ClientUpdatedEvent>,
         IConsumer<ClientDeletedEvent>
     {
-        public Task Consume(ConsumeContext<ClientUpdatedEvent> context)
+        public Task Consume(ConsumeContext<ClientDeletedEvent> context)
         {
             return Task.CompletedTask;
         }
 
-        public Task Consume(ConsumeContext<ClientDeletedEvent> context)
+        public Task Consume(ConsumeContext<ClientUpdatedEvent> context)
         {
             return Task.CompletedTask;
         }

--- a/tests/MassTransit.Tests/Batch_Specs.cs
+++ b/tests/MassTransit.Tests/Batch_Specs.cs
@@ -113,9 +113,12 @@
 
             var count = await BusTestHarness.Consumed.SelectAsync<PingMessage>().Take(6).Count();
 
-            Assert.That(count, Is.EqualTo(6));
+            Assert.Multiple(() =>
+            {
+                Assert.That(count, Is.EqualTo(6));
 
-            Assert.That(_batches.Select(x => x.Length), Is.EquivalentTo(new[] { 1, 2, 3 }));
+                Assert.That(_batches.Select(x => x.Length), Is.EquivalentTo(new[] { 1, 2, 3 }));
+            });
         }
 
         readonly List<Batch<PingMessage>> _batches = new List<Batch<PingMessage>>();
@@ -156,8 +159,11 @@
 
             var count = await BusTestHarness.Consumed.SelectAsync<PingMessage>().Take(6).Count();
 
-            Assert.That(count, Is.EqualTo(6));
-            Assert.That(_batches.Select(x => x.Length), Is.EquivalentTo(new[] { 1, 2, 3 }));
+            Assert.Multiple(() =>
+            {
+                Assert.That(count, Is.EqualTo(6));
+                Assert.That(_batches.Select(x => x.Length), Is.EquivalentTo(new[] { 1, 2, 3 }));
+            });
         }
 
         readonly List<Batch<PingMessage>> _batches = new List<Batch<PingMessage>>();
@@ -198,7 +204,7 @@
 
             Batch<PingMessage> batch = await consumer.Completed;
 
-            Assert.That(batch.Length, Is.EqualTo(4));
+            Assert.That(batch, Has.Length.EqualTo(4));
         }
     }
 
@@ -217,7 +223,7 @@
 
             await _completed.Task;
 
-            Assert.That(_duplicateMessages.Count, Is.EqualTo(0));
+            Assert.That(_duplicateMessages, Is.Empty);
         }
 
         public Using_a_batch_consumer()

--- a/tests/MassTransit.Tests/Caching/Cache_Specs.cs
+++ b/tests/MassTransit.Tests/Caching/Cache_Specs.cs
@@ -46,12 +46,12 @@ namespace MassTransit.Tests.Caching
             {
                 await Task.Delay(1000);
 
-                return new Item(key) {Value = "First"};
+                return new Item(key) { Value = "First" };
             });
 
             Task<Item> second = _newCache.GetOrAdd(key, async key =>
             {
-                return new Item(key) {Value = "Second"};
+                return new Item(key) { Value = "Second" };
             });
 
             var item = await second;
@@ -62,9 +62,12 @@ namespace MassTransit.Tests.Caching
 
             await _newCache.Get(key);
 
-            Assert.That(timer.Elapsed + TimeSpan.FromSeconds(0.1), Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(timer.Elapsed + TimeSpan.FromSeconds(0.1), Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
 
-            Assert.That(item.Value, Is.EqualTo("First"));
+                Assert.That(item.Value, Is.EqualTo("First"));
+            });
         }
     }
 
@@ -76,7 +79,7 @@ namespace MassTransit.Tests.Caching
         [OneTimeSetUp]
         public void Setup()
         {
-            _newCache = new MassTransitCache<Guid, Item, CacheValue<Item>>(new UsageCachePolicy<Item>(), new CacheOptions {Capacity = 1000});
+            _newCache = new MassTransitCache<Guid, Item, CacheValue<Item>>(new UsageCachePolicy<Item>(), new CacheOptions { Capacity = 1000 });
         }
 
         [Test]
@@ -99,7 +102,7 @@ namespace MassTransit.Tests.Caching
         [OneTimeSetUp]
         public void Setup()
         {
-            _newCache = new MassTransitCache<Guid, Item, CacheValue<Item>>(new UsageCachePolicy<Item>(), new CacheOptions {Capacity = 1000});
+            _newCache = new MassTransitCache<Guid, Item, CacheValue<Item>>(new UsageCachePolicy<Item>(), new CacheOptions { Capacity = 1000 });
         }
 
         [Test]
@@ -134,7 +137,7 @@ namespace MassTransit.Tests.Caching
         [OneTimeSetUp]
         public void Setup()
         {
-            _newCache = new MassTransitCache<Guid, Item, CacheValue<Item>>(new UsageCachePolicy<Item>(), new CacheOptions {Capacity = 1000});
+            _newCache = new MassTransitCache<Guid, Item, CacheValue<Item>>(new UsageCachePolicy<Item>(), new CacheOptions { Capacity = 1000 });
 
             _samples = new int[SampleCount];
 
@@ -192,7 +195,7 @@ namespace MassTransit.Tests.Caching
         public void Setup()
         {
             _massTransitCache = new MassTransitCache<Guid, Item, ITimeToLiveCacheValue<Item>>(new TimeToLiveCachePolicy<Item>(TimeSpan.FromSeconds(30)),
-                new CacheOptions {Capacity = 1000});
+                new CacheOptions { Capacity = 1000 });
 
             _samples = new int[SampleCount];
 

--- a/tests/MassTransit.Tests/Caching/LegacyCacheUpgrade_Specs.cs
+++ b/tests/MassTransit.Tests/Caching/LegacyCacheUpgrade_Specs.cs
@@ -35,8 +35,11 @@ namespace MassTransit.Tests.Caching
             var value = await cache.GetOrAdd(helloKey, SimpleValueFactory.Healthy);
 
             Assert.That(value, Is.Not.Null);
-            Assert.That(value.Id, Is.EqualTo(helloKey));
-            Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Id, Is.EqualTo(helloKey));
+                Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            });
         }
 
         [Test]
@@ -51,14 +54,20 @@ namespace MassTransit.Tests.Caching
             Task<SimpleValue> readValueTask = cache.Get(helloKey);
 
             Assert.That(value, Is.Not.Null);
-            Assert.That(value.Id, Is.EqualTo(helloKey));
-            Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Id, Is.EqualTo(helloKey));
+                Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            });
 
             var readValue = await readValueTask;
 
             Assert.That(readValue, Is.Not.Null);
-            Assert.That(readValue.Id, Is.EqualTo(helloKey));
-            Assert.That(readValue.Value, Is.EqualTo("The key is Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(readValue.Id, Is.EqualTo(helloKey));
+                Assert.That(readValue.Value, Is.EqualTo("The key is Hello"));
+            });
         }
 
         [Test]
@@ -80,14 +89,20 @@ namespace MassTransit.Tests.Caching
             var value = await goodValueTask;
 
             Assert.That(value, Is.Not.Null);
-            Assert.That(value.Id, Is.EqualTo(helloKey));
-            Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Id, Is.EqualTo(helloKey));
+                Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            });
 
             var readValue = await readValueTask;
 
             Assert.That(readValue, Is.Not.Null);
-            Assert.That(readValue.Id, Is.EqualTo(helloKey));
-            Assert.That(readValue.Value, Is.EqualTo("The key is Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(readValue.Id, Is.EqualTo(helloKey));
+                Assert.That(readValue.Value, Is.EqualTo("The key is Hello"));
+            });
         }
 
         [Test]
@@ -108,16 +123,22 @@ namespace MassTransit.Tests.Caching
             var value = await goodValueTask;
 
             Assert.That(value, Is.Not.Null);
-            Assert.That(value.Id, Is.EqualTo(helloKey));
-            Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.Id, Is.EqualTo(helloKey));
+                Assert.That(value.Value, Is.EqualTo("The key is Hello"));
+            });
 
             Task<SimpleValue> readValueTask = cache.Get(helloKey);
 
             var readValue = await readValueTask;
 
             Assert.That(readValue, Is.Not.Null);
-            Assert.That(readValue.Id, Is.EqualTo(helloKey));
-            Assert.That(readValue.Value, Is.EqualTo("The key is Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(readValue.Id, Is.EqualTo(helloKey));
+                Assert.That(readValue.Value, Is.EqualTo("The key is Hello"));
+            });
         }
     }
 }

--- a/tests/MassTransit.Tests/Configuration/ConfigurationObserver_Specs.cs
+++ b/tests/MassTransit.Tests/Configuration/ConfigurationObserver_Specs.cs
@@ -36,9 +36,12 @@ namespace MassTransit.Tests.Configuration
                 });
             });
 
-            Assert.That(observer.ConsumerTypes.Contains(typeof(MyConsumer)));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MyConsumer), typeof(PingMessage))));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MyConsumer), typeof(PongMessage))));
+            Assert.Multiple(() =>
+            {
+                Assert.That(observer.ConsumerTypes, Does.Contain(typeof(MyConsumer)));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MyConsumer), typeof(PingMessage))));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MyConsumer), typeof(PongMessage))));
+            });
         }
 
         [Test]
@@ -58,9 +61,12 @@ namespace MassTransit.Tests.Configuration
                 });
             });
 
-            Assert.That(observer.ConsumerTypes.Contains(typeof(MyConsumer)));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MyConsumer), typeof(PingMessage))));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MyConsumer), typeof(PongMessage))));
+            Assert.Multiple(() =>
+            {
+                Assert.That(observer.ConsumerTypes, Does.Contain(typeof(MyConsumer)));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MyConsumer), typeof(PingMessage))));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MyConsumer), typeof(PongMessage))));
+            });
         }
 
         [Test]
@@ -82,7 +88,7 @@ namespace MassTransit.Tests.Configuration
                 });
             });
 
-            Assert.That(observer.MessageTypes.Contains(typeof(PingMessage)));
+            Assert.That(observer.MessageTypes, Does.Contain(typeof(PingMessage)));
         }
 
         [Test]
@@ -102,9 +108,12 @@ namespace MassTransit.Tests.Configuration
                 });
             });
 
-            Assert.That(observer.ConsumerTypes.Contains(typeof(MyConsumer)));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MyConsumer), typeof(PingMessage))));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MyConsumer), typeof(PongMessage))));
+            Assert.Multiple(() =>
+            {
+                Assert.That(observer.ConsumerTypes, Does.Contain(typeof(MyConsumer)));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MyConsumer), typeof(PingMessage))));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MyConsumer), typeof(PongMessage))));
+            });
         }
 
         [Test]
@@ -122,7 +131,7 @@ namespace MassTransit.Tests.Configuration
                 });
             });
 
-            Assert.That(observer.ExecuteActivityTypes.Contains((typeof(SetVariableActivity), typeof(SetVariableArguments))));
+            Assert.That(observer.ExecuteActivityTypes, Does.Contain((typeof(SetVariableActivity), typeof(SetVariableArguments))));
         }
 
         [Test]
@@ -149,8 +158,11 @@ namespace MassTransit.Tests.Configuration
                 });
             });
 
-            Assert.That(observer.ActivityTypes.Contains((typeof(TestActivity), typeof(TestArguments), compensateAddress)));
-            Assert.That(observer.CompensateActivityTypes.Contains((typeof(TestActivity), typeof(TestLog))));
+            Assert.Multiple(() =>
+            {
+                Assert.That(observer.ActivityTypes, Does.Contain((typeof(TestActivity), typeof(TestArguments), compensateAddress)));
+                Assert.That(observer.CompensateActivityTypes, Does.Contain((typeof(TestActivity), typeof(TestLog))));
+            });
         }
 
 

--- a/tests/MassTransit.Tests/Configuration/SagaConfigurationObserver_Specs.cs
+++ b/tests/MassTransit.Tests/Configuration/SagaConfigurationObserver_Specs.cs
@@ -35,9 +35,12 @@ namespace MassTransit.Tests.Configuration
                 });
             });
 
-            Assert.That(observer.SagaTypes.Contains(typeof(MySaga)));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MySaga), typeof(PingMessage))));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(MySaga), typeof(PongMessage))));
+            Assert.Multiple(() =>
+            {
+                Assert.That(observer.SagaTypes, Does.Contain(typeof(MySaga)));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MySaga), typeof(PingMessage))));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(MySaga), typeof(PongMessage))));
+            });
         }
 
 

--- a/tests/MassTransit.Tests/ConsumeObserver_Specs.cs
+++ b/tests/MassTransit.Tests/ConsumeObserver_Specs.cs
@@ -126,8 +126,11 @@ namespace MassTransit.Tests
 
                 await pingObserver.PostConsumed;
 
-                Assert.That(observer.Messages.Select<PingMessage>().First(), Is.Not.Null);
-                Assert.That(observer.Messages.Select<PongMessage>().First(), Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(observer.Messages.Select<PingMessage>().First(), Is.Not.Null);
+                    Assert.That(observer.Messages.Select<PongMessage>().First(), Is.Not.Null);
+                });
             }
         }
     }

--- a/tests/MassTransit.Tests/ContainerTests/Batch_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Batch_Specs.cs
@@ -30,11 +30,14 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 2 && x.Context.Message.Mode == BatchCompletionMode.Time));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message is { Count: 2, Mode: BatchCompletionMode.Time }), Is.True);
+            });
         }
     }
 
@@ -64,11 +67,15 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<TestOutboxBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestOutboxBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 2 && x.Context.Message.Mode == BatchCompletionMode.Time));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 2 && x.Context.Message.Mode == BatchCompletionMode.Time),
+                    Is.True);
+            });
         }
 
         [Test]
@@ -93,11 +100,15 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<TestRetryOutboxBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestRetryOutboxBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 2 && x.Context.Message.Mode == BatchCompletionMode.Time));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 2 && x.Context.Message.Mode == BatchCompletionMode.Time),
+                    Is.True);
+            });
         }
 
         [Test]
@@ -116,11 +127,15 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<TestOutboxBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestOutboxBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 2 && x.Context.Message.Mode == BatchCompletionMode.Time));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 2 && x.Context.Message.Mode == BatchCompletionMode.Time),
+                    Is.True);
+            });
         }
 
 
@@ -191,12 +206,17 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem(), new BatchItem(), new BatchItem(), new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(5).Count(), Is.EqualTo(5));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(5).Count(), Is.EqualTo(5));
 
-            Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 5 && x.Context.Message.Mode == BatchCompletionMode.Size));
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 1 && x.Context.Message.Mode == BatchCompletionMode.Time));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 5 && x.Context.Message.Mode == BatchCompletionMode.Size),
+                    Is.True);
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 1 && x.Context.Message.Mode == BatchCompletionMode.Time),
+                    Is.True);
+            });
         }
     }
 
@@ -222,11 +242,15 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(Enumerable.Range(0, 100).Select(_ => new BatchItem()));
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(100).Count(), Is.EqualTo(100));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(100).Count(), Is.EqualTo(100));
 
-            Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 100 && x.Context.Message.Mode == BatchCompletionMode.Size));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 100 && x.Context.Message.Mode == BatchCompletionMode.Size),
+                    Is.True);
+            });
         }
     }
 
@@ -251,12 +275,15 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem(), new BatchItem(), new BatchItem(), new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(5).Count(), Is.EqualTo(5));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(5).Count(), Is.EqualTo(5));
 
-            Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 5 && x.Context.Message.Mode == BatchCompletionMode.Size));
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message.Count == 1 && x.Context.Message.Mode == BatchCompletionMode.Time));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message is { Count: 5, Mode: BatchCompletionMode.Size }), Is.True);
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message is { Count: 1, Mode: BatchCompletionMode.Time }), Is.True);
+            });
         }
     }
 
@@ -280,11 +307,14 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+                Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+            });
         }
     }
 
@@ -310,11 +340,14 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+                Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -337,11 +370,14 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+                Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -366,11 +402,14 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+                Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -395,11 +434,14 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+                Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -431,11 +473,14 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.PublishBatch(new[] { new BatchItem(), new BatchItem() });
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Take(2).Count(), Is.EqualTo(2));
 
-            Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<FailingBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+                Assert.That(await harness.Published.SelectAsync<Fault<BatchItem>>().Take(2).Count(), Is.EqualTo(2));
+            });
         }
     }
 
@@ -463,11 +508,14 @@ namespace MassTransit.Tests.ContainerTests
             await harness.Bus.Publish(new BatchItem(), context => context.MessageId = correlation1);
             await harness.Bus.Publish(new BatchItem(), context => context.MessageId = correlation1);
 
-            Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Count(), Is.EqualTo(1));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Consumed.SelectAsync<BatchItem>().Count(), Is.EqualTo(1));
 
-            Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TestBatchConsumer>().Consumed.Any<Batch<BatchItem>>(), Is.True);
 
-            Assert.IsTrue(await harness.Published.Any<BatchResult>(x => x.Context.Message is { Count: 1, Mode: BatchCompletionMode.Time }));
+                Assert.That(await harness.Published.Any<BatchResult>(x => x.Context.Message is { Count: 1, Mode: BatchCompletionMode.Time }), Is.True);
+            });
         }
     }
 

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ConsumeContext.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ConsumeContext.cs
@@ -33,8 +33,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(messageConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(messageConsumeContext, sendEndpointProvider)");
+            });
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -83,8 +86,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -145,8 +151,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -210,8 +219,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -279,8 +291,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -348,8 +363,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -415,8 +433,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -479,8 +500,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -541,8 +565,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             var publishEndpoint = await PublishEndpoint;
             var sendEndpointProvider = await SendEndpointProvider;
 
-            Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
-            Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(publishEndpoint, sendEndpointProvider), "ReferenceEquals(publishEndpoint, sendEndpointProvider)");
+                Assert.That(ReferenceEquals(consumeContext, sendEndpointProvider), "ReferenceEquals(outboxConsumeContext, sendEndpointProvider)");
+            });
 
             await fault;
 
@@ -741,7 +768,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
     namespace UnitOfWorkComponents
     {
-        using System;
         using MassTransit.Configuration;
 
 

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_Consumer.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_Consumer.cs
@@ -245,7 +245,7 @@
             await InputQueueSendEndpoint.Send<SimpleMessageInterface>(new { Name = "test" });
 
             var result = await TaskCompletionSource.Task;
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_Courier.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_Courier.cs
@@ -12,6 +12,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Courier_ExecuteActivity :
         InMemoryContainerTestFixture
     {
+        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
+        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
+        Uri _executeAddress;
+        Guid _trackingNumber;
+
         [Test]
         public async Task Should_register_and_execute_the_activity()
         {
@@ -34,11 +39,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await _activityCompleted;
         }
 
-        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
-        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
-        Uri _executeAddress;
-        Guid _trackingNumber;
-
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
         {
             configurator.AddExecuteActivity<SetVariableActivity, SetVariableArguments>();
@@ -59,6 +59,10 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Courier_ExecuteActivity_Endpoint :
         InMemoryContainerTestFixture
     {
+        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
+        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
+        Guid _trackingNumber;
+
         [Test]
         public async Task Should_register_and_execute_the_activity()
         {
@@ -81,10 +85,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await _activityCompleted;
         }
 
-        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
-        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
-        Guid _trackingNumber;
-
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
         {
             configurator.AddExecuteActivity<SetVariableActivity, SetVariableArguments>()
@@ -96,6 +96,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Courier_Activity :
         InMemoryContainerTestFixture
     {
+        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
+        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
+        Uri _executeAddress;
+        Guid _trackingNumber;
+
         [Test]
         public async Task Should_register_and_execute_the_activity()
         {
@@ -113,11 +118,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await _completed;
             await _activityCompleted;
         }
-
-        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
-        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
-        Uri _executeAddress;
-        Guid _trackingNumber;
 
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
         {
@@ -142,6 +142,10 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Courier_Activity_Custom_Subscription :
         InMemoryContainerTestFixture
     {
+        Task<ConsumeContext<RegistrationCompleted>> _completed;
+        Uri _executeAddress;
+        Guid _trackingNumber;
+
         [Test]
         public async Task Should_register_and_execute_the_activity()
         {
@@ -162,10 +166,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
 
             Assert.That(completed.Message.Value, Is.EqualTo("Secret Value"));
         }
-
-        Task<ConsumeContext<RegistrationCompleted>> _completed;
-        Uri _executeAddress;
-        Guid _trackingNumber;
 
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
         {
@@ -197,6 +197,16 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Common_Activity_Filter :
         InMemoryContainerTestFixture
     {
+        readonly TaskCompletionSource<(TestActivity, MyId)> _activityTaskCompletionSource;
+        readonly TaskCompletionSource<MyId> _executeTaskCompletionSource;
+        Uri _executeAddress;
+
+        public Common_Activity_Filter()
+        {
+            _activityTaskCompletionSource = GetTask<(TestActivity, MyId)>();
+            _executeTaskCompletionSource = GetTask<MyId>();
+        }
+
         [Test]
         public async Task Should_use_scope()
         {
@@ -214,26 +224,15 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await executor.Execute(builder.Build(), InMemoryTestHarness.CancellationToken);
 
             var result = await _executeTaskCompletionSource.Task;
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
 
             var activityResult = await _activityTaskCompletionSource.Task;
-            Assert.IsNotNull(activityResult);
 
             Assert.That(result, Is.EqualTo(activityResult.Item2));
 
             ConsumeContext<RoutingSlipCompleted> completedContext = await completed;
 
             Assert.That(completedContext.GetVariable("HeaderValue", ""), Is.EqualTo("Bingo!"));
-        }
-
-        readonly TaskCompletionSource<(TestActivity, MyId)> _activityTaskCompletionSource;
-        readonly TaskCompletionSource<MyId> _executeTaskCompletionSource;
-        Uri _executeAddress;
-
-        public Common_Activity_Filter()
-        {
-            _activityTaskCompletionSource = GetTask<(TestActivity, MyId)>();
-            _executeTaskCompletionSource = GetTask<MyId>();
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -348,6 +347,10 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Courier_Activity_Endpoint :
         InMemoryContainerTestFixture
     {
+        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
+        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
+        Guid _trackingNumber;
+
         [Test]
         public async Task Should_register_and_execute_the_activity()
         {
@@ -365,10 +368,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await _completed;
             await _activityCompleted;
         }
-
-        Task<ConsumeContext<RoutingSlipActivityCompleted>> _activityCompleted;
-        Task<ConsumeContext<RoutingSlipCompleted>> _completed;
-        Guid _trackingNumber;
 
         protected override void ConfigureMassTransit(IBusRegistrationConfigurator configurator)
         {

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_SagaStateMachine.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_SagaStateMachine.cs
@@ -52,6 +52,13 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Common_StateMachine_Filter :
         InMemoryContainerTestFixture
     {
+        readonly TaskCompletionSource<MyId> _taskCompletionSource;
+
+        public Common_StateMachine_Filter()
+        {
+            _taskCompletionSource = GetTask<MyId>();
+        }
+
         [Test]
         public async Task Should_use_scope()
         {
@@ -62,14 +69,7 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             });
 
             var result = await _taskCompletionSource.Task;
-            Assert.NotNull(result);
-        }
-
-        readonly TaskCompletionSource<MyId> _taskCompletionSource;
-
-        public Common_StateMachine_Filter()
-        {
-            _taskCompletionSource = GetTask<MyId>();
+            Assert.That(result, Is.Not.Null);
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)
@@ -101,6 +101,17 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
     public class Common_StateMachine_FilterOrder :
         InMemoryContainerTestFixture
     {
+        readonly TaskCompletionSource<ConsumeContext<StartTest>> _messageCompletion;
+        readonly TaskCompletionSource<SagaConsumeContext<TestInstance>> _sagaCompletion;
+        readonly TaskCompletionSource<SagaConsumeContext<TestInstance, StartTest>> _sagaMessageCompletion;
+
+        public Common_StateMachine_FilterOrder()
+        {
+            _messageCompletion = GetTask<ConsumeContext<StartTest>>();
+            _sagaCompletion = GetTask<SagaConsumeContext<TestInstance>>();
+            _sagaMessageCompletion = GetTask<SagaConsumeContext<TestInstance, StartTest>>();
+        }
+
         [Test]
         public async Task Should_include_container_scope()
         {
@@ -115,17 +126,6 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await _sagaCompletion.Task;
 
             await _sagaMessageCompletion.Task;
-        }
-
-        readonly TaskCompletionSource<ConsumeContext<StartTest>> _messageCompletion;
-        readonly TaskCompletionSource<SagaConsumeContext<TestInstance>> _sagaCompletion;
-        readonly TaskCompletionSource<SagaConsumeContext<TestInstance, StartTest>> _sagaMessageCompletion;
-
-        public Common_StateMachine_FilterOrder()
-        {
-            _messageCompletion = GetTask<ConsumeContext<StartTest>>();
-            _sagaCompletion = GetTask<SagaConsumeContext<TestInstance>>();
-            _sagaMessageCompletion = GetTask<SagaConsumeContext<TestInstance, StartTest>>();
         }
 
         IFilter<SagaConsumeContext<TestInstance, StartTest>> CreateSagaMessageFilter()

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopePublish.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/Common_ScopePublish.cs
@@ -356,8 +356,11 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
             await InputQueueSendEndpoint.Send<SimpleMessageInterface>(new { Name = "test" });
 
             ConsumeContext<Fault<SimpleMessageInterface>> result = await TaskCompletionSource.Task;
-            Assert.IsNotNull(result);
-            Assert.IsFalse(Marker.Called);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(Marker.Called, Is.False);
+            });
         }
 
         protected override IServiceCollection ConfigureServices(IServiceCollection collection)

--- a/tests/MassTransit.Tests/ContainerTests/Common_Tests/MultiBus_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/Common_Tests/MultiBus_Specs.cs
@@ -44,15 +44,15 @@ namespace MassTransit.Tests.ContainerTests.Common_Tests
         [Test]
         public void Should_resolve_bus_declaration()
         {
-            Assert.NotNull(ServiceProvider.GetService<IBusOne>());
-            Assert.NotNull(ServiceProvider.GetService<IBusTwo>());
+            Assert.That(ServiceProvider.GetService<IBusOne>(), Is.Not.Null);
+            Assert.That(ServiceProvider.GetService<IBusTwo>(), Is.Not.Null);
         }
 
         [Test]
         public void Should_resolve_bus_instance()
         {
-            Assert.NotNull(ServiceProvider.GetService<IBusInstance<IBusOne>>());
-            Assert.NotNull(ServiceProvider.GetService<IBusInstance<IBusTwo>>());
+            Assert.That(ServiceProvider.GetService<IBusInstance<IBusOne>>(), Is.Not.Null);
+            Assert.That(ServiceProvider.GetService<IBusInstance<IBusTwo>>(), Is.Not.Null);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/ContainerTests/ContainerTestHarness_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/ContainerTestHarness_Specs.cs
@@ -138,15 +138,21 @@ namespace MassTransit.Tests.ContainerTests
                 OrderNumber = "123"
             });
 
-            Assert.That(await harness.Published.SelectAsync<Fault<SubmitOrder>>().Count(), Is.EqualTo(1));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Published.SelectAsync<Fault<SubmitOrder>>().Count(), Is.EqualTo(1));
 
-            Assert.That(await harness.Consumed.SelectAsync<SubmitOrder>().Count(), Is.EqualTo(1));
+                Assert.That(await harness.Consumed.SelectAsync<SubmitOrder>().Count(), Is.EqualTo(1));
+            });
 
             IConsumerTestHarness<SubmitOrderConsumer> consumerHarness = harness.GetConsumerHarness<SubmitOrderConsumer>();
 
-            Assert.That(await consumerHarness.Consumed.SelectAsync<SubmitOrder>().Count(), Is.EqualTo(1));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await consumerHarness.Consumed.SelectAsync<SubmitOrder>().Count(), Is.EqualTo(1));
 
-            Assert.That(SubmitOrderConsumer.Attempts, Is.EqualTo(4));
+                Assert.That(SubmitOrderConsumer.Attempts, Is.EqualTo(4));
+            });
         }
 
 
@@ -190,9 +196,12 @@ namespace MassTransit.Tests.ContainerTests
                 OrderNumber = "123"
             });
 
-            Assert.IsTrue(await harness.Sent.Any<OrderSubmitted>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.Sent.Any<OrderSubmitted>(), Is.True);
 
-            Assert.IsTrue(await harness.Consumed.Any<SubmitOrder>());
+                Assert.That(await harness.Consumed.Any<SubmitOrder>(), Is.True);
+            });
         }
 
 
@@ -233,15 +242,21 @@ namespace MassTransit.Tests.ContainerTests
                 TestKey = "Unique"
             });
 
-            Assert.IsTrue(await harness.Consumed.Any<StartTest>());
+            Assert.That(await harness.Consumed.Any<StartTest>(), Is.True);
             IReceivedMessage<StartTest> startTest = await harness.Consumed.SelectAsync<StartTest>().First();
-            Assert.That(startTest.Context.CorrelationId, Is.EqualTo(correlationId));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(startTest.Context.CorrelationId, Is.EqualTo(correlationId));
 
-            Assert.IsTrue(await harness.Published.Any<TestStarted>());
+                Assert.That(await harness.Published.Any<TestStarted>(), Is.True);
+            });
             IPublishedMessage<TestStarted> testStarted = await harness.Published.SelectAsync<TestStarted>().First();
-            Assert.That(testStarted.Context.InitiatorId, Is.EqualTo(correlationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(testStarted.Context.InitiatorId, Is.EqualTo(correlationId));
 
-            Assert.That(startTest.Context.ConversationId, Is.EqualTo(testStarted.Context.ConversationId));
+                Assert.That(startTest.Context.ConversationId, Is.EqualTo(testStarted.Context.ConversationId));
+            });
         }
     }
 }

--- a/tests/MassTransit.Tests/ContainerTests/DateOnlyTimeOnly_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/DateOnlyTimeOnly_Specs.cs
@@ -55,8 +55,11 @@ namespace MassTransit.Tests.ContainerTests
 
             IReceivedMessage<MyMessage> message = await harness.Consumed.SelectAsync<MyMessage>().FirstOrDefault();
 
-            Assert.That(message.Context.Message.Date, Is.EqualTo(dateOnly));
-            Assert.That(message.Context.Message.Time, Is.EqualTo(timeOnly));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Context.Message.Date, Is.EqualTo(dateOnly));
+                Assert.That(message.Context.Message.Time, Is.EqualTo(timeOnly));
+            });
         }
 
 

--- a/tests/MassTransit.Tests/ContainerTests/DependencyInjectionTestHarness2_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/DependencyInjectionTestHarness2_Specs.cs
@@ -48,7 +48,7 @@ namespace MassTransit.Tests.ContainerTests
 
                 // Assert
                 // did the actual saga consume the message
-                Assert.True(await sagaHarness.Consumed.Any<StartCommand>());
+                Assert.That(await sagaHarness.Consumed.Any<StartCommand>(), Is.True);
             }
             finally
             {
@@ -84,7 +84,7 @@ namespace MassTransit.Tests.ContainerTests
             // Assert
             // did the actual saga consume the message
             var sagaHarness = provider.GetRequiredService<ISagaStateMachineTestHarness<TestSagaStateMachine, TestSaga>>();
-            Assert.True(await sagaHarness.Consumed.Any<StartCommand>());
+            Assert.That(await sagaHarness.Consumed.Any<StartCommand>(), Is.True);
         }
 
 

--- a/tests/MassTransit.Tests/ContainerTests/DependencyInjectionTestHarness_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/DependencyInjectionTestHarness_Specs.cs
@@ -210,20 +210,26 @@ namespace MassTransit.Tests.ContainerTests
 
             await harness.Bus.Publish(new Start { CorrelationId = sagaId });
 
-            Assert.IsTrue(await harness.Consumed.Any<Start>(), "Message not received");
+            Assert.That(await harness.Consumed.Any<Start>(), Is.True, "Message not received");
 
             ISagaStateMachineTestHarness<TestStateMachine, Instance> sagaHarness = harness.GetSagaStateMachineHarness<TestStateMachine, Instance>();
 
-            Assert.That(await sagaHarness.Consumed.Any<Start>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await sagaHarness.Consumed.Any<Start>());
 
-            Assert.That(await sagaHarness.Created.Any(x => x.CorrelationId == sagaId));
+                Assert.That(await sagaHarness.Created.Any(x => x.CorrelationId == sagaId));
+            });
 
             var machine = provider.GetRequiredService<TestStateMachine>();
 
             var instance = sagaHarness.Created.ContainsInState(sagaId, sagaHarness.StateMachine, machine.Running);
-            Assert.IsNotNull(instance, "Saga instance not found");
+            Assert.Multiple(async () =>
+            {
+                Assert.That(instance, Is.Not.Null, "Saga instance not found");
 
-            Assert.IsTrue(await harness.Published.Any<Started>(), "Event not published");
+                Assert.That(await harness.Published.Any<Started>(), Is.True, "Event not published");
+            });
         }
 
 

--- a/tests/MassTransit.Tests/ContainerTests/HealthCheck_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/HealthCheck_Specs.cs
@@ -157,7 +157,7 @@ namespace MassTransit.Tests.ContainerTests
             IHostedService[] hostedServices = provider.GetServices<IHostedService>().ToArray();
 
             var result = await healthChecks.CheckHealthAsync(TestCancellationToken);
-            Assert.That(result.Status == HealthStatus.Unhealthy);
+            Assert.That(result.Status, Is.EqualTo(HealthStatus.Unhealthy));
 
             await Task.WhenAll(hostedServices.Select(x => x.StartAsync(TestCancellationToken)));
             try
@@ -204,7 +204,7 @@ namespace MassTransit.Tests.ContainerTests
             IHostedService[] hostedServices = provider.GetServices<IHostedService>().ToArray();
 
             var result = await healthChecks.CheckHealthAsync(TestCancellationToken);
-            Assert.That(result.Status == HealthStatus.Unhealthy);
+            Assert.That(result.Status, Is.EqualTo(HealthStatus.Unhealthy));
 
             await Task.WhenAll(hostedServices.Select(x => x.StartAsync(TestCancellationToken)));
             try

--- a/tests/MassTransit.Tests/ConversationId_Specs.cs
+++ b/tests/MassTransit.Tests/ConversationId_Specs.cs
@@ -70,9 +70,12 @@
 
             ConsumeContext<PongMessage> responseContext = await responseHandled;
 
-            Assert.That(responseContext.ConversationId.HasValue, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(responseContext.ConversationId.HasValue, Is.True);
 
-            Assert.That(responseContext.ConversationId, Is.EqualTo(context.ConversationId));
+                Assert.That(responseContext.ConversationId, Is.EqualTo(context.ConversationId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;
@@ -103,11 +106,14 @@
 
             ConsumeContext<PongMessage> responseContext = await responseHandled;
 
-            Assert.That(responseContext.ConversationId.HasValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(responseContext.ConversationId.HasValue);
 
-            Assert.That(responseContext.ConversationId.Value, Is.Not.EqualTo(conversationId));
+                Assert.That(responseContext.ConversationId.Value, Is.Not.EqualTo(conversationId));
 
-            Assert.That(responseContext.Headers.Get<Guid>(MessageHeaders.InitiatingConversationId), Is.EqualTo(conversationId));
+                Assert.That(responseContext.Headers.Get<Guid>(MessageHeaders.InitiatingConversationId), Is.EqualTo(conversationId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;
@@ -118,6 +124,7 @@
                 context.RespondAsync(new PongMessage(context.Message.CorrelationId), x => x.StartNewConversation()));
         }
     }
+
 
     [TestFixture]
     public class Starting_a_new_conversation_from_a_new_message :

--- a/tests/MassTransit.Tests/CorrelationId_Specs.cs
+++ b/tests/MassTransit.Tests/CorrelationId_Specs.cs
@@ -19,8 +19,11 @@
 
             ConsumeContext<PingMessage> context = await _handled;
 
-            Assert.That(context.CorrelationId.HasValue, Is.True);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(pingMessage.CorrelationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(pingMessage.CorrelationId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;
@@ -45,8 +48,11 @@
 
             ConsumeContext<PingMessage> context = await _handled;
 
-            Assert.That(context.CorrelationId.HasValue, Is.True);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(pingMessage.CorrelationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(pingMessage.CorrelationId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _handled;
@@ -71,8 +77,11 @@
 
             ConsumeContext<A> context = await _handled;
 
-            Assert.That(context.CorrelationId.HasValue, Is.True);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CorrelationId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CorrelationId));
+            });
         }
 
         Task<ConsumeContext<A>> _handled;
@@ -103,8 +112,11 @@
 
             ConsumeContext<A> context = await _handled;
 
-            Assert.That(context.CorrelationId.HasValue, Is.True);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CommandId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CommandId));
+            });
         }
 
         Task<ConsumeContext<A>> _handled;
@@ -135,8 +147,11 @@
 
             ConsumeContext<A> context = await _handled;
 
-            Assert.That(context.CorrelationId.HasValue, Is.True);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(message.EventId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(message.EventId));
+            });
         }
 
         Task<ConsumeContext<A>> _handled;
@@ -168,8 +183,11 @@
 
             ConsumeContext<A> context = await _handled;
 
-            Assert.That(context.CorrelationId.HasValue, Is.True);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CorrelationId.Value));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CorrelationId.Value));
+            });
         }
 
         Task<ConsumeContext<A>> _handled;
@@ -200,8 +218,11 @@
 
             ConsumeContext<A> context = await _handled;
 
-            Assert.That(context.CorrelationId.HasValue, Is.True);
-            Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CorrelationId.Value));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CorrelationId.HasValue, Is.True);
+                Assert.That(context.CorrelationId.Value, Is.EqualTo(message.CorrelationId.Value));
+            });
         }
 
         Task<ConsumeContext<A>> _handled;

--- a/tests/MassTransit.Tests/Courier/ArgumentOverload_Specs.cs
+++ b/tests/MassTransit.Tests/Courier/ArgumentOverload_Specs.cs
@@ -18,9 +18,12 @@
         {
             ConsumeContext<RoutingSlipCompleted> context = await _completed;
 
-            Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.Message.TrackingNumber, Is.EqualTo(_trackingNumber));
 
-            Assert.That(context.GetVariable<string>("Test"), Is.EqualTo("Used"));
+                Assert.That(context.GetVariable<string>("Test"), Is.EqualTo("Used"));
+            });
         }
 
         [Test]

--- a/tests/MassTransit.Tests/DelayedRedelivery_Specs.cs
+++ b/tests/MassTransit.Tests/DelayedRedelivery_Specs.cs
@@ -20,9 +20,12 @@ namespace MassTransit.Tests
 
             await Task.WhenAll(_received.Select(x => x.Task));
 
-            Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.9)));
-            Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.9)));
-            Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.9)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.9)));
+                Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.9)));
+                Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.9)));
+            });
 
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[1] - _timestamps[0]);
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[2] - _timestamps[1]);
@@ -74,9 +77,12 @@ namespace MassTransit.Tests
 
             await Task.WhenAll(_received.Select(x => x.Task));
 
-            Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.9)));
-            Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.9)));
-            Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.9)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.9)));
+                Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.9)));
+                Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.9)));
+            });
 
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[1] - _timestamps[0]);
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[2] - _timestamps[1]);
@@ -113,6 +119,7 @@ namespace MassTransit.Tests
         }
     }
 
+
     [TestFixture]
     [Category("Flaky")]
     public class Using_delayed_redelivery_with_new_message_id :
@@ -127,22 +134,28 @@ namespace MassTransit.Tests
 
             await Task.WhenAll(_received.Select(x => x.Task));
 
-            Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.9)));
-            Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.9)));
-            Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.9)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_timestamps[1] - _timestamps[0], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.9)));
+                Assert.That(_timestamps[2] - _timestamps[1], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.9)));
+                Assert.That(_timestamps[3] - _timestamps[2], Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(2.9)));
+            });
 
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[1] - _timestamps[0]);
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[2] - _timestamps[1]);
             TestContext.Out.WriteLine("Interval: {0}", _timestamps[3] - _timestamps[2]);
 
-            Assert.That(_received[0].Task.Result.MessageId.Value, Is.EqualTo(messageId));
-            Assert.That(_received[1].Task.Result.MessageId.Value, Is.Not.EqualTo(messageId));
-            Assert.That(_received[2].Task.Result.MessageId.Value, Is.Not.EqualTo(messageId));
-            Assert.That(_received[3].Task.Result.MessageId.Value, Is.Not.EqualTo(messageId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_received[0].Task.Result.MessageId.Value, Is.EqualTo(messageId));
+                Assert.That(_received[1].Task.Result.MessageId.Value, Is.Not.EqualTo(messageId));
+                Assert.That(_received[2].Task.Result.MessageId.Value, Is.Not.EqualTo(messageId));
+                Assert.That(_received[3].Task.Result.MessageId.Value, Is.Not.EqualTo(messageId));
 
-            Assert.That(_received[1].Task.Result.GetHeader(MessageHeaders.OriginalMessageId, default(Guid?)), Is.EqualTo((Guid?)messageId));
-            Assert.That(_received[2].Task.Result.GetHeader(MessageHeaders.OriginalMessageId, default(Guid?)), Is.EqualTo((Guid?)messageId));
-            Assert.That(_received[3].Task.Result.GetHeader(MessageHeaders.OriginalMessageId, default(Guid?)), Is.EqualTo((Guid?)messageId));
+                Assert.That(_received[1].Task.Result.GetHeader(MessageHeaders.OriginalMessageId, default(Guid?)), Is.EqualTo((Guid?)messageId));
+                Assert.That(_received[2].Task.Result.GetHeader(MessageHeaders.OriginalMessageId, default(Guid?)), Is.EqualTo((Guid?)messageId));
+                Assert.That(_received[3].Task.Result.GetHeader(MessageHeaders.OriginalMessageId, default(Guid?)), Is.EqualTo((Guid?)messageId));
+            });
         }
 
         TaskCompletionSource<ConsumeContext<PingMessage>>[] _received;

--- a/tests/MassTransit.Tests/ExceptionInfo_Specs.cs
+++ b/tests/MassTransit.Tests/ExceptionInfo_Specs.cs
@@ -22,7 +22,7 @@ namespace MassTransit.Tests
 
             ConsumeContext<Fault<PingMessage>> fault = await faulted;
 
-            Assert.That(fault.Message.Exceptions.Length, Is.EqualTo(1));
+            Assert.That(fault.Message.Exceptions, Has.Length.EqualTo(1));
 
             var exceptionInfo = fault.Message.Exceptions.Single();
 
@@ -73,14 +73,17 @@ namespace MassTransit.Tests
 
             ConsumeContext<Fault<PingMessage>> fault = await faulted;
 
-            Assert.That(fault.Message.Exceptions.Length, Is.EqualTo(1));
+            Assert.That(fault.Message.Exceptions, Has.Length.EqualTo(1));
 
             var exceptionInfo = fault.Message.Exceptions.Single();
 
-            Assert.That(exceptionInfo.ExceptionType, Is.EqualTo(TypeCache<IntentionalTestException>.ShortName));
+            Assert.Multiple(() =>
+            {
+                Assert.That(exceptionInfo.ExceptionType, Is.EqualTo(TypeCache<IntentionalTestException>.ShortName));
 
-            Assert.That(exceptionInfo.Data.TryGetValue("Username", out string username) ? username : "", Is.EqualTo("Frank"));
-            Assert.That(exceptionInfo.Data.TryGetValue("CustomerId", out long? customerId) ? customerId : 0, Is.EqualTo(27));
+                Assert.That(exceptionInfo.Data.TryGetValue("Username", out string username) ? username : "", Is.EqualTo("Frank"));
+                Assert.That(exceptionInfo.Data.TryGetValue("CustomerId", out long? customerId) ? customerId : 0, Is.EqualTo(27));
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/ExcessiveAsyncFault_Specs.cs
+++ b/tests/MassTransit.Tests/ExcessiveAsyncFault_Specs.cs
@@ -25,7 +25,7 @@
 
                 IReceivedMessage<Fault<PingMessage>>[] messages = _consumer.Received.Select<Fault<PingMessage>>().Take(limit).ToArray();
 
-                Assert.That(messages.Length, Is.EqualTo(limit));
+                Assert.That(messages, Has.Length.EqualTo(limit));
 
                 Assert.That(messages.Select(x => x.Context.Message.Exceptions[0].ExceptionType == TypeCache<IntentionalTestException>.ShortName).Count(),
                     Is.EqualTo(limit));

--- a/tests/MassTransit.Tests/FaultPublish_Specs.cs
+++ b/tests/MassTransit.Tests/FaultPublish_Specs.cs
@@ -113,10 +113,13 @@
             await TestContext.Out.WriteLineAsync(string.Join(Environment.NewLine, fault.Context.Message.FaultMessageTypes));
             await TestContext.Out.WriteLineAsync(string.Join(Environment.NewLine, fault.Context.SupportedMessageTypes));
 
-            Assert.That(fault.Context.Message.FaultMessageTypes.Contains(MessageUrn.ForTypeString<BaseMessageType>()));
-            Assert.That(fault.Context.Message.FaultMessageTypes.Contains(MessageUrn.ForTypeString<ActualMessageType>()));
+            Assert.Multiple(() =>
+            {
+                Assert.That(fault.Context.Message.FaultMessageTypes, Does.Contain(MessageUrn.ForTypeString<BaseMessageType>()));
+                Assert.That(fault.Context.Message.FaultMessageTypes, Does.Contain(MessageUrn.ForTypeString<ActualMessageType>()));
 
-            Assert.That(fault.Context.SupportedMessageTypes.Contains(MessageUrn.ForTypeString<Fault<BaseMessageType>>()));
+                Assert.That(fault.Context.SupportedMessageTypes, Does.Contain(MessageUrn.ForTypeString<Fault<BaseMessageType>>()));
+            });
         }
 
         BaseMessageConsumer _consumer;
@@ -174,11 +177,14 @@
             await TestContext.Out.WriteLineAsync(string.Join(Environment.NewLine, fault.Context.Message.FaultMessageTypes));
             await TestContext.Out.WriteLineAsync(string.Join(Environment.NewLine, fault.Context.SupportedMessageTypes));
 
-            Assert.That(fault.Context.Message.FaultMessageTypes.Contains(MessageUrn.ForTypeString<BaseMessageType>()));
-            Assert.That(fault.Context.Message.FaultMessageTypes.Contains(MessageUrn.ForTypeString<ActualMessageType>()));
+            Assert.Multiple(() =>
+            {
+                Assert.That(fault.Context.Message.FaultMessageTypes, Does.Contain(MessageUrn.ForTypeString<BaseMessageType>()));
+                Assert.That(fault.Context.Message.FaultMessageTypes, Does.Contain(MessageUrn.ForTypeString<ActualMessageType>()));
 
-            Assert.That(fault.Context.SupportedMessageTypes.Contains(MessageUrn.ForTypeString<Fault<BaseMessageType>>()));
-            Assert.That(fault.Context.SupportedMessageTypes.Contains(MessageUrn.ForTypeString<Fault<ActualMessageType>>()));
+                Assert.That(fault.Context.SupportedMessageTypes, Does.Contain(MessageUrn.ForTypeString<Fault<BaseMessageType>>()));
+                Assert.That(fault.Context.SupportedMessageTypes, Does.Contain(MessageUrn.ForTypeString<Fault<ActualMessageType>>()));
+            });
         }
 
         BaseMessageConsumer _consumer;
@@ -198,7 +204,7 @@
         {
             public Task Consume(ConsumeContext<BaseMessageType> context)
             {
-                if (context.TryGetMessage<ActualMessageType>(out ConsumeContext<ActualMessageType> actualContext))
+                if (context.TryGetMessage(out ConsumeContext<ActualMessageType> actualContext))
                     return actualContext.NotifyFaulted(TimeSpan.Zero, TypeCache<FaultConsumer>.ShortName, new IntentionalTestException());
 
                 throw new InvalidOperationException("This was not expected, but gets the job done");

--- a/tests/MassTransit.Tests/Initializers/Expando_Specs.cs
+++ b/tests/MassTransit.Tests/Initializers/Expando_Specs.cs
@@ -39,7 +39,7 @@ namespace MassTransit.Tests.Initializers
         public void Should_have_an_interface_from_dictionary_converter()
         {
             var factory = new PropertyProviderFactory<IDictionary<string, object>>();
-            Assert.IsTrue(factory.TryGetPropertyConverter(out IPropertyConverter<MessageContract, object> converter));
+            Assert.That(factory.TryGetPropertyConverter(out IPropertyConverter<MessageContract, object> converter), Is.True);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace MassTransit.Tests.Initializers
             dto.Add(nameof(MessageContract.CustomerId), "SuperMart");
             dto.Add(nameof(MessageContract.UniqueId), uniqueId);
 
-            InitializeContext<MessageEnvelope> message = await MessageInitializerCache<MessageEnvelope>.Initialize(new {Contract = dto});
+            InitializeContext<MessageEnvelope> message = await MessageInitializerCache<MessageEnvelope>.Initialize(new { Contract = dto });
 
             Assert.That(message.Message.Contract, Is.Not.Null);
             Assert.That(message.Message.Contract.Id, Is.EqualTo(27));

--- a/tests/MassTransit.Tests/Initializers/MessageInitializer_Specs.cs
+++ b/tests/MassTransit.Tests/Initializers/MessageInitializer_Specs.cs
@@ -20,7 +20,7 @@ namespace MassTransit.Tests.Initializers
         {
             IRequestClient<SimpleRequest> client = CreateRequestClient<SimpleRequest>();
 
-            Response<SimpleResponse> response = await client.GetResponse<SimpleResponse>(new {Name = "Hello"});
+            Response<SimpleResponse> response = await client.GetResponse<SimpleResponse>(new { Name = "Hello" });
 
             Assert.That(response.Message.Name, Is.EqualTo("Hello"));
             Assert.That(response.Message.Value, Is.EqualTo("World"));
@@ -30,7 +30,7 @@ namespace MassTransit.Tests.Initializers
         {
             configurator.Handler<SimpleRequest>(async context =>
             {
-                await context.RespondAsync<SimpleResponse>(new {Value = "World"});
+                await context.RespondAsync<SimpleResponse>(new { Value = "World" });
             });
         }
     }
@@ -66,7 +66,7 @@ namespace MassTransit.Tests.Initializers
         {
             IRequestClient<SimpleRequest> client = CreateRequestClient<SimpleRequest>();
 
-            Response<SimpleResponse> response = await client.GetResponse<SimpleResponse>(new {Name = "Hello"});
+            Response<SimpleResponse> response = await client.GetResponse<SimpleResponse>(new { Name = "Hello" });
 
             Assert.That(response.Message.Name, Is.EqualTo("Hello"));
             Assert.That(response.Message.Value, Is.Null);
@@ -122,7 +122,7 @@ namespace MassTransit.Tests.Initializers
         public void Should_handle_basic_dictionary()
         {
             Assert.That(_response.Message.Strings, Is.Not.Null);
-            Assert.That(_response.Message.Strings.Count, Is.EqualTo(2));
+            Assert.That(_response.Message.Strings, Has.Count.EqualTo(2));
             Assert.That(_response.Message.Strings["Hello"], Is.EqualTo("World"));
             Assert.That(_response.Message.Strings["Thank You"], Is.EqualTo("Next"));
         }
@@ -131,7 +131,7 @@ namespace MassTransit.Tests.Initializers
         public void Should_handle_conversion_dictionary()
         {
             Assert.That(_response.Message.IntToStrings, Is.Not.Null);
-            Assert.That(_response.Message.IntToStrings.Count, Is.EqualTo(2));
+            Assert.That(_response.Message.IntToStrings, Has.Count.EqualTo(2));
             Assert.That(_response.Message.IntToStrings[100], Is.EqualTo("1000"));
             Assert.That(_response.Message.IntToStrings[200], Is.EqualTo("2000"));
         }
@@ -159,7 +159,7 @@ namespace MassTransit.Tests.Initializers
         public void Should_handle_enumerable_decimal()
         {
             Assert.That(_response.Message.Amounts, Is.Not.Null);
-            Assert.That(_response.Message.Amounts.Count, Is.EqualTo(2));
+            Assert.That(_response.Message.Amounts, Has.Count.EqualTo(2));
             Assert.That(_response.Message.Amounts[0], Is.EqualTo(98.6m));
             Assert.That(_response.Message.Amounts[1], Is.EqualTo(98.6m));
         }
@@ -196,7 +196,7 @@ namespace MassTransit.Tests.Initializers
         public void Should_handle_int_to_string_array()
         {
             Assert.That(_response.Message.Numbers, Is.Not.Null);
-            Assert.That(_response.Message.Numbers.Length, Is.EqualTo(3));
+            Assert.That(_response.Message.Numbers, Has.Length.EqualTo(3));
             Assert.That(_response.Message.Numbers[0], Is.EqualTo("12"));
             Assert.That(_response.Message.Numbers[1], Is.EqualTo("24"));
             Assert.That(_response.Message.Numbers[2], Is.EqualTo("36"));
@@ -212,7 +212,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public void Should_handle_interface_type_array()
         {
-            Assert.That(_response.Message.SubValues.Length, Is.EqualTo(2));
+            Assert.That(_response.Message.SubValues, Has.Length.EqualTo(2));
             Assert.That(_response.Message.SubValues[0].Text, Is.EqualTo("Frank"));
             Assert.That(_response.Message.SubValues[1].Text, Is.EqualTo("Lola"));
         }
@@ -221,7 +221,7 @@ namespace MassTransit.Tests.Initializers
         public void Should_handle_lists()
         {
             Assert.That(_response.Message.StringList, Is.Not.Null);
-            Assert.That(_response.Message.StringList.Count, Is.EqualTo(2));
+            Assert.That(_response.Message.StringList, Has.Count.EqualTo(2));
             Assert.That(_response.Message.StringList[0], Is.EqualTo("Frank"));
             Assert.That(_response.Message.StringList[1], Is.EqualTo("Estelle"));
         }
@@ -248,9 +248,12 @@ namespace MassTransit.Tests.Initializers
         public void Should_handle_object_dictionary()
         {
             Assert.That(_response.Message.StringSubValues, Is.Not.Null);
-            Assert.That(_response.Message.StringSubValues.Count, Is.EqualTo(2));
-            Assert.That(_response.Message.StringSubValues["A"].Text, Is.EqualTo("Eh"));
-            Assert.That(_response.Message.StringSubValues["B"].Text, Is.EqualTo("Bee"));
+            Assert.That(_response.Message.StringSubValues, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_response.Message.StringSubValues["A"].Text, Is.EqualTo("Eh"));
+                Assert.That(_response.Message.StringSubValues["B"].Text, Is.EqualTo("Bee"));
+            });
         }
 
         [Test]
@@ -263,10 +266,13 @@ namespace MassTransit.Tests.Initializers
         public void Should_handle_string_array()
         {
             Assert.That(_response.Message.Names, Is.Not.Null);
-            Assert.That(_response.Message.Names.Length, Is.EqualTo(3));
-            Assert.That(_response.Message.Names[0], Is.EqualTo("Curly"));
-            Assert.That(_response.Message.Names[1], Is.EqualTo("Larry"));
-            Assert.That(_response.Message.Names[2], Is.EqualTo("Moe"));
+            Assert.That(_response.Message.Names, Has.Length.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_response.Message.Names[0], Is.EqualTo("Curly"));
+                Assert.That(_response.Message.Names[1], Is.EqualTo("Larry"));
+                Assert.That(_response.Message.Names[2], Is.EqualTo("Moe"));
+            });
         }
 
         [Test]
@@ -312,11 +318,11 @@ namespace MassTransit.Tests.Initializers
                 NullableValue = 42,
                 NotNullableValue = (int?)69,
                 NullableDecimalValue = 123.45m,
-                Numbers = new[] {12, 24, 36},
-                Names = new[] {"Curly", "Larry", "Moe"},
+                Numbers = new[] { 12, 24, 36 },
+                Names = new[] { "Curly", "Larry", "Moe" },
                 Exception = new IntentionalTestException("It Happens"),
-                SubValue = new {Text = "Mary"},
-                SubValues = new object[] {new {Text = "Frank"}, new {Text = "Lola"}},
+                SubValue = new { Text = "Mary" },
+                SubValues = new object[] { new { Text = "Frank" }, new { Text = "Lola" } },
                 Amount = 867.53m,
                 Amounts = Enumerable.Repeat(98.6m, 2),
                 AsyncValue = GetIntResult().Select(x => x.Number),
@@ -326,22 +332,22 @@ namespace MassTransit.Tests.Initializers
                 ServiceAddress = new Uri("http://masstransit-project.com"),
                 OtherAddress = "http://github.com",
                 StringAddress = new Uri("loopback://localhost"),
-                StringList = new[] {"Frank", "Estelle"},
-                NewProperty = new SubProperty {NewProperty = "Hello"},
+                StringList = new[] { "Frank", "Estelle" },
+                NewProperty = new SubProperty { NewProperty = "Hello" },
                 Strings = new Dictionary<string, string>
                 {
-                    {"Hello", "World"},
-                    {"Thank You", "Next"}
+                    { "Hello", "World" },
+                    { "Thank You", "Next" }
                 },
                 StringSubValues = new Dictionary<string, object>
                 {
-                    {"A", new {Text = "Eh"}},
-                    {"B", new {Text = "Bee"}}
+                    { "A", new { Text = "Eh" } },
+                    { "B", new { Text = "Bee" } }
                 },
                 IntToStrings = new Dictionary<int, long>
                 {
-                    {100, 1000},
-                    {200, 2000}
+                    { 100, 1000 },
+                    { 200, 2000 }
                 }
             });
         }

--- a/tests/MassTransit.Tests/Initializers/PropertyProvider_Specs.cs
+++ b/tests/MassTransit.Tests/Initializers/PropertyProvider_Specs.cs
@@ -21,43 +21,43 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_async_arrays()
         {
-            var input = new {IntArray = new[] {Task.FromResult(1), Task.FromResult(2), Task.FromResult(3)}};
+            var input = new { IntArray = new[] { Task.FromResult(1), Task.FromResult(2), Task.FromResult(3) } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (long[])default);
 
             long[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new long[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new long[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_async_arrays_with_nulls()
         {
-            var input = new {IntArray = new[] {Task.FromResult(1), Task.FromResult(2), null, Task.FromResult(3)}};
+            var input = new { IntArray = new[] { Task.FromResult(1), Task.FromResult(2), null, Task.FromResult(3) } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (long[])default);
 
             long[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new long[] {1, 2, 0, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new long[] { 1, 2, 0, 3 }));
         }
 
         [Test]
         public async Task Should_support_async_convertible_arrays()
         {
-            var input = new {IntArray = Task.FromResult(new[] {1, 2, 3})};
+            var input = new { IntArray = Task.FromResult(new[] { 1, 2, 3 }) };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (long[])default);
 
             long[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new long[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new long[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_async_input_types()
         {
-            var input = new {IntValue = Task.FromResult(27)};
+            var input = new { IntValue = Task.FromResult(27) };
 
             var provider = GetPropertyProvider(input, x => x.IntValue, 69);
 
@@ -69,19 +69,19 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_async_matching_arrays()
         {
-            var input = new {IntArray = Task.FromResult(new[] {1, 2, 3})};
+            var input = new { IntArray = Task.FromResult(new[] { 1, 2, 3 }) };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (int[])default);
 
             int[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_async_matching_enumerable()
         {
-            var input = new {IntArray = Task.FromResult(new[] {1, 2, 3})};
+            var input = new { IntArray = Task.FromResult(new[] { 1, 2, 3 }) };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (IEnumerable<int>)default);
 
@@ -98,7 +98,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_async_matching_lists()
         {
-            var input = new {IntArray = Task.FromResult(new[] {1, 2, 3})};
+            var input = new { IntArray = Task.FromResult(new[] { 1, 2, 3 }) };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (List<int>)default);
 
@@ -115,7 +115,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_async_matching_readonly_lists()
         {
-            var input = new {IntArray = Task.FromResult(new[] {1, 2, 3})};
+            var input = new { IntArray = Task.FromResult(new[] { 1, 2, 3 }) };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (IReadOnlyList<int>)default);
 
@@ -132,7 +132,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_async_result_convertible_arrays()
         {
-            var input = new {IntArray = new[] {1, 2, 3}};
+            var input = new { IntArray = new[] { 1, 2, 3 } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (Task<long[]>)default);
 
@@ -140,13 +140,13 @@ namespace MassTransit.Tests.Initializers
 
             long[] arrayValue = await arrayTask;
 
-            Assert.That(arrayValue, Is.EqualTo(new long[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new long[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_async_result_types()
         {
-            var input = new {IntValue = 27};
+            var input = new { IntValue = 27 };
 
             var provider = GetPropertyProvider(input, x => x.IntValue, Task.FromResult(69));
 
@@ -159,67 +159,67 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_convertible_arrays()
         {
-            var input = new {IntArray = new[] {1, 2, 3}};
+            var input = new { IntArray = new[] { 1, 2, 3 } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (long[])default);
 
             long[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new long[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new long[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_convertible_arrays_from_strings()
         {
-            var input = new {StringArray = new[] {"1", "2", "", "3"}};
+            var input = new { StringArray = new[] { "1", "2", "", "3" } };
 
             var provider = GetPropertyProvider(input, x => x.StringArray, (int?[])default);
 
             int?[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new int?[] {1, 2, default, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new int?[] { 1, 2, default, 3 }));
         }
 
         [Test]
         public async Task Should_support_convertible_arrays_to_nullable_types()
         {
-            var input = new {IntArray = new[] {1, 2, 3}};
+            var input = new { IntArray = new[] { 1, 2, 3 } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (long?[])default);
 
             long?[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new long?[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new long?[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_convertible_arrays_to_strings()
         {
-            var input = new {IntArray = new[] {1, 2, 3}};
+            var input = new { IntArray = new[] { 1, 2, 3 } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (string[])default);
 
             string[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new[] {"1", "2", "3"}));
+            Assert.That(arrayValue, Is.EqualTo(new[] { "1", "2", "3" }));
         }
 
         [Test]
         public async Task Should_support_convertible_arrays_with_nullable_types()
         {
-            var input = new {IntArray = new int?[] {1, 2, 3}};
+            var input = new { IntArray = new int?[] { 1, 2, 3 } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (long[])default);
 
             long[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new long[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new long[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_convertible_property_types()
         {
-            var input = new {IntValue = 27};
+            var input = new { IntValue = 27 };
 
             var longProvider = GetPropertyProvider(input, x => x.IntValue, 69L);
 
@@ -235,8 +235,8 @@ namespace MassTransit.Tests.Initializers
             {
                 Strings = new Dictionary<string, string>
                 {
-                    {"Hello", "World"},
-                    {"Thank You", "Next"}
+                    { "Hello", "World" },
+                    { "Thank You", "Next" }
                 }
             };
 
@@ -245,9 +245,12 @@ namespace MassTransit.Tests.Initializers
             IDictionary<string, string> dictionary = await provider.GetProperty(CreateInitializeContext(input));
 
             Assert.That(dictionary, Is.Not.Null);
-            Assert.That(dictionary.Count, Is.EqualTo(2));
-            Assert.That(dictionary["Hello"], Is.EqualTo("World"));
-            Assert.That(dictionary["Thank You"], Is.EqualTo("Next"));
+            Assert.That(dictionary, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(dictionary["Hello"], Is.EqualTo("World"));
+                Assert.That(dictionary["Thank You"], Is.EqualTo("Next"));
+            });
         }
 
         [Test]
@@ -257,8 +260,8 @@ namespace MassTransit.Tests.Initializers
             {
                 Strings = new Dictionary<string, string>
                 {
-                    {"1", "One"},
-                    {"2", "Two"}
+                    { "1", "One" },
+                    { "2", "Two" }
                 }
             };
 
@@ -267,9 +270,12 @@ namespace MassTransit.Tests.Initializers
             IDictionary<int, string> dictionary = await provider.GetProperty(CreateInitializeContext(input));
 
             Assert.That(dictionary, Is.Not.Null);
-            Assert.That(dictionary.Count, Is.EqualTo(2));
-            Assert.That(dictionary[1], Is.EqualTo("One"));
-            Assert.That(dictionary[2], Is.EqualTo("Two"));
+            Assert.That(dictionary, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(dictionary[1], Is.EqualTo("One"));
+                Assert.That(dictionary[2], Is.EqualTo("Two"));
+            });
         }
 
         [Test]
@@ -279,8 +285,8 @@ namespace MassTransit.Tests.Initializers
             {
                 Strings = new Dictionary<string, string>
                 {
-                    {"Hello", "World"},
-                    {"Thank You", "Next"}
+                    { "Hello", "World" },
+                    { "Thank You", "Next" }
                 }
             };
 
@@ -289,9 +295,12 @@ namespace MassTransit.Tests.Initializers
             IDictionary<string, object> dictionary = await provider.GetProperty(CreateInitializeContext(input));
 
             Assert.That(dictionary, Is.Not.Null);
-            Assert.That(dictionary.Count, Is.EqualTo(2));
-            Assert.That(dictionary["Hello"], Is.EqualTo("World"));
-            Assert.That(dictionary["Thank You"], Is.EqualTo("Next"));
+            Assert.That(dictionary, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(dictionary["Hello"], Is.EqualTo("World"));
+                Assert.That(dictionary["Thank You"], Is.EqualTo("Next"));
+            });
         }
 
         [Test]
@@ -301,8 +310,8 @@ namespace MassTransit.Tests.Initializers
             {
                 Strings = (IEnumerable<KeyValuePair<string, string>>)new Dictionary<string, string>
                 {
-                    {"Hello", "World"},
-                    {"Thank You", "Next"}
+                    { "Hello", "World" },
+                    { "Thank You", "Next" }
                 }
             };
 
@@ -311,15 +320,18 @@ namespace MassTransit.Tests.Initializers
             IDictionary<string, string> dictionary = await provider.GetProperty(CreateInitializeContext(input));
 
             Assert.That(dictionary, Is.Not.Null);
-            Assert.That(dictionary.Count, Is.EqualTo(2));
-            Assert.That(dictionary["Hello"], Is.EqualTo("World"));
-            Assert.That(dictionary["Thank You"], Is.EqualTo("Next"));
+            Assert.That(dictionary, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(dictionary["Hello"], Is.EqualTo("World"));
+                Assert.That(dictionary["Thank You"], Is.EqualTo("Next"));
+            });
         }
 
         [Test]
         public async Task Should_support_enums()
         {
-            var input = new {Status = TaskStatus.RanToCompletion};
+            var input = new { Status = TaskStatus.RanToCompletion };
 
             var provider = GetPropertyProvider(input, x => x.Status, TaskStatus.Canceled);
 
@@ -331,7 +343,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_enums_from_int()
         {
-            var input = new {Status = (int)TaskStatus.RanToCompletion};
+            var input = new { Status = (int)TaskStatus.RanToCompletion };
 
             var provider = GetPropertyProvider(input, x => x.Status, TaskStatus.Canceled);
 
@@ -343,7 +355,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_enums_from_long()
         {
-            var input = new {Status = (long)TaskStatus.RanToCompletion};
+            var input = new { Status = (long)TaskStatus.RanToCompletion };
 
             var provider = GetPropertyProvider(input, x => x.Status, TaskStatus.Canceled);
 
@@ -355,7 +367,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_enums_from_strings()
         {
-            var input = new {Status = TaskStatus.RanToCompletion.ToString()};
+            var input = new { Status = TaskStatus.RanToCompletion.ToString() };
 
             var provider = GetPropertyProvider(input, x => x.Status, TaskStatus.Canceled);
 
@@ -367,7 +379,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_exceptions()
         {
-            var input = new {Exception = new IntentionalTestException("It Happens")};
+            var input = new { Exception = new IntentionalTestException("It Happens") };
 
             var provider = GetPropertyProvider(input, x => x.Exception, (ExceptionInfo)default);
 
@@ -382,7 +394,7 @@ namespace MassTransit.Tests.Initializers
         {
             var id = NewId.NextGuid();
 
-            var input = new {IdValue = new IdVariable(id)};
+            var input = new { IdValue = new IdVariable(id) };
 
             var provider = GetPropertyProvider(input, x => x.IdValue, Guid.Empty);
 
@@ -396,7 +408,7 @@ namespace MassTransit.Tests.Initializers
         {
             var id = NewId.NextGuid();
 
-            var input = new {IdValue = new IdVariable(id)};
+            var input = new { IdValue = new IdVariable(id) };
 
             var provider = GetPropertyProvider(input, x => x.IdValue, (string)default);
 
@@ -408,7 +420,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_interface_initializer()
         {
-            var input = new {Message = new {Text = "Hello"}};
+            var input = new { Message = new { Text = "Hello" } };
 
             var provider = GetPropertyProvider(input, x => x.Message, (MessageContract)default);
 
@@ -447,28 +459,37 @@ namespace MassTransit.Tests.Initializers
             var message = await provider.GetProperty(CreateInitializeContext(input));
 
             Assert.That(message, Is.Not.Null);
-            Assert.That(message.Text, Is.EqualTo("Hello"));
-            Assert.That(message.Headers, Is.Not.Null);
-            Assert.That(message.Headers.Length, Is.EqualTo(2));
-            Assert.That(message.Headers[0].Key, Is.EqualTo("Format"));
-            Assert.That(message.Headers[0].Value, Is.EqualTo("CSV"));
-            Assert.That(message.Headers[1].Key, Is.EqualTo("Length"));
-            Assert.That(message.Headers[1].Value, Is.EqualTo("2457"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Text, Is.EqualTo("Hello"));
+                Assert.That(message.Headers, Is.Not.Null);
+            });
+            Assert.That(message.Headers, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.Headers[0].Key, Is.EqualTo("Format"));
+                Assert.That(message.Headers[0].Value, Is.EqualTo("CSV"));
+                Assert.That(message.Headers[1].Key, Is.EqualTo("Length"));
+                Assert.That(message.Headers[1].Value, Is.EqualTo("2457"));
+            });
         }
 
         [Test]
         public async Task Should_support_interface_initializer_with_array()
         {
-            var input = new {Messages = new[] {new {Text = "Hello"}, new {Text = "World"}}};
+            var input = new { Messages = new[] { new { Text = "Hello" }, new { Text = "World" } } };
 
             var provider = GetPropertyProvider(input, x => x.Messages, (MessageContract[])default);
 
             MessageContract[] message = await provider.GetProperty(CreateInitializeContext(input));
 
             Assert.That(message, Is.Not.Null);
-            Assert.That(message.Length, Is.EqualTo(2));
-            Assert.That(message[0].Text, Is.EqualTo("Hello"));
-            Assert.That(message[1].Text, Is.EqualTo("World"));
+            Assert.That(message, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message[0].Text, Is.EqualTo("Hello"));
+                Assert.That(message[1].Text, Is.EqualTo("World"));
+            });
         }
 
         [Test]
@@ -478,8 +499,8 @@ namespace MassTransit.Tests.Initializers
             {
                 Messages = new Dictionary<string, object>
                 {
-                    {"Hello", new {Text = "Hello"}},
-                    {"World", new {Text = "World"}}
+                    { "Hello", new { Text = "Hello" } },
+                    { "World", new { Text = "World" } }
                 }
             };
 
@@ -488,39 +509,42 @@ namespace MassTransit.Tests.Initializers
             IDictionary<string, MessageContract> message = await provider.GetProperty(CreateInitializeContext(input));
 
             Assert.That(message, Is.Not.Null);
-            Assert.That(message.Count, Is.EqualTo(2));
-            Assert.That(message["Hello"].Text, Is.EqualTo("Hello"));
-            Assert.That(message["World"].Text, Is.EqualTo("World"));
+            Assert.That(message, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message["Hello"].Text, Is.EqualTo("Hello"));
+                Assert.That(message["World"].Text, Is.EqualTo("World"));
+            });
         }
 
         [Test]
         public async Task Should_support_matching_arrays()
         {
-            var input = new {IntArray = new[] {1, 2, 3}};
+            var input = new { IntArray = new[] { 1, 2, 3 } };
 
             var provider = GetPropertyProvider(input, x => x.IntArray, (int[])default);
 
             int[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new[] {1, 2, 3}));
+            Assert.That(arrayValue, Is.EqualTo(new[] { 1, 2, 3 }));
         }
 
         [Test]
         public async Task Should_support_matching_enumerable()
         {
-            var input = new {Decimals = Enumerable.Repeat(98.7m, 2)};
+            var input = new { Decimals = Enumerable.Repeat(98.7m, 2) };
 
             var provider = GetPropertyProvider(input, x => x.Decimals, (decimal[])default);
 
             decimal[] arrayValue = await provider.GetProperty(CreateInitializeContext(input));
 
-            Assert.That(arrayValue, Is.EqualTo(new[] {98.7m, 98.7m}));
+            Assert.That(arrayValue, Is.EqualTo(new[] { 98.7m, 98.7m }));
         }
 
         [Test]
         public async Task Should_support_matching_property_types()
         {
-            var input = new {IntValue = 27};
+            var input = new { IntValue = 27 };
 
             var provider = GetPropertyProvider(input, x => x.IntValue);
 
@@ -532,7 +556,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_multiple_result_types_for_single_property()
         {
-            var input = new {IntValue = 27};
+            var input = new { IntValue = 27 };
 
             var provider = GetPropertyProvider(input, x => x.IntValue);
 
@@ -550,7 +574,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_nullable_input_types()
         {
-            var input = new {IntValue = (int?)27};
+            var input = new { IntValue = (int?)27 };
 
             var provider = GetPropertyProvider(input, x => x.IntValue, 69);
 
@@ -568,7 +592,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_nullable_result_types()
         {
-            var input = new {IntValue = 27};
+            var input = new { IntValue = 27 };
 
             var provider = GetPropertyProvider(input, x => x.IntValue, (int?)69);
 
@@ -586,7 +610,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_object()
         {
-            var input = new {IntValue = 27};
+            var input = new { IntValue = 27 };
 
             var provider = GetPropertyProvider(input, x => x.IntValue, (object)default);
 
@@ -598,7 +622,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_string_to_uri()
         {
-            var input = new {Address = "http://localhost/"};
+            var input = new { Address = "http://localhost/" };
 
             var uriProvider = GetPropertyProvider(input, x => x.Address, (Uri)default);
 
@@ -610,7 +634,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_uri()
         {
-            var input = new {Address = new Uri("http://localhost/")};
+            var input = new { Address = new Uri("http://localhost/") };
 
             var uriProvider = GetPropertyProvider(input, x => x.Address, (Uri)default);
 
@@ -622,7 +646,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_uri_to_string()
         {
-            var input = new {Address = new Uri("http://localhost/")};
+            var input = new { Address = new Uri("http://localhost/") };
 
             var stringProvider = GetPropertyProvider(input, x => x.Address, (string)default);
 
@@ -634,7 +658,7 @@ namespace MassTransit.Tests.Initializers
         [Test]
         public async Task Should_support_value_to_string_types()
         {
-            var input = new {IntValue = 27};
+            var input = new { IntValue = 27 };
 
             var stringProvider = GetPropertyProvider(input, x => x.IntValue, (string)default);
 

--- a/tests/MassTransit.Tests/Introspection_Specs.cs
+++ b/tests/MassTransit.Tests/Introspection_Specs.cs
@@ -18,7 +18,7 @@
         public void Should_extract_receive_endpoint_addresses()
         {
             List<Uri> receiveAddresses = Bus.GetReceiveEndpointAddresses().ToList();
-            Assert.Contains(InputQueueAddress, receiveAddresses);
+            Assert.That(receiveAddresses, Does.Contain(InputQueueAddress));
         }
 
         [Test]

--- a/tests/MassTransit.Tests/MessageData/NestedInitializer_Specs.cs
+++ b/tests/MassTransit.Tests/MessageData/NestedInitializer_Specs.cs
@@ -69,14 +69,14 @@ namespace MassTransit.Tests.MessageData
             configurator.Handler<Documents>(async context =>
             {
                 Assert.That(context.Message.Bodies, Is.Not.Null);
-                Assert.That(context.Message.Bodies.Length, Is.EqualTo(2));
+                Assert.That(context.Message.Bodies, Has.Length.EqualTo(2));
 
                 Assert.That(context.Message.Bodies[0].Body, Is.Not.Null);
                 Assert.That(context.Message.Bodies[0].Body.HasValue);
 
                 byte[] bodyValue = await context.Message.Bodies[0].Body.Value;
                 Assert.That(bodyValue, Is.Not.Null);
-                Assert.That(bodyValue.Length, Is.EqualTo(10000));
+                Assert.That(bodyValue, Has.Length.EqualTo(10000));
 
                 Assert.That(context.Message.Bodies[0].FileName, Is.Not.Null);
                 Assert.That(context.Message.Bodies[0].FileName, Is.EqualTo("first.txt"));

--- a/tests/MassTransit.Tests/MessageData/ResponseMessageData_Specs.cs
+++ b/tests/MassTransit.Tests/MessageData/ResponseMessageData_Specs.cs
@@ -22,9 +22,12 @@ namespace MassTransit.Tests.MessageData
                 Key = "Hello"
             });
 
-            Assert.That(response.Message.Key, Is.EqualTo("Hello"));
+            Assert.Multiple(async () =>
+            {
+                Assert.That(response.Message.Key, Is.EqualTo("Hello"));
 
-            Assert.That(await response.Message.Value.Value, Is.Not.Empty);
+                Assert.That(await response.Message.Value.Value, Is.Not.Empty);
+            });
         }
 
         [Test]

--- a/tests/MassTransit.Tests/Middleware/Agents/Agent_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Agents/Agent_Specs.cs
@@ -126,8 +126,11 @@
             Assert.That(async () => await supervisor.Send(pipe), Throws.TypeOf<IntentionalTestException>());
             await supervisor.Send(pipe);
 
-            Assert.That(lastValue, Is.EqualTo("2"));
-            Assert.That(count, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(lastValue, Is.EqualTo("2"));
+                Assert.That(count, Is.EqualTo(3));
+            });
 
             await supervisor.Stop();
 

--- a/tests/MassTransit.Tests/Middleware/Caching/Bucket_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Caching/Bucket_Specs.cs
@@ -57,7 +57,7 @@
 
             Task<SimpleValue>[] values = cache.GetAll().ToArray();
 
-            Assert.That(values.Length, Is.EqualTo(101));
+            Assert.That(values, Has.Length.EqualTo(101));
         }
 
         [Test]
@@ -89,7 +89,7 @@
 
             Task<SimpleValue>[] values = cache.GetAll().ToArray();
 
-            Assert.That(values.Length, Is.EqualTo(60));
+            Assert.That(values, Has.Length.EqualTo(60));
         }
 
         [Test]

--- a/tests/MassTransit.Tests/Middleware/Clone_a_payload_cache.cs
+++ b/tests/MassTransit.Tests/Middleware/Clone_a_payload_cache.cs
@@ -20,11 +20,12 @@
 
             p2.GetOrAddPayload(() => new Item2("bill"));
 
-            Item2 i2;
-            Assert.That(p.TryGetPayload(out i2), Is.False);
-            Assert.That(p2.TryGetPayload(out i2), Is.True);
-            Item i1;
-            Assert.That(p2.TryGetPayload(out i1), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(p.TryGetPayload(out Item2 _), Is.False);
+                Assert.That(p2.TryGetPayload(out Item2 _), Is.True);
+            });
+            Assert.That(p2.TryGetPayload(out Item _), Is.True);
         }
 
 

--- a/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionGeneric_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionGeneric_Specs.cs
@@ -13,25 +13,25 @@ namespace MassTransit.Tests.Middleware.Internals
         [Test]
         public void Should_close_generic_type()
         {
-            Assert.IsTrue(typeof(GenericClass).ClosesType(typeof(IGeneric<>)));
+            Assert.That(typeof(GenericClass).ClosesType(typeof(IGeneric<>)), Is.True);
         }
 
         [Test]
         public void Should_not_close_nested_open_generic_base_class()
         {
-            Assert.IsFalse(typeof(SuperGenericBaseClass<>).ClosesType(typeof(GenericBaseClass<>)));
+            Assert.That(typeof(SuperGenericBaseClass<>).ClosesType(typeof(GenericBaseClass<>)), Is.False);
         }
 
         [Test]
         public void Should_not_close_nested_open_generic_interface_in_base_class()
         {
-            Assert.IsFalse(typeof(SuperGenericBaseClass<>).ClosesType(typeof(IGeneric<>)));
+            Assert.That(typeof(SuperGenericBaseClass<>).ClosesType(typeof(IGeneric<>)), Is.False);
         }
 
         [Test]
         public void Should_not_close_open_generic_type()
         {
-            Assert.IsFalse(typeof(GenericBaseClass<>).ClosesType(typeof(IGeneric<>)));
+            Assert.That(typeof(GenericBaseClass<>).ClosesType(typeof(IGeneric<>)), Is.False);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionMoreGeneric_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Internals/TypeExtensionMoreGeneric_Specs.cs
@@ -13,7 +13,7 @@ namespace MassTransit.Tests.Middleware.Internals
         [Test]
         public void Should_not_close_open_generic()
         {
-            Assert.IsFalse(typeof(ISingleGeneric<>).ClosesType(typeof(ISingleGeneric<>)));
+            Assert.That(typeof(ISingleGeneric<>).ClosesType(typeof(ISingleGeneric<>)), Is.False);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/Middleware/Internals/TypeExtension_Specs.cs
+++ b/tests/MassTransit.Tests/Middleware/Internals/TypeExtension_Specs.cs
@@ -11,67 +11,67 @@ namespace MassTransit.Tests.Middleware.Internals
         [Test]
         public void Should_match_a_generic_base_class_implementation_of_the_interface()
         {
-            Assert.IsTrue(typeof(NonGenericSubClass).HasInterface<IGeneric<int>>());
+            Assert.That(typeof(NonGenericSubClass).HasInterface<IGeneric<int>>(), Is.True);
         }
 
         [Test]
         public void Should_match_a_generic_interface()
         {
-            Assert.IsTrue(typeof(GenericClass).HasInterface<IGeneric<int>>());
+            Assert.That(typeof(GenericClass).HasInterface<IGeneric<int>>(), Is.True);
         }
 
         [Test]
         public void Should_match_a_regular_interface_by_type_argument_on_an_object()
         {
-            Assert.IsTrue(typeof(GenericClass).HasInterface(typeof(INotGeneric)));
+            Assert.That(typeof(GenericClass).HasInterface(typeof(INotGeneric)), Is.True);
         }
 
         [Test]
         public void Should_match_a_regular_interface_on_an_object()
         {
-            Assert.IsTrue(typeof(GenericClass).HasInterface<INotGeneric>());
+            Assert.That(typeof(GenericClass).HasInterface<INotGeneric>(), Is.True);
         }
 
         [Test]
         public void Should_match_a_regular_interface_using_the_generic_argument()
         {
-            Assert.IsTrue(typeof(GenericClass).HasInterface<INotGeneric>());
+            Assert.That(typeof(GenericClass).HasInterface<INotGeneric>(), Is.True);
         }
 
         [Test]
         public void Should_match_a_regular_interface_using_the_generic_argument_on_a_subclass()
         {
-            Assert.IsTrue(typeof(GenericSubClass).HasInterface<INotGeneric>());
+            Assert.That(typeof(GenericSubClass).HasInterface<INotGeneric>(), Is.True);
         }
 
         [Test]
         public void Should_match_a_regular_interface_using_the_type_argument()
         {
-            Assert.IsTrue(typeof(GenericClass).HasInterface(typeof(INotGeneric)));
+            Assert.That(typeof(GenericClass).HasInterface(typeof(INotGeneric)), Is.True);
         }
 
         [Test]
         public void Should_match_a_regular_interface_using_the_type_argument_on_a_subclass()
         {
-            Assert.IsTrue(typeof(GenericSubClass).HasInterface(typeof(INotGeneric)));
+            Assert.That(typeof(GenericSubClass).HasInterface(typeof(INotGeneric)), Is.True);
         }
 
         [Test]
         public void Should_match_an_open_generic_interface()
         {
-            Assert.IsTrue(typeof(GenericClass).HasInterface(typeof(IGeneric<>)));
+            Assert.That(typeof(GenericClass).HasInterface(typeof(IGeneric<>)), Is.True);
         }
 
         [Test]
         public void Should_match_an_open_generic_interface_in_a_base_class()
         {
-            Assert.IsTrue(typeof(NonGenericSubClass).HasInterface(typeof(IGeneric<>)));
+            Assert.That(typeof(NonGenericSubClass).HasInterface(typeof(IGeneric<>)), Is.True);
         }
 
         [Test]
         public void Should_not_match_a_regular_interface_that_is_not_implemented()
         {
-            Assert.IsFalse(typeof(GenericClass).HasInterface<IDisposable>());
+            Assert.That(typeof(GenericClass).HasInterface<IDisposable>(), Is.False);
         }
 
 

--- a/tests/MassTransit.Tests/MultiBusRequest_Specs.cs
+++ b/tests/MassTransit.Tests/MultiBusRequest_Specs.cs
@@ -47,8 +47,11 @@ namespace MassTransit.Tests
                 __Header_Test_Value = "Hello, World"
             }, timeout: harness.TestInactivityTimeout);
 
-            Assert.That(response.Message.Value, Is.EqualTo("Key: Hello"));
-            Assert.That(response.Headers.Get<string>("Test-Value"), Is.EqualTo("Hello, World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.Value, Is.EqualTo("Key: Hello"));
+                Assert.That(response.Headers.Get<string>("Test-Value"), Is.EqualTo("Hello, World"));
+            });
         }
 
 

--- a/tests/MassTransit.Tests/MultiTestConsumer_Specs.cs
+++ b/tests/MassTransit.Tests/MultiTestConsumer_Specs.cs
@@ -27,8 +27,13 @@
                 await Bus.Publish(pingMessage);
                 await Bus.Publish(pingMessage2);
 
-                Assert.IsTrue(consumer.Received.Select<PingMessage>(received => received.Context.Message.CorrelationId == pingMessage.CorrelationId).Any());
-                Assert.IsTrue(consumer.Received.Select<PingMessage>(received => received.Context.Message.CorrelationId == pingMessage2.CorrelationId).Any());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(consumer.Received.Select<PingMessage>(received => received.Context.Message.CorrelationId == pingMessage.CorrelationId).Any(),
+                        Is.True);
+                    Assert.That(consumer.Received.Select<PingMessage>(received => received.Context.Message.CorrelationId == pingMessage2.CorrelationId).Any(),
+                        Is.True);
+                });
             }
             finally
             {
@@ -49,7 +54,7 @@
             {
                 await Bus.Publish(new PingMessage());
 
-                Assert.IsTrue(received.Select().Any());
+                Assert.That(received.Select().Any(), Is.True);
             }
             finally
             {
@@ -71,8 +76,12 @@
                 await Bus.Publish(pingMessage);
                 await Bus.Publish(new PongMessage(pingMessage.CorrelationId));
 
-                Assert.IsTrue(consumer.Received.Select<PingMessage>().Any());
-                Assert.IsTrue(consumer.Received.Select<PongMessage>(received => received.Context.Message.CorrelationId == pingMessage.CorrelationId).Any());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(consumer.Received.Select<PingMessage>().Any(), Is.True);
+                    Assert.That(consumer.Received.Select<PongMessage>(received => received.Context.Message.CorrelationId == pingMessage.CorrelationId).Any(),
+                        Is.True);
+                });
             }
             finally
             {

--- a/tests/MassTransit.Tests/Pipeline/Transaction_Specs.cs
+++ b/tests/MassTransit.Tests/Pipeline/Transaction_Specs.cs
@@ -26,7 +26,7 @@
                     {
                         Console.WriteLine("ExecuteAsync: {0}", Thread.CurrentThread.ManagedThreadId);
 
-                        Assert.IsNotNull(Transaction.Current);
+                        Assert.That(Transaction.Current, Is.Not.Null);
                         Console.WriteLine("Isolation Level: {0}", Transaction.Current.IsolationLevel);
                     }
                 }));
@@ -52,7 +52,7 @@
                     {
                         Console.WriteLine("ExecuteAsync: {0}", Thread.CurrentThread.ManagedThreadId);
 
-                        Assert.IsNotNull(Transaction.Current);
+                        Assert.That(Transaction.Current, Is.Not.Null);
                         Console.WriteLine("Isolation Level: {0}", Transaction.Current.IsolationLevel);
 
                         scope.Complete();
@@ -81,7 +81,7 @@
                     {
                         Console.WriteLine("ExecuteAsync: {0}", Thread.CurrentThread.ManagedThreadId);
 
-                        Assert.IsNotNull(Transaction.Current);
+                        Assert.That(Transaction.Current, Is.Not.Null);
                         Console.WriteLine("Isolation Level: {0}", Transaction.Current.IsolationLevel);
                         scope.Complete();
                     }
@@ -108,7 +108,7 @@
                     {
                         Console.WriteLine("ExecuteAsync: {0}", Thread.CurrentThread.ManagedThreadId);
 
-                        Assert.IsNotNull(Transaction.Current);
+                        Assert.That(Transaction.Current, Is.Not.Null);
                         Console.WriteLine("Isolation Level: {0}", Transaction.Current.IsolationLevel);
 
                         Thread.Sleep(5000);

--- a/tests/MassTransit.Tests/PollingAlgorithm_Specs.cs
+++ b/tests/MassTransit.Tests/PollingAlgorithm_Specs.cs
@@ -87,8 +87,11 @@ namespace MassTransit.Tests
             await algorithm.Run(GetMessages, ProcessMessage, GroupMessages, OrderMessages);
             await algorithm.Run(GetMessages, ProcessMessage, GroupMessages, OrderMessages);
 
-            Assert.That(algorithm.ActiveRequestCount, Is.EqualTo(0));
-            Assert.That(algorithm.MaxActiveRequestCount, Is.EqualTo(10));
+            Assert.Multiple(() =>
+            {
+                Assert.That(algorithm.ActiveRequestCount, Is.EqualTo(0));
+                Assert.That(algorithm.MaxActiveRequestCount, Is.EqualTo(10));
+            });
         }
 
         [Test]
@@ -120,9 +123,12 @@ namespace MassTransit.Tests
 
             request = await state.BeginRequest();
             await request.Complete(state.ResultLimit);
-            Assert.That(state.RequestCount, Is.EqualTo(10));
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.RequestCount, Is.EqualTo(10));
 
-            Assert.That(state.ActiveRequestCount, Is.EqualTo(0));
+                Assert.That(state.ActiveRequestCount, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -134,8 +140,11 @@ namespace MassTransit.Tests
                 RequestResultLimit = 10
             });
 
-            Assert.That(algorithm.RequestCount, Is.EqualTo(1));
-            Assert.That(algorithm.ResultLimit, Is.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(algorithm.RequestCount, Is.EqualTo(1));
+                Assert.That(algorithm.ResultLimit, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -147,14 +156,20 @@ namespace MassTransit.Tests
                 RequestResultLimit = 100
             });
 
-            Assert.That(algorithm.RequestCount, Is.EqualTo(1));
-            Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            Assert.Multiple(() =>
+            {
+                Assert.That(algorithm.RequestCount, Is.EqualTo(1));
+                Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            });
 
             var request = await algorithm.BeginRequest();
             await request.Complete(algorithm.ResultLimit);
 
-            Assert.That(algorithm.RequestCount, Is.EqualTo(1));
-            Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            Assert.Multiple(() =>
+            {
+                Assert.That(algorithm.RequestCount, Is.EqualTo(1));
+                Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            });
         }
 
         [Test]
@@ -166,14 +181,20 @@ namespace MassTransit.Tests
                 RequestResultLimit = 100
             });
 
-            Assert.That(algorithm.RequestCount, Is.EqualTo(1));
-            Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            Assert.Multiple(() =>
+            {
+                Assert.That(algorithm.RequestCount, Is.EqualTo(1));
+                Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            });
 
             var request = await algorithm.BeginRequest();
             await request.Complete(0);
 
-            Assert.That(algorithm.RequestCount, Is.EqualTo(1));
-            Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            Assert.Multiple(() =>
+            {
+                Assert.That(algorithm.RequestCount, Is.EqualTo(1));
+                Assert.That(algorithm.ResultLimit, Is.EqualTo(100));
+            });
         }
 
 

--- a/tests/MassTransit.Tests/PublishSubscribe_Specs.cs
+++ b/tests/MassTransit.Tests/PublishSubscribe_Specs.cs
@@ -63,8 +63,11 @@ namespace MassTransit.Tests
 
             ConsumeContext<PingMessage> context = await _received;
 
-            Assert.That(context.RequestId.HasValue, Is.True);
-            Assert.That(context.RequestId.Value, Is.EqualTo(_requestId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.RequestId.HasValue, Is.True);
+                Assert.That(context.RequestId.Value, Is.EqualTo(_requestId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _received;
@@ -89,8 +92,11 @@ namespace MassTransit.Tests
 
             ConsumeContext<PingMessage> context = await _received;
 
-            Assert.That(context.RequestId.HasValue, Is.True);
-            Assert.That(context.RequestId.Value, Is.EqualTo(_requestId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.RequestId.HasValue, Is.True);
+                Assert.That(context.RequestId.Value, Is.EqualTo(_requestId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _received;
@@ -160,8 +166,11 @@ namespace MassTransit.Tests
 
             ConsumeContext<PingMessage> context = await _received;
 
-            Assert.That(context.RequestId.HasValue, Is.True);
-            Assert.That(context.RequestId, Is.EqualTo(_requestId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.RequestId.HasValue, Is.True);
+                Assert.That(context.RequestId, Is.EqualTo(_requestId));
+            });
         }
 
         Task<ConsumeContext<PingMessage>> _received;

--- a/tests/MassTransit.Tests/ReliableMessaging/ReliableInMemory_Specs.cs
+++ b/tests/MassTransit.Tests/ReliableMessaging/ReliableInMemory_Specs.cs
@@ -121,9 +121,12 @@ namespace MassTransit.Tests.ReliableMessaging
             ISagaStateMachineTestHarness<ReliableStateMachine, ReliableState>? sagaHarness =
                 harness.GetSagaStateMachineHarness<ReliableStateMachine, ReliableState>();
 
-            Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
 
-            Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+            });
         }
 
         [Test]
@@ -150,9 +153,12 @@ namespace MassTransit.Tests.ReliableMessaging
             ISagaStateMachineTestHarness<ReliableStateMachine, ReliableState>? sagaHarness =
                 harness.GetSagaStateMachineHarness<ReliableStateMachine, ReliableState>();
 
-            Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await sagaHarness.Consumed.Any<CreateState>(), Is.True);
 
-            Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+                Assert.That(await sagaHarness.Exists(sagaId, x => x.Verified), Is.Not.Null);
+            });
         }
 
         [Test]

--- a/tests/MassTransit.Tests/RequestClientNew_Specs.cs
+++ b/tests/MassTransit.Tests/RequestClientNew_Specs.cs
@@ -38,9 +38,12 @@
                 response = await request.GetResponse<Value>();
             }
 
-            Assert.That(response.RequestId.HasValue, Is.True);
-            Assert.That(response.Headers.TryGetHeader("Frank", out var value), Is.True);
-            Assert.That(value, Is.EqualTo("Mary"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.RequestId.HasValue, Is.True);
+                Assert.That(response.Headers.TryGetHeader("Frank", out var value), Is.True);
+                Assert.That(value, Is.EqualTo("Mary"));
+            });
         }
 
         [Test]
@@ -104,9 +107,12 @@
             }
             catch (RequestFaultException exception)
             {
-                Assert.That(exception.Fault.Exceptions.First().ExceptionType, Is.EqualTo(TypeCache<IntentionalTestException>.ShortName));
-                Assert.That(exception.RequestType, Is.EqualTo(TypeCache<GetValue>.ShortName));
-                Assert.That(exception.Fault.FaultMessageTypes, Is.EqualTo(MessageTypeCache<GetValue>.MessageTypeNames));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(exception.Fault.Exceptions.First().ExceptionType, Is.EqualTo(TypeCache<IntentionalTestException>.ShortName));
+                    Assert.That(exception.RequestType, Is.EqualTo(TypeCache<GetValue>.ShortName));
+                    Assert.That(exception.Fault.FaultMessageTypes, Is.EqualTo(MessageTypeCache<GetValue>.MessageTypeNames));
+                });
             }
             catch
             {
@@ -163,9 +169,12 @@
 
             Response<MemberRegistered, ExistingMemberFound> response = await client.GetResponse<MemberRegistered, ExistingMemberFound>(new RegisterMember());
 
-            Assert.That(response.Is(out Response<MemberRegistered> _), Is.True, "Should have been registered");
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Is(out Response<MemberRegistered> _), Is.True, "Should have been registered");
 
-            Assert.That(response.Is(out Response<ExistingMemberFound> _), Is.False, "Should not have been an existing member");
+                Assert.That(response.Is(out Response<ExistingMemberFound> _), Is.False, "Should not have been an existing member");
+            });
         }
 
         [Test]
@@ -176,9 +185,12 @@
             Response<MemberRegistered, ExistingMemberFound> response =
                 await client.GetResponse<MemberRegistered, ExistingMemberFound>(new RegisterMember { MemberId = "Johnny5" });
 
-            Assert.That(response.Is(out Response<MemberRegistered> _), Is.False, "Should not have been registered");
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Is(out Response<MemberRegistered> _), Is.False, "Should not have been registered");
 
-            Assert.That(response.Is(out Response<ExistingMemberFound> _), Is.True, "Should have been an existing member");
+                Assert.That(response.Is(out Response<ExistingMemberFound> _), Is.True, "Should have been an existing member");
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/RequestClient_Specs.cs
+++ b/tests/MassTransit.Tests/RequestClient_Specs.cs
@@ -97,8 +97,11 @@
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Assert.That(unhandledExceptions, Is.Empty);
-            Assert.That(unobservedTaskExceptions, Is.Empty);
+            Assert.Multiple(() =>
+            {
+                Assert.That(unhandledExceptions, Is.Empty);
+                Assert.That(unobservedTaskExceptions, Is.Empty);
+            });
         }
     }
 
@@ -113,7 +116,9 @@
         {
             var mediator = MassTransit.Bus.Factory.CreateMediator(x =>
             {
-                x.Handler<PingMessage>(async context => {});
+                x.Handler<PingMessage>(async context =>
+                {
+                });
             });
 
             List<object> unhandledExceptions = new List<object>();
@@ -140,10 +145,14 @@
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Assert.That(unhandledExceptions, Is.Empty, "Unhandled");
-            Assert.That(unobservedTaskExceptions, Is.Empty, "Unobserved");
+            Assert.Multiple(() =>
+            {
+                Assert.That(unhandledExceptions, Is.Empty, "Unhandled");
+                Assert.That(unobservedTaskExceptions, Is.Empty, "Unobserved");
+            });
         }
     }
+
 
     [TestFixture]
     [Explicit]
@@ -182,8 +191,11 @@
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Assert.That(unhandledExceptions, Is.Empty, "Unhandled");
-            Assert.That(unobservedTaskExceptions, Is.Empty, "Unobserved");
+            Assert.Multiple(() =>
+            {
+                Assert.That(unhandledExceptions, Is.Empty, "Unhandled");
+                Assert.That(unobservedTaskExceptions, Is.Empty, "Unobserved");
+            });
         }
     }
 

--- a/tests/MassTransit.Tests/Retry_Specs.cs
+++ b/tests/MassTransit.Tests/Retry_Specs.cs
@@ -233,10 +233,13 @@
 
             await fault;
 
-            Assert.That(_attempts, Is.EqualTo(4));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_attempts, Is.EqualTo(4));
 
-            Assert.That(_lastCount, Is.EqualTo(2));
-            Assert.That(_lastAttempt, Is.EqualTo(3));
+                Assert.That(_lastCount, Is.EqualTo(2));
+                Assert.That(_lastAttempt, Is.EqualTo(3));
+            });
         }
 
         int _attempts;
@@ -283,10 +286,13 @@
 
             await fault;
 
-            Assert.That(_attempts, Is.EqualTo(6));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_attempts, Is.EqualTo(6));
 
-            Assert.That(_lastCount, Is.EqualTo(4));
-            Assert.That(_lastAttempt, Is.EqualTo(5));
+                Assert.That(_lastCount, Is.EqualTo(4));
+                Assert.That(_lastAttempt, Is.EqualTo(5));
+            });
         }
 
         static int _attempts;
@@ -326,6 +332,17 @@
             IConsumer<YourMessage>,
             IConsumer<Fault<YourMessage>>
         {
+            public Task Consume(ConsumeContext<Fault<YourMessage>> context)
+            {
+                var faultRetryCount = context.Headers.Get(MessageHeaders.FaultRetryCount, default(int?)) ?? 0;
+
+                TestContext.Out.WriteLine($"Attempt (from fault consumer): {faultRetryCount}");
+
+                TestContext.Out.WriteLine(@"Faulted, won't retry any more.");
+
+                return Task.CompletedTask;
+            }
+
             public Task Consume(ConsumeContext<YourMessage> context)
             {
                 Interlocked.Increment(ref _attempts);
@@ -336,17 +353,6 @@
                 TestContext.Out.WriteLine($"Attempt: {context.GetRetryAttempt()}");
 
                 throw new Exception("Big bad exception");
-            }
-
-            public Task Consume(ConsumeContext<Fault<YourMessage>> context)
-            {
-                var faultRetryCount = context.Headers.Get(MessageHeaders.FaultRetryCount, default(int?)) ?? 0;
-
-                TestContext.Out.WriteLine($"Attempt (from fault consumer): {faultRetryCount}");
-
-                TestContext.Out.WriteLine(@"Faulted, won't retry any more.");
-
-                return Task.CompletedTask;
             }
         }
     }
@@ -369,10 +375,13 @@
 
             await fault;
 
-            Assert.That(Consumer.Attempts, Is.EqualTo(4));
+            Assert.Multiple(() =>
+            {
+                Assert.That(Consumer.Attempts, Is.EqualTo(4));
 
-            Assert.That(Consumer.LastCount, Is.EqualTo(2));
-            Assert.That(Consumer.LastAttempt, Is.EqualTo(3));
+                Assert.That(Consumer.LastCount, Is.EqualTo(2));
+                Assert.That(Consumer.LastAttempt, Is.EqualTo(3));
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -423,10 +432,13 @@
 
             await fault;
 
-            Assert.That(_attempts, Is.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_attempts, Is.EqualTo(1));
 
-            Assert.That(_lastAttempt, Is.EqualTo(0));
-            Assert.That(_lastCount, Is.EqualTo(0));
+                Assert.That(_lastAttempt, Is.EqualTo(0));
+                Assert.That(_lastCount, Is.EqualTo(0));
+            });
         }
 
         int _attempts;
@@ -476,9 +488,12 @@
 
             await fault;
 
-            Assert.That(_attempts, Is.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_attempts, Is.EqualTo(1));
 
-            Assert.That(_lastAttempt, Is.EqualTo(0));
+                Assert.That(_lastAttempt, Is.EqualTo(0));
+            });
         }
 
         int _attempts;
@@ -571,11 +586,14 @@
 
             var payload = await _payload.Task;
 
-            Assert.That(payload.PostCreateCount, Is.EqualTo(0), "PostCreateCount");
-            Assert.That(payload.RetryCompletedCount, Is.EqualTo(1), "RetryCompletedCount");
-            Assert.That(payload.PreRetryCount, Is.EqualTo(1), "PreRetryCount");
-            Assert.That(payload.PostFaultCount, Is.EqualTo(1), "PostFaultCount");
-            Assert.That(payload.RetryFaultCount, Is.EqualTo(0), "RetryFaultCount");
+            Assert.Multiple(() =>
+            {
+                Assert.That(payload.PostCreateCount, Is.EqualTo(0), "PostCreateCount");
+                Assert.That(payload.RetryCompletedCount, Is.EqualTo(1), "RetryCompletedCount");
+                Assert.That(payload.PreRetryCount, Is.EqualTo(1), "PreRetryCount");
+                Assert.That(payload.PostFaultCount, Is.EqualTo(1), "PostFaultCount");
+                Assert.That(payload.RetryFaultCount, Is.EqualTo(0), "RetryFaultCount");
+            });
         }
 
         int _attempts;

--- a/tests/MassTransit.Tests/Saga/Locator/SagaExpression_Specs.cs
+++ b/tests/MassTransit.Tests/Saga/Locator/SagaExpression_Specs.cs
@@ -26,7 +26,7 @@ namespace MassTransit.Tests.Saga.Locator
 
             Guid? matches = await _repository.ShouldContainSaga(filter, TestTimeout);
 
-            Assert.IsTrue(matches.HasValue);
+            Assert.That(matches.HasValue, Is.True);
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace MassTransit.Tests.Saga.Locator
 
             Guid? matches = await _repository.ShouldContainSaga(filter, TestTimeout);
 
-            Assert.IsTrue(matches.HasValue);
+            Assert.That(matches.HasValue, Is.True);
         }
 
         public SagaExpression_Specs()

--- a/tests/MassTransit.Tests/Saga/NewOrExisting_Specs.cs
+++ b/tests/MassTransit.Tests/Saga/NewOrExisting_Specs.cs
@@ -21,9 +21,12 @@ namespace MassTransit.Tests.Saga
             await InputQueueSendEndpoint.Send(message);
 
             var saga = _sagaHarness.Sagas.Contains(sagaId);
-            Assert.That(saga, Is.Not.Null);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(saga, Is.Not.Null);
 
-            Assert.That(await _sagaHarness.Consumed.Any<EventMessage>());
+                Assert.That(await _sagaHarness.Consumed.Any<EventMessage>());
+            });
         }
 
         [Test]
@@ -36,9 +39,12 @@ namespace MassTransit.Tests.Saga
             await InputQueueSendEndpoint.Send(message);
 
             var saga = _sagaHarness.Sagas.Contains(sagaId);
-            Assert.That(saga, Is.Not.Null);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(saga, Is.Not.Null);
 
-            Assert.That(await _sagaHarness.Consumed.Any<CreateMessage>());
+                Assert.That(await _sagaHarness.Consumed.Any<CreateMessage>());
+            });
 
             await InputQueueSendEndpoint.Send(new EventMessage(sagaId));
 

--- a/tests/MassTransit.Tests/Saga/PartitionSaga_Specs.cs
+++ b/tests/MassTransit.Tests/Saga/PartitionSaga_Specs.cs
@@ -28,7 +28,7 @@
             for (var i = 0; i < Limit; i++)
             {
                 Guid? guid = await _repository.ShouldContainSaga(ids[i], TestTimeout);
-                Assert.IsTrue(guid.HasValue);
+                Assert.That(guid.HasValue, Is.True);
             }
 
             timer.Stop();

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Combine_Assigned_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Combine_Assigned_Specs.cs
@@ -19,8 +19,11 @@
             await _machine.RaiseEvent(_instance, _machine.First);
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsTrue(_instance.Called);
-            Assert.IsEmpty(_machine.NextEvents(_instance.CurrentState));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.Called, Is.True);
+                Assert.That(_machine.NextEvents(_instance.CurrentState), Is.Empty);
+            });
         }
 
         [Test]
@@ -195,8 +198,11 @@
 
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.That(_instance.Called, Is.False);
-            Assert.That(_machine.NextEvents(_machine.GetState("Final")), Is.Empty);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.Called, Is.False);
+                Assert.That(_machine.NextEvents(_machine.GetState("Final")), Is.Empty);
+            });
         }
 
         TestStateMachine _machine;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Combine_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Combine_Specs.cs
@@ -18,7 +18,7 @@
             await _machine.RaiseEvent(_instance, _machine.First);
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
@@ -30,7 +30,7 @@
 
             await _machine.RaiseEvent(_instance, _machine.First);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         [Test]
@@ -42,7 +42,7 @@
 
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         TestStateMachine _machine;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/CompositeCondition_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/CompositeCondition_Specs.cs
@@ -18,8 +18,11 @@
             await _machine.RaiseEvent(_instance, _machine.Second);
             await _machine.RaiseEvent(_instance, _machine.First);
 
-            Assert.IsTrue(_instance.Called);
-            Assert.IsTrue(_instance.SecondFirst);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.Called, Is.True);
+                Assert.That(_instance.SecondFirst, Is.True);
+            });
         }
 
         [Test]
@@ -32,19 +35,20 @@
             await _machine.RaiseEvent(_instance, _machine.First);
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsFalse(_instance.Called);
-            Assert.IsFalse(_instance.SecondFirst);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.Called, Is.False);
+                Assert.That(_instance.SecondFirst, Is.False);
+            });
         }
-
 
         TestStateMachine _machine;
         Instance _instance;
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public CompositeEventStatus CompositeStatus { get; set; }
             public bool Called { get; set; }
             public bool CalledAfterAll { get; set; }
@@ -52,6 +56,7 @@ SagaStateMachineInstance
             public bool SecondFirst { get; set; }
             public bool First { get; set; }
             public bool Second { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -78,7 +83,7 @@ SagaStateMachineInstance
                             context.Instance.Second = true;
                             context.Instance.CalledAfterAll = false;
                         })
-                    );
+                );
 
                 CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/CompositeEventMultipleStates_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/CompositeEventMultipleStates_Specs.cs
@@ -8,9 +8,6 @@
     [TestFixture]
     public class When_combining_events_into_a_single_event_into_a_single_event
     {
-        TestStateMachine _machine;
-        Instance _instance;
-
         [Test]
         public async Task Should_have_called_combined_event_when_compositeevent_defined_before()
         {
@@ -21,7 +18,7 @@
             await _machine.RaiseEvent(_instance, _machine.First);
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
@@ -34,8 +31,11 @@
             await _machine.RaiseEvent(_instance, _machine.First);
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
+
+        TestStateMachine _machine;
+        Instance _instance;
 
 
         sealed class TestStateMachine :
@@ -75,6 +75,7 @@
             public Event Third { get; private set; }
         }
 
+
         class Instance :
             SagaStateMachineInstance
         {
@@ -92,13 +93,13 @@
             public int CompositeStatus { get; set; }
             public int CurrentState { get; set; }
 
-            public Guid CorrelationId { get; set; }
-
             public bool? Called
             {
                 get { return _called; }
                 set { _called = value; }
             }
+
+            public Guid CorrelationId { get; set; }
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/CompositeOrder_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/CompositeOrder_Specs.cs
@@ -18,7 +18,7 @@
             await _machine.RaiseEvent(_instance, _machine.First);
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
@@ -31,7 +31,7 @@
             await _machine.RaiseEvent(_instance, _machine.First);
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsTrue(_instance.CalledAfterAll);
+            Assert.That(_instance.CalledAfterAll, Is.True);
         }
 
         [Test]
@@ -43,7 +43,7 @@
 
             await _machine.RaiseEvent(_instance, _machine.First);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         [Test]
@@ -55,7 +55,7 @@
 
             await _machine.RaiseEvent(_instance, _machine.Second);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         TestStateMachine _machine;
@@ -63,13 +63,13 @@
 
 
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public CompositeEventStatus CompositeStatus { get; set; }
             public bool Called { get; set; }
             public bool CalledAfterAll { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
 
 
@@ -84,9 +84,15 @@ SagaStateMachineInstance
 
                 During(Waiting,
                     When(First)
-                        .Then(context => { context.Instance.CalledAfterAll = false; }),
+                        .Then(context =>
+                        {
+                            context.Instance.CalledAfterAll = false;
+                        }),
                     When(Second)
-                        .Then(context => { context.Instance.CalledAfterAll = false; }));
+                        .Then(context =>
+                        {
+                            context.Instance.CalledAfterAll = false;
+                        }));
 
                 CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/EventObservable_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/EventObservable_Specs.cs
@@ -16,7 +16,7 @@
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.That(_observer.Events.Count, Is.EqualTo(1));
+            Assert.That(_observer.Events, Has.Count.EqualTo(1));
         }
 
         Instance _instance;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Exception_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Exception_Specs.cs
@@ -23,13 +23,13 @@
         [Test]
         public void Should_have_called_the_async_if_block()
         {
-            Assert.IsTrue(_instance.CalledThenClauseAsync);
+            Assert.That(_instance.CalledThenClauseAsync, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_async_then_block()
         {
-            Assert.IsTrue(_instance.ThenAsyncShouldBeCalled);
+            Assert.That(_instance.ThenAsyncShouldBeCalled, Is.True);
         }
 
         [Test]
@@ -41,49 +41,49 @@
         [Test]
         public void Should_have_called_the_false_async_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseAsyncShouldBeCalled);
+            Assert.That(_instance.ElseAsyncShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_false_condition_else_block()
         {
-            Assert.IsTrue(_instance.ElseShouldBeCalled);
+            Assert.That(_instance.ElseShouldBeCalled, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
         public void Should_have_called_the_first_if_block()
         {
-            Assert.IsTrue(_instance.CalledThenClause);
+            Assert.That(_instance.CalledThenClause, Is.True);
         }
 
         [Test]
         public void Should_not_have_called_the_false_async_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenAsyncShouldNotBeCalled);
+            Assert.That(_instance.ThenAsyncShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_false_condition_then_block()
         {
-            Assert.IsFalse(_instance.ThenShouldNotBeCalled);
+            Assert.That(_instance.ThenShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_regular_exception()
         {
-            Assert.IsFalse(_instance.ShouldNotBeCalled);
+            Assert.That(_instance.ShouldNotBeCalled, Is.False);
         }
 
         [Test]
         public void Should_not_have_called_the_second_action()
         {
-            Assert.IsTrue(_instance.NotCalled);
+            Assert.That(_instance.NotCalled, Is.True);
         }
 
         Instance _instance;
@@ -275,7 +275,7 @@
         [Test]
         public void Should_have_called_the_subsequent_action()
         {
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         Instance _instance;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Observable_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Observable_Specs.cs
@@ -87,7 +87,7 @@
         [Test]
         public void Should_have_all_events()
         {
-            Assert.That(_eventObserver.Events.Count, Is.EqualTo(2));
+            Assert.That(_eventObserver.Events, Has.Count.EqualTo(2));
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/SubStateOnEnter_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/SubStateOnEnter_Specs.cs
@@ -26,7 +26,7 @@ namespace MassTransit.Tests.SagaStateMachineTests.Automatonymous
             await machine.RaiseEvent(instance, machine.ToSub); // go to s21 --> Enter s2 is missing here!
             await machine.RaiseEvent(instance, machine.Quit);
 
-            Assert.That(eventObserver.Events.Count, Is.EqualTo(2));
+            Assert.That(eventObserver.Events, Has.Count.EqualTo(2));
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Transition_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Transition_Specs.cs
@@ -10,7 +10,7 @@
         [Test]
         public void Should_call_the_enter_event()
         {
-            Assert.IsTrue(_instance.EnterCalled);
+            Assert.That(_instance.EnterCalled, Is.True);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Visualizer_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Automatonymous/Visualizer_Specs.cs
@@ -12,7 +12,7 @@
         [Test]
         public void Should_parse_the_graph()
         {
-            Assert.IsNotNull(_graph);
+            Assert.That(_graph, Is.Not.Null);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/CatchInitial_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/CatchInitial_Specs.cs
@@ -152,9 +152,12 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             ISagaStateMachineTestHarness<SomeStateMachine, SomeState> sagaHarness = harness.GetSagaStateMachineHarness<SomeStateMachine, SomeState>();
 
-            Assert.That(await sagaHarness.Consumed.Any<SomeEvent>(), Is.True);
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await sagaHarness.Consumed.Any<SomeEvent>(), Is.True);
 
-            Assert.That(await sagaHarness.NotExists(id), Is.Null);
+                Assert.That(await sagaHarness.NotExists(id), Is.Null);
+            });
         }
     }
 }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/CompositeEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/CompositeEvent_Specs.cs
@@ -16,16 +16,17 @@
         {
             var message = new StartMessage();
 
-            Task<ConsumeContext<CompleteMessage>> received = await ConnectPublishHandler<CompleteMessage>(x => x.Message.CorrelationId == message.CorrelationId);
+            Task<ConsumeContext<CompleteMessage>> received =
+                await ConnectPublishHandler<CompleteMessage>(x => x.Message.CorrelationId == message.CorrelationId);
 
             await Bus.Publish(message);
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.Waiting, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new FirstMessage(message.CorrelationId));
             saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.WaitingForSecond, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new SecondMessage(message.CorrelationId));
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/CompositeEventsInInitialState_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/CompositeEventsInInitialState_Specs.cs
@@ -22,7 +22,7 @@
             await InputQueueSendEndpoint.Send(secondMessage);
 
             Guid? saga = await _repository.ShouldContainSaga(x => x.CorrelationId == correlationId, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             Task<ConsumeContext<CompleteMessage>> received =
                 await ConnectPublishHandler<CompleteMessage>(x => x.Message.CorrelationId == correlationId);

--- a/tests/MassTransit.Tests/SagaStateMachineTests/ConfigureConsumeTopology_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/ConfigureConsumeTopology_Specs.cs
@@ -19,7 +19,7 @@ namespace MassTransit.Tests.SagaStateMachineTests
             await Bus.Publish(new Start { CorrelationId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSaga(sagaId, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             var handler = await ConnectPublishHandler<Suspend>();
 
@@ -28,12 +28,12 @@ namespace MassTransit.Tests.SagaStateMachineTests
             await handler;
 
             saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Running, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new Stop() { CorrelationId = sagaId });
 
             saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Final, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/CorrelateGuid_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/CorrelateGuid_Specs.cs
@@ -20,12 +20,12 @@
 
             Guid? saga = await _repository.ShouldContainSagaInState(state => state.TransactionId == id, _machine, x => x.Active, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish<CommitTransaction>(new { TransactionId = id });
 
             saga = await _repository.ShouldContainSagaInState(state => state.TransactionId == id, _machine, x => x.Final, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         InMemorySagaRepository<TransactionState> _repository;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/CorrelateUsingTopology_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/CorrelateUsingTopology_Specs.cs
@@ -10,6 +10,9 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
     namespace CorrelationEvents
     {
+        using System;
+
+
         public interface BeginTransaction
         {
             Guid TransactionId { get; }
@@ -46,12 +49,12 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             Guid? saga = await _repository.ShouldContainSagaInState(id, _machine, x => x.Active, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish<CommitTransaction>(new { TransactionId = id });
 
             saga = await _repository.ShouldContainSagaInState(id, _machine, x => x.Final, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         static Using_topology_for_event_correlation()

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Combine_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Combine_Specs.cs
@@ -18,7 +18,7 @@
             await _machine.RaiseEvent(_instance, First);
             await _machine.RaiseEvent(_instance, Second);
 
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
@@ -30,7 +30,7 @@
 
             await _machine.RaiseEvent(_instance, First);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         [Test]
@@ -42,7 +42,7 @@
 
             await _machine.RaiseEvent(_instance, Second);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         State Waiting;
@@ -140,7 +140,7 @@
 
             await _machine.RaiseEvent(_instance, Second);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         State Waiting;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/CompositeOrder_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/CompositeOrder_Specs.cs
@@ -18,7 +18,7 @@
             await _machine.RaiseEvent(_instance, First);
             await _machine.RaiseEvent(_instance, Second);
 
-            Assert.IsTrue(_instance.Called);
+            Assert.That(_instance.Called, Is.True);
         }
 
         [Test]
@@ -31,7 +31,7 @@
             await _machine.RaiseEvent(_instance, First);
             await _machine.RaiseEvent(_instance, Second);
 
-            Assert.IsTrue(_instance.CalledAfterAll);
+            Assert.That(_instance.CalledAfterAll, Is.True);
         }
 
         [Test]
@@ -43,7 +43,7 @@
 
             await _machine.RaiseEvent(_instance, First);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
         [Test]
@@ -55,18 +55,20 @@
 
             await _machine.RaiseEvent(_instance, Second);
 
-            Assert.IsFalse(_instance.Called);
+            Assert.That(_instance.Called, Is.False);
         }
 
+
         class Instance :
-SagaStateMachineInstance
+            SagaStateMachineInstance
         {
-            public Guid CorrelationId { get; set; }
             public CompositeEventStatus CompositeStatus { get; set; }
             public bool Called { get; set; }
             public bool CalledAfterAll { get; set; }
             public State CurrentState { get; set; }
+            public Guid CorrelationId { get; set; }
         }
+
 
         State Waiting;
         Event Start;
@@ -86,21 +88,26 @@ SagaStateMachineInstance
                     .Event("First", out First)
                     .Event("Second", out Second)
                     .Initially()
-                        .When(Start, b => b.TransitionTo(Waiting))
+                    .When(Start, b => b.TransitionTo(Waiting))
                     .During(Waiting)
-                        .When(First, b => b.Then(context => { context.Instance.CalledAfterAll = false; }))
-                        .When(Second, b => b.Then(context => { context.Instance.CalledAfterAll = false; }))
+                    .When(First, b => b.Then(context =>
+                    {
+                        context.Instance.CalledAfterAll = false;
+                    }))
+                    .When(Second, b => b.Then(context =>
+                    {
+                        context.Instance.CalledAfterAll = false;
+                    }))
                     .CompositeEvent("Third", out Third, b => b.CompositeStatus, First, Second)
                     .During(Waiting)
-                        .When(Third, b => b
-                            .Then(context =>
-                            {
-                                context.Instance.Called = true;
-                                context.Instance.CalledAfterAll = true;
-                            })
-                            .Finalize()
-                        )
-
+                    .When(Third, b => b
+                        .Then(context =>
+                        {
+                            context.Instance.Called = true;
+                            context.Instance.CalledAfterAll = true;
+                        })
+                        .Finalize()
+                    )
                 );
         }
     }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Event_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Event_Specs.cs
@@ -23,19 +23,19 @@
         [Test]
         public void It_should_create_configured_events()
         {
-            Assert.IsInstanceOf<TriggerEvent>(_eventB);
+            Assert.That(_eventB, Is.InstanceOf<TriggerEvent>());
         }
 
         [Test]
         public void It_should_create_the_proper_event_type_for_data_events()
         {
-            Assert.IsInstanceOf<MessageEvent<A>>(_eventA);
+            Assert.That(_eventA, Is.InstanceOf<MessageEvent<A>>());
         }
 
         [Test]
         public void It_should_create_the_proper_event_type_for_simple_events()
         {
-            Assert.IsInstanceOf<TriggerEvent>(_hello);
+            Assert.That(_hello, Is.InstanceOf<TriggerEvent>());
         }
 
         Event _hello;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Group_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Group_Specs.cs
@@ -16,8 +16,11 @@
         [Test]
         public void Should_have_captured_initial_data()
         {
-            Assert.That(_instance.VehicleMake, Is.EqualTo("Audi"));
-            Assert.That(_instance.VehicleModel, Is.EqualTo("A6"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_instance.VehicleMake, Is.EqualTo("Audi"));
+                Assert.That(_instance.VehicleModel, Is.EqualTo("A6"));
+            });
         }
 
         State BeingServiced;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Introspection_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Introspection_Specs.cs
@@ -15,7 +15,7 @@ namespace MassTransit.Tests.SagaStateMachineTests.Dynamic_Modify
         {
             List<Event> events = _machine.Events.ToList();
 
-            Assert.That(events.Count, Is.EqualTo(4));
+            Assert.That(events, Has.Count.EqualTo(4));
             Assert.That(events, Does.Contain(Ignored));
             Assert.That(events, Does.Contain(Handshake));
             Assert.That(events, Does.Contain(Hello));

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Observable_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Observable_Specs.cs
@@ -139,7 +139,7 @@
         [Test]
         public void Should_raise_the_event()
         {
-            Assert.That(_observer.Events.Count, Is.EqualTo(4));
+            Assert.That(_observer.Events, Has.Count.EqualTo(4));
         }
 
         State<Instance> Resting;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/RaiseEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/RaiseEvent_Specs.cs
@@ -33,8 +33,11 @@
                 );
 
             await machine.RaiseEvent(instance, Thing, new Data { Condition = true });
-            Assert.That(instance.CurrentState, Is.EqualTo(True));
-            Assert.That(instance.Initialized.HasValue, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(instance.CurrentState, Is.EqualTo(True));
+                Assert.That(instance.Initialized.HasValue, Is.True);
+            });
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/UnobservedEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/UnobservedEvent_Specs.cs
@@ -123,7 +123,7 @@
 
             var nextEvents = await _machine.NextEvents(instance);
 
-            Assert.IsTrue(nextEvents.Any(x => x.Name.Equals("Charge")));
+            Assert.That(nextEvents.Any(x => x.Name.Equals("Charge")), Is.True);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Dynamic Modify/Visualizer_Specs.cs
@@ -12,7 +12,7 @@
         [Test]
         public void Should_parse_the_graph()
         {
-            Assert.IsNotNull(_graph);
+            Assert.That(_graph, Is.Not.Null);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/DynamicEvent_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/DynamicEvent_Specs.cs
@@ -33,12 +33,12 @@ namespace MassTransit.Tests.SagaStateMachineTests
             await Bus.Publish(new Start { ServiceId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSaga(sagaId, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new Stop { ServiceId = sagaId });
 
             saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Final, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             Guid? saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Fault_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Fault_Specs.cs
@@ -18,13 +18,13 @@
             await InputQueueSendEndpoint.Send(message);
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.WaitingToStart, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await InputQueueSendEndpoint.Send(new Start(message.CorrelationId));
 
             saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.FailedToStart, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         [Test]
@@ -62,7 +62,7 @@
 
             saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, x => x.FailedToStart, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         [Test]

--- a/tests/MassTransit.Tests/SagaStateMachineTests/FilterFault_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/FilterFault_Specs.cs
@@ -20,7 +20,7 @@
             await InputQueueSendEndpoint.Send(message);
 
             Guid? saga = await _repository.ShouldContainSagaInState(message.CorrelationId, _machine, _machine.WaitingToStart, TimeSpan.FromSeconds(8));
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await InputQueueSendEndpoint.Send(new Start(message.CorrelationId));
 
@@ -28,7 +28,7 @@
 
             saga = await _repository.ShouldContainSagaInState(x => x.CorrelationId == message.CorrelationId && x.StartAttempts == 1, _machine,
                 _machine.WaitingToStart, TimeSpan.FromSeconds(8));
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Finalize_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Finalize_Specs.cs
@@ -25,12 +25,12 @@
             await InputQueueSendEndpoint.Send(firstMessage);
 
             Guid? saga = await _repository.ShouldContainSagaInState(correlationId, _machine, x => x.OtherState, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             _taskCompletionSource.SetResult(true);
 
             saga = await LoadSagaRepository.ShouldNotContainSaga(correlationId, TestTimeout);
-            Assert.IsFalse(saga.HasValue);
+            Assert.That(saga.HasValue, Is.False);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Ignore_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Ignore_Specs.cs
@@ -21,12 +21,12 @@
             await Bus.Publish(new Start { CorrelationId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Running, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new Start { CorrelationId = sagaId });
 
             var faultMessage = await GetFaultMessage(TimeSpan.FromSeconds(3));
-            Assert.IsNull(faultMessage?.Exceptions.Select(ex => $"{ex.ExceptionType}: {ex.Message}").First());
+            Assert.That(faultMessage?.Exceptions.Select(ex => $"{ex.ExceptionType}: {ex.Message}").First(), Is.Null);
         }
 
         protected async Task<Fault> GetFaultMessage(TimeSpan timeout)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/InMemoryDeadlock_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/InMemoryDeadlock_Specs.cs
@@ -16,24 +16,24 @@
         {
             var id = NewId.NextGuid();
 
-            await InputQueueSendEndpoint.Send<CreateInstance>(new {CorrelationId = id});
+            await InputQueueSendEndpoint.Send<CreateInstance>(new { CorrelationId = id });
 
             Guid? saga = await _repository.ShouldContainSagaInState(id, _machine, _machine.Active, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
-            await InputQueueSendEndpoint.Send<CompleteInstance>(new {CorrelationId = id});
+            await InputQueueSendEndpoint.Send<CompleteInstance>(new { CorrelationId = id });
 
             await Task.Delay(990);
 
             await Console.Out.WriteLineAsync("Sending duplicate message");
 
-            await InputQueueSendEndpoint.Send<CancelInstance>(new {CorrelationId = id});
+            await InputQueueSendEndpoint.Send<CancelInstance>(new { CorrelationId = id });
 
             id = NewId.NextGuid();
-            await InputQueueSendEndpoint.Send<CreateInstance>(new {CorrelationId = id});
+            await InputQueueSendEndpoint.Send<CreateInstance>(new { CorrelationId = id });
             Guid? saga2 = await _repository.ShouldContainSagaInState(id, _machine, _machine.Active, TestTimeout);
-            Assert.IsTrue(saga2.HasValue);
+            Assert.That(saga2.HasValue, Is.True);
         }
 
         InMemorySagaRepository<Instance> _repository;

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Partitioning_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Partitioning_Specs.cs
@@ -28,7 +28,7 @@
             for (var i = 0; i < Limit; i++)
             {
                 Guid? guid = await _repository.ShouldContainSaga(ids[i], TestTimeout);
-                Assert.IsTrue(guid.HasValue);
+                Assert.That(guid.HasValue, Is.True);
             }
 
             timer.Stop();

--- a/tests/MassTransit.Tests/SagaStateMachineTests/RemoveWhen_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/RemoveWhen_Specs.cs
@@ -20,7 +20,7 @@ namespace MassTransit.Tests.SagaStateMachineTests
 
             Guid? saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         [Test]
@@ -31,12 +31,12 @@ namespace MassTransit.Tests.SagaStateMachineTests
             await Bus.Publish(new Start { CorrelationId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSaga(sagaId, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new Stop { CorrelationId = sagaId });
 
             saga = await _repository.ShouldNotContainSaga(sagaId, TestTimeout);
-            Assert.IsFalse(saga.HasValue);
+            Assert.That(saga.HasValue, Is.False);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Request2_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Request2_Specs.cs
@@ -30,7 +30,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(memberId, _machine, x => x.Registered, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 var sagaInstance = _repository[saga.Value].Instance;
                 Assert.That(sagaInstance.Name, Is.EqualTo("Frank"));

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Request3_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Request3_Specs.cs
@@ -1,14 +1,14 @@
 ﻿namespace MassTransit.Tests.SagaStateMachineTests
 {
-    using System;
-    using System.Threading.Tasks;
-    using MassTransit.Testing;
-    using NUnit.Framework;
-    using TestFramework;
-
-
     namespace Request3_Specs
     {
+        using System;
+        using System.Threading.Tasks;
+        using MassTransit.Testing;
+        using NUnit.Framework;
+        using TestFramework;
+
+
         [TestFixture]
         public class Sending_a_request_from_a_state_machine :
             InMemoryTestFixture
@@ -30,7 +30,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(memberId, _machine, x => x.Registered, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 var sagaInstance = _repository[saga.Value].Instance;
                 Assert.That(sagaInstance.Name, Is.EqualTo("Frank"));
@@ -167,9 +167,7 @@
                         .TransitionTo(NameValidationFaulted),
                     When(ValidateName.TimeoutExpired)
                         .TransitionTo(NameValidationTimeout));
-            }
-
-            // ReSharper disable UnassignedGetOnlyAutoProperty
+            } // ReSharper disable UnassignedGetOnlyAutoProperty
             public Request<TestState, ValidateName, NameValidated, NameInvalid, NameAlreadyExists> ValidateName { get; }
 
             public Event<RegisterMember> Register { get; }

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Request_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Request_Specs.cs
@@ -30,7 +30,7 @@
 
                 Guid? saga = await _repository.ShouldContainSagaInState(memberId, _machine, x => x.Registered, TestTimeout);
 
-                Assert.IsTrue(saga.HasValue);
+                Assert.That(saga.HasValue, Is.True);
 
                 var sagaInstance = _repository[saga.Value].Instance;
                 Assert.That(sagaInstance.Name, Is.EqualTo("Frank"));

--- a/tests/MassTransit.Tests/SagaStateMachineTests/SagaConfigurationObserver_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/SagaConfigurationObserver_Specs.cs
@@ -43,10 +43,13 @@
                 });
             });
 
-            Assert.That(observer.SagaTypes.Contains(typeof(Instance)));
-            Assert.That(observer.StateMachineTypes.Contains(typeof(TestStateMachine)));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(Instance), typeof(Start))));
-            Assert.That(observer.MessageTypes.Contains(Tuple.Create(typeof(Instance), typeof(Stop))));
+            Assert.Multiple(() =>
+            {
+                Assert.That(observer.SagaTypes, Does.Contain(typeof(Instance)));
+                Assert.That(observer.StateMachineTypes, Does.Contain(typeof(TestStateMachine)));
+                Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(Instance), typeof(Start))));
+            });
+            Assert.That(observer.MessageTypes, Does.Contain(Tuple.Create(typeof(Instance), typeof(Stop))));
         }
 
 

--- a/tests/MassTransit.Tests/SagaStateMachineTests/SimpleStateMachine_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/SimpleStateMachine_Specs.cs
@@ -19,12 +19,12 @@
             await Bus.Publish(new Start { CorrelationId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSaga(sagaId, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new Stop { CorrelationId = sagaId });
 
             saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Final, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         [Test]
@@ -36,7 +36,7 @@
 
             Guid? saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -130,12 +130,12 @@
             await Bus.Publish(new Start { CorrelationId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSaga(sagaId, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new Stop { CorrelationId = sagaId });
 
             saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Final, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         [Test]
@@ -147,7 +147,7 @@
 
             Guid? saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)
@@ -236,12 +236,12 @@
             await Bus.Publish(new Start { ServiceId = sagaId });
 
             Guid? saga = await _repository.ShouldContainSaga(sagaId, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
 
             await Bus.Publish(new Stop { ServiceId = sagaId });
 
             saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Final, TestTimeout);
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         [Test]
@@ -253,7 +253,7 @@
 
             Guid? saga = await _repository.ShouldContainSagaInState(sagaId, _machine, x => x.Running, TestTimeout);
 
-            Assert.IsTrue(saga.HasValue);
+            Assert.That(saga.HasValue, Is.True);
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/SagaStateMachineTests/Testing_Specs.cs
+++ b/tests/MassTransit.Tests/SagaStateMachineTests/Testing_Specs.cs
@@ -21,12 +21,12 @@
             await harness.Start();
             try
             {
-                await harness.InputQueueSendEndpoint.Send(new Start {CorrelationId = sagaId});
+                await harness.InputQueueSendEndpoint.Send(new Start { CorrelationId = sagaId });
 
-                Assert.IsTrue(harness.Consumed.Select<Start>().Any(), "Message not received");
+                Assert.That(harness.Consumed.Select<Start>().Any(), Is.True, "Message not received");
 
                 var instance = saga.Created.ContainsInState(sagaId, _machine, _machine.Running);
-                Assert.IsNotNull(instance, "Saga instance not found");
+                Assert.That(instance, Is.Not.Null, "Saga instance not found");
             }
             finally
             {
@@ -45,16 +45,16 @@
             await harness.Start();
             try
             {
-                await harness.InputQueueSendEndpoint.Send(new Start {CorrelationId = sagaId});
+                await harness.InputQueueSendEndpoint.Send(new Start { CorrelationId = sagaId });
 
-                Assert.IsTrue(harness.Consumed.Select<Start>().Any(), "Start not received");
+                Assert.That(harness.Consumed.Select<Start>().Any(), Is.True, "Start not received");
 
-                await harness.InputQueueSendEndpoint.Send(new Stop {CorrelationId = sagaId});
+                await harness.InputQueueSendEndpoint.Send(new Stop { CorrelationId = sagaId });
 
-                Assert.IsTrue(harness.Consumed.Select<Stop>().Any(), "Stop not received");
+                Assert.That(harness.Consumed.Select<Stop>().Any(), Is.True, "Stop not received");
 
                 var instance = saga.Created.ContainsInState(sagaId, _machine, _machine.Final);
-                Assert.IsNotNull(instance, "Saga instance not found");
+                Assert.That(instance, Is.Not.Null, "Saga instance not found");
             }
             finally
             {

--- a/tests/MassTransit.Tests/SendContextMiddleware_Specs.cs
+++ b/tests/MassTransit.Tests/SendContextMiddleware_Specs.cs
@@ -148,23 +148,29 @@ namespace MassTransit.Tests
                 ISentMessage<A> a = sendObserver.Messages.Select<A>().FirstOrDefault();
                 ISentMessage<B> b = sendObserver.Messages.Select<B>().FirstOrDefault();
 
-                Assert.That(a, Is.Not.Null);
-                Assert.That(b, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a, Is.Not.Null);
+                    Assert.That(b, Is.Not.Null);
+                });
 
                 Dictionary<string, object> ah = a.Context.Headers.GetAll().ToDictionary(x => x.Key, x => x.Value);
                 Dictionary<string, object> bh = b.Context.Headers.GetAll().ToDictionary(x => x.Key, x => x.Value);
 
-                Assert.That(ah.ContainsKey("x-send-filter"), Is.True);
-                Assert.That(ah.ContainsKey("x-send-message-filter"), Is.True);
-                Assert.That(ah["x-send-filter"], Is.EqualTo("send-filter"));
-                Assert.That(ah["x-send-message-filter"], Is.EqualTo("send-message-filter"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ah.ContainsKey("x-send-filter"), Is.True);
+                    Assert.That(ah.ContainsKey("x-send-message-filter"), Is.True);
+                    Assert.That(ah["x-send-filter"], Is.EqualTo("send-filter"));
+                    Assert.That(ah["x-send-message-filter"], Is.EqualTo("send-message-filter"));
 
-                Assert.That(bh.ContainsKey("x-send-filter"),Is.True);
-                Assert.That(bh.ContainsKey("x-send-message-filter"), Is.True);
+                    Assert.That(bh.ContainsKey("x-send-filter"), Is.True);
+                    Assert.That(bh.ContainsKey("x-send-message-filter"), Is.True);
 
-                // those fails, as while they DO have ",has-consume-context" they don't have access to SomePayload
-                Assert.That(bh["x-send-filter"], Is.EqualTo("send-filter,has-consume-context,has-some-payload:hello"));
-                Assert.That(bh["x-send-message-filter"], Is.EqualTo("send-message-filter,has-consume-context,has-some-payload:hello"));
+                    // those fails, as while they DO have ",has-consume-context" they don't have access to SomePayload
+                    Assert.That(bh["x-send-filter"], Is.EqualTo("send-filter,has-consume-context,has-some-payload:hello"));
+                    Assert.That(bh["x-send-message-filter"], Is.EqualTo("send-message-filter,has-consume-context,has-some-payload:hello"));
+                });
             }
         }
 
@@ -424,23 +430,29 @@ namespace MassTransit.Tests
                 IPublishedMessage<A> a = publishObserver.Messages.Select<A>().FirstOrDefault();
                 IPublishedMessage<B> b = publishObserver.Messages.Select<B>().FirstOrDefault();
 
-                Assert.That(a, Is.Not.Null);
-                Assert.That(b, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(a, Is.Not.Null);
+                    Assert.That(b, Is.Not.Null);
+                });
 
                 Dictionary<string, object> ah = a.Context.Headers.GetAll().ToDictionary(x => x.Key, x => x.Value);
                 Dictionary<string, object> bh = b.Context.Headers.GetAll().ToDictionary(x => x.Key, x => x.Value);
 
-                Assert.That(ah.ContainsKey("x-send-filter"));
-                Assert.That(ah.ContainsKey("x-send-message-filter"));
-                Assert.That(ah["x-send-filter"], Is.EqualTo("send-filter"));
-                Assert.That(ah["x-send-message-filter"], Is.EqualTo("send-message-filter"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ah.ContainsKey("x-send-filter"));
+                    Assert.That(ah.ContainsKey("x-send-message-filter"));
+                    Assert.That(ah["x-send-filter"], Is.EqualTo("send-filter"));
+                    Assert.That(ah["x-send-message-filter"], Is.EqualTo("send-message-filter"));
 
-                Assert.That(bh.ContainsKey("x-send-filter"));
-                Assert.That(bh.ContainsKey("x-send-message-filter"));
+                    Assert.That(bh.ContainsKey("x-send-filter"));
+                    Assert.That(bh.ContainsKey("x-send-message-filter"));
 
-                // those fails, as while they DO have ",has-consume-context" they don't have access to SomePayload
-                Assert.That(bh["x-send-filter"], Is.EqualTo("send-filter,has-consume-context,has-some-payload:hello"));
-                Assert.That(bh["x-send-message-filter"], Is.EqualTo("send-message-filter,has-consume-context,has-some-payload:hello"));
+                    // those fails, as while they DO have ",has-consume-context" they don't have access to SomePayload
+                    Assert.That(bh["x-send-filter"], Is.EqualTo("send-filter,has-consume-context,has-some-payload:hello"));
+                    Assert.That(bh["x-send-message-filter"], Is.EqualTo("send-message-filter,has-consume-context,has-some-payload:hello"));
+                });
             }
         }
 

--- a/tests/MassTransit.Tests/SendObserver_Specs.cs
+++ b/tests/MassTransit.Tests/SendObserver_Specs.cs
@@ -26,8 +26,11 @@
 
                     await observer.PreSent;
                     await observer.SendFaulted;
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    });
                 }
             }
 
@@ -42,8 +45,11 @@
                     await observer.PreSent;
                     await observer.PostSent;
 
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    });
                 }
             }
 
@@ -57,8 +63,11 @@
 
                     await observer.PreSent;
 
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                    });
                 }
             }
 
@@ -73,11 +82,14 @@
 
                     await observer.SendFaulted;
 
-                    Assert.That(observer.PostSent.Status, Is.EqualTo(TaskStatus.WaitingForActivation));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PostSent.Status, Is.EqualTo(TaskStatus.WaitingForActivation));
 
-                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                    Assert.That(observer.PostSentCount, Is.EqualTo(0));
-                    Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                        Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                        Assert.That(observer.PostSentCount, Is.EqualTo(0));
+                        Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    });
                 }
             }
         }
@@ -99,9 +111,12 @@
                     await observer.PostSent;
                     await observer.SendFaulted;
 
-                    Assert.That(observer.PreSentCount, Is.EqualTo(2));
-                    Assert.That(observer.PostSentCount, Is.EqualTo(1));
-                    Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(observer.PreSentCount, Is.EqualTo(2));
+                        Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                        Assert.That(observer.SendFaultCount, Is.EqualTo(1));
+                    });
                 }
             }
 
@@ -134,11 +149,14 @@
 
                 await _observer.SendFaulted;
 
-                Assert.That(_observer.PostSent.Status, Is.EqualTo(TaskStatus.WaitingForActivation));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(_observer.PostSent.Status, Is.EqualTo(TaskStatus.WaitingForActivation));
 
-                Assert.That(_observer.PreSentCount, Is.EqualTo(1));
-                Assert.That(_observer.PostSentCount, Is.EqualTo(0));
-                Assert.That(_observer.SendFaultCount, Is.EqualTo(1));
+                    Assert.That(_observer.PreSentCount, Is.EqualTo(1));
+                    Assert.That(_observer.PostSentCount, Is.EqualTo(0));
+                    Assert.That(_observer.SendFaultCount, Is.EqualTo(1));
+                });
             }
 
             SendObserver _observer;
@@ -264,8 +282,11 @@
                 await observer.PreSent;
                 await observer.PostSent;
 
-                Assert.That(observer.PreSentCount, Is.EqualTo(1));
-                Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(observer.PreSentCount, Is.EqualTo(1));
+                    Assert.That(observer.PostSentCount, Is.EqualTo(1));
+                });
             }
 
             [Test]
@@ -297,8 +318,11 @@
                 await observer.PreSent;
                 await observer.PostSent;
 
-                Assert.That(observer.PreSentCount, Is.EqualTo(2));
-                Assert.That(observer.PostSentCount, Is.EqualTo(2));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(observer.PreSentCount, Is.EqualTo(2));
+                    Assert.That(observer.PostSentCount, Is.EqualTo(2));
+                });
             }
         }
 

--- a/tests/MassTransit.Tests/SendProxy_Specs.cs
+++ b/tests/MassTransit.Tests/SendProxy_Specs.cs
@@ -22,9 +22,12 @@
             InitializeContext<IMessageType> context = await MessageInitializerCache<IMessageType>.Initialize(values);
 
             var message = context.Message;
-            Assert.That(message.CorrelationId, Is.EqualTo(values.CorrelationId));
-            Assert.That(message.Name, Is.EqualTo(values.Name));
-            Assert.That(message.Timestamp, Is.EqualTo(values.Timestamp));
+            Assert.Multiple(() =>
+            {
+                Assert.That(message.CorrelationId, Is.EqualTo(values.CorrelationId));
+                Assert.That(message.Name, Is.EqualTo(values.Name));
+                Assert.That(message.Timestamp, Is.EqualTo(values.Timestamp));
+            });
         }
 
 

--- a/tests/MassTransit.Tests/Serialization/Array_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/Array_Specs.cs
@@ -58,19 +58,19 @@
                 var result = SerializeAndReturn(someArray);
 
                 Assert.That(result.Elements, Is.Not.Null);
-                Assert.That(result.Elements.Length, Is.EqualTo(1));
+                Assert.That(result.Elements, Has.Length.EqualTo(1));
             }
 
             [Test]
             public void Should_serialize_a_single_element_collection()
             {
                 var someArray = new SomeCollection();
-                someArray.Elements = new ArrayElement[1] {new ArrayElement {Value = 27}};
+                someArray.Elements = new ArrayElement[1] { new ArrayElement { Value = 27 } };
 
                 var result = SerializeAndReturn(someArray);
 
                 Assert.That(result.Elements, Is.Not.Null);
-                Assert.That(result.Elements.Count, Is.EqualTo(1));
+                Assert.That(result.Elements, Has.Count.EqualTo(1));
             }
 
             public A_null_array(Type serializerType)

--- a/tests/MassTransit.Tests/Serialization/DateTimeConverter_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/DateTimeConverter_Specs.cs
@@ -23,20 +23,6 @@ public class DateTimeConverter_Specs
     }
 
     [Test]
-    public void Should_convert_date_time_offset_min_value()
-    {
-        var converter = new DateTimeOffsetTypeConverter();
-
-        var value = DateTimeOffset.MinValue;
-
-        Assert.That(converter.TryConvert(value, out string text));
-
-        Assert.That(converter.TryConvert(text, out var result));
-
-        Assert.That(result, Is.EqualTo(value));
-    }
-
-    [Test]
     public void Should_convert_date_time_min_value_to_offset()
     {
         var converter = new DateTimeTypeConverter();
@@ -44,10 +30,30 @@ public class DateTimeConverter_Specs
 
         var value = DateTime.MinValue.ToUniversalTime();
 
-        Assert.That(converter.TryConvert(value, out string text));
+        Assert.Multiple(() =>
+        {
+            Assert.That(converter.TryConvert(value, out string text));
 
-        Assert.That(offsetConverter.TryConvert(text, out var result));
+            Assert.That(offsetConverter.TryConvert(text, out var result));
 
-        Assert.That(result.UtcDateTime, Is.EqualTo(value));
+            Assert.That(result.UtcDateTime, Is.EqualTo(value));
+        });
+    }
+
+    [Test]
+    public void Should_convert_date_time_offset_min_value()
+    {
+        var converter = new DateTimeOffsetTypeConverter();
+
+        var value = DateTimeOffset.MinValue;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(converter.TryConvert(value, out string text));
+
+            Assert.That(converter.TryConvert(text, out var result));
+
+            Assert.That(result, Is.EqualTo(value));
+        });
     }
 }

--- a/tests/MassTransit.Tests/Serialization/Forward_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/Forward_Specs.cs
@@ -25,15 +25,21 @@ namespace MassTransit.Tests.Serialization
 
             ConsumeContext<Command> handled = await _handled;
 
-            Assert.That(handled.Message.CommandId, Is.EqualTo(message.CommandId));
-            Assert.That(handled.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+            Assert.Multiple(() =>
+            {
+                Assert.That(handled.Message.CommandId, Is.EqualTo(message.CommandId));
+                Assert.That(handled.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+            });
 
             ConsumeContext<BagOfCrap> forwarded = await _forwarded;
 
-            Assert.That(forwarded.Message.CommandId, Is.EqualTo(message.CommandId));
-            Assert.That(forwarded.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
-            Assert.That(forwarded.Message.Crap, Is.EqualTo("All"));
-            Assert.That(forwarded.ReceiveContext.ContentType.MediaType, Is.EqualTo(NewtonsoftJsonMessageSerializer.ContentTypeHeaderValue));
+            Assert.Multiple(() =>
+            {
+                Assert.That(forwarded.Message.CommandId, Is.EqualTo(message.CommandId));
+                Assert.That(forwarded.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+                Assert.That(forwarded.Message.Crap, Is.EqualTo("All"));
+                Assert.That(forwarded.ReceiveContext.ContentType.MediaType, Is.EqualTo(NewtonsoftJsonMessageSerializer.ContentTypeHeaderValue));
+            });
         }
 
         Task<ConsumeContext<Command>> _handled;

--- a/tests/MassTransit.Tests/Serialization/IEnumerable_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/IEnumerable_Specs.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using MassTransit.Serialization;
     using NUnit.Framework;
-    using RequestClientMessages;
 
 
     [TestFixture(typeof(NewtonsoftJsonMessageSerializer))]
@@ -47,12 +46,15 @@
         [Test]
         public void Should_not_convert_to_a_dictionary()
         {
-            var message = new ListStringObjectMessage { Properties = new[]
+            var message = new ListStringObjectMessage
             {
-                new KeyValuePair<string, object>("Frank", "Mary"),
-                new KeyValuePair<string, object>("Peter", "Mary"),
-                new KeyValuePair<string, object>("Frank", "Peter")
-            }.ToList() };
+                Properties = new[]
+                {
+                    new KeyValuePair<string, object>("Frank", "Mary"),
+                    new KeyValuePair<string, object>("Peter", "Mary"),
+                    new KeyValuePair<string, object>("Frank", "Peter")
+                }.ToList()
+            };
 
             var result = SerializeAndReturn(message);
 
@@ -81,7 +83,7 @@
             var result = SerializeAndReturn(message);
 
             Assert.That(result.Values, Is.Not.Null);
-            Assert.That(result.Values.Length, Is.EqualTo(6), "Length");
+            Assert.That(result.Values, Has.Length.EqualTo(6), "Length");
             Assert.That(result.Values[1, 1], Is.EqualTo(4), "Value");
         }
 

--- a/tests/MassTransit.Tests/Serialization/Interface_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/Interface_Specs.cs
@@ -2,7 +2,6 @@ namespace MassTransit.Tests.Serialization
 {
     using System;
     using System.Linq;
-    using System.Reflection;
     using System.Threading.Tasks;
     using MassTransit.Configuration;
     using MassTransit.Serialization;
@@ -31,7 +30,9 @@ namespace MassTransit.Tests.Serialization
 
             var result = SerializeAndReturn(complaint);
 
+            #pragma warning disable NUnit2010
             Assert.That(complaint.Equals(result), Is.True);
+            #pragma warning restore NUnit2010
         }
 
         [Test]

--- a/tests/MassTransit.Tests/Serialization/JobDeserialization_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/JobDeserialization_Specs.cs
@@ -63,7 +63,7 @@ namespace MassTransit.Tests.Serialization
             var job = startJobContext.GetJob<ConvertVideo>()
                 ?? throw new SerializationException($"The job could not be deserialized: {TypeCache<ConvertVideo>.ShortName}");
 
-            Assert.That(job.Details.Count, Is.EqualTo(2));
+            Assert.That(job.Details, Has.Count.EqualTo(2));
         }
 
         protected async Task<ConsumeContext<T>> GetConsumeContext<T>(object values)

--- a/tests/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
@@ -5,7 +5,6 @@ namespace MassTransit.Tests.Serialization
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
     using System.Text;
     using System.Xml.Linq;
     using MassTransit.Serialization;
@@ -55,7 +54,7 @@ namespace MassTransit.Tests.Serialization
                 }
             };
 
-            _envelope = new Envelope {Message = _message};
+            _envelope = new Envelope { Message = _message };
 
             _envelope.MessageType.Add(_message.GetType().ToMessageName());
             _envelope.MessageType.Add(typeof(MessageA).ToMessageName());
@@ -112,11 +111,14 @@ namespace MassTransit.Tests.Serialization
                 result = _deserializer.Deserialize<Envelope>(jsonReader);
             }
 
-            Assert.That(result.MessageType.Count, Is.EqualTo(3));
-            Assert.That(result.MessageType[0], Is.EqualTo(typeof(TestMessage).ToMessageName()));
-            Assert.That(result.MessageType[1], Is.EqualTo(typeof(MessageA).ToMessageName()));
-            Assert.That(result.MessageType[2], Is.EqualTo(typeof(MessageB).ToMessageName()));
-            Assert.That(result.Headers.Count, Is.EqualTo(1));
+            Assert.That(result.MessageType, Has.Count.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.MessageType[0], Is.EqualTo(typeof(TestMessage).ToMessageName()));
+                Assert.That(result.MessageType[1], Is.EqualTo(typeof(MessageA).ToMessageName()));
+                Assert.That(result.MessageType[2], Is.EqualTo(typeof(MessageB).ToMessageName()));
+                Assert.That(result.Headers, Has.Count.EqualTo(1));
+            });
         }
 
         [Test]
@@ -155,10 +157,13 @@ namespace MassTransit.Tests.Serialization
             {
                 var message = (TestMessage)_serializer.Deserialize(jsonReader, typeof(TestMessage));
 
-                Assert.That(message.Name, Is.EqualTo("Joe"));
-                Assert.That(message.Details.Count, Is.EqualTo(2));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(message.Name, Is.EqualTo("Joe"));
+                    Assert.That(message.Details, Has.Count.EqualTo(2));
 
-                Assert.That(message.EnumDetails.Count(), Is.EqualTo(1));
+                    Assert.That(message.EnumDetails.Count(), Is.EqualTo(1));
+                });
             }
         }
 
@@ -180,11 +185,14 @@ namespace MassTransit.Tests.Serialization
                     ContractResolver = new CamelCasePropertyNamesContractResolver()
                 });
 
-            Assert.That(result.MessageType.Count, Is.EqualTo(3));
-            Assert.That(result.MessageType[0], Is.EqualTo(typeof(TestMessage).ToMessageName()));
-            Assert.That(result.MessageType[1], Is.EqualTo(typeof(MessageA).ToMessageName()));
-            Assert.That(result.MessageType[2], Is.EqualTo(typeof(MessageB).ToMessageName()));
-            Assert.That(result.Headers.Count, Is.EqualTo(1));
+            Assert.That(result.MessageType, Has.Count.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.MessageType[0], Is.EqualTo(typeof(TestMessage).ToMessageName()));
+                Assert.That(result.MessageType[1], Is.EqualTo(typeof(MessageA).ToMessageName()));
+                Assert.That(result.MessageType[2], Is.EqualTo(typeof(MessageB).ToMessageName()));
+                Assert.That(result.Headers, Has.Count.EqualTo(1));
+            });
         }
 
         [Test]
@@ -347,7 +355,7 @@ namespace MassTransit.Tests.Serialization
         [Test]
         public void Should_use_converter_for_deserialization()
         {
-            var obj = new MessageB {Value = "Joe"};
+            var obj = new MessageB { Value = "Joe" };
 
             var result = SerializeAndReturn(obj);
 
@@ -357,7 +365,7 @@ namespace MassTransit.Tests.Serialization
         [Test]
         public void Should_use_converter_for_serialization()
         {
-            var obj = new MessageA {Value = "Joe"};
+            var obj = new MessageA { Value = "Joe" };
 
             var result = SerializeAndReturn(obj);
 
@@ -383,7 +391,7 @@ namespace MassTransit.Tests.Serialization
                 Assert.That(reader.Value, Is.EqualTo("value"));
                 reader.Read();
                 var value = (string)reader.Value;
-                return new MessageA {Value = value};
+                return new MessageA { Value = value };
             }
 
             public override bool CanConvert(Type objectType)
@@ -408,7 +416,7 @@ namespace MassTransit.Tests.Serialization
 
             public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
             {
-                return new MessageB {Value = "Monster"};
+                return new MessageB { Value = "Monster" };
             }
 
             public override bool CanConvert(Type objectType)
@@ -448,7 +456,7 @@ namespace MassTransit.Tests.Serialization
         [Test]
         public void Should_use_converter_for_deserialization()
         {
-            var obj = new SimpleMessage {ValueB = "Joe"};
+            var obj = new SimpleMessage { ValueB = "Joe" };
 
             var result = SerializeAndReturn(obj);
 
@@ -458,7 +466,7 @@ namespace MassTransit.Tests.Serialization
         [Test]
         public void Should_use_converter_for_serialization()
         {
-            var obj = new SimpleMessage {ValueA = "Joe"};
+            var obj = new SimpleMessage { ValueA = "Joe" };
 
             var result = SerializeAndReturn(obj);
 
@@ -527,7 +535,7 @@ namespace MassTransit.Tests.Serialization
         public void Should_deserialize_correctly()
         {
             // arrange
-            var message = new MessageA {Decimal = decimal.MaxValue};
+            var message = new MessageA { Decimal = decimal.MaxValue };
 
             // act, assert
             var serializedMessage = JsonConvert.SerializeObject(message, NewtonsoftJsonMessageSerializer.SerializerSettings);
@@ -542,7 +550,7 @@ namespace MassTransit.Tests.Serialization
         public void Should_deserialize_correctly_with_stj()
         {
             // arrange
-            var message = new MessageA {Decimal = decimal.MaxValue};
+            var message = new MessageA { Decimal = decimal.MaxValue };
 
             // act, assert
             var serializedMessage = JsonConvert.SerializeObject(message, NewtonsoftJsonMessageSerializer.SerializerSettings);

--- a/tests/MassTransit.Tests/Serialization/MisnamedProperty_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/MisnamedProperty_Specs.cs
@@ -20,8 +20,11 @@
 
             Response<CommonResponse> response = await client.GetResponse<CommonResponse>(request);
 
-            Assert.That(response.Message.Message, Is.EqualTo(message));
-            Assert.That(response.Message.Name, Is.EqualTo("I am lost!"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.Message.Message, Is.EqualTo(message));
+                Assert.That(response.Message.Name, Is.EqualTo("I am lost!"));
+            });
         }
 
         protected override void ConfigureInMemoryReceiveEndpoint(IInMemoryReceiveEndpointConfigurator configurator)

--- a/tests/MassTransit.Tests/Serialization/NsbInterop_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/NsbInterop_Specs.cs
@@ -37,8 +37,11 @@ namespace MassTransit.Tests.Serialization
 
             await harness.Bus.Publish(new PlaceOrder { OrderId = NewId.NextGuid() });
 
-            Assert.IsTrue(await harness.GetConsumerHarness<PlaceOrderConsumer>().Consumed.Any<PlaceOrder>());
-            Assert.IsFalse(await harness.GetConsumerHarness<TerminateProcessConsumer>().Consumed.Any<TerminateProcess>());
+            Assert.Multiple(async () =>
+            {
+                Assert.That(await harness.GetConsumerHarness<PlaceOrderConsumer>().Consumed.Any<PlaceOrder>(), Is.True);
+                Assert.That(await harness.GetConsumerHarness<TerminateProcessConsumer>().Consumed.Any<TerminateProcess>(), Is.False);
+            });
         }
 
 

--- a/tests/MassTransit.Tests/Serialization/PolymorphicProperty_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/PolymorphicProperty_Specs.cs
@@ -75,7 +75,7 @@
 
                 ConsumeContext<ITestMessage> context = await _handled;
 
-                Assert.IsInstanceOf<TestConcreteClass>(context.Message.Data);
+                Assert.That(context.Message.Data, Is.InstanceOf<TestConcreteClass>());
             }
 
             Task<ConsumeContext<ITestMessage>> _handled;
@@ -110,9 +110,9 @@
                 ConsumeContext<ITestArrayMessage> context = await _handled;
 
                 Assert.That(context.Message.Data, Is.Not.Null);
-                Assert.That(context.Message.Data.Length, Is.EqualTo(1));
+                Assert.That(context.Message.Data, Has.Length.EqualTo(1));
 
-                Assert.IsInstanceOf<TestConcreteClass>(context.Message.Data[0]);
+                Assert.That(context.Message.Data[0], Is.InstanceOf<TestConcreteClass>());
             }
 
             Task<ConsumeContext<ITestArrayMessage>> _handled;
@@ -149,9 +149,9 @@
                 ConsumeContext<ITestListMessage> context = await _handled;
 
                 Assert.That(context.Message.Data, Is.Not.Null);
-                Assert.That(context.Message.Data.Count, Is.EqualTo(1));
+                Assert.That(context.Message.Data, Has.Count.EqualTo(1));
 
-                Assert.IsInstanceOf<TestConcreteClass>(context.Message.Data[0]);
+                Assert.That(context.Message.Data[0], Is.InstanceOf<TestConcreteClass>());
             }
 
             Task<ConsumeContext<ITestListMessage>> _handled;

--- a/tests/MassTransit.Tests/Serialization/ProtoBufAsJson_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/ProtoBufAsJson_Specs.cs
@@ -13,13 +13,13 @@ namespace MassTransit.Tests.Serialization
         public void Should_return_the_array_values()
         {
             var tb = new TradesBookedMT();
-            tb.Trades.Add(new TradeBookedMT {Currency = "AUD"});
-            tb.Trades.Add(new TradeBookedMT {Currency = "USD"});
+            tb.Trades.Add(new TradeBookedMT { Currency = "AUD" });
+            tb.Trades.Add(new TradeBookedMT { Currency = "USD" });
 
             var result = SerializeAndReturn(tb);
 
             Assert.That(result.Trades, Is.Not.Null);
-            Assert.That(result.Trades.Count, Is.EqualTo(2));
+            Assert.That(result.Trades, Has.Count.EqualTo(2));
         }
 
         public Serializing_a_protocol_buffer_message(Type serializerType)

--- a/tests/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/ReceiveFault_Serialization_Specs.cs
@@ -68,7 +68,7 @@
         void TestCanSerialize(ReceiveFaultEvent fault)
         {
             byte[] bytes = Serialize(fault);
-            Assert.That(bytes.Length, Is.GreaterThan(0));
+            Assert.That(bytes, Is.Not.Empty);
         }
     }
 }

--- a/tests/MassTransit.Tests/Serialization/SeparateSerializer_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/SeparateSerializer_Specs.cs
@@ -68,11 +68,14 @@
 
             ConsumeContext<Command> context = await _handled;
 
-            Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(NewtonsoftRawJsonMessageSerializer.RawJsonContentType),
-                $"unexpected content-type {context.ReceiveContext.ContentType}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(NewtonsoftRawJsonMessageSerializer.RawJsonContentType),
+                    $"unexpected content-type {context.ReceiveContext.ContentType}");
 
-            Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
-            Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+                Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
+                Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+            });
         }
 
         Task<ConsumeContext<Command>> _handled;
@@ -104,6 +107,7 @@
         }
     }
 
+
     [TestFixture]
     public class Sending_and_consuming_raw_xml :
         InMemoryTestFixture
@@ -121,11 +125,14 @@
 
             ConsumeContext<Command> context = await _handled;
 
-            Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(RawXmlMessageSerializer.RawXmlContentType),
-                $"unexpected content-type {context.ReceiveContext.ContentType}");
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.ReceiveContext.ContentType, Is.EqualTo(RawXmlMessageSerializer.RawXmlContentType),
+                    $"unexpected content-type {context.ReceiveContext.ContentType}");
 
-            Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
-            Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+                Assert.That(context.Message.CommandId, Is.EqualTo(message.CommandId));
+                Assert.That(context.Message.ItemNumber, Is.EqualTo(message.ItemNumber));
+            });
         }
 
         Task<ConsumeContext<Command>> _handled;

--- a/tests/MassTransit.Tests/Serialization/SerializationTest.cs
+++ b/tests/MassTransit.Tests/Serialization/SerializationTest.cs
@@ -141,12 +141,15 @@ namespace MassTransit.Tests.Serialization
 
             Assert.That(messageContext, Is.Not.Null);
 
-            Assert.That(messageContext.SourceAddress, Is.EqualTo(_sourceAddress));
-            Assert.That(messageContext.DestinationAddress, Is.EqualTo(_destinationAddress));
-            Assert.That(messageContext.FaultAddress, Is.EqualTo(_faultAddress));
-            Assert.That(messageContext.ResponseAddress, Is.EqualTo(_responseAddress));
-            Assert.That(messageContext.RequestId.HasValue, Is.EqualTo(true));
-            Assert.That(messageContext.RequestId.Value, Is.EqualTo(_requestId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(messageContext.SourceAddress, Is.EqualTo(_sourceAddress));
+                Assert.That(messageContext.DestinationAddress, Is.EqualTo(_destinationAddress));
+                Assert.That(messageContext.FaultAddress, Is.EqualTo(_faultAddress));
+                Assert.That(messageContext.ResponseAddress, Is.EqualTo(_responseAddress));
+                Assert.That(messageContext.RequestId.HasValue, Is.EqualTo(true));
+                Assert.That(messageContext.RequestId.Value, Is.EqualTo(_requestId));
+            });
 
             return messageContext.Message;
         }

--- a/tests/MassTransit.Tests/Testing/StandaloneConsumer_Specs.cs
+++ b/tests/MassTransit.Tests/Testing/StandaloneConsumer_Specs.cs
@@ -22,9 +22,12 @@
             {
                 await harness.InputQueueSendEndpoint.Send(new PingMessage());
 
-                Assert.That(harness.Consumed.Select<PingMessage>().Any(), Is.True);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(harness.Consumed.Select<PingMessage>().Any(), Is.True);
 
-                Assert.That(consumer.Consumed.Select<PingMessage>().Any(), Is.True);
+                    Assert.That(consumer.Consumed.Select<PingMessage>().Any(), Is.True);
+                });
             }
             finally
             {

--- a/tests/MassTransit.Tests/Testing/StateMachineSagaTest_Specs.cs
+++ b/tests/MassTransit.Tests/Testing/StateMachineSagaTest_Specs.cs
@@ -72,16 +72,22 @@ namespace MassTransit.Tests.Testing
         public async Task Should_receive_the_fault_with_data()
         {
             await _saga.Exists(_sagaId);
-            Assert.That(_harness.Consumed.Select<StartMessage>().Any(), Is.True);
-            Assert.That(_harness.Consumed.Select<Fault<ExecuteRequest>>().Any(), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_harness.Consumed.Select<StartMessage>().Any(), Is.True);
+                Assert.That(_harness.Consumed.Select<Fault<ExecuteRequest>>().Any(), Is.True);
+            });
 
             var result = (Fault<ExecuteRequest>)_harness.Consumed.Select<Fault<ExecuteRequest>>().Single().MessageObject;
-            Assert.That(result.FaultId, Is.EqualTo(_faultId));
-            Assert.That(result.FaultedMessageId, Is.EqualTo(_faultedMessageId));
-            Assert.That(result.Timestamp, Is.EqualTo(_timestamp));
-            Assert.That(result.FaultMessageTypes, Is.EqualTo(_faultMessageTypes));
-            Assert.That(result.Message, Is.Not.Null);
-            Assert.That(result.Exceptions, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.FaultId, Is.EqualTo(_faultId));
+                Assert.That(result.FaultedMessageId, Is.EqualTo(_faultedMessageId));
+                Assert.That(result.Timestamp, Is.EqualTo(_timestamp));
+                Assert.That(result.FaultMessageTypes, Is.EqualTo(_faultMessageTypes));
+                Assert.That(result.Message, Is.Not.Null);
+                Assert.That(result.Exceptions, Is.Not.Null);
+            });
         }
 
         [OneTimeTearDown]

--- a/tests/MassTransit.Tests/Threading_Specs.cs
+++ b/tests/MassTransit.Tests/Threading_Specs.cs
@@ -24,7 +24,7 @@
             {
                 var timer = Stopwatch.StartNew();
                 Bus.Publish(new A());
-                Assert.IsTrue(_before.WaitOne(TimeSpan.FromSeconds(30)), "Consumer thread failed to start");
+                Assert.That(_before.WaitOne(TimeSpan.FromSeconds(30)), Is.True, "Consumer thread failed to start");
                 timer.Stop();
                 latency.Add(timer.ElapsedMilliseconds);
             }
@@ -34,7 +34,7 @@
             _wait.Set();
 
             for (var i = 0; i < 100; i++)
-                Assert.IsTrue(_after.WaitOne(TimeSpan.FromSeconds(30)), "Consumer thread failed to complete");
+                Assert.That(_after.WaitOne(TimeSpan.FromSeconds(30)), Is.True, "Consumer thread failed to complete");
 
             Console.WriteLine("Elapsed Time: {0}", DateTime.Now - now);
         }

--- a/tests/MassTransit.Tests/Timeout_Specs.cs
+++ b/tests/MassTransit.Tests/Timeout_Specs.cs
@@ -19,11 +19,14 @@
             await InputQueueSendEndpoint.Send(new PingMessage());
             await Task.WhenAny(_succeeded, faulted);
 
-            Assert.IsTrue(_firstCalled);
-            Assert.IsTrue(_firstRequested.HasValue);
-            Assert.IsFalse(_firstRequested.Value);
-            Assert.IsFalse(_secondCalled);
-            Assert.IsFalse(_secondRequested.HasValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_firstCalled, Is.True);
+                Assert.That(_firstRequested.HasValue, Is.True);
+                Assert.That(_firstRequested.Value, Is.False);
+                Assert.That(_secondCalled, Is.False);
+                Assert.That(_secondRequested.HasValue, Is.False);
+            });
         }
 
         Task _succeeded;

--- a/tests/MassTransit.Tests/Topology/CreateTopology_Specs.cs
+++ b/tests/MassTransit.Tests/Topology/CreateTopology_Specs.cs
@@ -43,22 +43,31 @@
 
                 ConsumeContext<INewUserEvent> context = await handled;
 
-                Assert.IsTrue(context.CorrelationId.HasValue);
-                Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(context.CorrelationId.HasValue, Is.True);
+                    Assert.That(context.CorrelationId.Value, Is.EqualTo(transactionId));
+                });
 
                 await harness.InputQueueSendEndpoint.Send<OtherMessage>(new { CorrelationId = transactionId });
 
                 ConsumeContext<OtherMessage> otherContext = await otherHandled;
 
-                Assert.IsTrue(otherContext.CorrelationId.HasValue);
-                Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(otherContext.CorrelationId.HasValue, Is.True);
+                    Assert.That(otherContext.CorrelationId.Value, Is.EqualTo(transactionId));
+                });
 
                 await harness.InputQueueSendEndpoint.Send<LegacyMessage>(new { TransactionId = transactionId });
 
                 ConsumeContext<LegacyMessage> legacyContext = await legacyHandled;
 
-                Assert.IsTrue(legacyContext.CorrelationId.HasValue);
-                Assert.That(legacyContext.CorrelationId.Value, Is.EqualTo(transactionId));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(legacyContext.CorrelationId.HasValue, Is.True);
+                    Assert.That(legacyContext.CorrelationId.Value, Is.EqualTo(transactionId));
+                });
             }
             finally
             {

--- a/tests/MassTransit.Tests/Transforms/SendTransform_Specs.cs
+++ b/tests/MassTransit.Tests/Transforms/SendTransform_Specs.cs
@@ -12,12 +12,15 @@
         [Test]
         public async Task Should_not_affect_published_messages()
         {
-            await Bus.Publish(new A {First = "Hello"});
+            await Bus.Publish(new A { First = "Hello" });
 
             ConsumeContext<A> result = await _received;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.Null);
+            });
         }
 
         Task<ConsumeContext<A>> _received;
@@ -54,12 +57,15 @@
         [Test]
         public async Task Should_change_the_property()
         {
-            await InputQueueSendEndpoint.Send(new A {First = "Hello"});
+            await InputQueueSendEndpoint.Send(new A { First = "Hello" });
 
             ConsumeContext<A> result = await _received;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.EqualTo("World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.EqualTo("World"));
+            });
         }
 
         Task<ConsumeContext<A>> _received;
@@ -96,12 +102,15 @@
         [Test]
         public async Task Should_transform_on_publish()
         {
-            await Bus.Publish(new A {First = "Hello"});
+            await Bus.Publish(new A { First = "Hello" });
 
             ConsumeContext<A> result = await _received;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.EqualTo("World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.EqualTo("World"));
+            });
         }
 
         Task<ConsumeContext<A>> _received;
@@ -138,12 +147,15 @@
         [Test]
         public async Task Should_not_transform_on_send()
         {
-            await InputQueueSendEndpoint.Send(new A {First = "Hello"});
+            await InputQueueSendEndpoint.Send(new A { First = "Hello" });
 
             ConsumeContext<A> result = await _received;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.Null);
+            });
         }
 
         Task<ConsumeContext<A>> _received;

--- a/tests/MassTransit.Tests/Transforms/SetProperty_Specs.cs
+++ b/tests/MassTransit.Tests/Transforms/SetProperty_Specs.cs
@@ -12,12 +12,15 @@
         [Test]
         public async Task Should_have_the_message_property()
         {
-            await InputQueueSendEndpoint.Send(new A {First = "Hello"});
+            await InputQueueSendEndpoint.Send(new A { First = "Hello" });
 
             ConsumeContext<A> result = await _received;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.EqualTo("World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.EqualTo("World"));
+            });
         }
 
         Task<ConsumeContext<A>> _received;
@@ -52,12 +55,15 @@
         [Test]
         public async Task Should_have_the_message_property()
         {
-            await InputQueueSendEndpoint.Send(new A {First = "Hello"});
+            await InputQueueSendEndpoint.Send(new A { First = "Hello" });
 
             ConsumeContext<A> result = await _received;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.EqualTo("World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.EqualTo("World"));
+            });
         }
 
         Task<ConsumeContext<A>> _received;
@@ -92,18 +98,21 @@
         {
             Task<ConsumeContext<IA>> unmodified = await ConnectPublishHandler<IA>();
 
-            await Bus.Publish(new A {First = "Hello"});
+            await Bus.Publish(new A { First = "Hello" });
 
             ConsumeContext<IA> result = await _received;
             ConsumeContext<IA> original = await unmodified;
             var tweaked = await _tweaked.Task;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.EqualTo("World"));
-            Assert.That(tweaked.Second, Is.EqualTo("World"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.EqualTo("World"));
+                Assert.That(tweaked.Second, Is.EqualTo("World"));
 
-            Assert.That(original.Message.First, Is.EqualTo("Hello"));
-            Assert.That(original.Message.Second, Is.Null);
+                Assert.That(original.Message.First, Is.EqualTo("Hello"));
+                Assert.That(original.Message.Second, Is.Null);
+            });
         }
 
         Task<ConsumeContext<IA>> _received;
@@ -149,19 +158,22 @@
         {
             Task<ConsumeContext<IA>> unmodified = await ConnectPublishHandler<IA>();
 
-            await Bus.Publish(new A {First = "Hello"});
+            await Bus.Publish(new A { First = "Hello" });
 
             ConsumeContext<IA> result = await _received;
             ConsumeContext<IA> original = await unmodified;
             var tweaked = await _tweaked.Task;
 
-            Assert.That(result.Message.First, Is.EqualTo("Hello"));
-            Assert.That(result.Message.Second, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("Hello"));
+                Assert.That(result.Message.Second, Is.Null);
 
-            Assert.That(tweaked.Second, Is.EqualTo("World"));
+                Assert.That(tweaked.Second, Is.EqualTo("World"));
 
-            Assert.That(original.Message.First, Is.EqualTo("Hello"));
-            Assert.That(original.Message.Second, Is.Null);
+                Assert.That(original.Message.First, Is.EqualTo("Hello"));
+                Assert.That(original.Message.Second, Is.Null);
+            });
         }
 
         Task<ConsumeContext<IA>> _received;

--- a/tests/MassTransit.Tests/Transforms/TransformClass_Specs.cs
+++ b/tests/MassTransit.Tests/Transforms/TransformClass_Specs.cs
@@ -13,12 +13,15 @@
         [Test]
         public async Task Should_have_the_message_property()
         {
-            await InputQueueSendEndpoint.Send(new A {First = "Hello"});
+            await InputQueueSendEndpoint.Send(new A { First = "Hello" });
 
             ConsumeContext<A> result = await _received;
 
-            Assert.That(result.Message.First, Is.EqualTo("First"));
-            Assert.That(result.Message.Second, Is.EqualTo("Second"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Message.First, Is.EqualTo("First"));
+                Assert.That(result.Message.Second, Is.EqualTo("Second"));
+            });
         }
 
         Task<ConsumeContext<A>> _received;


### PR DESCRIPTION
- Migrate to NUnit4
- Drop support of `netstandard2.0` in TestFramework. 