### PR TITLE
Add Configuration for Compression in AzureStorageMessageDataRepository for Claim Check

### DIFF
--- a/doc/content/3.documentation/3.patterns/8.claim-check.md
+++ b/doc/content/3.documentation/3.patterns/8.claim-check.md
@@ -57,7 +57,7 @@ public async Task Consume(ConsumeContext<IndexDocumentContent> context)
 }
 ```
 
-To initialize a message contract with one or more `MessageData<T>` properties, the `byte[]`, `string`, or `Stream` value can be specified and the data will be stored to the repository by the initializer. If the message has the _TimeToLive_ header property specified, that same value will be used for the message data in the repository. 
+To initialize a message contract with one or more `MessageData<T>` properties, the `byte[]`, `string`, or `Stream` value can be specified and the data will be stored to the repository by the initializer. If the message has the _TimeToLive_ header property specified, that same value will be used for the message data in the repository.
 
 ```csharp
 Guid documentId = NewId.NextGuid();
@@ -159,7 +159,7 @@ MessageDataDefaults.AlwaysWriteToRepository = false;
 MassTransit includes several message data repositories.
 
 | Name                              | Description                                                                                  |
-|:----------------------------------|:---------------------------------------------------------------------------------------------|
+| :-------------------------------- | :------------------------------------------------------------------------------------------- |
 | InMemoryMessageDataRepository     | Entirely in memory, meant for unit testing                                                   |
 | FileSystemMessageDataRepository   | Writes message data to the file system, which may be a network drive or other shared storage |
 | MongoDbMessageDataRepository      | Stores message data using MongoDB's GridFS                                                   |
@@ -196,11 +196,11 @@ IMessageDataRepository CreateRepository(string connectionString, string database
 
 > [MassTransit.Azure.Storage](https://www.nuget.org/packages/MassTransit.Azure.Storage/)
 
-An Azure Cloud Storage account can be used to store message data. To configure Azure storage, first create the BlobServiceClient object using your connection string, and then use the extension method to create the repository as shown below. You can replace `message-data` with the desired container name.
+An Azure Cloud Storage account can be used to store message data. To configure Azure storage, first create the BlobServiceClient object using your connection string, and then use the extension method to create the repository as shown below. You can replace `message-data` with the desired container name. You can set the `compress` flag to true to compress your blob files as `.gz` files, helping reduce cloud storage costs. The consumer side will automatically detect and decompress the `.gz` files.
 
 ```csharp
 var client = new BlobServiceClient("<storage account connection string>");
-_repository = client.CreateMessageDataRepository("message-data");
+_repository = client.CreateMessageDataRepository("message-data", compress: true);
 ```
 
 Previous to version 7.1.8 of MassTransit this was done creating a CloudStorageAccount object from your connection string the following way.

--- a/src/Persistence/MassTransit.Azure.Storage/AzureStorage/MessageData/AzureStorageMessageDataRepository.cs
+++ b/src/Persistence/MassTransit.Azure.Storage/AzureStorage/MessageData/AzureStorageMessageDataRepository.cs
@@ -3,6 +3,7 @@ namespace MassTransit.AzureStorage.MessageData
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.IO.Compression;
     using System.Threading;
     using System.Threading.Tasks;
     using Azure;
@@ -19,36 +20,38 @@ namespace MassTransit.AzureStorage.MessageData
     {
         readonly BlobContainerClient _container;
         readonly IBlobNameGenerator _nameGenerator;
+        readonly bool _compress;
 
-        public AzureStorageMessageDataRepository(string connectionString, string containerName)
-            : this(new BlobServiceClient(connectionString), containerName)
+        public AzureStorageMessageDataRepository(string connectionString, string containerName, bool compress = false)
+            : this(new BlobServiceClient(connectionString), containerName, compress)
         {
         }
 
-        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string accountName, string accountKey)
-            : this(new BlobServiceClient(serviceUri, new StorageSharedKeyCredential(accountName, accountKey)), containerName)
+        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string accountName, string accountKey, bool compress = false)
+            : this(new BlobServiceClient(serviceUri, new StorageSharedKeyCredential(accountName, accountKey)), containerName, compress)
         {
         }
 
-        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string signature)
-            : this(new BlobServiceClient(serviceUri, new AzureSasCredential(signature)), containerName)
+        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string signature, bool compress = false)
+            : this(new BlobServiceClient(serviceUri, new AzureSasCredential(signature)), containerName, compress)
         {
         }
 
