### PR TITLE
Generate interfaces using init properties correctly

### DIFF
--- a/src/MassTransit/Internals/Reflection/DynamicImplementationBuilder.cs
+++ b/src/MassTransit/Internals/Reflection/DynamicImplementationBuilder.cs
@@ -7,6 +7,7 @@
     using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
+    using System.Runtime.CompilerServices;
 
 
     public class DynamicImplementationBuilder :
@@ -108,8 +109,13 @@
         {
             var setMethodBuilder = typeBuilder.DefineMethod("set_" + propertyInfo.Name,
                 PropertyAccessMethodAttributes,
+                CallingConventions.HasThis,
+                typeof(void),
+                ReturnTypeCustomModifiersForProperty(propertyInfo),
                 null,
-                new[] { propertyInfo.PropertyType });
+                new[] { propertyInfo.PropertyType },
+                null,
+                null);
 
             var il = setMethodBuilder.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
@@ -177,6 +183,18 @@
             });
 
             return callback(builder);
+        }
+
+        static Type[] ReturnTypeCustomModifiersForProperty(PropertyInfo propertyInfo)
+        {
+            Type[] returnTypeCustomModifiers = null;
+
+            #if NET5_0_OR_GREATER
+                var hasInitSetter = propertyInfo.SetMethod?.ReturnParameter?.GetRequiredCustomModifiers()?.Contains(typeof(IsExternalInit)) ?? false;
+                returnTypeCustomModifiers = hasInitSetter ? new[] { typeof(IsExternalInit) } : null;
+            #endif
+
+            return returnTypeCustomModifiers;
         }
     }
 }

--- a/tests/MassTransit.Tests/Serialization/Interface_Specs.cs
+++ b/tests/MassTransit.Tests/Serialization/Interface_Specs.cs
@@ -67,11 +67,23 @@ namespace MassTransit.Tests.Serialization
 
     public interface ComplaintAdded
     {
+        #if NET5_0_OR_GREATER
+            /// <summary>
+            /// Explicit init declaration to test init properties are dynamically created correctly in > .NET 5.
+            /// </summary>
+            int Id { get; init; }
+        #else
+            int Id { get; set; }
+        #endif
+
         User AddedBy { get; }
 
         DateTime AddedAt { get; }
 
-        string Subject { get; }
+        /// <summary>
+        /// Explicit set declaration to test set properties are dynamically created correctly.
+        /// </summary>
+        string Subject { get; set; }
 
         string Body { get; }
 
@@ -159,6 +171,12 @@ namespace MassTransit.Tests.Serialization
         {
         }
 
+        #if NET5_0_OR_GREATER
+            public int Id { get; init; }
+        #else
+            public int Id { get; set; }
+        #endif
+
         public User AddedBy { get; set; }
 
         public DateTime AddedAt { get; set; }
@@ -176,7 +194,7 @@ namespace MassTransit.Tests.Serialization
             if (ReferenceEquals(this, other))
                 return true;
             return AddedBy.Equals(other.AddedBy) && other.AddedAt.Equals(AddedAt) && Equals(other.Subject, Subject) && Equals(other.Body, Body)
-                && Equals(other.Area, Area);
+                && Equals(other.Area, Area) && Equals(other.Id, Id);
         }
 
         public override bool Equals(object obj)
@@ -199,6 +217,7 @@ namespace MassTransit.Tests.Serialization
                 result = (result * 397) ^ (Subject != null ? Subject.GetHashCode() : 0);
                 result = (result * 397) ^ (Body != null ? Body.GetHashCode() : 0);
                 result = (result * 397) ^ Area.GetHashCode();
+                result = (result * 397) ^ Id.GetHashCode();
                 return result;
             }
         }


### PR DESCRIPTION
# Overview

This PR fixes #5818 by conditionally applying the `IsExternalInit` modifier to dynamically generated interface implementations of properties where:

- the published concrete implementation contains it
- the consuming assembly is on .NET 5 or greater (as `IsExternalInit` was only added in .NET 5).

# Testing

- Tested by modifying a unit test to specify an `init` property and a `set` property (and verifying they fail without this fix).
- Tested on the repository of the original reported issue in the `after-fix` branch which I published this branch's NuGet packages in as a local repository source: https://github.com/lsymds/repro-mass-transit-interface-property-inits/tree/after-fix 
- Tested on a version of the repository of the original reported issue configured to run .NET Core 3.1 in a Docker container to verify the return type modifiers having no adverse affects (screenshot in image below).

![verification](https://github.com/user-attachments/assets/0e188f60-618e-4bc1-b618-b191b63cc46e)

