### PR TITLE
Fix skipping some queue notification registrations

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
@@ -226,7 +226,7 @@ namespace MassTransit.SqlTransport.PostgreSql
                                 foreach (var queueId in _notificationTokens.Keys)
                                 {
                                     if (queueIds.Contains(queueId))
-                                        break;
+                                        continue;
 
                                     await connection.Connection.ExecuteScalarAsync<int>($"LISTEN \"{sanitizedSchemaName}_msg_{queueId}\"", Stopping)
                                         .ConfigureAwait(false);


### PR DESCRIPTION
I noticed that in some of my tests, some queues were not listened correctly.

This happened usually with services that register multiple queues at once and was caused by a foreach loop being interrupted when a queue was already being listened. The loop should continue to the next queue instead of breaking completely.