### PR TITLE
Use ChannelWriter's TryComplete instead of Complete

### DIFF
--- a/src/MassTransit/Testing/Implementations/AsyncElementList.cs
+++ b/src/MassTransit/Testing/Implementations/AsyncElementList.cs
@@ -103,7 +103,7 @@ namespace MassTransit.Testing.Implementations
             finally
             {
                 handle.Disconnect();
-                channel.Writer.Complete();
+                channel.Writer.TryComplete();
             }
         }
 

--- a/src/MassTransit/Transports/Fabric/MessageQueue.cs
+++ b/src/MassTransit/Transports/Fabric/MessageQueue.cs
@@ -80,7 +80,7 @@ namespace MassTransit.Transports.Fabric
 
         protected override async Task StopAgent(StopContext context)
         {
-            _channel.Writer.Complete();
+            _channel.Writer.TryComplete();
 
             await _channel.Reader.Completion.ConfigureAwait(false);
 

--- a/src/MassTransit/Util/ChannelExecutor.cs
+++ b/src/MassTransit/Util/ChannelExecutor.cs
@@ -60,7 +60,7 @@ namespace MassTransit.Util
             if (_disposed)
                 return;
 
-            _channel.Writer.Complete();
+            _channel.Writer.TryComplete();
 
             await _readerTask.ConfigureAwait(false);
 

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Batcher.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Batcher.cs
@@ -44,7 +44,7 @@ namespace MassTransit.AmazonSqsTransport
 
         public async ValueTask DisposeAsync()
         {
-            _channel.Writer.Complete();
+            _channel.Writer.TryComplete();
 
             await _batchTask.ConfigureAwait(false);
 

--- a/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/BatchCheckpointer.cs
+++ b/src/Transports/MassTransit.EventHubIntegration/EventHubIntegration/Checkpoints/BatchCheckpointer.cs
@@ -39,7 +39,7 @@ namespace MassTransit.EventHubIntegration.Checkpoints
 
         public async ValueTask DisposeAsync()
         {
-            _channel.Writer.Complete();
+            _channel.Writer.TryComplete();
 
             await _checkpointTask.ConfigureAwait(false);
         }

--- a/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Checkpoints/BatchCheckpointer.cs
+++ b/src/Transports/MassTransit.KafkaIntegration/KafkaIntegration/Checkpoints/BatchCheckpointer.cs
@@ -42,7 +42,7 @@ namespace MassTransit.KafkaIntegration.Checkpoints
 
         public async ValueTask DisposeAsync()
         {
-            _channel.Writer.Complete();
+            _channel.Writer.TryComplete();
 
             await _checkpointTask.ConfigureAwait(false);
         }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/BatchPublisher.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/BatchPublisher.cs
@@ -61,7 +61,7 @@ namespace MassTransit.RabbitMqTransport
 
         public async ValueTask DisposeAsync()
         {
-            _publishChannel.Writer.Complete();
+            _publishChannel.Writer.TryComplete();
 
             await _publishTask.ConfigureAwait(false);
         }


### PR DESCRIPTION
We are seeing dispose problems sometimes in our integration test suite utilizing test harness and in-memory setup. As the [`Complete` just calls `TryComplete`](https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelWriter.cs#L70-L76) and throws exception if unsuccessful it feels that having the `Try` version in dispose makes more sense to ensure proper cleanup.

```
TearDown : System.Threading.Channels.ChannelClosedException : The channel has been closed.
 StackTrace: --TearDown
    at System.Threading.Channels.ChannelWriter`1.Complete(Exception error)
    at MassTransit.Util.ChannelExecutor.DisposeAsync() in /_/src/MassTransit/Util/ChannelExecutor.cs:line 63
    at MassTransit.InMemoryTransport.InMemoryReceiveTransport.ReceiveTransportAgent.ActiveAndActualAgentsCompleted(StopContext context) in /_/src/MassTransit/InMemoryTransport/InMemoryTransport/InMemoryReceiveTransport.cs:line 162
    at MassTransit.Middleware.Agent.Stop(StopContext context) in /_/src/MassTransit.Abstractions/Middleware/Middleware/Agent.cs:line 88
    at MassTransit.Middleware.Agent.Stop(StopContext context) in /_/src/MassTransit.Abstractions/Middleware/Middleware/Agent.cs:line 88
    at MassTransit.Transports.ReceiveEndpoint.Stop(Boolean removed, CancellationToken cancellationToken) in /_/src/MassTransit/Transports/ReceiveEndpoint.cs:line 175
    at MassTransit.Transports.ReceiveEndpoint.Stop(Boolean removed, CancellationToken cancellationToken) in /_/src/MassTransit/Transports/ReceiveEndpoint.cs:line 175
    at MassTransit.Transports.ReceiveEndpointCollection.StopAgent(StopContext context) in /_/src/MassTransit/Transports/ReceiveEndpointCollection.cs:line 106
    at MassTransit.Middleware.Agent.Stop(StopContext context) in /_/src/MassTransit.Abstractions/Middleware/Middleware/Agent.cs:line 88
    at MassTransit.Middleware.Agent.Stop(StopContext context) in /_/src/MassTransit.Abstractions/Middleware/Middleware/Agent.cs:line 88
    at MassTransit.Transports.BaseHost.Stop(CancellationToken cancellationToken) in /_/src/MassTransit/Transports/BaseHost.cs:line 154
    at MassTransit.MassTransitBus.Handle.StopAsync(CancellationToken cancellationToken) in /_/src/MassTransit/MassTransitBus.cs:line 386
    at MassTransit.MassTransitBus.Handle.StopAsync(CancellationToken cancellationToken) in /_/src/MassTransit/MassTransitBus.cs:line 386
    at MassTransit.MassTransitBus.Handle.StopAsync(CancellationToken cancellationToken) in /_/src/MassTransit/MassTransitBus.cs:line 402
    at MassTransit.MassTransitBus.StopAsync(CancellationToken cancellationToken) in /_/src/MassTransit/MassTransitBus.cs:line 265
    at MassTransit.MassTransitBus.StopAsync(CancellationToken cancellationToken) in /_/src/MassTransit/MassTransitBus.cs:line 265
    at MassTransit.MassTransitHostedService.StopAsync(CancellationToken cancellationToken) in /_/src/MassTransit/MassTransitHostedService.cs:line 59
    at MassTransit.MassTransitHostedService.StopAsync(CancellationToken cancellationToken) in /_/src/MassTransit/MassTransitHostedService.cs:line 59
```