-        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string tenantId, string clientId, string clientSecret)
-            : this(new BlobServiceClient(serviceUri, new ClientSecretCredential(tenantId, clientId, clientSecret)), containerName)
+        public AzureStorageMessageDataRepository(Uri serviceUri, string containerName, string tenantId, string clientId, string clientSecret, bool compress = false)
+            : this(new BlobServiceClient(serviceUri, new ClientSecretCredential(tenantId, clientId, clientSecret)), containerName, compress)
         {
         }
 
-        public AzureStorageMessageDataRepository(BlobServiceClient client, string containerName)
-            : this(client, containerName, new NewIdBlobNameGenerator())
+        public AzureStorageMessageDataRepository(BlobServiceClient client, string containerName, bool compress = false)
+            : this(client, containerName, new NewIdBlobNameGenerator(), compress)
         {
         }
 
-        public AzureStorageMessageDataRepository(BlobServiceClient client, string containerName, IBlobNameGenerator nameGenerator)
+        public AzureStorageMessageDataRepository(BlobServiceClient client, string containerName, IBlobNameGenerator nameGenerator, bool compress = false)
         {
             _container = client.GetBlobContainerClient(containerName);
             _nameGenerator = nameGenerator;
+            _compress = compress;
         }
 
         public void PostCreate(IBus bus)
@@ -115,7 +118,8 @@ namespace MassTransit.AzureStorage.MessageData
             {
                 LogContext.Debug?.Log("GET Message Data: {Address} ({Blob})", address, blob.Name);
 
-                return await blob.OpenReadAsync(new BlobOpenReadOptions(false), cancellationToken).ConfigureAwait(false);
+                var stream = await blob.OpenReadAsync(new BlobOpenReadOptions(false), cancellationToken).ConfigureAwait(false);
+                return blobName.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) || _compress ? new GZipStream(stream, CompressionMode.Decompress, true) : stream;
             }
             catch (RequestFailedException exception)
             {
@@ -128,7 +132,23 @@ namespace MassTransit.AzureStorage.MessageData
             var blobName = _nameGenerator.GenerateBlobName();
             var blob = _container.GetBlobClient(blobName);
 
-            await blob.UploadAsync(stream, cancellationToken).ConfigureAwait(false);
+            if (_compress)
+            {
+                blobName += ".gz";
+                blob = _container.GetBlobClient(blobName);
+                var compressedStream = new MemoryStream();
+                using (var gzipStream = new GZipStream(compressedStream, CompressionMode.Compress, leaveOpen: true))
+                {
+                    await stream.CopyToAsync(gzipStream);
+                }
+
+                compressedStream.Position = 0;
+                await blob.UploadAsync(compressedStream, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await blob.UploadAsync(stream, cancellationToken).ConfigureAwait(false);
+            }
 
             await SetBlobExpiration(blob, timeToLive).ConfigureAwait(false);
 

--- a/src/Persistence/MassTransit.Azure.Storage/Configuration/AzureStorageConfigurationExtensions.cs
+++ b/src/Persistence/MassTransit.Azure.Storage/Configuration/AzureStorageConfigurationExtensions.cs
@@ -6,9 +6,9 @@ namespace MassTransit
 
     public static class AzureStorageConfigurationExtensions
     {
-        public static AzureStorageMessageDataRepository CreateMessageDataRepository(this BlobServiceClient client, string containerName)
+        public static AzureStorageMessageDataRepository CreateMessageDataRepository(this BlobServiceClient client, string containerName, bool compress = false)
         {
-            return new AzureStorageMessageDataRepository(client, containerName);
+            return new AzureStorageMessageDataRepository(client, containerName, compress);
         }
     }
 }

--- a/src/Persistence/MassTransit.Azure.Storage/Configuration/MessageDataRepositorySelectorExtensions.cs
+++ b/src/Persistence/MassTransit.Azure.Storage/Configuration/MessageDataRepositorySelectorExtensions.cs
@@ -13,9 +13,10 @@
         /// <param name="selector"></param>
         /// <param name="connectionString"></param>
         /// <param name="containerName">Specify the container name (defaults to message-data)</param>
+        /// <param name="compress">Specify if the file should be compressed (defaults to false)</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static IMessageDataRepository AzureStorage(this IMessageDataRepositorySelector selector, string connectionString, string containerName = default)
+        public static IMessageDataRepository AzureStorage(this IMessageDataRepositorySelector selector, string connectionString, string containerName = default, bool compress = false)
         {
             if (selector is null)
                 throw new ArgumentNullException(nameof(selector));
@@ -25,7 +26,7 @@
 
             var client = new BlobServiceClient(connectionString);
 
-            var repository = client.CreateMessageDataRepository(containerName ?? "message-data");
+            var repository = client.CreateMessageDataRepository(containerName ?? "message-data", compress);
 
             return repository;
         }

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/Configuration.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/Configuration.cs
@@ -30,6 +30,11 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
                 ? TestContext.Parameters.Get(nameof(StorageAccount))
                 : Environment.GetEnvironmentVariable("MT_AZURE_STORAGE_ACCOUNT") ?? "";
 
+        public static string? Compress =>
+            TestContext.Parameters.Exists(nameof(Compress))
+                ? TestContext.Parameters.Get(nameof(Compress))
+                : Environment.GetEnvironmentVariable("MT_AZURE_STORAGE_COMPRESS") ?? "false";
+
         public static ServiceBusAdministrationClient GetManagementClient()
         {
             var hostAddress = AzureServiceBusEndpointUriCreator.Create(ServiceNamespace);

--- a/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
+++ b/tests/MassTransit.Azure.ServiceBus.Core.Tests/MessageData_Specs.cs
@@ -58,6 +58,57 @@ namespace MassTransit.Azure.ServiceBus.Core.Tests
         }
     }
 
