### PR TITLE
Fix Summary Docs for Transport-Specific Extension Methods

### DIFF
--- a/src/MassTransit/SqlTransport/Configuration/SqlConfigureEndpointCallbackExtensions.cs
+++ b/src/MassTransit/SqlTransport/Configuration/SqlConfigureEndpointCallbackExtensions.cs
@@ -6,7 +6,7 @@ using System;
 public static class SqlConfigureEndpointCallbackExtensions
 {
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback to the endpoint.
+    /// Add a SQL specific configure callback to the endpoint.
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>
@@ -24,7 +24,7 @@ public static class SqlConfigureEndpointCallbackExtensions
     }
 
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback for configured endpoints
+    /// Add a SQL specific configure callback for configured endpoints
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>

--- a/src/Transports/MassTransit.ActiveMqTransport/Configuration/ActiveMqConfigureEndpointCallbackExtensions.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/Configuration/ActiveMqConfigureEndpointCallbackExtensions.cs
@@ -6,7 +6,7 @@ using System;
 public static class ActiveMqConfigureEndpointCallbackExtensions
 {
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback to the endpoint.
+    /// Add an ActiveMQ specific configure callback to the endpoint.
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>
@@ -24,7 +24,7 @@ public static class ActiveMqConfigureEndpointCallbackExtensions
     }
 
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback for configured endpoints
+    /// Add an ActiveMQ specific configure callback for configured endpoints
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsConfigureEndpointCallbackExtensions.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsConfigureEndpointCallbackExtensions.cs
@@ -6,7 +6,7 @@ using System;
 public static class AmazonSqsConfigureEndpointCallbackExtensions
 {
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback to the endpoint.
+    /// Add an Amazon SQS specific configure callback to the endpoint.
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>
@@ -24,7 +24,7 @@ public static class AmazonSqsConfigureEndpointCallbackExtensions
     }
 
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback for configured endpoints
+    /// Add an Amazon SQS specific configure callback for configured endpoints
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>

--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqConfigureEndpointCallbackExtensions.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/RabbitMqConfigureEndpointCallbackExtensions.cs
@@ -6,7 +6,7 @@ using System;
 public static class RabbitMqConfigureEndpointCallbackExtensions
 {
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback to the endpoint.
+    /// Add a RabbitMQ specific configure callback to the endpoint.
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>
@@ -24,7 +24,7 @@ public static class RabbitMqConfigureEndpointCallbackExtensions
     }
 
     /// <summary>
-    /// Add an Azure Service Bus specific configure callback to the endpoint.
+    /// Add a RabbitMQ specific configure callback for configured endpoints
     /// </summary>
     /// <param name="configurator"></param>
     /// <param name="callback"></param>


### PR DESCRIPTION
Hi there!

There were some duplicated summary docs for the configure endpoints callback extension methods for transport-specific configuration change introduced in [this commit](https://github.com/MassTransit/MassTransit/commit/b96514a4a8985ed4d15573cdf805ef7c3a737e6e#diff-62e720eb1364e2d014f8a58f4376080b79220b6ece283397f36dcf8f69a3ffa3) - this PR just fixes them up.

Let me know if things don't look correct & I shall amend as needed.