### PR TITLE
MaintenanceOptOut

### DIFF
--- a/doc/content/3.documentation/2.configuration/serialization.md
+++ b/doc/content/3.documentation/2.configuration/serialization.md
@@ -188,9 +188,9 @@ MassTransit provides several options when dealing with raw JSON messages. The op
 
 | Option              | Value | Default | Notes                                                        |
 |:--------------------|:-----:|:-------:|:-------------------------------------------------------------|
-| AnyMessageType      |   1   |    Y    | Messages will match any consumed message type                |
+| AnyMessageType      |   1   |    N    | Messages will match any consumed message type                |
 | AddTransportHeaders |   2   |    Y    | MassTransit will add the above headers to outbound messages  |
-| CopyHeaders         |   4   |    N    | Received message headers will be copied to outbound messages |
+| CopyHeaders         |   4   |    Y    | Received message headers will be copied to outbound messages |
 
 In cases where MassTransit is used and raw JSON messages are preferred, the non-default options are recommended.
 
@@ -225,8 +225,13 @@ Serialization customizations for using raw JSON is generally recommended on indi
 To configure a receive endpoint so that it can _receive_ raw JSON messages, specify the default content type and add the deserializer as shown below. When a raw JSON message is received, it will be delivered to every consumer configured on the receive endpoint.
 
 ```csharp
-endpointConfigurator.DefaultContentType = new ContentType("application/json");
-endpointConfigurator.UseRawJsonDeserializer();
+endpointConfigurator.UseRawJsonDeserializer(isDefault: true);
+```
+
+If there is no `Message-Type` header that meets MassTransit's requirements (typical for messages not produced by MassTransit), specify the deserializer should return all message types consumed by the consumer. This should only be used when the consumer has only a single `IConsumer<T>` interface.
+
+```csharp
+endpointConfigurator.UseRawJsonDeserializer(RawSerializerOptions.All, isDefault: true);
 ```
 
 If messages produced by consumers on the receive endpoint should also be in the raw JSON format, `UseRawJsonSerializer()` may be used instead.

--- a/src/MassTransit/SqlTransport/Configuration/ISqlHostConfigurator.cs
+++ b/src/MassTransit/SqlTransport/Configuration/ISqlHostConfigurator.cs
@@ -67,6 +67,12 @@ public interface ISqlHostConfigurator
     int ConnectionLimit { set; }
 
     /// <summary>
+    /// Opt out of ongoing maintenance and cleanup jobs (metrics consolidation, topology cleanup, etc.)
+    /// Should typically not be used, reserved for use cases such as delegating maintenance activities explicitly as application quantities grow.
+    /// </summary>
+    bool MaintenanceOptOut { set; }
+
+    /// <summary>
     /// How often database maintenance should be performed (metrics consolidation, topology cleanup, etc.)
     /// </summary>
     TimeSpan MaintenanceInterval { set; }

--- a/src/MassTransit/SqlTransport/Configuration/ISqlHostConfigurator.cs
+++ b/src/MassTransit/SqlTransport/Configuration/ISqlHostConfigurator.cs
@@ -67,10 +67,9 @@ public interface ISqlHostConfigurator
     int ConnectionLimit { set; }
 
     /// <summary>
-    /// Opt out of ongoing maintenance and cleanup jobs (metrics consolidation, topology cleanup, etc.)
-    /// Should typically not be used, reserved for use cases such as delegating maintenance activities explicitly as application quantities grow.
+    /// Should typically be left to the default (true), reserved for use cases such as delegating maintenance activities explicitly as application quantities grow.
     /// </summary>
-    bool MaintenanceOptOut { set; }
+    bool MaintenanceEnabled { set; }
 
     /// <summary>
     /// How often database maintenance should be performed (metrics consolidation, topology cleanup, etc.)

--- a/src/MassTransit/SqlTransport/Configuration/SqlTransportOptions.cs
+++ b/src/MassTransit/SqlTransport/Configuration/SqlTransportOptions.cs
@@ -25,8 +25,8 @@ public class SqlTransportOptions
     public int? ConnectionLimit { get; set; }
 
     /// <summary>
-    /// Opt out of ongoing maintenance and cleanup jobs (metrics consolidation, topology cleanup, etc.)
-    /// Should typically not be used, reserved for use cases such as delegating maintenance activities explicitly as application quantities grow.
+    /// Disable maintenance and cleanup jobs (metrics consolidation, topology cleanup, etc.)
+    /// Should typically be left to the default (false), reserved for use cases such as delegating maintenance activities explicitly as application quantities grow.
     /// </summary>
