### PR TITLE
Convenience extension for session based batching in ASB and explicit control of MaxConcurrentSessions

### DIFF
--- a/doc/content/3.documentation/2.configuration/2.transports/3.azure-service-bus.md
+++ b/doc/content/3.documentation/2.configuration/2.transports/3.azure-service-bus.md
@@ -88,17 +88,6 @@ services.AddMassTransit(x =>
 | TokenCredential      |          | Use a specific token-based credential, such as a managed identity token, to access the namespace.  You can use the [DefaultAzureCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) to automatically apply any one of several credential types. |
 | TransportType        |          | Change the transport type from the default (AMQP) to use WebSockets                                                                                                                                                                                                                                          |
 
-### Receive Settings
-
-| Property             | Type     | Description                                                                                                                                                                                                                                                                                                  |
-|----------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| PrefetchCount        | int      | The number of unacknowledged messages that can be processed concurrently (default based on CPU count)                                                                                                                                                                                                        |
-| MaxConcurrentCalls   | int      | How many concurrent messages to dispatch (transport-throttled)                                                                                                                                                                                                                                               |
-| LockDuration         | TimeSpan | How long to hold message locks (max is 5 minutes)                                                                                                                                                                                                                                                            |
-| MaxAutoRenewDuration | TimeSpan | How long to renew message locks (maximum consumer duration)                                                                                                                                                                                                                                                  |
-| RequiresSession      | bool     | If true, a message SessionId must be specified when sending messages to the queue                                                                                                                                                                                                                            |
-| MaxDeliveryCount     | int      | How many times the transport will redeliver the message on negative acknowledgment. This is different from retry, this is the transport redelivering the message to a receive endpoint before moving it to the dead letter queue.                                                                            |
-
 For example, to configure the transport type to use AMQP over Web Sockets:
 
 ```csharp
@@ -109,7 +98,19 @@ cfg.Host(connectionString, h =>
 
 ```
 
-## Transport Options
+### Receive Settings
+
+| Property             | Type     | Description                                                                                                                                                                                                                                                                                                  |
+|----------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PrefetchCount        | int      | The number of unacknowledged messages that can be processed concurrently (default based on CPU count)                                                                                                                                                                                                        |
+| MaxConcurrentCalls   | int      | How many concurrent messages to dispatch (transport-throttled)                                                                                                                                                                                                                                               |
+| LockDuration         | TimeSpan | How long to hold message locks (max is 5 minutes)                                                                                                                                                                                                                                                            |
+| MaxAutoRenewDuration | TimeSpan | How long to renew message locks (maximum consumer duration)                                                                                                                                                                                                                                                  |
+| MaxDeliveryCount     | int      | How many times the transport will redeliver the message on negative acknowledgment. This is different from retry, this is the transport redelivering the message to a receive endpoint before moving it to the dead letter queue.                                                                            |
+| RequiresSession      | bool     | If true, a message SessionId must be specified when sending messages to the queue (see [sessions](#using-service-bus-sessions))                                                                                                                                                                              |
+
+
+### Transport Options
 
 All Azure Service Bus transport options can be configured using the `.Host()` method. The most commonly used settings can be configured via transport options.
 
@@ -175,6 +176,33 @@ services.AddMassTransit(x =>
     });
 });
 ```
+
+### Using Service Bus Sessions
+
+#### Receive Settings
+| Property                     | Type     | Description                                                                                                                                                                                                                                                                                                  |
+|------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| RequiresSession              | bool     | Set to true                                                                                                                                                                                                                                                                                                  |
+| MaxConcurrentSessions        | int      | How many concurrent sessions to receive messages from (transport-throttled)                                                                                                                                                                                                                                  |
+| MaxConcurrentCallsPerSession | int      | How many concurrent messages to dispatch from each session (transport-throttled)                                                                                                                                                                                                                             |
+| SessionIdleTimeout           | TimeSpan | How long to wait to receive a message before abandoning the session for another                                                                                                                                                                                                                              |
+
+#### Batch Consumer
+
+For batch-based in-order processing of sessions:
+
+```csharp
+AddConsumer<MyBatchConsumer>(cfg =>
+{
+    cfg.SetServiceBusSessionBatchOptions(o =>            
+        o.SetMessageLimitPerSession(8)
+            .SetMaxConcurrentSessions(4)
+            .SetSessionIdleTimeout(TimeSpan.FromSeconds(30))
+            .SetTimeLimit(TimeSpan.FromSeconds(5))
+    );
+});
+```
+Batches will be grouped by [SessionId](/documentation/transports/azure-service-bus#sessionid)
 
 ## Performance
 

--- a/src/MassTransit.Abstractions/Configuration/Consumers/BatchOptions.cs
+++ b/src/MassTransit.Abstractions/Configuration/Consumers/BatchOptions.cs
@@ -20,6 +20,8 @@ namespace MassTransit
             MessageLimit = 10;
             TimeLimit = TimeSpan.FromSeconds(1);
             TimeLimitStart = BatchTimeLimitStart.FromFirst;
+
+            configureCallback = DefaultConfigure;
         }
 
         /// <summary>
@@ -47,7 +49,20 @@ namespace MassTransit
         /// </summary>
         public object? GroupKeyProvider { get; private set; }
 
+        private ConfigureCallback? configureCallback;
+        public BatchOptions OverrideConfigure(ConfigureCallback callback)
+        {
+            configureCallback = callback;
+            return this;
+        }
+        public delegate void ConfigureCallback(string name, IReceiveEndpointConfigurator configurator);
+
         public void Configure(string name, IReceiveEndpointConfigurator configurator)
+        {
+            configureCallback?.Invoke(name, configurator);            
+        }
+
+        private void DefaultConfigure(string name, IReceiveEndpointConfigurator configurator)
         {
             var messageCapacity = ConcurrencyLimit * MessageLimit;
 

--- a/src/MassTransit.Abstractions/Configuration/Consumers/BatchOptions.cs
+++ b/src/MassTransit.Abstractions/Configuration/Consumers/BatchOptions.cs
@@ -50,7 +50,7 @@ namespace MassTransit
         public object? GroupKeyProvider { get; private set; }
 
         private ConfigureCallback? configureCallback;
-        public BatchOptions OverrideConfigure(ConfigureCallback callback)
+        public BatchOptions SetConfigureCallback(ConfigureCallback callback)
         {
             configureCallback = callback;
             return this;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ClientSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ClientSettings.cs
@@ -26,6 +26,11 @@ namespace MassTransit.AzureServiceBusTransport
         TimeSpan SessionIdleTimeout { get; }
 
         /// <summary>
+        /// The maximum number of concurrent sessions
+        /// </summary>
+        int MaxConcurrentSessions { get; }
+
+        /// <summary>
         /// The maximum number of concurrent calls per session
         /// </summary>
         int MaxConcurrentCallsPerSession { get; }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ClientSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ClientSettings.cs
@@ -22,8 +22,9 @@ namespace MassTransit.AzureServiceBusTransport
 
         /// <summary>
         /// The timeout before a message session is abandoned
+        ///   - if unset the SDK will use <see href="https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusretryoptions.trytimeout?view=azure-dotnet#azure-messaging-servicebus-servicebusretryoptions-trytimeout">ServiceBusRetryOptions.TryTimeout</see>
         /// </summary>
-        TimeSpan SessionIdleTimeout { get; }
+        TimeSpan? SessionIdleTimeout { get; }
 
         /// <summary>
         /// The maximum number of concurrent sessions

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEndpointEntityConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEndpointEntityConfigurator.cs
@@ -17,6 +17,7 @@
 
         public bool? RequiresSession { get; set; }
 
+        public int? MaxConcurrentSessions { get; set; }
         public int? MaxConcurrentCallsPerSession { get; set; }
     }
 }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
@@ -80,6 +80,11 @@
             set => _configurator.RequiresSession = value;
         }
 
+        public int MaxConcurrentSessions
+        {
+            set => _configurator.MaxConcurrentSessions = value;
+        }
+
         public int MaxConcurrentCallsPerSession
         {
             set => _configurator.MaxConcurrentCallsPerSession = value;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusEntityReceiveEndpointConfiguration.cs
@@ -100,7 +100,7 @@
             set => _settings.SessionIdleTimeout = value;
         }
 
-        public TimeSpan SessionIdleTimeout
+        public TimeSpan? SessionIdleTimeout
         {
             set => _settings.SessionIdleTimeout = value;
         }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusQueueConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Configuration/ServiceBusQueueConfigurator.cs
@@ -32,6 +32,7 @@ namespace MassTransit.AzureServiceBusTransport.Configuration
 
         public bool? RequiresSession { get; set; }
 
+        public int? MaxConcurrentSessions { get; set; }
         public int? MaxConcurrentCallsPerSession { get; set; }
 
         public IEnumerable<ValidationResult> Validate()

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusConnectionContext.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusConnectionContext.cs
@@ -289,7 +289,7 @@
                 PrefetchCount = settings.PrefetchCount,
                 MaxAutoLockRenewalDuration = settings.MaxAutoRenewDuration,
                 ReceiveMode = ServiceBusReceiveMode.PeekLock,
-                MaxConcurrentSessions = settings.MaxConcurrentCalls,
+                MaxConcurrentSessions = settings.MaxConcurrentSessions,
                 MaxConcurrentCallsPerSession = settings.MaxConcurrentCallsPerSession,
                 SessionIdleTimeout = settings.SessionIdleTimeout
             };

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Defaults.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Defaults.cs
@@ -26,6 +26,9 @@
         public static TimeSpan SessionIdleTimeout { get; set; } = TimeSpan.FromSeconds(10);
         public static TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
 
+        public static int MaxConcurrentSessions { get; set; } = 8;
+        public static int MaxConcurrentCallsPerSessions { get; set; } = 1;
+
         public static CreateQueueOptions GetCreateQueueOptions(string queueName)
         {
             return new CreateQueueOptions(queueName)

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Defaults.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Defaults.cs
@@ -16,14 +16,7 @@
         public static TimeSpan TemporaryAutoDeleteOnIdle { get; set; } = TimeSpan.FromMinutes(5);
         public static TimeSpan MaxAutoRenewDuration { get; set; } = TimeSpan.FromMinutes(5);
 
-        [Obsolete("use SessionIdleTimeout instead")]
-        public static TimeSpan MessageWaitTimeout
-        {
-            get => SessionIdleTimeout;
-            set => SessionIdleTimeout = value;
-        }
-
-        public static TimeSpan SessionIdleTimeout { get; set; } = TimeSpan.FromSeconds(10);
+        public static TimeSpan? SessionIdleTimeout { get; set; } = null;  //SDK's default is undefined - explicitly defined here for clarity
         public static TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
 
         public static int MaxConcurrentSessions { get; set; } = 8;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/BaseClientSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/BaseClientSettings.cs
@@ -22,6 +22,7 @@ namespace MassTransit.AzureServiceBusTransport.Topology
         public IServiceBusEndpointEntityConfigurator Configurator { get; }
 
         public abstract bool RequiresSession { get; }
+        public abstract int MaxConcurrentSessions { get; }
         public abstract int MaxConcurrentCallsPerSession { get; }
 
         public TimeSpan SessionIdleTimeout { get; set; }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/BaseClientSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/BaseClientSettings.cs
@@ -25,7 +25,7 @@ namespace MassTransit.AzureServiceBusTransport.Topology
         public abstract int MaxConcurrentSessions { get; }
         public abstract int MaxConcurrentCallsPerSession { get; }
 
-        public TimeSpan SessionIdleTimeout { get; set; }
+        public TimeSpan? SessionIdleTimeout { get; set; }
 
         public int MaxConcurrentCalls => Math.Max(_configuration.Transport.GetConcurrentMessageLimit(), 1);
         public int PrefetchCount => _configuration.Transport.PrefetchCount;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/ReceiveEndpointSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/ReceiveEndpointSettings.cs
@@ -25,8 +25,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology
         public override bool RequiresSession => _queueConfigurator.RequiresSession ?? false;
 
         public bool RemoveSubscriptions { get; set; }
-        public override int MaxConcurrentSessions => _queueConfigurator.MaxConcurrentSessions ?? 1;
-        public override int MaxConcurrentCallsPerSession => _queueConfigurator.MaxConcurrentCallsPerSession ?? 1;
+        public override int MaxConcurrentSessions => _queueConfigurator.MaxConcurrentSessions ?? Defaults.MaxConcurrentSessions;
+        public override int MaxConcurrentCallsPerSession => _queueConfigurator.MaxConcurrentCallsPerSession ?? Defaults.MaxConcurrentCallsPerSessions;
 
         public override string Path => _queueConfigurator.FullPath;
 

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/ReceiveEndpointSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/ReceiveEndpointSettings.cs
@@ -25,6 +25,7 @@ namespace MassTransit.AzureServiceBusTransport.Topology
         public override bool RequiresSession => _queueConfigurator.RequiresSession ?? false;
 
         public bool RemoveSubscriptions { get; set; }
+        public override int MaxConcurrentSessions => _queueConfigurator.MaxConcurrentSessions ?? 1;
         public override int MaxConcurrentCallsPerSession => _queueConfigurator.MaxConcurrentCallsPerSession ?? 1;
 
         public override string Path => _queueConfigurator.FullPath;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/SubscriptionEndpointSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/SubscriptionEndpointSettings.cs
@@ -36,6 +36,7 @@ namespace MassTransit.AzureServiceBusTransport.Topology
         public IServiceBusSubscriptionConfigurator SubscriptionConfigurator => _subscriptionConfigurator;
 
         public override bool RequiresSession => _subscriptionConfigurator.RequiresSession ?? false;
+        public override int MaxConcurrentSessions => _subscriptionConfigurator.MaxConcurrentSessions ?? 1;
         public override int MaxConcurrentCallsPerSession => _subscriptionConfigurator.MaxConcurrentCallsPerSession ?? 1;
 
         CreateTopicOptions SubscriptionSettings.CreateTopicOptions => _createTopicOptions;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/SubscriptionEndpointSettings.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Topology/SubscriptionEndpointSettings.cs
@@ -36,8 +36,8 @@ namespace MassTransit.AzureServiceBusTransport.Topology
         public IServiceBusSubscriptionConfigurator SubscriptionConfigurator => _subscriptionConfigurator;
 
         public override bool RequiresSession => _subscriptionConfigurator.RequiresSession ?? false;
-        public override int MaxConcurrentSessions => _subscriptionConfigurator.MaxConcurrentSessions ?? 1;
-        public override int MaxConcurrentCallsPerSession => _subscriptionConfigurator.MaxConcurrentCallsPerSession ?? 1;
+        public override int MaxConcurrentSessions => _subscriptionConfigurator.MaxConcurrentSessions ?? Defaults.MaxConcurrentSessions;
+        public override int MaxConcurrentCallsPerSession => _subscriptionConfigurator.MaxConcurrentCallsPerSession ?? Defaults.MaxConcurrentCallsPerSessions;
 
         CreateTopicOptions SubscriptionSettings.CreateTopicOptions => _createTopicOptions;
         CreateSubscriptionOptions SubscriptionSettings.CreateSubscriptionOptions => _subscriptionConfigurator.GetCreateSubscriptionOptions();

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
@@ -34,6 +34,11 @@ public static class ServiceBusBatchingExtensions
                   sb.MaxConcurrentSessions = sessionOptions.MaxConcurrentSessions;
                   sb.MaxConcurrentCallsPerSession = sessionOptions.MessageLimitPerSession;
                   sb.SessionIdleTimeout = sessionOptions.SessionIdleTimeout;
+
+                  if (sb.PrefetchCount != 0 && sb.PrefetchCount < sessionOptions.MessageLimitPerSession)
+                  {
+                      sb.PrefetchCount = sessionOptions.MessageLimitPerSession;
+                  }
               });
         });
 

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
@@ -27,7 +27,7 @@ public static class ServiceBusBatchingExtensions
               .SetTimeLimitStart(sessionOptions.TimeLimitStart)
               .SetConfigureCallback((name, configurator) =>
               {
-                  if (configurator is not IServiceBusReceiveEndpointConfigurator sb) throw new ArgumentException("Expecting IServiceBusReceiveEndpointConfigurator", nameof(configure));
+                  if (configurator is not IServiceBusReceiveEndpointConfigurator sb) throw new ArgumentException("Expecting IServiceBusReceiveEndpointConfigurator", nameof(configurator));
 
                   sb.RequiresSession = true;
 

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
@@ -4,10 +4,18 @@ namespace MassTransit;
 
 public static class ServiceBusBatchingExtensions
 {
-    public static void BatchBySession<TConsumer>(this IConsumerConfigurator<TConsumer> consumerConfigurator, Action<SessionBatchOptions> configure)
+    /// <summary>
+    /// Configures <see cref="BatchOptions"/> for batching with Azure Service Bus sessions to ensure in-order processing of sessions
+    ///   - Sessions will be delivered as batches of up to <see cref="ServiceBusSessionBatchOptions.MessageLimitPerSession"/>
+    ///   - Batches from up to <see cref="ServiceBusSessionBatchOptions.MaxConcurrentSessions"/> sessions will be processed concurrently
+    ///   
+    /// Note: Consider max concurrency impacts of the SDK to avoid thread exhaustion
+    ///   - total number of concurrent calls = <see cref="ServiceBusSessionBatchOptions.MaxConcurrentSessions"/> * <see cref="ServiceBusSessionBatchOptions.MessageLimitPerSession"/>
+    /// </summary>
+    public static void SetServiceBusSessionBatchOptions<TConsumer>(this IConsumerConfigurator<TConsumer> consumerConfigurator, Action<ServiceBusSessionBatchOptions> configure)
         where TConsumer : class
     {
-        SessionBatchOptions sessionOptions = new();
+        ServiceBusSessionBatchOptions sessionOptions = new();
         configure(sessionOptions);
 
         consumerConfigurator.Options<BatchOptions>(o =>
@@ -17,7 +25,7 @@ public static class ServiceBusBatchingExtensions
               .SetMessageLimit(sessionOptions.MessageLimitPerSession)
               .SetTimeLimit(sessionOptions.TimeLimit)
               .SetTimeLimitStart(sessionOptions.TimeLimitStart)
-              .OverrideConfigure((name, configurator) =>
+              .SetConfigureCallback((name, configurator) =>
               {
                   if (configurator is not IServiceBusReceiveEndpointConfigurator sb) throw new ArgumentException("Expecting IServiceBusReceiveEndpointConfigurator", nameof(configure));
 

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusBatchingExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace MassTransit;
+
+public static class ServiceBusBatchingExtensions
+{
+    public static void BatchBySession<TConsumer>(this IConsumerConfigurator<TConsumer> consumerConfigurator, Action<SessionBatchOptions> configure)
+        where TConsumer : class
+    {
+        SessionBatchOptions sessionOptions = new();
+        configure(sessionOptions);
+
+        consumerConfigurator.Options<BatchOptions>(o =>
+        {
+            o.GroupBy<object, string>(e => e.SessionId())
+              .SetConcurrencyLimit(sessionOptions.MaxConcurrentSessions)
+              .SetMessageLimit(sessionOptions.MessageLimitPerSession)
+              .SetTimeLimit(sessionOptions.TimeLimit)
+              .SetTimeLimitStart(sessionOptions.TimeLimitStart)
+              .OverrideConfigure((name, configurator) =>
+              {
+                  if (configurator is not IServiceBusReceiveEndpointConfigurator sb) throw new ArgumentException("Expecting IServiceBusReceiveEndpointConfigurator", nameof(configure));
+
+                  sb.RequiresSession = true;
+
+                  sb.MaxConcurrentSessions = sessionOptions.MaxConcurrentSessions;
+                  sb.MaxConcurrentCallsPerSession = sessionOptions.MessageLimitPerSession;
+                  sb.SessionIdleTimeout = sessionOptions.SessionIdleTimeout;
+              });
+        });
+
+    }
+}

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusSessionBatchOptions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusSessionBatchOptions.cs
@@ -17,7 +17,7 @@ public class ServiceBusSessionBatchOptions
     /// <summary>
     /// The timeout before a message session is abandoned
     /// </summary>
-    public TimeSpan SessionIdleTimeout { get;  set; } = AzureServiceBusTransport.Defaults.SessionIdleTimeout;
+    public TimeSpan? SessionIdleTimeout { get;  set; } = AzureServiceBusTransport.Defaults.SessionIdleTimeout;
 
     /// <summary>
     /// The maximum time to wait before delivering a partial batch

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusSessionBatchOptions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/ServiceBusSessionBatchOptions.cs
@@ -2,7 +2,7 @@
 
 namespace MassTransit;
 
-public record SessionBatchOptions
+public class ServiceBusSessionBatchOptions
 {
     /// <summary>
     /// The maximum number of messages in a single batch
@@ -33,17 +33,17 @@ public record SessionBatchOptions
     /// Sets the maximum number of messages in a single batch
     /// </summary>
     /// <param name="limit">The message limit</param>
-    public SessionBatchOptions SetMessageLimitPerSession(int limit)
+    public ServiceBusSessionBatchOptions SetMessageLimitPerSession(int limit)
     {
         MessageLimitPerSession = limit;
         return this;
     }
 
     /// <summary>
-    /// Sets  maximum number of concurrent sessions
+    /// Sets the maximum number of concurrent sessions
     /// </summary>
     /// <param name="limit">The maximum number of concurrent sessions</param>
-    public SessionBatchOptions SetMaxConcurrentSessions(int limit)
+    public ServiceBusSessionBatchOptions SetMaxConcurrentSessions(int limit)
     {
         MaxConcurrentSessions = limit;
         return this;
@@ -53,7 +53,7 @@ public record SessionBatchOptions
     /// Sets the maximum time to wait for messages within a session before abandoning the session for another
     /// </summary>
     /// <param name="limit">The time limit</param>
-    public SessionBatchOptions SetSessionIdleTimeout(TimeSpan limit)
+    public ServiceBusSessionBatchOptions SetSessionIdleTimeout(TimeSpan limit)
     {
         SessionIdleTimeout = limit;
         return this;
@@ -63,7 +63,7 @@ public record SessionBatchOptions
     /// Sets the maximum time to wait before delivering a partial batch
     /// </summary>
     /// <param name="limit">The time limit</param>
-    public SessionBatchOptions SetTimeLimit(TimeSpan limit)
+    public ServiceBusSessionBatchOptions SetTimeLimit(TimeSpan limit)
     {
         TimeLimit = limit;
         return this;
@@ -73,7 +73,7 @@ public record SessionBatchOptions
     /// Sets the starting point for the <see cref="TimeLimit"/>
     /// </summary>
     /// <param name="timeLimitStart">The starting point</param>
-    public SessionBatchOptions SetTimeLimitStart(BatchTimeLimitStart timeLimitStart)
+    public ServiceBusSessionBatchOptions SetTimeLimitStart(BatchTimeLimitStart timeLimitStart)
     {
         TimeLimitStart = timeLimitStart;
         return this;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/SessionBatchOptions.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Batching/SessionBatchOptions.cs
@@ -1,0 +1,81 @@
+﻿using System;
+
+namespace MassTransit;
+
+public record SessionBatchOptions
+{
+    /// <summary>
+    /// The maximum number of messages in a single batch
+    /// </summary>
+    public int MessageLimitPerSession { get; set; } = 10;
+    
+    /// <summary>
+    /// The maximum number of concurrent sessions
+    /// </summary>
+    public int MaxConcurrentSessions { get; set; } = 1;
+
+    /// <summary>
+    /// The timeout before a message session is abandoned
+    /// </summary>
+    public TimeSpan SessionIdleTimeout { get;  set; } = AzureServiceBusTransport.Defaults.SessionIdleTimeout;
+
+    /// <summary>
+    /// The maximum time to wait before delivering a partial batch
+    /// </summary>
+    public TimeSpan TimeLimit { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The starting point for the <see cref="TimeLimit" />
+    /// </summary>
+    public BatchTimeLimitStart TimeLimitStart { get; set; } = BatchTimeLimitStart.FromFirst;
+
+    /// <summary>
+    /// Sets the maximum number of messages in a single batch
+    /// </summary>
+    /// <param name="limit">The message limit</param>
+    public SessionBatchOptions SetMessageLimitPerSession(int limit)
+    {
+        MessageLimitPerSession = limit;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets  maximum number of concurrent sessions
+    /// </summary>
+    /// <param name="limit">The maximum number of concurrent sessions</param>
+    public SessionBatchOptions SetMaxConcurrentSessions(int limit)
+    {
+        MaxConcurrentSessions = limit;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum time to wait for messages within a session before abandoning the session for another
+    /// </summary>
+    /// <param name="limit">The time limit</param>
+    public SessionBatchOptions SetSessionIdleTimeout(TimeSpan limit)
+    {
+        SessionIdleTimeout = limit;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum time to wait before delivering a partial batch
+    /// </summary>
+    /// <param name="limit">The time limit</param>
+    public SessionBatchOptions SetTimeLimit(TimeSpan limit)
+    {
+        TimeLimit = limit;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the starting point for the <see cref="TimeLimit"/>
+    /// </summary>
+    /// <param name="timeLimitStart">The starting point</param>
+    public SessionBatchOptions SetTimeLimitStart(BatchTimeLimitStart timeLimitStart)
+    {
+        TimeLimitStart = timeLimitStart;
+        return this;
+    }
+}

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusBusFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusBusFactoryConfigurator.cs
@@ -209,7 +209,7 @@ namespace MassTransit.Configuration
             set => _settings.SessionIdleTimeout = value;
         }
 
-        public TimeSpan SessionIdleTimeout
+        public TimeSpan? SessionIdleTimeout
         {
             set => _settings.SessionIdleTimeout = value;
         }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusBusFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/Configuration/ServiceBusBusFactoryConfigurator.cs
@@ -189,6 +189,11 @@ namespace MassTransit.Configuration
             set => _queueConfigurator.RequiresSession = value;
         }
 
+        public int MaxConcurrentSessions
+        {
+            set => _queueConfigurator.MaxConcurrentSessions = value;
+        }
+
         public int MaxConcurrentCallsPerSession
         {
             set => _queueConfigurator.MaxConcurrentCallsPerSession = value;

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusEndpointConfigurator.cs
@@ -52,6 +52,11 @@
         bool RequiresSession { set; }
 
         /// <summary>
+        /// If session is required, sets the maximum concurrent sessions (defaults to 1)
+        /// </summary>
+        int MaxConcurrentSessions { set; }
+
+        /// <summary>
         /// If session is required, sets the maximum concurrent calls per session (defaults to 1)
         /// </summary>
         int MaxConcurrentCallsPerSession { set; }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusEndpointConfigurator.cs
@@ -75,7 +75,7 @@
         /// <summary>
         /// Sets the message session idle timeout period
         /// </summary>
-        TimeSpan SessionIdleTimeout { set; }
+        TimeSpan? SessionIdleTimeout { set; }
 
         /// <summary>
         /// Sets the maximum time for locks/sessions to be automatically renewed

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusEndpointEntityConfigurator.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/Configuration/IServiceBusEndpointEntityConfigurator.cs
@@ -22,6 +22,11 @@ namespace MassTransit
         bool? RequiresSession { set; }
 
         /// <summary>
+        /// Sets the maximum number of concurrent sessions
+        /// </summary>
+        int? MaxConcurrentSessions { set; }
+
+        /// <summary>
         /// Sets the maximum number of concurrent calls per session
         /// </summary>
         int? MaxConcurrentCallsPerSession { set; }


### PR DESCRIPTION
The aim is for batch-based in-order processing of messages within an ASB session.
* Our use case is we want to have:
  *  X sessions processing concurrently (we scale out competing consumers as needed)
  *  each session is processing batches of up to Y messages within a time limit Z
     
We had 2 issues:
1. `MaxConcurrentSessions` is currently derived from the batch options (ConcurrencyLimit * MessageLimit) 
   -  Used with `MaxConcurrentCallsPerSession` it is quite difficult to control the max concurrency of the [ServiceBusSessionProcessor](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebussessionprocessor?view=azure-dotnet).
   -  Seemingly reasonable batch options can easily suffer thread exhaustion
    - MessageLimit: 500, ConcurrencyLimit: 5, GroupBy: SessionId(), MaxConcurrentCallsPerSession = 500
      - [total number of concurrent calls = (500 * 5) * 500](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebussessionprocessoroptions.maxconcurrentcallspersession?view=azure-dotnet#definition)
2. The batch options have to match the `IServiceBusReceiveEndpointConfigurator` parameters to work correctly
   - for example if MaxConcurrentCallsPerSession > MessageLimit sequencing across batches can get messed up

Solution:
1. expose `MaxConcurrentSessions` as a ClientSetting, allow overriding BatchOptions.Configure to better align with session batching
2. Offer an extension method to configure session batching using more explicit session semantics

Admittedly, the extension method is a bit ugly.  Looking forward to any suggestions to improve this.

Usage of extension method.
```
    internal class TestConsumerDefinition : ConsumerDefinition<TestConsumer>
    {
        public TestConsumerDefinition()
        {
            Endpoint(x => x.Name = "cleigh-test-consumer");
        }

        protected override void ConfigureConsumer(
          IReceiveEndpointConfigurator endpointConfigurator,
          IConsumerConfigurator<TestConsumer> consumerConfigurator,
          IRegistrationContext context
        )
        {
            consumerConfigurator.SetServiceBusSessionBatchOptions(o =>            
                o.SetMessageLimitPerSession(8)
                 .SetMaxConcurrentSessions(4)
                 .SetSessionIdleTimeout(TimeSpan.FromSeconds(30))
                 .SetTimeLimit(TimeSpan.FromSeconds(5))
            );
        }
    }