### PR TITLE
Allow skipping SQL transport schema creation

### DIFF
--- a/src/MassTransit/SqlTransport/Configuration/SqlTransportMigrationOptions.cs
+++ b/src/MassTransit/SqlTransport/Configuration/SqlTransportMigrationOptions.cs
@@ -8,6 +8,13 @@ namespace MassTransit
         public bool CreateDatabase { get; set; }
 
         /// <summary>
+        /// If true, the schema for transport components will be created/updated on startup
+        ///
+        /// Use this, without CreateDatabase, if you do not have the required permissions to create the schema and grant access
+        /// </summary>
+        public bool CreateSchema { get; set; }
+
+        /// <summary>
         /// If true, the infrastructure components for the transport will be created/updated on startup
         ///
         /// Use this, without CreateDatabase, if you do not have the required permissions to create databases and logins

--- a/src/MassTransit/SqlTransport/SqlTransport/ISqlTransportDatabaseMigrator.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/ISqlTransportDatabaseMigrator.cs
@@ -7,6 +7,7 @@ namespace MassTransit.SqlTransport
     public interface ISqlTransportDatabaseMigrator
     {
         Task CreateDatabase(SqlTransportOptions options, CancellationToken cancellationToken = default);
+        Task CreateSchemaIfNotExist(SqlTransportOptions options, CancellationToken cancellationToken = default);
         Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken = default);
         Task DeleteDatabase(SqlTransportOptions options, CancellationToken cancellationToken = default);
     }

--- a/src/MassTransit/SqlTransport/SqlTransport/SqlTransportMigrationHostedService.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/SqlTransportMigrationHostedService.cs
@@ -33,6 +33,13 @@ namespace MassTransit.SqlTransport
                 await _migrator.CreateDatabase(_transportOptions, cancellationToken).ConfigureAwait(false);
             }
 
+            if (_options.CreateSchema)
+            {
+                _logger.LogInformation("MassTransit SQL Transport creating schema for database {Database}", _transportOptions.Database);
+
+                await _migrator.CreateSchemaIfNotExist(_transportOptions, cancellationToken).ConfigureAwait(false);
+            }
+
             if (_options.CreateInfrastructure)
             {
                 _logger.LogInformation("MassTransit SQL Transport creating infrastructure for database {Database}", _transportOptions.Database);

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/Configuration/PostgresSqlTransportConfigurationExtensions.cs
@@ -13,6 +13,7 @@ namespace MassTransit
             services.AddPostgresMigrationHostedService(options =>
             {
                 options.CreateDatabase = create;
+                options.CreateSchema = create;
                 options.CreateInfrastructure = create;
                 options.DeleteDatabase = delete;
             });
@@ -29,6 +30,7 @@ namespace MassTransit
                 .Configure(options =>
                 {
                     options.CreateDatabase = true;
+                    options.CreateSchema = true;
                     options.CreateInfrastructure = true;
                     options.DeleteDatabase = false;
 

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDatabaseMigrator.cs
@@ -1228,8 +1228,6 @@ namespace MassTransit.SqlTransport.PostgreSql
 
         public async Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken)
         {
-            await CreateSchemaIfNotExist(options, cancellationToken).ConfigureAwait(false);
-
             await using var connection = PostgresSqlTransportConnection.GetDatabaseConnection(options);
             await connection.Open(cancellationToken).ConfigureAwait(false);
 
@@ -1271,7 +1269,7 @@ namespace MassTransit.SqlTransport.PostgreSql
             }
         }
 
-        async Task CreateSchemaIfNotExist(SqlTransportOptions options, CancellationToken cancellationToken)
+        public async Task CreateSchemaIfNotExist(SqlTransportOptions options, CancellationToken cancellationToken)
         {
             await using var connection = PostgresSqlTransportConnection.GetDatabaseAdminConnection(options);
             await connection.Open(cancellationToken).ConfigureAwait(false);

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/Configuration/SqlServerDbTransportConfigurationExtensions.cs
@@ -13,6 +13,7 @@ namespace MassTransit
             services.AddSqlServerMigrationHostedService(options =>
             {
                 options.CreateDatabase = create;
+                options.CreateSchema = create;
                 options.CreateInfrastructure = create;
                 options.DeleteDatabase = delete;
             });
@@ -29,6 +30,7 @@ namespace MassTransit
                 .Configure(options =>
                 {
                     options.CreateDatabase = true;
+                    options.CreateSchema = true;
                     options.CreateInfrastructure = true;
                     options.DeleteDatabase = false;
 

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
@@ -1623,8 +1623,6 @@ END
 
         public async Task CreateInfrastructure(SqlTransportOptions options, CancellationToken cancellationToken)
         {
-            await CreateSchemaIfNotExist(options, cancellationToken).ConfigureAwait(false);
-
             await using var connection = SqlServerSqlTransportConnection.GetDatabaseConnection(options);
             await connection.Open(cancellationToken).ConfigureAwait(false);
 
@@ -1694,7 +1692,7 @@ END
             }
         }
 
-        async Task CreateSchemaIfNotExist(SqlTransportOptions options, CancellationToken cancellationToken)
+        public async Task CreateSchemaIfNotExist(SqlTransportOptions options, CancellationToken cancellationToken)
         {
             await using var connection = SqlServerSqlTransportConnection.GetDatabaseAdminConnection(options);
             await connection.Open(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Used with integrated authentication, e.g. MS Entra, when a migrator cannot properly extract a user name from a connection string.
I've tested this in Azure Web App using Azure SQL server transport authenticating with a managed identity.

fixes https://github.com/MassTransit/MassTransit/issues/5665
