### PR TITLE
Rearrange index for performance optimization

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/EntityFrameworkOutboxConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/EntityFrameworkOutboxConfigurationExtensions.cs
@@ -341,8 +341,8 @@ namespace MassTransit
             outbox.Property(p => p.OutboxId).IsRequired(false);
             outbox.HasIndex(p => new
             {
-                p.OutboxId,
                 p.SequenceNumber,
+                p.OutboxId
             }).IsUnique();
             outbox.HasOne<OutboxState>().WithMany().IsRequired(false)
                 .HasForeignKey(p => p.OutboxId);


### PR DESCRIPTION
[<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->]
Changes as described at: (https://github.com/MassTransit/MassTransit/discussions/3515#discussioncomment-11103344)


Azure Portal Suggests the following Index
![image](https://github.com/user-attachments/assets/2e820be0-63fd-4ebc-864d-8dc6f9d17201)

```
CREATE NONCLUSTERED INDEX [IX_OutboxMessage_OutboxId_SequenceNumber] 
ON [dbo].[OutboxMessage] ([OutboxId], [SequenceNumber]) INCLUDE ([Body], 
[ContentType], [ConversationId], [CorrelationId], 
[DestinationAddress], [EnqueueTime], [ExpirationTime],
[FaultAddress], [Headers], [InboxConsumerId],
[InboxMessageId], [InitiatorId], [MessageId],
[MessageType], [Properties], [RequestId],
[ResponseAddress], [SentTime], [SourceAddress]) 
WITH (ONLINE = ON)
```

The inclusion of columns as part of the index, requires the use of `Microsoft.EntityFrameworkCore.SqlServer` which does not seem to be used in your repo. I thus went without adding the columns. 



