### PR TITLE
[ActiveMQ] Allow direct topic subscription

### DIFF
--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/ConsumerConsumeTopicTopologySpecification.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/ConsumerConsumeTopicTopologySpecification.cs
@@ -1,0 +1,40 @@
+﻿using MassTransit.ActiveMqTransport.Topology;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MassTransit.ActiveMqTransport.Configuration
+{
+    public class ConsumerConsumeTopicTopologySpecification :
+        ActiveMqTopicBindingConfigurator,
+        IActiveMqConsumeTopologySpecification
+    {
+        readonly IActiveMqConsumerEndpointQueueNameFormatter _consumerEndpointQueueNameFormatter;
+
+        public ConsumerConsumeTopicTopologySpecification(string topicName, IActiveMqConsumerEndpointQueueNameFormatter consumerEndpointQueueNameFormatter,
+            bool durable = true, bool autoDelete = false)
+            : base(topicName, durable, autoDelete)
+        {
+            _consumerEndpointQueueNameFormatter = consumerEndpointQueueNameFormatter;
+        }
+
+        public ConsumerConsumeTopicTopologySpecification(Topic topic, IActiveMqConsumerEndpointQueueNameFormatter consumerEndpointQueueNameFormatter)
+            : base(topic)
+        {
+            _consumerEndpointQueueNameFormatter = consumerEndpointQueueNameFormatter;
+        }
+
+        public IEnumerable<ValidationResult> Validate()
+        {
+            return Enumerable.Empty<ValidationResult>();
+        }
+
+        public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
+        {
+            var topic = builder.CreateTopic(EntityName, Durable, AutoDelete);
+
+            _ = builder.BindConsumer(topic, null, Selector);
+        }
+    }
+}

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Topology/ActiveMqConsumeTopology.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Topology/ActiveMqConsumeTopology.cs
@@ -58,16 +58,13 @@ namespace MassTransit.ActiveMqTransport.Topology
 
         public void Bind(string topicName, Action<IActiveMqTopicBindingConfigurator>? configure = null)
         {
-            if (string.IsNullOrEmpty(_publishTopology.VirtualTopicPrefix) || topicName.StartsWith(_publishTopology.VirtualTopicPrefix))
-            {
-                var specification = new ConsumerConsumeTopologySpecification(topicName, ConsumerEndpointQueueNameFormatter);
+            IActiveMqTopicBindingConfigurator specification = (string.IsNullOrEmpty(_publishTopology.VirtualTopicPrefix) || topicName.StartsWith(_publishTopology.VirtualTopicPrefix))
+                    ? new ConsumerConsumeTopologySpecification(topicName, ConsumerEndpointQueueNameFormatter)
+                : new ConsumerConsumeTopicTopologySpecification(topicName, ConsumerEndpointQueueNameFormatter);
 
-                configure?.Invoke(specification);
+            configure?.Invoke(specification);
 
-                _specifications.Add(specification);
-            }
-            else
-                _specifications.Add(new InvalidActiveMqConsumeTopologySpecification("Bind", $"Only virtual topics can be bound: {topicName}"));
+            _specifications.Add((IActiveMqConsumeTopologySpecification)specification);
         }
 
         public override string CreateTemporaryQueueName(string tag)

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Topology/BrokerTopologyBuilder.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Topology/BrokerTopologyBuilder.cs
@@ -48,7 +48,7 @@ namespace MassTransit.ActiveMqTransport.Topology
 
             var exchangeEntity = Topics.Get(topic);
 
-            var queueEntity = Queues.Get(queue);
+            var queueEntity = (queue != null) ? Queues.Get(queue) : null;
 
             var binding = new ConsumerEntity(id, exchangeEntity, queueEntity, selector);
 

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Topology/Entities/ConsumerEntity.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Topology/Entities/ConsumerEntity.cs
@@ -23,7 +23,7 @@ namespace MassTransit.ActiveMqTransport.Topology
         public static IEqualityComparer<ConsumerEntity> EntityComparer { get; } = new ConsumerEntityEqualityComparer();
 
         public Topic Source => _topic.Topic;
