### PR TITLE
feat: configure activity propagation

### DIFF
--- a/src/MassTransit/Logging/Diagnostics/DiagnosticHeaders.cs
+++ b/src/MassTransit/Logging/Diagnostics/DiagnosticHeaders.cs
@@ -8,6 +8,7 @@ namespace MassTransit.Logging
         public const string DiagnosticId = "Diagnostic-Id";
         public const string ActivityId = "MT-Activity-Id";
         public const string ActivityCorrelationContext = "MT-Activity-Correlation-Context";
+        public const string ActivityPropagation = "MT-Activity-Propagation";
 
         public const string MessageId = "messaging.masstransit.message_id";
         public const string CorrelationId = "messaging.masstransit.correlation_id";


### PR DESCRIPTION
Add header MT-Activity-Propagation that configures how remote activity is treated. Either:
1. Link the remote activity
2. Use as parent activity (default)
3. Create new activity without reference to remote activity

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
