### PR TITLE
Updated MessagePack to 3.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Marten" Version="7.31.3" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
-    <PackageVersion Include="MessagePack" Version="2.5.192" />
+    <PackageVersion Include="MessagePack" Version="3.1.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.0" />

--- a/src/MassTransit/Internals/Reflection/DynamicImplementationBuilder.cs
+++ b/src/MassTransit/Internals/Reflection/DynamicImplementationBuilder.cs
@@ -167,7 +167,12 @@
 
             var builder = _moduleBuilders.GetOrAdd(assemblyName, name =>
             {
+
+            #if NETFRAMEWORK
+                const AssemblyBuilderAccess access = AssemblyBuilderAccess.RunAndSave;
+            #else
                 const AssemblyBuilderAccess access = AssemblyBuilderAccess.RunAndCollect;
+            #endif
 
                 var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), access);
 


### PR DESCRIPTION
Hi.

I saw the `MessagePack` authors released a new major version, and out of pure curiosity I updated `MassTransit` to use the latest version.
Unfortunately, two tests seem to fail due to the following exception for the `.NET Framework 4.7.2` run:
> System.NotSupportedException: A non-collectible assembly may not reference a collectible assembly.

I was able to track down the cause of the error, which I believe turned out to be `MassTransit` generating dynamic assemblies that are 'collectible', while `MessagePack` itself is generating 'non-collectible' assemblies, and referencing ours.

Normally I would not suggest making these sorts of changes, simply because some other library is doing so, but in this case I'd argue it'd make sense to change.
All dynamically generated types are cached, so as far as my understanding goes, they'd never be unloaded regardless, due to them still 'being in use'.