### PR TITLE
Migrate to TaskExecutor

### DIFF
--- a/src/MassTransit/Util/ChannelExecutor.cs
+++ b/src/MassTransit/Util/ChannelExecutor.cs
@@ -249,6 +249,7 @@ namespace MassTransit.Util
             }
         }
 
+
         readonly struct RunFuture<T> :
             IFuture
         {

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Batcher.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Batcher.cs
@@ -13,7 +13,7 @@ namespace MassTransit.AmazonSqsTransport
     {
         readonly Task _batchTask;
         readonly Channel<BatchEntry<TEntry>> _channel;
-        readonly ChannelExecutor _executor;
+        readonly TaskExecutor _executor;
         readonly BatchSettings _settings;
 
         protected Batcher(BatchSettings settings = null)
@@ -29,7 +29,7 @@ namespace MassTransit.AmazonSqsTransport
             };
 
             _channel = Channel.CreateBounded<BatchEntry<TEntry>>(channelOptions);
-            _executor = new ChannelExecutor(2, _settings.BatchLimit);
+            _executor = new TaskExecutor(2, _settings.BatchLimit);
             _batchTask = Task.Run(WaitForBatch);
         }
 
@@ -90,7 +90,6 @@ namespace MassTransit.AmazonSqsTransport
                         {
                             break;
                         }
-
                     }
                 }
                 catch (OperationCanceledException exception) when (exception.CancellationToken == batchToken.Token && batch.Count > 0)


### PR DESCRIPTION
- Adding prefetch option for TaskExecutor
- Replace usage of ChannelExecutor completely