### PR TITLE
using sql_logins as a replecament for syslogins

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
@@ -32,7 +32,7 @@ GRANT CREATE VIEW to {0};
 GRANT REFERENCES to {0};
 ";
 
-        const string LoginExistsSql = @"SELECT 1 FROM sys.syslogins WHERE [name] = '{0}'";
+        const string LoginExistsSql = @"SELECT 1 FROM sys.sql_logins WHERE [name] = '{0}'";
         const string CreateLoginSql = @"CREATE LOGIN {0} WITH PASSWORD = '{1}';";
 
         const string CreateUserSql = @"


### PR DESCRIPTION
When running `CreateDatabase` option in migration, I've encountered an issue in SQL Server in Azure, that object: `sys.syslogins` does not exists.

The workaround is just to set `CreateDatabase` to `false`, but a fix is to use a new name of `syslogins` which is `sql_logins` as per:
![image](https://github.com/user-attachments/assets/25212b40-f350-4571-b97a-395d9dd39312)

URL do doc: https://learn.microsoft.com/en-us/sql/relational-databases/system-tables/mapping-system-tables-to-system-views-transact-sql?view=sql-server-ver16

and important information:
_This SQL Server 2000 system table is included as a view for backward compatibility. We recommend that you use the current SQL Server system views instead. To find the equivalent system view or views, see [Mapping System Tables to System Views (Transact-SQL)](https://learn.microsoft.com/en-us/sql/relational-databases/system-tables/mapping-system-tables-to-system-views-transact-sql?view=sql-server-ver16). This feature will be removed in a future version of Microsoft SQL Server. Avoid using this feature in new development work, and plan to modify applications that currently use this feature._

From: https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-syslogins-transact-sql?view=sql-server-ver16

Once changed locally, it worked fine for me.

A note: I have used not changed version without issues in SQL server as docker, azure SQL as docker, and even SQL server, but that particular SQL Server in Azure just did not worked :(