### PR TITLE
Proposal: allow for option in RabbitMqReceiveEndpointConfiguration to not deploy any topology changes in RMQ

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqReceiveEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqReceiveEndpointConfigurator.cs
@@ -94,5 +94,12 @@
         /// <param name="s">seconds</param>
         /// <param name="ms">milliseconds</param>
         void SetDeliveryAcknowledgementTimeout(int? d = null, int? h = null, int? m = null, int? s = null, int? ms = null);
+
+        /// <summary>
+        /// a switch to enable or disable the deployment of the consume topology.
+        /// if set to false, the exchange with the queue will not be declared.
+        /// Default value is True for backwards compatibility.
+        /// </summary>
+        bool DeployConsumeTopology { set; }
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointBuilder.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointBuilder.cs
@@ -73,6 +73,9 @@ namespace MassTransit.RabbitMqTransport.Configuration
             if (settings.QueueName.Equals(RabbitMqExchangeNames.ReplyTo, StringComparison.OrdinalIgnoreCase))
                 return topologyBuilder.BuildBrokerTopology();
 
+            if (!settings.DeployConsumeTopology)
+                return topologyBuilder.BuildBrokerTopology();
+
             var queueArguments = new Dictionary<string, object>(settings.QueueArguments);
 
             if (settings.QueueExpiration.HasValue)

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveEndpointConfiguration.cs
@@ -304,5 +304,10 @@ namespace MassTransit.RabbitMqTransport.Configuration
         {
             return _inputAddress.IsValueCreated || base.IsAlreadyConfigured();
         }
+
+        public bool DeployConsumeTopology
+        {
+            set => _settings.DeployConsumeTopology = value;
+        }
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveSettings.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqReceiveSettings.cs
@@ -44,5 +44,7 @@ namespace MassTransit.RabbitMqTransport.Configuration
         {
             return GetEndpointAddress(hostAddress);
         }
+
+        public bool DeployConsumeTopology { get; set; } = true;
     }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/ReceiveSettings.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/ReceiveSettings.cs
@@ -74,5 +74,12 @@
         /// Get the input address for the transport on the specified host
         /// </summary>
         Uri GetInputAddress(Uri hostAddress);
+
+        /// <summary>
+        /// a switch to enable or disable the deployment of the consume topology.
+        /// if set to false, the exchange with the queue will not be declared.
+        /// Default value is True for backwards compatibility.
+        /// </summary>
+        bool DeployConsumeTopology { get; }
     }
 }


### PR DESCRIPTION
Good evening we are currently working in a Banking ecosystem and we are planning to use MassTransit as it is an amazing option for consuming/publishing across our used brokers (RMQ/Kafka).

As our Rmq Topology is configured through other Teams that have ownership of RMQ deployments we found out that it's not possible to avoid all deployments using for example the following code.

```
                    busConfigurator.ReceiveEndpoint("bidis_queue", e =>
                    {
                        e.PrefetchCount = 10;
                        e.BindQueue = false;
                    });
```

even with this code configuration there is a deployment of an exchange `bidis_queue` 😛 

![default_exchange_no_queue](https://github.com/user-attachments/assets/c5039996-97c4-4026-85d7-5b45d156d8ba)

Our proposal is for a new switch `DeployConsumeTopology` in `RabbitMqReceiveEndpointConfiguration`  in order to disable all queue/exchanges. 

In order to reach a state like the following,

```
                    busConfigurator.ReceiveEndpoint("bidis_queue", e =>
                    {
                        e.PrefetchCount = 10;
                        e.DeployConsumeTopology = false; //override default value of true
                    });
```

![no_deployments_rmq](https://github.com/user-attachments/assets/e0e8f6c4-394d-4d12-ba5c-60cdc73b2cf0)

If this pull request does not make any sense, I am open also to investigate other approaches to support this option🙏 

Thanks  in advance for your time,

Christos


