### PR TITLE
Fix summaries of methods referring to message type while no messageType parameter is available

### DIFF
--- a/src/MassTransit.Abstractions/Contexts/TimeSpanContextScheduleExtensions.cs
+++ b/src/MassTransit.Abstractions/Contexts/TimeSpanContextScheduleExtensions.cs
@@ -174,8 +174,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
@@ -192,8 +191,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
@@ -210,8 +208,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/Contexts/TimeSpanScheduleExtensions.cs
+++ b/src/MassTransit.Abstractions/Contexts/TimeSpanScheduleExtensions.cs
@@ -183,8 +183,7 @@
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
@@ -202,8 +201,7 @@
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
@@ -221,8 +219,7 @@
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/Contexts/TimeSpanSchedulePublishExtensions.cs
+++ b/src/MassTransit.Abstractions/Contexts/TimeSpanSchedulePublishExtensions.cs
@@ -174,8 +174,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Publishes an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
@@ -192,8 +191,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Publishes an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>
@@ -210,8 +208,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Publishes an object as a message.
         /// </summary>
         /// <param name="scheduler">The message scheduler</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/IPublishEndpoint.cs
+++ b/src/MassTransit.Abstractions/IPublishEndpoint.cs
@@ -54,16 +54,14 @@ namespace MassTransit
             where T : class;
 
         /// <summary>
-        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Publishes an object as a message.
         /// </summary>
         /// <param name="message">The message object</param>
         /// <param name="cancellationToken"></param>
         Task Publish(object message, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Publishes an object as a message.
         /// </summary>
         /// <param name="message">The message object</param>
         /// <param name="publishPipe"></param>

--- a/src/MassTransit.Abstractions/ISendEndpoint.cs
+++ b/src/MassTransit.Abstractions/ISendEndpoint.cs
@@ -59,8 +59,7 @@ namespace MassTransit
         Task Send(object message, Type messageType, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="message">The message object</param>
         /// <param name="pipe"></param>

--- a/src/MassTransit.Abstractions/SchedulePublishExtensions.cs
+++ b/src/MassTransit.Abstractions/SchedulePublishExtensions.cs
@@ -106,8 +106,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="context">The consume context</param>
         /// <param name="scheduledTime">The time at which the message should be delivered to the queue</param>
@@ -305,8 +304,7 @@ namespace MassTransit
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="context">The consume context</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/Scheduling/ConsumeContextSchedulerExtensions.cs
+++ b/src/MassTransit.Abstractions/Scheduling/ConsumeContextSchedulerExtensions.cs
@@ -103,8 +103,7 @@
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="context">The consume context</param>
         /// <param name="message">The message object</param>
@@ -299,8 +298,7 @@
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="context">The consume context</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/Scheduling/ConsumeContextSelfSchedulerExtensions.cs
+++ b/src/MassTransit.Abstractions/Scheduling/ConsumeContextSelfSchedulerExtensions.cs
@@ -98,8 +98,7 @@
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="context">The consume context</param>
         /// <param name="message">The message object</param>
@@ -284,8 +283,7 @@
         }
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="context">The consume context</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/Scheduling/IMessageScheduler.cs
+++ b/src/MassTransit.Abstractions/Scheduling/IMessageScheduler.cs
@@ -76,8 +76,7 @@
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
         /// <param name="scheduledTime">The time at which the message should be delivered to the queue</param>
@@ -211,8 +210,7 @@
         Task<ScheduledMessage> SchedulePublish(DateTime scheduledTime, object message, Type messageType, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduledTime">The time at which the message should be delivered to the queue</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/Scheduling/IRecurringMessageScheduler.cs
+++ b/src/MassTransit.Abstractions/Scheduling/IRecurringMessageScheduler.cs
@@ -77,8 +77,7 @@
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="destinationAddress">The destination address where the schedule message should be sent</param>
         /// <param name="schedule">The schedule for the message to be delivered</param>
@@ -208,8 +207,7 @@
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Publishes an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Publishes an object as a message.
         /// </summary>
         /// <param name="schedule">The schedule for the message to be delivered</param>
         /// <param name="message">The message object</param>

--- a/src/MassTransit.Abstractions/Scheduling/MessageSchedulerContext.cs
+++ b/src/MassTransit.Abstractions/Scheduling/MessageSchedulerContext.cs
@@ -66,8 +66,7 @@ namespace MassTransit
         Task<ScheduledMessage> ScheduleSend(DateTime scheduledTime, object message, Type messageType, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sends an object as a message, using the message type specified. If the object cannot be cast
-        /// to the specified message type, an exception will be thrown.
+        /// Sends an object as a message.
         /// </summary>
         /// <param name="scheduledTime">The time at which the message should be delivered to the queue</param>
         /// <param name="message">The message object</param>


### PR DESCRIPTION
I just noticed that several methods that refer to a specified message type in the summary (warning about an exception being thrown if the message could not be casted to the message type) actually didn't have a message type parameter.

I updated the summaries for those cases. I removed the mention of casting, assuming that there isn't a concern for that for these methods.