### PR TITLE
Fix: Add Required Base Class props with NpgSqlDataSource Injection 

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -30,6 +30,8 @@ namespace MassTransit.SqlTransport.PostgreSql
             _dataSource = dataSource;
 
             IsProvidedDataSource = true;
+
+            ConnectionString = _dataSource.ConnectionString;
         }
 
         public PostgresSqlHostSettings(SqlTransportOptions options)

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -31,7 +31,7 @@ namespace MassTransit.SqlTransport.PostgreSql
 
             IsProvidedDataSource = true;
 
-            ConnectionString = _dataSource.ConnectionString;
+            ConnectionString = dataSource.ConnectionString;
         }
 
         public PostgresSqlHostSettings(SqlTransportOptions options)


### PR DESCRIPTION
@phatboyg 

Currently when `dataSource` is injected into the `BusConfigurator`, the application fails to start with this error, given the `host` is required in the base class `ConfigurationSqlHostSettings`.. 

```
Unhandled exception. MassTransit.ConfigurationException: Host cannot be empty

at MassTransit.SqlTransport.Configuration.ConfigurationSqlHostSettings.FormatHostAddress() in /_/src/MassTransit/SqlTransport/SqlTransport/Configuration/ConfigurationSqlHostSettings.cs:line 107

at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)

at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)

at System.Lazy`1.CreateValue()

at System.Lazy`1.get_Value()

at MassTransit.SqlTransport.Configuration.ConfigurationSqlHostSettings.get_HostAddress() in /_/src/MassTransit/SqlTransport/SqlTransport/Configuration/ConfigurationSqlHostSettings.cs:line 88

at MassTransit.SqlTransport.Configuration.SqlHostConfiguration.get_HostAddress() in /_/src/MassTransit/SqlTransport/SqlTransport/Configuration/SqlHostConfiguration.cs:line 45

at MassTransit.SqlTransport.Configuration.SqlReceiveEndpointConfiguration.FormatInputAddress() in /_/src/MassTransit/SqlTransport/SqlTransport/Configuration/SqlReceiveEndpointConfiguration.cs:line 203

at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)

```

This change essentially sets the `connectionString` so that the `host` and other details required by the base class `ConfigurationSqlHostSettings` are set, even when a `dataSource` is passed in. 