### PR TITLE
IRabbitMqEndpointConfigurator no longer exists, have to use IRabbitMqQueueConfigurator

### DIFF
--- a/doc/content/3.documentation/2.configuration/0.index.md
+++ b/doc/content/3.documentation/2.configuration/0.index.md
@@ -166,7 +166,7 @@ To conditionally apply transport-specific settings, the `cfg` parameter can be p
 ```csharp
 x.AddConfigureEndpointsCallback((name, cfg) =>
 {
-    if (cfg is IRabbitMqReceiveEndpointConfigurator rmq)
+    if (cfg is IRabbitMqQueueConfigurator rmq)
         rmq.SetQuorumQueue(3);
         
     cfg.UseMessageRetry(r => r.Immediate(2));        


### PR DESCRIPTION
IRabbitMqEndpointConfigurator no longer exists, have to use IRabbitMqQueueConfigurator to enable quorum queues.
