### PR TITLE
docs: in-memory outbox configuration link redirecting to 404

### DIFF
--- a/doc/content/3.documentation/3.patterns/10.in-memory-outbox.md
+++ b/doc/content/3.documentation/3.patterns/10.in-memory-outbox.md
@@ -52,7 +52,7 @@ The In-Memory Outbox, a feature included with MassTransit, holds published and s
 
 > MassTransit consumes messages in _acknowledgement_ mode. The broker locks the message and the message is invisible to other consumers until it is either acknowledged (ack'd) by the consumer or negatively-acknowledged (n'ack'd) explictly by the consumer or implicitly due to a service or network failure.
 
-The full configuration is in the [documentation](/usage/exceptions.md#redelivery), a simple example is shown below.
+The full configuration is in the [documentation](/documentation/concepts/exceptions#redelivery), a simple example is shown below.
 
 ```cs
 cfg.ReceiveEndpoint("r-trashy-saga", e =>


### PR DESCRIPTION
fixes the configuration link redirecting to a 404 page