### PR TITLE
Update 13.job-consumers.md

### DIFF
--- a/doc/content/3.documentation/3.patterns/13.job-consumers.md
+++ b/doc/content/3.documentation/3.patterns/13.job-consumers.md
@@ -378,7 +378,7 @@ To retry a faulted or canceled job, call the `RetryJob` extension method on an `
 [HttpPut("{jobId}")]
 public async Task<IActionResult> RetryJob(Guid jobId, [FromServices] IPublishEndpoint publishEndpoint)
 {
-    var jobId = await publishEndpoint.CancelJob(jobId);
+    var jobId = await publishEndpoint.RetryJob(jobId);
 
     return Ok();
 }


### PR DESCRIPTION
Fix typo in 13.job-consumers.md where the RetryJob code example was calling the wrong method