-    public bool MaintenanceOptOut { get; set; }
+    public bool DisableMaintenance { get; set; }
 }

--- a/src/MassTransit/SqlTransport/Configuration/SqlTransportOptions.cs
+++ b/src/MassTransit/SqlTransport/Configuration/SqlTransportOptions.cs
@@ -23,4 +23,10 @@ public class SqlTransportOptions
     /// If specified, changes the connection limit from the default value (10)
     /// </summary>
     public int? ConnectionLimit { get; set; }
+
+    /// <summary>
+    /// Opt out of ongoing maintenance and cleanup jobs (metrics consolidation, topology cleanup, etc.)
+    /// Should typically not be used, reserved for use cases such as delegating maintenance activities explicitly as application quantities grow.
+    /// </summary>
+    public bool MaintenanceOptOut { get; set; }
 }

--- a/src/MassTransit/SqlTransport/SqlHostSettings.cs
+++ b/src/MassTransit/SqlTransport/SqlHostSettings.cs
@@ -25,7 +25,7 @@ namespace MassTransit
 
         int ConnectionLimit { get; }
 
-        bool MaintenanceOptOut { get; }
+        bool MaintenanceEnabled { get; }
         TimeSpan MaintenanceInterval { get; }
         TimeSpan QueueCleanupInterval { get; }
         int MaintenanceBatchSize { get; }

--- a/src/MassTransit/SqlTransport/SqlHostSettings.cs
+++ b/src/MassTransit/SqlTransport/SqlHostSettings.cs
@@ -25,6 +25,7 @@ namespace MassTransit
 
         int ConnectionLimit { get; }
 
+        bool MaintenanceOptOut { get; }
         TimeSpan MaintenanceInterval { get; }
         TimeSpan QueueCleanupInterval { get; }
         int MaintenanceBatchSize { get; }

--- a/src/MassTransit/SqlTransport/SqlTransport/Configuration/ConfigurationSqlHostSettings.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/Configuration/ConfigurationSqlHostSettings.cs
@@ -44,7 +44,7 @@ namespace MassTransit.SqlTransport.Configuration
 
             _hostAddress = new Lazy<Uri>(FormatHostAddress);
 
-            MaintenanceOptOut = false;
+            MaintenanceEnabled = true;
             MaintenanceInterval = TimeSpan.FromSeconds(5);
             QueueCleanupInterval = TimeSpan.FromMinutes(1);
             MaintenanceBatchSize = 10000;
@@ -64,7 +64,7 @@ namespace MassTransit.SqlTransport.Configuration
 
         public int ConnectionLimit { get; set; }
 
-        public bool MaintenanceOptOut { get; set; }
+        public bool MaintenanceEnabled { get; set; }
         public TimeSpan MaintenanceInterval { get; set; }
         public TimeSpan QueueCleanupInterval { get; set; }
         public int MaintenanceBatchSize { get; set; }

--- a/src/MassTransit/SqlTransport/SqlTransport/Configuration/ConfigurationSqlHostSettings.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/Configuration/ConfigurationSqlHostSettings.cs
@@ -44,6 +44,7 @@ namespace MassTransit.SqlTransport.Configuration
 
             _hostAddress = new Lazy<Uri>(FormatHostAddress);
 
+            MaintenanceOptOut = false;
             MaintenanceInterval = TimeSpan.FromSeconds(5);
             QueueCleanupInterval = TimeSpan.FromMinutes(1);
             MaintenanceBatchSize = 10000;
@@ -63,6 +64,7 @@ namespace MassTransit.SqlTransport.Configuration
 
         public int ConnectionLimit { get; set; }
 
+        public bool MaintenanceOptOut { get; set; }
         public TimeSpan MaintenanceInterval { get; set; }
         public TimeSpan QueueCleanupInterval { get; set; }
         public int MaintenanceBatchSize { get; set; }

--- a/src/MassTransit/SqlTransport/SqlTransport/Configuration/SqlHostConfigurator.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/Configuration/SqlHostConfigurator.cs
@@ -87,6 +87,11 @@ namespace MassTransit.SqlTransport.Configuration
             set => _settings.ConnectionLimit = value;
         }
 
+        public bool MaintenanceOptOut
+        {
+            set => _settings.MaintenanceOptOut = value;
+        }
+
         public TimeSpan MaintenanceInterval
         {
             set => _settings.MaintenanceInterval = value;

--- a/src/MassTransit/SqlTransport/SqlTransport/Configuration/SqlHostConfigurator.cs
+++ b/src/MassTransit/SqlTransport/SqlTransport/Configuration/SqlHostConfigurator.cs
@@ -87,9 +87,9 @@ namespace MassTransit.SqlTransport.Configuration
             set => _settings.ConnectionLimit = value;
         }
 
