### PR TITLE
Fixed typo in code on the Azure Service Bus configuration page

### DIFF
--- a/doc/content/3.documentation/2.configuration/2.transports/3.azure-service-bus.md
+++ b/doc/content/3.documentation/2.configuration/2.transports/3.azure-service-bus.md
@@ -158,13 +158,13 @@ To use the built-in dead-letter queue for all skipped and faulted messages on al
 ```csharp
 services.AddMassTransit(x =>
 {
-    x.AddConfigureEndpointsCallback((_,cfg) =>
+    x.AddConfigureEndpointsCallback((_, cfg) =>
     {
-        if(cfg is IServiceBusReceiveEndpointConfigurator sb)
+        if (cfg is IServiceBusReceiveEndpointConfigurator sb)
         {
             sb.ConfigureDeadLetterQueueDeadLetterTransport();
             sb.ConfigureDeadLetterQueueErrorTransport();
-        });
+        }
     });    
     
     x.UsingAzureServiceBus((context, cfg) =>


### PR DESCRIPTION
Fixed typo in code on the Azure Service Bus configuration page