### PR TITLE
Verify Valkey support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,6 +395,28 @@ jobs:
       - name: Test Redis
         run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
         working-directory: tests/MassTransit.RedisIntegration.Tests
+  test-valkey:
+    name: "Storage: Valkey"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    services:
+      valkey:
+        image: valkey/valkey:8
+        ports:
+          - '6379:6379'
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install .NET Core SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Test Valkey
+        run: dotnet test -c Release --logger GitHubActions --filter Category!=Flaky
+        working-directory: tests/MassTransit.RedisIntegration.Tests
   test-hangfire:
     name: "Scheduler: Hangfire"
     timeout-minutes: 10
@@ -517,6 +539,7 @@ jobs:
       - test-mongo
       - test-nhibernate
       - test-redis
+      - test-valkey
       - test-hangfire
       - test-quartz
       # - test-eventhub

--- a/doc/content/3.documentation/2.configuration/4.persistence/redis.md
+++ b/doc/content/3.documentation/2.configuration/4.persistence/redis.md
@@ -8,6 +8,10 @@ Redis is a very popular key-value store, which is known for being very fast. To 
 Redis only supports event correlation by _CorrelationId_, it does not support queries. If a saga uses expression-based correlation, a _NotImplementedByDesignException_ will be thrown.
 ::
 
+::alert{type="info"}
+The Redis package also supports the recent fork of Redis called [Valkey](https://github.com/valkey-io/valkey)
+::
+
 Storing a saga in Redis requires an additional interface, _ISagaVersion_, which has a _Version_ property used for optimistic concurrency. An example saga is shown below.
 
 ```csharp

--- a/tests/MassTransit.RedisIntegration.Tests/docker-compose.yml
+++ b/tests/MassTransit.RedisIntegration.Tests/docker-compose.yml
@@ -1,9 +1,13 @@
 ﻿# this compose file will start local services the same as those running on appveyor CI for testing.
 
-version: '2.3'
 services:
   redis:
-    image: "redis:5.0.7"
+    image: "redis:7.4.1"
     container_name: redis
+    ports:
+      - '6379:6379'
+  valkey:
+    image: "valkey/valkey:8"
+    container_name: valkey
     ports:
       - '6379:6379'


### PR DESCRIPTION
Now that the Valkey fork of Redis is getting some good [support from AWS](https://aws.amazon.com/about-aws/whats-new/2024/10/amazon-elasticache-valkey/) I wanted to see if all of our tests passed. 

They do locally! Let's see about on CI!

![CleanShot 2024-10-09 at 16 13 35@2x](https://github.com/user-attachments/assets/4c2b1c80-e513-4438-8835-14f4baaa13a1)