-        public bool MaintenanceOptOut
+        public bool MaintenanceEnabled
         {
-            set => _settings.MaintenanceOptOut = value;
+            set => _settings.MaintenanceEnabled = value;
         }
 
         public TimeSpan MaintenanceInterval

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
@@ -52,7 +52,8 @@ namespace MassTransit.SqlTransport.PostgreSql
             _agent = new NotificationAgent(this, hostConfiguration);
             supervisor.AddConsumeAgent(_agent);
 
-            supervisor.AddConsumeAgent(new MaintenanceAgent(this, hostConfiguration));
+            if(!_hostSettings.MaintenanceOptOut)
+                supervisor.AddConsumeAgent(new MaintenanceAgent(this, hostConfiguration));
 
             _executor = new TaskExecutor(hostConfiguration.Settings.ConnectionLimit);
         }

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresDbConnectionContext.cs
@@ -52,7 +52,7 @@ namespace MassTransit.SqlTransport.PostgreSql
             _agent = new NotificationAgent(this, hostConfiguration);
             supervisor.AddConsumeAgent(_agent);
 
-            if(!_hostSettings.MaintenanceOptOut)
+            if(_hostSettings.MaintenanceEnabled)
                 supervisor.AddConsumeAgent(new MaintenanceAgent(this, hostConfiguration));
 
             _executor = new TaskExecutor(hostConfiguration.Settings.ConnectionLimit);

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -53,7 +53,7 @@ namespace MassTransit.SqlTransport.PostgreSql
             if (options.ConnectionLimit.HasValue)
                 ConnectionLimit = options.ConnectionLimit.Value;
 
-            MaintenanceOptOut = options.MaintenanceOptOut;
+            MaintenanceEnabled = !options.DisableMaintenance;
         }
 
         public string? MultipleHosts { get; set; }

--- a/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.PostgreSql/SqlTransport/PostgreSql/PostgresSqlHostSettings.cs
@@ -52,6 +52,8 @@ namespace MassTransit.SqlTransport.PostgreSql
 
             if (options.ConnectionLimit.HasValue)
                 ConnectionLimit = options.ConnectionLimit.Value;
+
+            MaintenanceOptOut = options.MaintenanceOptOut;
         }
 
         public string? MultipleHosts { get; set; }

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDbConnectionContext.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDbConnectionContext.cs
@@ -42,7 +42,7 @@ public class SqlServerDbConnectionContext :
 
         Topology = hostConfiguration.Topology;
 
-        if(!_hostSettings.MaintenanceOptOut)
+        if(_hostSettings.MaintenanceEnabled)
             supervisor.AddConsumeAgent(new MaintenanceAgent(this, hostConfiguration));
 
         _executor = new TaskExecutor(hostConfiguration.Settings.ConnectionLimit);

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDbConnectionContext.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerDbConnectionContext.cs
@@ -42,7 +42,8 @@ public class SqlServerDbConnectionContext :
 
         Topology = hostConfiguration.Topology;
 
-        supervisor.AddConsumeAgent(new MaintenanceAgent(this, hostConfiguration));
+        if(!_hostSettings.MaintenanceOptOut)
+            supervisor.AddConsumeAgent(new MaintenanceAgent(this, hostConfiguration));
 
         _executor = new TaskExecutor(hostConfiguration.Settings.ConnectionLimit);
     }

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerSqlHostSettings.cs
@@ -42,6 +42,8 @@ namespace MassTransit.SqlTransport.SqlServer
 
             if (options.ConnectionLimit.HasValue)
                 ConnectionLimit = options.ConnectionLimit.Value;
+
+            MaintenanceOptOut = options.MaintenanceOptOut;
         }
 
         public string? ConnectionString

--- a/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerSqlHostSettings.cs
+++ b/src/Transports/MassTransit.SqlTransport.SqlServer/SqlTransport/SqlServer/SqlServerSqlHostSettings.cs
@@ -43,7 +43,7 @@ namespace MassTransit.SqlTransport.SqlServer
             if (options.ConnectionLimit.HasValue)
                 ConnectionLimit = options.ConnectionLimit.Value;
 
-            MaintenanceOptOut = options.MaintenanceOptOut;
+            MaintenanceEnabled = !options.DisableMaintenance;
         }
 
         public string? ConnectionString


### PR DESCRIPTION
Added a `MaintenanceOptOut` concept to support disabling maintenance jobs on smaller hosts. looking to delegate the responsibility and cut down on contention/noise.