### PR TITLE
Upgrade Quartz to version 3.12.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>CS1587,CS1591,CS1998,NU5105,NETSDK1188</NoWarn>
+    <NoWarn>CS1591,CS1998</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,10 +81,8 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="1.5.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageVersion Include="prometheus-net" Version="6.0.0" />
-    <PackageVersion Include="Quartz" Version="3.11.0" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.11.0" />
-    <PackageVersion Include="Quartz.Plugins.TimeZoneConverter" Version="3.11.0" />
-    <PackageVersion Include="Quartz.Serialization.Json" Version="3.11.0" />
+    <PackageVersion Include="Quartz" Version="3.12.0" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.12.0" />
     <PackageVersion Include="QuikGraph" Version="2.5.0" />
     <PackageVersion Include="QuikGraph.Graphviz" Version="2.5.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />

--- a/src/MassTransit.Abstractions/Contexts/RespondAsyncExecuteExtensions.cs
+++ b/src/MassTransit.Abstractions/Contexts/RespondAsyncExecuteExtensions.cs
@@ -46,7 +46,6 @@ namespace MassTransit
         /// <param name="context">The context to send the message</param>
         /// <param name="message">The message</param>
         /// <param name="callback">The callback for the send context</param>
-        // <param name="cancellationToken">To cancel the send from happening</param>
         /// <returns>The task which is completed once the Send is acknowledged by the broker</returns>
         public static Task RespondAsync(this ConsumeContext context, object message, Action<SendContext> callback)
         {

--- a/src/Scheduling/MassTransit.QuartzIntegration/MassTransit.QuartzIntegration.csproj
+++ b/src/Scheduling/MassTransit.QuartzIntegration/MassTransit.QuartzIntegration.csproj
@@ -24,8 +24,6 @@
   <ItemGroup>
     <PackageReference Include="Quartz" />
     <PackageReference Include="Quartz.Extensions.Hosting" />
-    <PackageReference Include="Quartz.Plugins.TimeZoneConverter" />
-    <PackageReference Include="Quartz.Serialization.Json" />
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqSslConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqSslConfigurator.cs
@@ -48,22 +48,5 @@ namespace MassTransit.RabbitMqTransport.Configuration
         public LocalCertificateSelectionCallback CertificateSelectionCallback { get; set; }
 
         public RemoteCertificateValidationCallback CertificateValidationCallback { get; set; }
-
-        /// <summary>
-        /// Configures the rabbit mq client connection for Sll properties.
-        /// </summary>
-        /// <param name="builder">Builder with appropriate properties set.</param>
-        /// <returns>A connection factory builder</returns>
-        /// <remarks>
-        /// SSL configuration in Rabbit MQ is a complex topic.  In order to ensure that rabbit can work without client presenting a client certificate
-        /// and working just like an SSL enabled web-site which does not require certificate you need to have the following settings in your rabbitmq.config
-        /// file.
-        ///      {ssl_options, [{cacertfile,"/path_to/cacert.pem"},
-        ///            {certfile,"/path_to/server/cert.pem"},
-        ///            {keyfile,"/path_to/server/key.pem"},
-        ///            {verify,verify_none},
-        ///            {fail_if_no_peer_cert,false}]}
-        /// The last 2 lines are the important ones.
-        /// </remarks>
     }
 }

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/QuartzOutbox_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/QuartzOutbox_Specs.cs
@@ -17,9 +17,8 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
         public async Task Should_delay_message_scheduling_until_the_outbox_messages_are_delivered()
         {
             await using var provider = new ServiceCollection()
-                .AddQuartz(q =>
+                .AddQuartz(_ =>
                 {
-                    q.UseMicrosoftDependencyInjectionJobFactory();
                 })
                 .AddBusOutboxServices()
                 .AddMassTransitTestHarness(x =>

--- a/tests/MassTransit.QuartzIntegration.Tests/Container_Specs.cs
+++ b/tests/MassTransit.QuartzIntegration.Tests/Container_Specs.cs
@@ -22,9 +22,7 @@ namespace MassTransit.QuartzIntegration.Tests
         public async Task Should_work_properly()
         {
             await using var provider = new ServiceCollection()
-                .AddQuartz(q =>
-                {
-                    q.UseMicrosoftDependencyInjectionJobFactory();
+                .AddQuartz(_ => {
                 })
                 .AddMassTransitTestHarness(x =>
                 {
@@ -70,9 +68,8 @@ namespace MassTransit.QuartzIntegration.Tests
         public async Task Should_work_properly_with_message_headers()
         {
             await using var provider = new ServiceCollection()
-                .AddQuartz(q =>
+                .AddQuartz(_ =>
                 {
-                    q.UseMicrosoftDependencyInjectionJobFactory();
                 })
                 .AddMassTransitTestHarness(x =>
                 {


### PR DESCRIPTION
https://github.com/quartznet/quartznet/releases/tag/v3.12.0

* remove promotion of Quartz's Newtonsoft based `Quartz.Serialization.Json`, users ideally could add  `Quartz.Serialization.SystemTextJson` themselves if they want to use JSON serializer
* remove unused `Quartz.Plugins.TimeZoneConverter`, users can add if they need it
* fix XML doc comments
* remove unnecessary compiler warnings suppression
* remove usage of obsolete `UseMicrosoftDependencyInjectionJobFactory`

