### PR TITLE
Log retry as info

### DIFF
--- a/src/MassTransit/Configuration/Configuration/BaseHostConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/BaseHostConfiguration.cs
@@ -55,7 +55,7 @@ namespace MassTransit.Configuration
             {
                 _logContext = value;
 
-                SendLogContext = value?.    CreateLogContext(LogCategoryName.Transport.Send);
+                SendLogContext = value?.CreateLogContext(LogCategoryName.Transport.Send);
                 ReceiveLogContext = value?.CreateLogContext(LogCategoryName.Transport.Receive);
             }
         }

--- a/src/MassTransit/Configuration/Configuration/BaseHostConfiguration.cs
+++ b/src/MassTransit/Configuration/Configuration/BaseHostConfiguration.cs
@@ -55,7 +55,7 @@ namespace MassTransit.Configuration
             {
                 _logContext = value;
 
-                SendLogContext = value?.CreateLogContext(LogCategoryName.Transport.Send);
+                SendLogContext = value?.    CreateLogContext(LogCategoryName.Transport.Send);
                 ReceiveLogContext = value?.CreateLogContext(LogCategoryName.Transport.Receive);
             }
         }

--- a/src/MassTransit/RetryPolicies/PipeRetryExtensions.cs
+++ b/src/MassTransit/RetryPolicies/PipeRetryExtensions.cs
@@ -96,7 +96,7 @@ namespace MassTransit.RetryPolicies
             while (context.CancellationToken.IsCancellationRequested == false)
             {
                 if (log)
-                    LogContext.Warning?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                    LogContext.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {
@@ -133,7 +133,7 @@ namespace MassTransit.RetryPolicies
             while (context.CancellationToken.IsCancellationRequested == false)
             {
                 if (log)
-                    LogContext.Warning?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                    LogContext.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {

--- a/src/MassTransit/RetryPolicies/PipeRetryExtensions.cs
+++ b/src/MassTransit/RetryPolicies/PipeRetryExtensions.cs
@@ -4,11 +4,14 @@ namespace MassTransit.RetryPolicies
     using System.Threading;
     using System.Threading.Tasks;
     using Internals;
+    using Logging;
     using Middleware;
 
 
     public static class PipeRetryExtensions
     {
+        static readonly ILogContext _namedLogger = LogContext.CreateLogContext(typeof(PipeRetryExtensions).FullName);
+
         public static Task Retry(this IRetryPolicy retryPolicy, Func<Task> retryMethod, CancellationToken cancellationToken = default)
         {
             return Retry(retryPolicy, retryMethod, true, cancellationToken);
@@ -96,7 +99,7 @@ namespace MassTransit.RetryPolicies
             while (context.CancellationToken.IsCancellationRequested == false)
             {
                 if (log)
-                    LogContext.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                    _namedLogger.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {
@@ -133,7 +136,7 @@ namespace MassTransit.RetryPolicies
             while (context.CancellationToken.IsCancellationRequested == false)
             {
                 if (log)
-                    LogContext.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                    _namedLogger.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {

--- a/src/MassTransit/RetryPolicies/PipeRetryExtensions.cs
+++ b/src/MassTransit/RetryPolicies/PipeRetryExtensions.cs
@@ -10,7 +10,7 @@ namespace MassTransit.RetryPolicies
 
     public static class PipeRetryExtensions
     {
-        static readonly ILogContext _namedLogger = LogContext.CreateLogContext(typeof(PipeRetryExtensions).FullName);
+        static readonly ILogContext NamedLogger = LogContext.CreateLogContext(typeof(PipeRetryExtensions).FullName);
 
         public static Task Retry(this IRetryPolicy retryPolicy, Func<Task> retryMethod, CancellationToken cancellationToken = default)
         {
@@ -99,7 +99,7 @@ namespace MassTransit.RetryPolicies
             while (context.CancellationToken.IsCancellationRequested == false)
             {
                 if (log)
-                    _namedLogger.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                    NamedLogger.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {
@@ -136,7 +136,7 @@ namespace MassTransit.RetryPolicies
             while (context.CancellationToken.IsCancellationRequested == false)
             {
                 if (log)
-                    _namedLogger.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
+                    NamedLogger.Info?.Log(retryContext.Exception, "Retrying {Delay}: {Message}", retryContext.Delay, retryContext.Exception.Message);
 
                 try
                 {


### PR DESCRIPTION
When using Redis with ConcurrencyMode.Pessimistic - there is high propability for retry getting Saga Locks.
Logging this af Warnings is a bit extensive in systems that limits the amount of logs.

