### PR TITLE
Allow setting RabbitMQ stream filter consumer argument

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqStreamConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqStreamConfigurator.cs
@@ -22,6 +22,11 @@ public interface IRabbitMqStreamConfigurator
     long MaxSegmentSize { set; }
 
     /// <summary>
+    /// Set the stream filter value for the consumer
+    /// </summary>
+    void UsingFilter(string filter);
+
+    /// <summary>
     /// Begin consuming messages from the specified offset
     /// </summary>
     /// <param name="offset"></param>

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqSendContextExtensions.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqSendContextExtensions.cs
@@ -82,5 +82,32 @@
             sendContext.AwaitAck = awaitAck;
             return true;
         }
+
+        /// <summary>
+        /// Sets the filter value used for server-side streams filtering.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="filterValue"></param>
+        public static void SetStreamFilterValue(this SendContext context, string filterValue)
+        {
+            if (!context.TryGetPayload(out RabbitMqSendContext sendContext))
+                throw new ArgumentException("The RabbitMqSendContext was not available");
+
+            sendContext.Headers.Set("x-stream-filter-value", filterValue);
+        }
+
+        /// <summary>
+        /// Sets the filter value used for server-side streams filtering.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="filterValue"></param>
+        public static bool TrySetStreamFilterValue(this SendContext context, string filterValue)
+        {
+            if (!context.TryGetPayload(out RabbitMqSendContext sendContext))
+                return false;
+
+            sendContext.Headers.Set("x-stream-filter-value", filterValue);
+            return true;
+        }
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqStreamConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqStreamConfigurator.cs
@@ -43,6 +43,11 @@ public class RabbitMqStreamConfigurator :
         set => _settings.QueueArguments["x-stream-max-segment-size-bytes"] = value;
     }
 
+    public void UsingFilter(string filter)
+    {
+        _settings.ConsumeArguments["x-stream-filter"] = filter;
+    }
+
     public void FromOffset(long offset)
     {
         _settings.ConsumeArguments["x-stream-offset"] = offset;


### PR DESCRIPTION
RabbitMQ 3.13 introduced server side filtering for streams using the combination of the `x-stream-filter-value` message header and the `x-stream-filter` consumer argument. Currently, MassTransit does not expose the consumer arguments directly but does provide `IRabbitMqStreamConfigurator` to configure streams.

This PR adds support for setting the stream filter consumer argument.

Up until now we used reflection to set the value and it works as expected:
```csharp
public static class MassTransitStreamExtensions
{
    public static void UsingFilter(this IRabbitMqStreamConfigurator configurator, string filterValue)
    {
        var settingsField = configurator.GetType().GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance);
        if (settingsField == null) return;

        var consumerSettings = settingsField.GetValue(configurator) as RabbitMqReceiveSettings;
        if (consumerSettings == null) return;

        consumerSettings.ConsumeArguments["x-stream-filter"] = filterValue;
    }
}
```
![image](https://github.com/user-attachments/assets/7a4f563f-296f-4649-aa62-b90c14c1a962)

For more information on stream filtering, see:
https://www.rabbitmq.com/blog/2023/10/16/stream-filtering
https://www.rabbitmq.com/docs/streams

