### PR TITLE
Removed `diff=astextplain`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,18 +1,6 @@
 # Set default behavior to automatically normalize line endings.
 * text=auto
 
-*.doc  diff=astextplain
-*.DOC	diff=astextplain
-*.docx	diff=astextplain
-*.DOCX	diff=astextplain
-*.dot	diff=astextplain
-*.DOT	diff=astextplain
-*.pdf	diff=astextplain
-*.PDF	diff=astextplain
-*.rtf	diff=astextplain
-*.RTF	diff=astextplain
-*.md    diff=astextplain
-
 *.jpg  	binary
 *.png 	binary
 *.gif 	binary


### PR DESCRIPTION
Removed `diff=astextplain` as that causes issues in some environments with `git diff` and seems to be a relic from the past.