### PR TITLE
Fix : Add schema when passing in connectionString or npgsqldatasource

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -76,7 +76,7 @@ namespace MassTransit.SqlTransport.PostgreSql
                 Username = builder.Username;
                 Password = builder.Password;
 
-                Schema = "transport";
+                Schema = builder.SearchPath ?? "transport";
 
                 _builder = builder;
             }

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -76,6 +76,8 @@ namespace MassTransit.SqlTransport.PostgreSql
                 Username = builder.Username;
                 Password = builder.Password;
 
+                Schema = "transport";
+
                 _builder = builder;
             }
         }


### PR DESCRIPTION
@phatboyg 

All [`SqlStatements` within the `SqlTransport.Postgresql`](https://github.com/MassTransit/MassTransit/blob/35c6ba7643f8294e5a541928a13d79524ccbd5ff/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/SqlStatements.cs) require a valid `schema` to be interpolated. 

Currently when `connectionString` or `NpgSqlDataSource` is passed in instead of the `SqlTransportOptions`, **_the MassTransit bus, is not started and errors out_** given the `Schema` is not set in the `PostgresSqlHostSettings`. 



Corresponding Error: 

```
 ---> Npgsql.PostgresException (0x80004005): 42601: zero-length delimited identifier at or near """"
      
      POSITION: 15
         at Npgsql.Internal.NpgsqlConnector.ReadMessageLong(Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications, Boolean isReadingPrependedMessage)
         at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
         at Npgsql.NpgsqlDataReader.NextResult(Boolean async, Boolean isConsuming, CancellationToken cancellationToken)


```

This PR essentially makes the fix so that either the `SearchPath` is set as the schema, or it defaults to `transport` similar to the one being [set in `SqlTransportOptions`.](https://github.com/MassTransit/MassTransit/blob/35c6ba7643f8294e5a541928a13d79524ccbd5ff/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlTransportConnection.cs#L105)