### PR TITLE
Support Azure Redis with Credentials

### DIFF
--- a/src/Persistence/MassTransit.RedisIntegration/Configuration/Configuration/ConnectionMultiplexerFactory.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/Configuration/Configuration/ConnectionMultiplexerFactory.cs
@@ -26,19 +26,19 @@ public class ConnectionMultiplexerFactory :
         }
     }
 
-    public IConnectionMultiplexer GetConnectionMultiplexer(string configuration)
+    public IConnectionMultiplexer GetConnectionMultiplexer(ConfigurationOptions configuration)
     {
-        IConnectionMultiplexer MultiplexerFactory(string configurationString)
+        IConnectionMultiplexer MultiplexerFactory(ConfigurationOptions configurationOptions)
         {
-            LogContext.Debug?.Log("Creating Redis Connection Multiplexer: {Options}", ConfigurationOptions.Parse(configurationString).ToString(false));
-            return ConnectionMultiplexer.Connect(configurationString);
+            LogContext.Debug?.Log("Creating Redis Connection Multiplexer: {Options}", configurationOptions.ToString(false));
+            return ConnectionMultiplexer.Connect(configurationOptions);
         }
 
-        Lazy<IConnectionMultiplexer> ValueFactory(string x)
+        Lazy<IConnectionMultiplexer> ValueFactory(ConfigurationOptions x)
         {
             return new Lazy<IConnectionMultiplexer>(() => MultiplexerFactory(x));
         }
 
-        return _connectionMultiplexers.GetOrAdd(configuration, ValueFactory).Value;
+        return _connectionMultiplexers.GetOrAdd(configuration.ToString(false), ValueFactory(configuration)).Value;
     }
 }

--- a/src/Persistence/MassTransit.RedisIntegration/Configuration/Configuration/RedisSagaRepositoryConfigurator.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/Configuration/Configuration/RedisSagaRepositoryConfigurator.cs
@@ -41,11 +41,9 @@ namespace MassTransit.Configuration
 
         public void DatabaseConfiguration(ConfigurationOptions configurationOptions)
         {
-            var configurationString = configurationOptions.ToString(true);
-
             IConnectionMultiplexer Factory(IServiceProvider provider)
             {
-                return provider.GetRequiredService<IConnectionMultiplexerFactory>().GetConnectionMultiplexer(configurationString);
+                return provider.GetRequiredService<IConnectionMultiplexerFactory>().GetConnectionMultiplexer(configurationOptions);
             }
 
             _connectionFactory = Factory;

--- a/src/Persistence/MassTransit.RedisIntegration/Configuration/IConnectionMultiplexerFactory.cs
+++ b/src/Persistence/MassTransit.RedisIntegration/Configuration/IConnectionMultiplexerFactory.cs
@@ -5,5 +5,5 @@ using StackExchange.Redis;
 
 public interface IConnectionMultiplexerFactory
 {
-    IConnectionMultiplexer GetConnectionMultiplexer(string configuration);
+    IConnectionMultiplexer GetConnectionMultiplexer(ConfigurationOptions configuration);
 }


### PR DESCRIPTION
Azure provides an SDK Extension method to support Managed Identity Credentials authentication when using the Azure Redis instances: [Microsoft.Azure.StackExchangeRedis](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis)

This is not possible to use with the MassTransit.RedisIntegration - due to the fact that Redis ConfigurationOptions is parsed to a string before connecting with the ConnectionMultiplexerFactory.

Use of Azure Redis credentials with MassTransit StateMachine

```
x.AddSagaStateMachine<TestStateMachineSaga, TestInstance>()
    .RedisRepository(configurator =>
    {
        var configurationOptions = ConfigurationOptions.Parse("RedisUrl");
        configurationOptions.ConfigureForAzureAsync(new AzureCacheOptions { TokenCredential = new DefaultAzureCredential()}).Wait();
        configurator.DatabaseConfiguration(configurationOptions);
    });
```

I tested this out locally with an actual Azure Redis instance, when this change is not you will get the following error:

```c#
[13:26:23 WRN] Retrying 00:00:01.0010000: The message timed out in the backlog attempting to send because no connection became available (5000ms) - Last Connection Exception: It was not possible to connect to the redis server(s). There was an authentication failure; check that passwords (or client certificates) are configured correctly: (RedisServerException) NOAUTH Returned - connection has not yet authentica
ted ConnectTimeout, command=SET, timeout: 5000, inst: 0, qu: 0, qs: 0, aw: False, bw: CheckingForTimeout, rs: NotStarted, ws: Initializing, in: 0, last-in: 0, cur-in: 0, sync-ops: 0, async-ops: 2, serverEndpoint: ...redis.cache.windows.net:6380, conn-sec: n/a, aoc: 0, mc: 1/1/0, mgr: 10 of 10 available, clientName: AP-44569074(SE.Redis-v2.7.33.41805), IOCP: (Busy=0,Free=1000,Min=1,Max=1000), WORKER: (Busy=1,Free=32766,Min=12,Max=32767), POOL: (Threads=14,QueuedItems=0,CompletedItems=3320,Timers=463), v: 2.7.33.41805 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts) <s:MassTransit>
StackExchange.Redis.RedisConnectionException: The message timed out in the backlog attempting to send because no connection became available (5000ms) - Last Connection Exception: It was not possible to connect to the redis server(s). There was an authentication failure; check that passwords (or client certificates) are configured correctly: (RedisServerException) NOAUTH Returned - connection has not yet authen
ticated ConnectTimeout, command=SET, timeout: 5000, inst: 0, qu: 0, qs: 0, aw: False, bw: CheckingForTimeout, rs: NotStarted, ws: Initializing, in: 0, last-in: 0, cur-in: 0, sync-ops: 0, async-ops: 2, serverEndpoint: ...redis.cache.windows.net:6380, conn-sec: n/a, aoc: 0, mc: 1/1/0, mgr: 10 of 10 available, clientName: AP-44569074(SE.Redis-v2.7.33.41805), IOCP: (Busy=0,Free=1000,Min=1,Max=1000), WORKER: (Busy=1,Free=32766,Min=12,Max=32767), POOL: (Threads=14,QueuedItems=0,CompletedItems=3320,Timers=463), v: 2.7.33.41805 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)
 ---> StackExchange.Redis.RedisConnectionException: It was not possible to connect to the redis server(s). There was an authentication failure; check that passwords (or client certificates) are configured correctly: (RedisServerException) NOAUTH Returned - connection has not yet authenticated ConnectTimeout
 ---> StackExchange.Redis.RedisServerException: NOAUTH Returned - connection has not yet authenticated
   --- End of inner exception stack trace ---
   --- End of inner exception stack trace ---
   at MassTransit.RedisIntegration.Saga.RedisDatabaseContext`1.SagaLock.<Lock>g__LockAsync|6_0() in /_/src/Persistence/MassTransit.RedisIntegration/RedisIntegration/Saga/RedisDatabaseContext.cs:line 158
   at MassTransit.RetryPolicies.PipeRetryExtensions.Retry[T](IRetryPolicy retryPolicy, Func`1 retryMethod, Boolean log, CancellationToken cancellationToken) in /_/src/MassTransit/RetryPolicies/PipeRetryExtensions.cs:line 66
```
