### PR TITLE
Added ability to set the base address for mediators

### DIFF
--- a/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
@@ -51,12 +51,13 @@ namespace MassTransit
         /// </summary>
         /// <param name="collection"></param>
         /// <param name="configure"></param>
-        public static IServiceCollection AddMediator(this IServiceCollection collection, Action<IMediatorRegistrationConfigurator> configure = null)
+        /// <param name="baseAddress"></param>
+        public static IServiceCollection AddMediator(this IServiceCollection collection, Uri baseAddress, Action<IMediatorRegistrationConfigurator> configure = null)
         {
             if (collection.Any(d => d.ServiceType == typeof(IMediator)))
                 throw new ConfigurationException("AddMediator() was already called and may only be called once per container.");
 
-            var configurator = new ServiceCollectionMediatorConfigurator(collection);
+            var configurator = new ServiceCollectionMediatorConfigurator(collection, baseAddress);
 
             configure?.Invoke(configurator);
 
@@ -65,6 +66,17 @@ namespace MassTransit
             configurator.Complete();
 
             return collection;
+        }
+
+        /// <summary>
+        /// Adds the MassTransit Mediator to the <paramref name="collection" />, and allows consumers, sagas, and activities (which are not supported
+        /// by the Mediator) to be configured.
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="configure"></param>
+        public static IServiceCollection AddMediator(this IServiceCollection collection, Action<IMediatorRegistrationConfigurator> configure = null)
+        {
+            return AddMediator(collection, null, configure);
         }
 
         /// <summary>

--- a/src/MassTransit/Configuration/MediatorConfigurationExtensions.cs
+++ b/src/MassTransit/Configuration/MediatorConfigurationExtensions.cs
@@ -18,11 +18,26 @@ namespace MassTransit
         /// <exception cref="ArgumentNullException"></exception>
         public static IMediator CreateMediator(this IBusFactorySelector selector, Action<IMediatorConfigurator> configure)
         {
+            return CreateMediator(selector, null, configure);
+        }
+
+        /// <summary>
+        /// Create a mediator, which sends messages to consumers, handlers, and sagas. Messages are dispatched to the consumers asynchronously.
+        /// Consumers are not directly coupled to the sender. Can be used entirely in-memory without a broker.
+        /// </summary>
+        /// <param name="selector"></param>
+        /// <param name="configure"></param>
+        /// <param name="baseAddress"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static IMediator CreateMediator(this IBusFactorySelector selector, Uri baseAddress, Action<IMediatorConfigurator> configure)
+        {
             if (configure == null)
                 throw new ArgumentNullException(nameof(configure));
 
+            baseAddress ??= new Uri("loopback://localhost/");
             var topologyConfiguration = new InMemoryTopologyConfiguration(InMemoryBus.CreateMessageTopology());
-            var busConfiguration = new InMemoryBusConfiguration(topologyConfiguration, new Uri("loopback://localhost"));
+            var busConfiguration = new InMemoryBusConfiguration(topologyConfiguration, baseAddress);
 
             if (LogContext.Current != null)
                 busConfiguration.HostConfiguration.LogContext = LogContext.Current;


### PR DESCRIPTION
I needed the ability to change the mediator base address to fix a problem we are having running multiple tests in parallel. The issue we ran into was a message not consumed on the loopback://localhost address. I found out we can change the base address for the InMemoryBus and tried to do the same for the mediator. 

I added tests that also passed using the new mediator with a given address.

![image](https://github.com/user-attachments/assets/b7a204cf-80a2-4d3e-9a30-188282dbdfa7)
