### PR TITLE
Fix order of commands in Postgres migration script to prevent permission denied

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
@@ -21,8 +21,8 @@ namespace MassTransit.SqlTransport.PostgreSql
 
         const string GrantRoleSql = """
             GRANT USAGE ON SCHEMA "{1}" TO "{0}";
-            ALTER SCHEMA "{1}" OWNER TO "{0}";
             GRANT "{0}" TO "{2}";
+            ALTER SCHEMA "{1}" OWNER TO "{0}";
             GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{1}" TO "{0}";
             GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "{1}" TO "{0}";
             ALTER DEFAULT PRIVILEGES IN SCHEMA "{1}" GRANT ALL PRIVILEGES ON TABLES TO "{0}";


### PR DESCRIPTION
Hi @phatboyg 

With this fix I want to address a permission denied issue that happens when you run the migration script with a PG user that has limited permissions and is not superadmin. This is usually the case for cloud environments such as Azure Database for Postgres - Flexible Server.

Given the script (PostgresDatabaseMigrator.cs)
```
GRANT USAGE ON SCHEMA "{1}" TO "{0}";
ALTER SCHEMA "{1}" OWNER TO "{0}";
GRANT "{0}" TO "{2}";
```
the alter schema command fails with this error: [42501] ERROR: must be able to SET ROLE "transport".

This happens because PG tries to verify if the current user has the permission to set that role but we are giving this permission in the next line.
When the 2 lines are inverted, the permissions are granted correctly and the script succeeds.

Steps to reproduce:
1. Run postgres via the docker compose file tests/MassTransit.SqlTransport.Tests/docker-compose.yml
2. Create a db and a limited user via:
```
CREATE DATABASE "masstransit";
CREATE USER "masstransit-admin" WITH CREATEROLE password 'yourpassword';
GRANT CREATE ON DATABASE "masstransit" TO "masstransit-admin";
```
3. Run masstransit with CreateDatabase=false and CreateInfrastructure=true

Outcome:
[42501] ERROR: must be able to SET ROLE "transport"

When inverting the operations, the commands run successfully:
```
GRANT "transport" TO "masstransit-admin"
completed in 28 ms

ALTER SCHEMA "testSchema" OWNER TO "transport"
completed in 25 ms
```


…

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
