### PR TITLE
Adding NpgSqlDataSource in PostgreSQL transport registration

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresBusFactoryConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresBusFactoryConfiguratorExtensions.cs
@@ -52,6 +52,9 @@
         /// used with this overload
         /// </param>
         /// <param name="configure">The configuration callback for the bus factory</param>
+        /// <remarks>The dataSource is also only used for application level credentials when running
+        /// sqlTransport with MassTransit and not quite used to run migrations which require admin
+        /// level access on the operating database </remarks>
         public static void UsingPostgres(this IBusRegistrationConfigurator configurator, NpgsqlDataSource dataSource,
             Action<IBusRegistrationContext, ISqlBusFactoryConfigurator>? configure = null)
         {

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresBusFactoryConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresBusFactoryConfiguratorExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace MassTransit
 {
     using System;
+    using Npgsql;
     using SqlTransport.Configuration;
 
 
@@ -37,6 +38,26 @@
             configurator.SetBusFactory(new SqlRegistrationBusFactory((context, cfg) =>
             {
                 cfg.UsePostgres(connectionString);
+
+                configure?.Invoke(context, cfg);
+            }));
+        }
+
+        /// <summary>
+        /// Configure the bus to use the PostgreSQL database transport
+        /// </summary>
+        /// <param name="configurator">The registration configurator (configured via AddMassTransit)</param>
+        /// <param name="dataSource">
+        /// The dataSource used by the transport <see cref="SqlTransportOptions" /> are not
+        /// used with this overload
+        /// </param>
+        /// <param name="configure">The configuration callback for the bus factory</param>
+        public static void UsingPostgres(this IBusRegistrationConfigurator configurator, NpgsqlDataSource dataSource,
+            Action<IBusRegistrationContext, ISqlBusFactoryConfigurator>? configure = null)
+        {
+            configurator.SetBusFactory(new SqlRegistrationBusFactory((context, cfg) =>
+            {
+                cfg.UsePostgres(dataSource);
 
                 configure?.Invoke(context, cfg);
             }));

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresHostConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresHostConfigurationExtensions.cs
@@ -3,6 +3,7 @@ namespace MassTransit
     using System;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Options;
+    using Npgsql;
     using SqlTransport.PostgreSql;
 
 
@@ -32,6 +33,21 @@ namespace MassTransit
         public static void UsePostgres(this ISqlBusFactoryConfigurator configurator, string connectionString, Action<ISqlHostConfigurator>? configure = null)
         {
             var hostConfigurator = new PostgresSqlHostConfigurator(connectionString);
+
+            configure?.Invoke(hostConfigurator);
+
+            configurator.Host(hostConfigurator.Settings);
+        }
+
+        /// <summary>
+        /// Configures the database transport to use PostgreSQL as the storage engine
+        /// </summary>
+        /// <param name="configurator"></param>
+        /// <param name="dataSource">A valid PostgreSQL data Source</param>
+        /// <param name="configure"></param>
+        public static void UsePostgres(this ISqlBusFactoryConfigurator configurator, NpgsqlDataSource dataSource, Action<ISqlHostConfigurator>? configure = null)
+        {
+            var hostConfigurator = new PostgresSqlHostConfigurator(dataSource);
 
             configure?.Invoke(hostConfigurator);
 

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
@@ -122,7 +122,7 @@ namespace MassTransit.SqlTransport.PostgreSql
 
         public async Task<IPostgresSqlTransportConnection> CreateConnection(CancellationToken cancellationToken)
         {
-            var connection = new PostgresSqlTransportConnection(_hostSettings.GetConnectionString());
+            var connection = _hostSettings.DataSource is not null ? new PostgresSqlTransportConnection(_hostSettings.DataSource) : new PostgresSqlTransportConnection(_hostSettings.GetConnectionString());
 
             await connection.Open(cancellationToken).ConfigureAwait(false);
 

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostConfigurator.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostConfigurator.cs
@@ -2,6 +2,7 @@ namespace MassTransit.SqlTransport.PostgreSql
 {
     using System;
     using Configuration;
+    using Npgsql;
 
 
     public class PostgresSqlHostConfigurator :
@@ -28,6 +29,11 @@ namespace MassTransit.SqlTransport.PostgreSql
 
         public PostgresSqlHostConfigurator(string connectionString)
             : this(new PostgresSqlHostSettings(connectionString))
+        {
+        }
+
+        public PostgresSqlHostConfigurator(NpgsqlDataSource dataSource)
+            : this(new PostgresSqlHostSettings(dataSource))
         {
         }
 

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -67,7 +67,7 @@ namespace MassTransit.SqlTransport.PostgreSql
             }
         }
 
-        public NpgsqlDataSource? DataSource { get; set; }
+        public NpgsqlDataSource? DataSource { get; }
 
         public override ConnectionContextFactory CreateConnectionContextFactory(ISqlHostConfiguration hostConfiguration)
         {

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -21,6 +21,11 @@ namespace MassTransit.SqlTransport.PostgreSql
             ConnectionString = connectionString;
         }
 
+        public PostgresSqlHostSettings(NpgsqlDataSource dataSource)
+        {
+            DataSource = dataSource;
+        }
+
         public PostgresSqlHostSettings(SqlTransportOptions options)
         {
             var builder = PostgresSqlTransportConnection.CreateBuilder(options);
@@ -61,6 +66,8 @@ namespace MassTransit.SqlTransport.PostgreSql
                 _builder = builder;
             }
         }
+
+        public NpgsqlDataSource? DataSource { get; set; }
 
         public override ConnectionContextFactory CreateConnectionContextFactory(ISqlHostConfiguration hostConfiguration)
         {

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlTransportConnection.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlTransportConnection.cs
@@ -15,6 +15,11 @@ namespace MassTransit.SqlTransport.PostgreSql
             Connection = new NpgsqlConnection(connectionString);
         }
 
+        public PostgresSqlTransportConnection(NpgsqlDataSource npgsqlDataSource)
+        {
+            Connection = npgsqlDataSource.CreateConnection();
+        }
+
         public ValueTask DisposeAsync()
         {
             return Connection.DisposeAsync();


### PR DESCRIPTION
 @phatboyg 

Currently for SQL Transport only a static password is allowed.

However, for connecting with Amazon RDS, or Aurora or TimeScale Db or any other modern database, we would want to generate an access token rather than using the plain text password. 

This feature can be done by using the [`NpgSqlDataSource` ](https://www.npgsql.org/doc/api/Npgsql.NpgsqlDataSource.html) which in turn allows consumers to configure the access tokens being generated with `dataSource.UsePeriodicPasswordProvider`. 

This makes the implementation agnostic of the underlying database, and the clients, can provide their own implementation of this when creating a `npgsqlDataSource` and passing it through in the bus registration similar to `connectionString` in existing implementation.. 

Example Usage: 

```
//This dataSource is created by the consumer and is then passed into MassTransit 
var dataSource = dataSourceBuilder
.Host("HostName")
.UsePeriodicPasswordProvider(async (settings, cancellationToken) =>
                {
                    return await Task.Run(() =>
                        RDSAuthTokenGenerator.GenerateAuthToken(); or GoogleAuthTokenGenerator.GenerateAuthToken();
                },
                TimeSpan.FromSeconds(configuration.TokenRefreshIntervalInSeconds),
                TimeSpan.FromSeconds(configuration.TokenRefreshRetry)))
.Build();


//The dataSource created by the consumer is then registered with MassTransit similar to passing `connectionString` currently 
busConfig.UsingPostgres(dataSource, (ctx, cfg) =>
            {
                cfg.AutoStart = false;
                cfg.ConfigureEndpoints(ctx);
            });
```

This change also doesn't add any new packages.. and passes tests. 

Also The dataSource is also only used for application level credentials when running sqlTransport with `MassTransit` and not quite used to run migrations which require admin level access on the operating database.  