-        public Queue Destination => _queue.Queue;
+        public Queue Destination => _queue?.Queue;
         public string Selector { get; }
 
         public long Id { get; }
@@ -35,7 +35,7 @@ namespace MassTransit.ActiveMqTransport.Topology
                 new[]
                 {
                     $"source: {Source.EntityName}",
-                    $"destination: {Destination.EntityName}",
+                    $"destination: {Destination?.EntityName}",
                     string.IsNullOrWhiteSpace(Selector) ? "" : $"selector: {Selector}"
                 }.Where(x => !string.IsNullOrWhiteSpace(x)));
         }
@@ -57,7 +57,9 @@ namespace MassTransit.ActiveMqTransport.Topology
                 if (x.GetType() != y.GetType())
                     return false;
 
-                return x._topic.Equals(y._topic) && x._queue.Equals(y._queue) && string.Equals(x.Selector, y.Selector);
+                return x._topic.Equals(y._topic)
+                    && ((x._queue != null && x._queue.Equals(y._queue)) || (x._queue == null && y._queue == null))
+                    && string.Equals(x.Selector, y.Selector);
             }
 
             public int GetHashCode(ConsumerEntity obj)
@@ -65,7 +67,8 @@ namespace MassTransit.ActiveMqTransport.Topology
                 unchecked
                 {
                     var hashCode = obj._topic.GetHashCode();
-                    hashCode = (hashCode * 397) ^ obj._queue.GetHashCode();
+                    if (obj._queue != null)
+                        hashCode = (hashCode * 397) ^ obj._queue.GetHashCode();
                     if (obj.Selector != null)
                         hashCode = (hashCode * 397) ^ obj.Selector.GetHashCode();
 
@@ -91,12 +94,16 @@ namespace MassTransit.ActiveMqTransport.Topology
                 if (x.GetType() != y.GetType())
                     return false;
 
-                return string.Equals(x._queue.EntityName, y._queue.EntityName);
+                return (x._queue == null && y._queue == null)
+                    ? string.Equals(x._topic.EntityName, y._topic.EntityName)
+                    : string.Equals(x._queue?.EntityName, y._queue?.EntityName);
             }
 
             public int GetHashCode(ConsumerEntity obj)
             {
-                return obj._queue.EntityName.GetHashCode();
+                return (obj._queue == null)
+                    ? obj._topic.EntityName.GetHashCode()
+                    : obj._queue.EntityName.GetHashCode();
             }
         }
     }

