### PR TITLE
Update link to Azure service bus configuration page in Azure service bus quickstart page 

### DIFF
--- a/doc/content/2.quick-starts/3.azure-service-bus.md
+++ b/doc/content/2.quick-starts/3.azure-service-bus.md
@@ -98,5 +98,5 @@ At this point, the service is connecting to Azure Service Bus and publishing mes
 ## What is next
 
 - [Azure Service Bus transport overview](/documentation/transports/azure-service-bus)
-- [Azure Service Bus transport configuration](/configuration/transports/azure-service-bus)
+- [Azure Service Bus transport configuration](/documentation/configuration/transports/azure-service-bus)
 - [Azure Service Bus sample](https://github.com/MassTransit/Sample-AzureServiceBus)


### PR DESCRIPTION
In Azure Service bus [quickstart page](https://masstransit.io/quick-starts/azure-service-bus), link to configuration page ends up with a 404. This PR updates the link to configuration page.

