### PR TITLE
fix: truncate stacktrace on ASB if too long

### DIFF
--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/MessageSendEndpointContext.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/MessageSendEndpointContext.cs
@@ -24,11 +24,13 @@ namespace MassTransit.AzureServiceBusTransport
 
         public Task Send(ServiceBusMessage message)
         {
+            ServiceBusHeaders.TruncateFaultHeaders(message.ApplicationProperties);
             return _client.SendMessageAsync(message);
         }
 
         public Task<long> ScheduleSend(ServiceBusMessage message, DateTime scheduleEnqueueTimeUtc)
         {
+            ServiceBusHeaders.TruncateFaultHeaders(message.ApplicationProperties);
             return _client.ScheduleMessageAsync(message, scheduleEnqueueTimeUtc);
         }
 

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusMessageLockContext.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/Contexts/ServiceBusMessageLockContext.cs
@@ -31,7 +31,7 @@ namespace MassTransit.AzureServiceBusTransport
         {
             return _deadLettered
                 ? Task.CompletedTask
-                : _eventArgs.AbandonMessageAsync(_message, ExceptionUtil.GetExceptionHeaderDictionary(exception));
+                : _eventArgs.AbandonMessageAsync(_message, GetExceptionHeaderDictionary(exception));
         }
 
         public async Task DeadLetter()
@@ -44,9 +44,16 @@ namespace MassTransit.AzureServiceBusTransport
 
         public async Task DeadLetter(Exception exception)
         {
-            await _eventArgs.DeadLetterMessageAsync(_message, ExceptionUtil.GetExceptionHeaderDictionary(exception)).ConfigureAwait(false);
+            await _eventArgs.DeadLetterMessageAsync(_message, GetExceptionHeaderDictionary(exception)).ConfigureAwait(false);
 
             _deadLettered = true;
+        }
+
+        private IDictionary<string, object> GetExceptionHeaderDictionary(Exception exception)
+        {
+            var dict = ExceptionUtil.GetExceptionHeaderDictionary(exception);
+            ServiceBusHeaders.TruncateFaultHeaders(dict);
+            return dict;
         }
     }
 }

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ServiceBusHeaders.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ServiceBusHeaders.cs
@@ -1,0 +1,21 @@
+﻿
+namespace MassTransit.AzureServiceBusTransport
+{
+    using System.Collections.Generic;
+
+    internal class ServiceBusHeaders
+    {
+        const int MAX_HEADER_LENGTH_BYTES = 32767;
+        const int MAX_HEADER_LENGTH = (MAX_HEADER_LENGTH_BYTES / sizeof(char)) - 1;
+
+        public static void TruncateFaultHeaders(IDictionary<string, object> headers)
+        {
+            if (headers.TryGetValue(MessageHeaders.FaultMessage, out var faultMessage)
+                && faultMessage is string message
+                && message.Length > MAX_HEADER_LENGTH)
+            {
+                headers[MessageHeaders.FaultMessage] = message.Substring(0, MAX_HEADER_LENGTH - 3) + "...";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently a draft, as I've not yet figured out how to verify that this works/added tests. Pushed to get early feedback.