### PR TITLE
Typo in AddSqlServerMigrationHostedService in docs

### DIFF
--- a/doc/content/3.documentation/6.transports/sql.md
+++ b/doc/content/3.documentation/6.transports/sql.md
@@ -147,7 +147,7 @@ service should be added **BEFORE** `AddMassTransit` in the configuration to ensu
 ```csharp
 services.AddPostgresMigrationHostedService();
 // OR
-services.AddSqlServersMigrationHostedService();
+services.AddSqlServerMigrationHostedService();
 ```
 
 To use an existing database (which may be the case with Azure SQL or Azure PostreSQL), you can skip database creation but still create all the tables and


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

There was an extra `s` in the example.