### PR TITLE
Update ScheduleJob.cs: replace HangfireScheduledMessageData with Hash…

### DIFF
--- a/src/Scheduling/MassTransit.HangfireIntegration/HangfireIntegration/ScheduleJob.cs
+++ b/src/Scheduling/MassTransit.HangfireIntegration/HangfireIntegration/ScheduleJob.cs
@@ -21,7 +21,7 @@ namespace MassTransit.HangfireIntegration
         }
 
         [HashCleanup]
-        public async Task SendMessage(HangfireScheduledMessageData messageData, PerformContext performContext)
+        public async Task SendMessage(HashedHangfireScheduledMessageData messageData, PerformContext performContext)
         {
             try
             {


### PR DESCRIPTION
The HashCleanup attribute doesn't work with the HangfireScheduledMessageData type because it does not implement the IHashedScheduleId interface. As a result, the hashId key is not removed from Redis database after job is executed. This commit fixes this issue.

Before: ![HashCleanup_before](https://github.com/user-attachments/assets/b02137ee-7151-40a3-9bfc-093662165881)

After: ![HashCleanup_after](https://github.com/user-attachments/assets/962c5243-c0f6-4876-bc97-4056e87e1785)
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
