### PR TITLE
Use GitHubActionsTestLogger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ./
 
       - name: Test Analyzers
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --no-build --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --no-build --filter Category!=Flaky
         working-directory: tests/MassTransit.Analyzers.Tests
 
   test-ubuntu:
@@ -64,11 +64,11 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Unit Tests
-        run: dotnet test -c Release -f net8.0 --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release -f net8.0 --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.Tests
 
       - name: Test Abstractions
-        run: dotnet test -c Release -f net8.0 --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release -f net8.0 --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.Abstractions.Tests
 
   test-activemq:
@@ -91,7 +91,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test ActiveMQ
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.ActiveMqTransport.Tests
 
   test-sql-transport:
@@ -125,7 +125,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test Database Transport
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter "Category!=Flaky&Category!=Integration"
+        run: dotnet test -c Release --logger GitHubActions --filter "Category!=Flaky&Category!=Integration"
         working-directory: tests/MassTransit.SqlTransport.Tests
 
 
@@ -146,7 +146,7 @@ jobs:
         env:
           MT_ASB_KEYVALUE: ${{ secrets.AZURE_SERVICEBUS }}
           MT_AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE }}
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.Azure.ServiceBus.Core.Tests
   test-rabbitmq:
     name: "Transports: RabbitMQ"
@@ -169,7 +169,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test RabbitMQ
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.RabbitMqTransport.Tests
   test-sqs:
     name: "Transports: SQS (+S3)"
@@ -192,7 +192,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test SQS
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.AmazonSqsTransport.Tests
   test-azure-table:
     name: "Storage: Azure Table"
@@ -215,7 +215,7 @@ jobs:
       - name: Test Azure Table
         env:
           MT_AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE }}
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter "Category!=Flaky&Category!=Integration"
+        run: dotnet test -c Release --logger GitHubActions --filter "Category!=Flaky&Category!=Integration"
         working-directory: tests/MassTransit.Azure.Table.Tests
 
       - name: Stop test environment
@@ -251,7 +251,7 @@ jobs:
         working-directory: tests/MassTransit.Azure.Cosmos.Tests
 
       - name: Test CosmosDB
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter "Category!=Flaky&Category!=Integration"
+        run: dotnet test -c Release --logger GitHubActions --filter "Category!=Flaky&Category!=Integration"
         working-directory: tests/MassTransit.Azure.Cosmos.Tests
 
       - name: Stop test environment
@@ -282,7 +282,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test Dapper
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter "Category!=Flaky&Category!=Integration"
+        run: dotnet test -c Release --logger GitHubActions --filter "Category!=Flaky&Category!=Integration"
         working-directory: tests/MassTransit.DapperIntegration.Tests
   test-entity-framework:
     name: "Storage: EntityFramework"
@@ -316,11 +316,11 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test EntityFrameworkCore
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter "Category!=Flaky&Category!=Integration"
+        run: dotnet test -c Release --logger GitHubActions --filter "Category!=Flaky&Category!=Integration"
         working-directory: tests/MassTransit.EntityFrameworkCoreIntegration.Tests
 
       - name: Test EntityFramework
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter "Category!=Flaky&Category!=Integration"
+        run: dotnet test -c Release --logger GitHubActions --filter "Category!=Flaky&Category!=Integration"
         working-directory: tests/MassTransit.EntityFrameworkIntegration.Tests
   test-marten:
     name: "Storage: Marten"
@@ -344,7 +344,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test Marten
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.MartenIntegration.Tests
   test-mongo:
     name: "Storage: MongoDB"
@@ -365,7 +365,7 @@ jobs:
         working-directory: tests/MassTransit.MongoDbIntegration.Tests
 
       - name: Test MongoDB
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.MongoDbIntegration.Tests
 
       - name: Stop test environment
@@ -386,7 +386,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test NHibernate
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.NHibernateIntegration.Tests
   test-redis:
     name: "Storage: Redis"
@@ -408,7 +408,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test Redis
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.RedisIntegration.Tests
   test-hangfire:
     name: "Scheduler: Hangfire"
@@ -424,7 +424,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test Hangfire
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.HangfireIntegration.Tests
   test-quartz:
     name: "Scheduler: Quartz"
@@ -440,7 +440,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test Quartz
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.QuartzIntegration.Tests
   test-eventhub:
     name: "Rider: EventHub"
@@ -460,7 +460,7 @@ jobs:
         working-directory: tests/MassTransit.EventHubIntegration.Tests
 
       - name: Test EventHub
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         env:
           MT_EH_NAMESPACE: ${{ secrets.AZURE_EVENTHUB }}
           MT_AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE }}
@@ -488,7 +488,7 @@ jobs:
         working-directory: tests/MassTransit.KafkaIntegration.Tests
 
       - name: Test Kafka
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.KafkaIntegration.Tests
 
       - name: Stop test environment
@@ -510,7 +510,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Test SignalR
-        run: dotnet test -c Release --logger:"console;verbosity=normal" --filter Category!=Flaky
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.SignalR.Tests
 
   calc-version:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,6 +103,7 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
+    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm proposing to use [GitHubActionsTestLogger](https://github.com/Tyrrrz/GitHubActionsTestLogger), which will create[ nice summaries](https://github.com/MassTransit/MassTransit/actions/runs/10229746155?pr=5384) and easier to find test failures instead of the need to browse trough build's console logs.