### PR TITLE
Introducing MassTransit Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Build Status
 | master        |    [![master](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml/badge.svg?branch=master&event=push)](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml)    |
 | develop       |   [![develop](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml/badge.svg?branch=develop&event=push)](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml)   |
 
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20MassTransit%20Guru-006BFF)](https://gurubase.io/g/masstransit)
-
 MassTransit NuGet Packages
 ---------------------------
 
@@ -73,6 +71,12 @@ MassTransit NuGet Packages
 Get help live at the MassTransit Discord server.
 
 [![alt Join the conversation](https://img.shields.io/discord/682238261753675864.svg "Discord")](https://discord.gg/rNpQgYn)
+
+## MassTransit Guru 
+
+You can [Ask MassTransit Guru](https://gurubase.io/g/masstransit), it is a MassTransit-focused AI to answer your questions.
+
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20MassTransit%20Guru-006BFF)](https://gurubase.io/g/masstransit)
 
 ## GitHub Issues
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Build Status
 | master        |    [![master](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml/badge.svg?branch=master&event=push)](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml)    |
 | develop       |   [![develop](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml/badge.svg?branch=develop&event=push)](https://github.com/MassTransit/MassTransit/actions/workflows/build.yml)   |
 
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20MassTransit%20Guru-006BFF)](https://gurubase.io/g/masstransit)
+
 MassTransit NuGet Packages
 ---------------------------
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [MassTransit Guru](https://gurubase.io/g/masstransit) to Gurubase. MassTransit Guru uses the data from this repo and data from the [docs](https://masstransit-project.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "MassTransit Guru", which highlights that MassTransit now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable MassTransit Guru in Gurubase, just let me know that's totally fine.
