### PR TITLE
Fixes `EndpointRoutingMiddleware matches endpoints setup by EndpointMiddleware...`

### DIFF
--- a/doc/content/3.documentation/2.configuration/0.index.md
+++ b/doc/content/3.documentation/2.configuration/0.index.md
@@ -589,15 +589,12 @@ The _AddMassTransit_ method adds an `IHealthCheck` to the service collection tha
 To configure health checks, map the ready and live endpoints in your ASP.NET application.
 
 ```csharp
-app.UseEndpoints(endpoints =>
+app.MapHealthChecks("/health/ready", new HealthCheckOptions()
 {
-    endpoints.MapHealthChecks("/health/ready", new HealthCheckOptions()
-    {
-        Predicate = (check) => check.Tags.Contains("ready"),
-    });
-
-    endpoints.MapHealthChecks("/health/live", new HealthCheckOptions());
+    Predicate = (check) => check.Tags.Contains("ready"),
 });
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions());
 ```
 
 **Example Output**


### PR DESCRIPTION
Resolves startup error:

> System.InvalidOperationException: 'EndpointRoutingMiddleware matches endpoints setup by EndpointMiddleware and so must be added to the request execution pipeline before EndpointMiddleware. Please add EndpointRoutingMiddleware by calling 'IApplicationBuilder.UseRouting' inside the call to 'Configure(...)' in the application startup code.'

Not sure about the behavior. I don't get the documented json output on those urls but the endpoints to return `Healthy`.

This is with:

    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.6" />