+    [TestFixture]
+    public class Sending_a_compressed_message_with_data :
+        AzureServiceBusTestFixture
+    {
+        [Test]
+        public async Task Should_store_and_retrieve_the_message_data_from_blob_storage()
+        {
+            var data = NewId.NextGuid().ToString();
+
+            var message = new DataMessage
+            {
+                CorrelationId = InVar.CorrelationId,
+                Data = await _repository.PutString(data)
+            };
+
+            await InputQueueSendEndpoint.Send(message);
+
+            ConsumeContext<DataMessage> consumeContext = await _handler;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(consumeContext.Message.Data.HasValue, Is.True);
+
+                Assert.That(_data, Is.EqualTo(data));
+            });
+        }
+
+        Task<ConsumeContext<DataMessage>> _handler;
+        string _data;
+        IMessageDataRepository _repository;
+
+        protected override void ConfigureServiceBusBus(IServiceBusBusFactoryConfigurator configurator)
+        {
+            _repository = configurator.UseMessageData(x => x.AzureStorage(Configuration.StorageAccount, compress: true));
+        }
+
+        protected override void ConfigureServiceBusReceiveEndpoint(IServiceBusReceiveEndpointConfigurator configurator)
+        {
+            _handler = Handler<DataMessage>(configurator, async context =>
+            {
+                _data = await context.Message.Data.Value;
+            });
+        }
+
+
+        public class DataMessage
+        {
+            public Guid CorrelationId { get; set; }
+            public MessageData<string> Data { get; set; }
+        }
+    }
 
     [TestFixture]
     public class Sending_a_message_with_object_data :


### PR DESCRIPTION
This update enables compression when using AzureStorageMessageDataRepository for claim check. 
Files will be compressed before being written to blob storage and saved as `.gz` files.

![image](https://github.com/user-attachments/assets/62e89ee5-a631-48d8-b6ab-1e3181e4bb08)

On the consumer side, there is no need to manually set the flag, as the system will automatically detect if the file in blob storage is a .gz file and decompress it accordingly.

### Changes Summary:
Added a compression option to the AzureStorageMessageDataRepository class.
Updated relevant methods to support compression.
Modified configuration extensions to handle the new compression feature.

Additionally, the documentation has been updated to reflect the new flag when initializing the AzureStorageMessageDataRepository:
![image](https://github.com/user-attachments/assets/bb199e52-c641-4af0-abd6-08fa88a59f42)