--- a/tests/MassTransit.ActiveMqTransport.Tests/ConsumerEntity_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/ConsumerEntity_Specs.cs
@@ -1,0 +1,54 @@
+﻿using MassTransit.ActiveMqTransport.Topology;
+using NUnit.Framework;
+using System.Collections;
+
+namespace MassTransit.ActiveMqTransport.Tests
+{
+    [TestFixture]
+    public class ConsumerEntity_Specs
+    {
+        [Test, TestCaseSource(nameof(CreateCasesForNameComparerEquals))]
+        public bool NameComparer_Equal_should_return_expected(ConsumerEntity left, ConsumerEntity right)
+        {
+            // Act
+            return ConsumerEntity.NameComparer.Equals(left, right);
+        }
+
+        [Test, TestCaseSource(nameof(CreateCasesForEntityComparerEquals))]
+        public bool ConsumerEntityComparer_Equal_should_return_expected(ConsumerEntity left, ConsumerEntity right)
+        {
+            // Act
+            return ConsumerEntity.EntityComparer.Equals(left, right);
+        }
+
+        public static IEnumerable CreateCasesForEntityComparerEquals()
+        {
+            var topic = new TopicEntity(1, "topic", false, true);
+            var queue = new QueueEntity(1, "queue", false, true);
+
+            yield return new TestCaseData(new ConsumerEntity(1, topic, queue, "selector"), new ConsumerEntity(1, topic, queue, "selector")).Returns(true);
+            yield return new TestCaseData(new ConsumerEntity(1, topic, queue, "selector"), null).Returns(false);
+            yield return new TestCaseData(null, new ConsumerEntity(1, topic, queue, "selector")).Returns(false);
+            yield return new TestCaseData(new ConsumerEntity(1, topic, null, "selector"), new ConsumerEntity(1, topic, queue, "selector")).Returns(false);
+            yield return new TestCaseData(new ConsumerEntity(1, topic, queue, "selector"), new ConsumerEntity(1, topic, null, "selector")).Returns(false);
+            yield return new TestCaseData(new ConsumerEntity(1, topic, null, "selector"), new ConsumerEntity(1, topic, null, "selector")).Returns(true);
+            yield return new TestCaseData(null, null).Returns(true);
+        }
+
+        public static IEnumerable CreateCasesForNameComparerEquals()
+        {
+            var leftTopic = new TopicEntity(1, "topic", false, true);
+            var leftQueue = new QueueEntity(1, "queue", false, true);
+            var rightTopic = new TopicEntity(1, "topic", false, true);
+            var rightQueue = new QueueEntity(1, "queue", false, true);
+
+            yield return new TestCaseData(new ConsumerEntity(1, leftTopic, leftQueue, "selector"), new ConsumerEntity(1, rightTopic, rightQueue, "selector")).Returns(true);
+            yield return new TestCaseData(new ConsumerEntity(1, leftTopic, leftQueue, "selector"), null).Returns(false);
+            yield return new TestCaseData(null, new ConsumerEntity(1, rightTopic, rightQueue, "selector")).Returns(false);
+            yield return new TestCaseData(new ConsumerEntity(1, leftTopic, null, "selector"), new ConsumerEntity(1, rightTopic, rightQueue, "selector")).Returns(false);
+            yield return new TestCaseData(new ConsumerEntity(1, leftTopic, leftQueue, "selector"), new ConsumerEntity(1, rightTopic, null, "selector")).Returns(false);
+            yield return new TestCaseData(new ConsumerEntity(1, leftTopic, null, "selector"), new ConsumerEntity(1, rightTopic, null, "selector")).Returns(true);
+            yield return new TestCaseData(null, null).Returns(true);
+        }
+    }
+}

--- a/tests/MassTransit.ActiveMqTransport.Tests/VirtualTopicEndpoint_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/VirtualTopicEndpoint_Specs.cs
@@ -7,13 +7,13 @@ namespace MassTransit.ActiveMqTransport.Tests
 
 
     [TestFixture]
-    public class Sending_to_a_topic_endpoint :
+    public class Sending_to_a_virtual_topic_endpoint :
         ActiveMqTestFixture
     {
         [Test]
         public async Task Should_succeed()
         {
-            var endpoint = await Bus.GetSendEndpoint(new Uri("topic:private"));
+            var endpoint = await Bus.GetSendEndpoint(new Uri("topic:VirtualTopic.private"));
             await endpoint.Send(new PrivateMessage {Value = "Hello"});
 
             ConsumeContext<PrivateMessage> context = await _handler;
@@ -27,7 +27,7 @@ namespace MassTransit.ActiveMqTransport.Tests
         {
             configurator.ConfigureConsumeTopology = false;
 
-            configurator.Bind("private");
+            configurator.Bind("VirtualTopic.private");
 
             _handler = Handled<PrivateMessage>(configurator);
 


### PR DESCRIPTION
Hello,

this PR allows to subscribe to a non-Virtual Topic on ActiveMQ broker. I tried to use as most existing code as possible.

I enhanced Bind method and in case when a topic name isn't start with the virtual topic name prefix it uses new specification class where is set only Topic and Queue is left null. Then I have to change code that uses Queue property to not throw exception in case of setting only Topic.

Also added tests to check new code.

