### PR TITLE
fix: MassTransit.Benchmark => Updating from .NET 6 to .NET 8

### DIFF
--- a/tests/MassTransit.Benchmark/Dockerfile
+++ b/tests/MassTransit.Benchmark/Dockerfile
@@ -1,9 +1,9 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 COPY ["Directory.Build.props", "."]


### PR DESCRIPTION
# Description 

This changes are so simple as the title: Updating Dockerfiles from .NET 6 to .NET 8!
