### PR TITLE
SqlTransport -> Use configured schema when listening to notifications

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/Helpers/NotifyChannel.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/Helpers/NotifyChannel.cs
@@ -1,0 +1,23 @@
+namespace MassTransit.SqlTransport.PostgreSql.Helpers;
+
+public static class NotifyChannel
+{
+    // Postgres channel name is an identifier and can contain maximum 63 characters.
+    // We need to reserve 19 characters for queueId being a long and
+    // 5 characters for the _msg_ separator. Schema can be at most 39 characters.
+    // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+    const int MaxSchemaNameLength = 39;
+    const string DefaultSchemaName = "transport";
+
+    public static string SanitizeSchemaName(string? schemaName)
+    {
+        if (string.IsNullOrWhiteSpace(schemaName))
+        {
+            return DefaultSchemaName;
+        }
+
+        return schemaName!.Length > MaxSchemaNameLength
+            ? schemaName.Substring(0, MaxSchemaNameLength)
+            : schemaName;
+    }
+}

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
@@ -200,10 +200,10 @@ namespace MassTransit.SqlTransport.PostgreSql
 
                             foreach (var queueId in queueIds)
                             {
-                                await connection.Connection.ExecuteScalarAsync<int>($"LISTEN transport_msg_{queueId}", Stopping)
+                                await connection.Connection.ExecuteScalarAsync<int>($"LISTEN {_context.Schema}_msg_{queueId}", Stopping)
                                     .ConfigureAwait(false);
 
-                                // LogContext.Debug?.Log("LISTEN transport_msg_{QueueId}", queueId);
+                                // LogContext.Debug?.Log("LISTEN {_context.Schema}_msg_{QueueId}", queueId);
                             }
 
                             while (!Stopping.IsCancellationRequested)
@@ -226,10 +226,10 @@ namespace MassTransit.SqlTransport.PostgreSql
                                     if (queueIds.Contains(queueId))
                                         break;
 
-                                    await connection.Connection.ExecuteScalarAsync<int>($"LISTEN transport_msg_{queueId}", Stopping)
+                                    await connection.Connection.ExecuteScalarAsync<int>($"LISTEN {_context.Schema}_msg_{queueId}", Stopping)
                                         .ConfigureAwait(false);
 
-                                    // LogContext.Debug?.Log("LISTEN transport_msg_{QueueId}", queueId);
+                                    // LogContext.Debug?.Log("LISTEN {_context.Schema}_msg_{QueueId}", queueId);
 
                                     queueIds.Add(queueId);
                                 }

--- a/tests/MassTransit.SqlTransport.Tests/PgSql/ChannelName_Specs.cs
+++ b/tests/MassTransit.SqlTransport.Tests/PgSql/ChannelName_Specs.cs
@@ -1,0 +1,37 @@
+namespace MassTransit.DbTransport.Tests.PgSql;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SqlTransport.PostgreSql.Helpers;
+
+[TestFixture]
+public class ChannelName_Specs
+{
+    [TestCase("string that has 40 characters 1234567890")]
+    public async Task Should_sanitize_schema(string schema)
+    {
+        var sanitizedSchema = NotifyChannel.SanitizeSchemaName(schema);
+
+        Assert.That(sanitizedSchema, Has.Length.EqualTo(39));
+        Assert.That(sanitizedSchema, Is.EqualTo("string that has 40 characters 123456789"));
+    }
+
+    [TestCase("string that has 38 characters 12345678")]
+    [TestCase("string that has 39 characters 123456789")]
+    public async Task Should_not_sanitize_schema(string schema)
+    {
+        var sanitizedSchema = NotifyChannel.SanitizeSchemaName(schema);
+
+        Assert.That(sanitizedSchema, Is.EqualTo(schema));
+    }
+
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase(null)]
+    public async Task Should_return_default(string schema)
+    {
+        var sanitizedSchema = NotifyChannel.SanitizeSchemaName(schema);
+
+        Assert.That(sanitizedSchema, Is.EqualTo("transport"));
+    }
+}


### PR DESCRIPTION
Hi @phatboyg 
I found an issue with the Listen (postgres) notifications part where the schema is hardcoded to be "transport"

Since it is allowed to have a different schema that is passed via options and the PostgresDatabaseMigrator uses it for creating the trigger script, we should have it aligned in the C# code.

PostgresDatabaseMigrator:
https://github.com/MassTransit/MassTransit/blob/41ea46fcb5421e892b81d38e9629e3ed39d8ad53/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs#L848


vs PostgresDbConnectionContext:
https://github.com/MassTransit/MassTransit/blob/41ea46fcb5421e892b81d38e9629e3ed39d8ad53/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs#L203

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
