### PR TITLE
Fixing failover parameters and adding priorityBackup and priorityURIs parameters

### DIFF
--- a/tests/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
@@ -116,7 +116,7 @@ namespace MassTransit.ActiveMqTransport.Tests
             settings.TransportOptions.Add("reconnectAttempts", "-1");
 
             Assert.That(settings.BrokerAddress, Is.EqualTo(new Uri(
-                "activemq:failover:(tcp://failover1:61616/?wireFormat.tightEncodingEnabled=true,tcp://failover2:61616/?wireFormat.tightEncodingEnabled=true)?reconnectAttempts=-1")));
+                "activemq:failover:(tcp://failover1:61616/?wireFormat.tightEncodingEnabled=true,tcp://failover2:61616/?wireFormat.tightEncodingEnabled=true)?transport.reconnectAttempts=-1")));
         }
 
         [Test]


### PR DESCRIPTION
Hello.

I encountered the fact that the failover transport parameters, such as randomize and backup, are not applied.

The bug is in the implementation of the Apache.NMS.ActiveMQ client.

When creating the transport, I need to add the prefix `"transport."` which is absent in the instruction https://activemq.apache.org/components/classic/documentation/failover-transport-reference

Here is the line where FailoverTransport is created and the prefix `"transport."` is specified: https://github.com/apache/activemq-nms-openwire/blob/main/src/Transport/Failover/FailoverTransportFactory.cs#L72

In the project activemq-nms-openwire the Issues section is off. This project is developing poorly.
As these parameters are currently not working and cannot be set using MassTransit, I suggest fixing this in MassTransit so that these parameters to be applied.
