### PR TITLE
add metrics enrichment

### DIFF
--- a/src/MassTransit.Abstractions/IMetricsContext.cs
+++ b/src/MassTransit.Abstractions/IMetricsContext.cs
@@ -1,0 +1,15 @@
+﻿namespace MassTransit
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides access to tags added to metrics.
+    /// </summary>
+    public interface IMetricsContext
+    {
+        /// <summary>
+        /// Gets the tag collection.
+        /// </summary>
+        ICollection<KeyValuePair<string, object?>> Tags { get; }
+    }
+}

--- a/src/MassTransit/MetricsContext.cs
+++ b/src/MassTransit/MetricsContext.cs
@@ -1,0 +1,15 @@
+﻿namespace MassTransit
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides access to tags added to metrics.
+    /// </summary>
+    public sealed class MetricsContext : IMetricsContext
+    {
+        /// <summary>
+        /// Gets the tag collection.
+        /// </summary>
+        public ICollection<KeyValuePair<string, object>> Tags { get; } = new List<KeyValuePair<string, object>>();
+    }
+}

--- a/src/MassTransit/Middleware/OutboxMessagePipe.cs
+++ b/src/MassTransit/Middleware/OutboxMessagePipe.cs
@@ -102,7 +102,7 @@ namespace MassTransit.Middleware
                         throw new ApplicationException("Simulated Delivery Failure Requested");
 
                     StartedActivity? activity = LogContext.Current?.StartOutboxDeliverActivity(message);
-                    StartedInstrument? instrument = LogContext.Current?.StartOutboxDeliveryInstrument(message);
+                    StartedInstrument? instrument = LogContext.Current?.StartOutboxDeliveryInstrument(context, message);
                     try
                     {
                         await endpoint.Send(new SerializedMessageBody(), pipe, token.Token).ConfigureAwait(false);


### PR DESCRIPTION
Update 1:

I'd like to use `IMetricsTagsFeature` to add Kafka topic name and some custom headers like tenant id to MassTransit metrics.

I added the `MetricsContext`. It is being applied in `LogContextInstrumentationExtensions`.
I haven't added it with GetOrAddPayload, I'd leave this to the developer. I think they can add MetricsContext before they add some custom tags like: `context.GetOrAddPayload<IMetricsContext>(() => new MetricsContext());`

---
Outdated:

I added the `IMetricsTagsFeature` property to `ReceiveContext` and `SendContext` and implemented the property in their classes.
`IMetricsTagsFeature` can be used to enhance built-in MassTransit metrics with custom tags.

I changed `LogContextInstrumentationExtensions` to use `IMetricsTagsFeature`. I couldn't add custom tags for two invocations of the `StartOutboxDeliveryInstrument` method because there is no `OutboxConsumeContext` in the EF and MongoDB `BusOutboxDeliveryService`. I don't know how to add custom metrics there.

The idea of this PR is based on [IHttpMetricsTagsFeature](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.features.ihttpmetricstagsfeature?view=aspnetcore-8.0) in aspnet.
Related PR: [aspnetcore/Add IHttpMetricsTagsFeature and IConnectionMetricsTagsFeature](https://github.com/dotnet/aspnetcore/issues/47493)

I'd like to use `IMetricsTagsFeature` to add Kafka topic name and some custom headers like tenant id to MassTransit metrics.