### PR TITLE
Throw configuration exception if bus was not added

### DIFF
--- a/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
@@ -42,6 +42,8 @@ namespace MassTransit
 
             configurator.Complete();
 
+            CheckForBusImplementation<IBus>(collection);
+
             return collection;
         }
 
@@ -108,7 +110,18 @@ namespace MassTransit
 
             configurator.Complete();
 
+            CheckForBusImplementation<TBus>(collection);
+
             return collection;
+        }
+
+        static void CheckForBusImplementation<TBus>(IServiceCollection collection)
+            where TBus : class, IBus
+        {
+            if (!collection.Any(x => x.ServiceType == typeof(TBus)))
+            {
+                throw new ConfigurationException("No IBus implementation was found in the container. Please ensure that the AddMassTransit() configures the bus (at least UsingInMemory)");
+            }
         }
 
         /// <summary>

--- a/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
+++ b/src/MassTransit/Configuration/DependencyInjection/DependencyInjectionRegistrationExtensions.cs
@@ -120,7 +120,7 @@ namespace MassTransit
         {
             if (!collection.Any(x => x.ServiceType == typeof(TBus)))
             {
-                throw new ConfigurationException("No IBus implementation was found in the container. Please ensure that the AddMassTransit() configures the bus (at least UsingInMemory)");
+                throw new ConfigurationException($"No {typeof(TBus)} implementation was found in the container. Please ensure that the AddMassTransit() configures the bus (at least UsingInMemory)");
             }
         }
 

--- a/tests/MassTransit.Tests/ContainerTests/EmptyBodyConfiguration_Specs.cs
+++ b/tests/MassTransit.Tests/ContainerTests/EmptyBodyConfiguration_Specs.cs
@@ -1,0 +1,31 @@
+﻿namespace MassTransit.Tests.ContainerTests;
+
+using System;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+
+[TestFixture]
+public class EmptyBodyConfiguration_Specs
+{
+    [Test]
+    public void Should_throw_when_no_bus_is_configured()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ConfigurationException>(() =>
+            services.AddMassTransit(x => { }));
+    }
+
+    [Test]
+    public void Should_throw_when_no_bus_is_configured_multibus()
+    {
+        var services = new ServiceCollection();
+        Assert.Throws(Is.InstanceOf<TargetInvocationException>().And.InnerException.InstanceOf<ConfigurationException>(),
+            () => services.AddMassTransit<ISecondBus>(x => { }));
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    public interface ISecondBus : IBus;
+}


### PR DESCRIPTION
I have just wasted an hour trying to figure out why I got the following exception:

```
Unhandled exception. System.AggregateException: Some services are not able to be constructed
(Error while validating the service descriptor 'ServiceType: MassTransit.DependencyInjection.IScopedBusContextProvider`1[MassTransit.IBus] Lifetime: Scoped ImplementationType:
 MassTransit.DependencyInjection.ScopedBusContextProvider`1[MassTransit.IBus]':
 Unable to resolve service for type 'MassTransit.IBus' while attempting to activate 'MassTransit.DependencyInjection.ScopedBusContextProvider`1[MassTransit.IBus]'.)
```
Turns out I had a switch statement to configure different providers based on configuration, but after merging another branch the configuration added a new value, causing the `AddMassTransit` call to be functionally empty.

I think throwing right away will help to mitigate situations like this, while also helping begginers who may forget to add `UsingInMemory`.

I am not sure where I should put the test though