### PR TITLE
Fix exception for username with special characters

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
@@ -38,7 +38,7 @@ GRANT REFERENCES to {0};
         const string CreateUserSql = @"
 IF ORIGINAL_LOGIN() != '{1}' OR CURRENT_USER = '{1}'
 BEGIN
-    CREATE USER {1} FOR LOGIN {1} WITH DEFAULT_SCHEMA = {0}
+    CREATE USER [{1}] FOR LOGIN [{1}] WITH DEFAULT_SCHEMA = [{0}]
 END
 ";
 


### PR DESCRIPTION
Pull Request for issue: #5413 

"Create user" script throws an error when username contains special characters
![image](https://github.com/user-attachments/assets/d6150155-185d-4e00-a0cb-d857b0bcdf24)
Adding square brackets solves the issue:
![image](https://github.com/user-attachments/assets/539e289b-b460-4daa-927f-c085dd83bb1a)
