### PR TITLE
Fix typo in 11.transactional-outbox.md

### DIFF
--- a/doc/content/3.documentation/3.patterns/11.transactional-outbox.md
+++ b/doc/content/3.documentation/3.patterns/11.transactional-outbox.md
@@ -8,7 +8,7 @@ The Transactional Outbox has two main components:
 
 - The **Bus Outbox** works within a container scope (such as the scope created for an ASP.NET Controller) and adds published and sent messages to the specified `DbContext`. Once the changes are saved, the messages are available to the delivery service which delivers them to the broker.
 
-- The **Consumer Outbox** is a combination of an _inbox_ and an _outbox_. The _inbox_ is used to keep track of received messages to guarantee  exactly-once consumer behavior. The _outbox_ is used to store published and sent messages until the consumer completes successfully. Once completed, the stored messages are delivered to the broker after which the received message is acknowledged. The Consumer Outbox works with all consumer types, including Consumers, Sagas, and Courier Actvities.
+- The **Consumer Outbox** is a combination of an _inbox_ and an _outbox_. The _inbox_ is used to keep track of received messages to guarantee  exactly-once consumer behavior. The _outbox_ is used to store published and sent messages until the consumer completes successfully. Once completed, the stored messages are delivered to the broker after which the received message is acknowledged. The Consumer Outbox works with all consumer types, including Consumers, Sagas, and Courier Activities.
 
 Either of these components can be used independently or both at the same time.
 


### PR DESCRIPTION
"Activities" was spelled incorrectly in `11.transactional-outbox.md`.