### PR TITLE
feat: conditional grant of a role to a principal

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
@@ -1,5 +1,6 @@
 namespace MassTransit.SqlTransport.PostgreSql
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Dapper;
@@ -1237,7 +1238,7 @@ namespace MassTransit.SqlTransport.PostgreSql
             }
 
             var principal = PostgresSqlTransportConnection.GetAdminMigrationPrincipal(options);
-            if (options.Role != principal)
+            if (!string.Equals(options.Role, principal, StringComparison.Ordinal))
             {
                 await connection.Connection.ExecuteScalarAsync<int>(string.Format(GrantRoleToPrincipalSql, options.Role, principal))
                     .ConfigureAwait(false);

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
@@ -18,10 +18,10 @@ namespace MassTransit.SqlTransport.PostgreSql
         const string DropSql = """DROP DATABASE "{0}" WITH (force)""";
         const string RoleExistsSql = "SELECT COUNT(*) FROM pg_catalog.pg_roles WHERE rolname = '{0}'";
         const string CreateRoleSql = """CREATE ROLE "{0}" """;
+        const string GrantRoleToPrincipalSql = """GRANT "{0}" TO "{1}";""";
 
         const string GrantRoleSql = """
             GRANT USAGE ON SCHEMA "{1}" TO "{0}";
-            GRANT "{0}" TO "{2}";
             ALTER SCHEMA "{1}" OWNER TO "{0}";
             GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{1}" TO "{0}";
             GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "{1}" TO "{0}";
@@ -1237,6 +1237,11 @@ namespace MassTransit.SqlTransport.PostgreSql
             }
 
             var principal = PostgresSqlTransportConnection.GetAdminMigrationPrincipal(options);
+            if (options.Role != principal)
+            {
+                await connection.Connection.ExecuteScalarAsync<int>(string.Format(GrantRoleToPrincipalSql, options.Role, principal))
+                    .ConfigureAwait(false);
+            }
 
             await connection.Connection.ExecuteScalarAsync<int>(string.Format(GrantRoleSql, options.Role, options.Schema, principal))
                 .ConfigureAwait(false);


### PR DESCRIPTION
In some rare situations, the principal name may coincide with the role name. In this case, the `GRANT [another_application] to [another_application]` command will result in an error: `role "another_application" is a member of role "another_application"`. Specifically, this can occur when using the username "another_application" in the connection string and setting `SqlTransportOptions.Role` = "another_application".

In such cases, it makes sense to add a check before assigning the role.

I ran the migration, and it completed successfully.