### PR TITLE
ProcessMetrics locking

### DIFF
--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDatabaseMigrator.cs
@@ -1399,6 +1399,13 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
+    declare @Lock int
+    EXEC @Lock = sp_getapplock @Resource = '_MT_ProcessMetrics',
+                               @LockMode = 'Exclusive',
+							   @LockOwner = 'Session'
+    IF (@Lock < 0)
+       RETURN;
+
     DECLARE @DeletedMetrics TABLE
                             (
                                 StartTime       datetime2 not null,
@@ -1513,6 +1520,9 @@ BEGIN
     DELETE
     FROM {0}.QueueMetric
     WHERE StartTime < DATEADD(DAY, -90, GETUTCDATE());
+
+    EXEC sp_releaseapplock @Resource = '_MT_ProcessMetrics', @LockOwner = 'Session';
+
 END
 ";
 


### PR DESCRIPTION
this approach looks to have stopped deadlocks - this allows the apps to always run process metrics as desired but prevents overruns/deadlocks on the sql server side.

mashing `F5` here shows the locks popping and disappearing
![image](https://github.com/user-attachments/assets/355a4d36-2255-49f1-8c7c-925fb8d1cc35)

in evaluating for the possibility of locks persisting in error flows, it seems that shouldn't happen

![image](https://github.com/user-attachments/assets/418ef2a0-9dc7-4c9c-965b-5527a0071e02)
(https://stackoverflow.com/a/77749020)

[MS docs](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver16#remarks
):
> Locks placed on a resource are associated with either the current transaction or the current session. Locks associated with the current transaction are released when the transaction commits or rolls back. Locks associated with the session are released when the session is logged out. When the server shuts down for any reason, all locks are released.

to test the theory, i commented out the release of the lock in the proc and it's still falling off from `sys.dm_tran_locks`

namespacing the lock name a bit as it seems like it should be globally unique
