### PR TITLE
Add name of exchange in error message when exchange names are the same

### DIFF
--- a/src/MassTransit/Transports/Fabric/MessageFabric.cs
+++ b/src/MassTransit/Transports/Fabric/MessageFabric.cs
@@ -33,7 +33,7 @@
         public void ExchangeBind(TContext context, string source, string destination, string routingKey)
         {
             if (source.Equals(destination))
-                throw new ArgumentException("The source and destination exchange cannot be the same");
+                throw new ArgumentException("The source and destination exchange cannot be the same: " + source);
 
             IMessageExchange<T> sourceExchange = GetOrAddExchange(context, source, ExchangeType.FanOut);
 


### PR DESCRIPTION
When trying to bind two exchanges with the same name, an ArgumentExcpetion is thrown. The original error message did not include the name of the exchange in question, which makes it hard(er) to understand where to fix the problem.
