### PR TITLE
Use Primary Constructors where applicable & Add docs for DynamoDB

### DIFF
--- a/doc/content/3.documentation/1.concepts/6.requests.md
+++ b/doc/content/3.documentation/1.concepts/6.requests.md
@@ -28,19 +28,12 @@ public record OrderStatusResult
 Request messages can be handled by any consumer type, including consumers, sagas, and routing slips. In this case, the consumer below consumes the _CheckOrderStatus_ message and responds with the _OrderStatusResult_ message.
 
 ```csharp
-public class CheckOrderStatusConsumer : 
+public class CheckOrderStatusConsumer(IOrderRepository orderRepository) :
     IConsumer<CheckOrderStatus>
 {
-    readonly IOrderRepository _orderRepository;
-
-    public CheckOrderStatusConsumer(IOrderRepository orderRepository)
-    {
-        _orderRepository = orderRepository;
-    }
-
     public async Task Consume(ConsumeContext<CheckOrderStatus> context)
     {
-        var order = await _orderRepository.Get(context.Message.OrderId);
+        var order = await orderRepository.Get(context.Message.OrderId);
         if (order == null)
             throw new InvalidOperationException("Order not found");
         
@@ -64,20 +57,13 @@ If the _OrderId_ was not found, the consumer throws an exception. MassTransit ca
 To use the request client, add the request client as a dependency as shown in the example API controller below.
 
 ```csharp
-public class RequestController :
+public class RequestController(IRequestClient<CheckOrderStatus> client) :
     Controller
 {
-    IRequestClient<CheckOrderStatus> _client;
-
-    public RequestController(IRequestClient<CheckOrderStatus> client)
-    {
-        _client = client;
-    }
-
     [HttpGet("{orderId}")]
     public async Task<IActionResult> Get(string orderId, CancellationToken cancellationToken)
     {
-        var response = await _client.GetResponse<OrderStatusResult>(new { orderId }, cancellationToken);
+        var response = await client.GetResponse<OrderStatusResult>(new { orderId }, cancellationToken);
 
         return Ok(response.Message);
     }
@@ -279,22 +265,13 @@ For backwards compatibility, if the new `MT-Request-AcceptType` header is not fo
 If there were multiple requests to be performed, it is easy to wait on all results at the same time, benefiting from the concurrent operation.
 
 ```csharp
-public class RequestController : 
-    Controller
+public class RequestController(IRequestClient<RequestA> clientA, IRequestClient<RequestB> clientB)
+    : Controller
 {
-    IRequestClient<RequestA> _clientA;
-    IRequestClient<RequestB> _clientB;
-
-    public RequestController(IRequestClient<RequestA> clientA, IRequestClient<RequestB> clientB)
-    {
-        _clientA = clientA;
-        _clientB = clientB;
-    }
-
     public async Task<ActionResult> Get()
     {
-        var resultA = _clientA.GetResponse(new RequestA());
-        var resultB = _clientB.GetResponse(new RequestB());
+        var resultA = clientA.GetResponse(new RequestA());
+        var resultB = clientB.GetResponse(new RequestB());
 
         await Task.WhenAll(resultA, resultB);
 

--- a/doc/content/3.documentation/2.configuration/4.persistence/dynamodb.md
+++ b/doc/content/3.documentation/2.configuration/4.persistence/dynamodb.md
@@ -27,8 +27,10 @@ builder.Services.AddMassTransit(cfg =>
     cfg.AddSagaStateMachine<OrderStateMachine, OrderState>()
         .DynamoDbRepository(config =>
         {
-            config.TableName = "Orders"; // required
-            config.ContextFactory(provider => new DynamoDBContext(dynamoDbClient)); // required. Refer to AWS SDK docs for how to create a context.
+            // required
+            config.TableName = "Orders";
+             // required. Refer to AWS SDK docs for how to create a context.
+            config.ContextFactory(provider => new DynamoDBContext(dynamoDbClient));
         });
 });
 ```

--- a/doc/content/3.documentation/2.configuration/4.persistence/dynamodb.md
+++ b/doc/content/3.documentation/2.configuration/4.persistence/dynamodb.md
@@ -1,3 +1,36 @@
 # DynamoDb
 
 [![alt NuGet](https://img.shields.io/nuget/v/MassTransit.DynamoDb.svg "NuGet")](https://nuget.org/packages/MassTransit.DynamoDb/)
+
+DynamoDB is a fully managed NoSQL database provided by AWS.
+Setting it up as a SagaRepository is simple, but do note that it requires implementing the _ISagaVersion_ interface
+that requires a _Version_ property for optimistic concurrency:
+
+```csharp
+public class OrderState :
+    SagaStateMachineInstance,
+    ISagaVersion
+{
+    public Guid CorrelationId { get; set; }
+    public int Version { get; set; }
+    public string CurrentState { get; set; }
+    public DateTime? OrderDate { get; set; }
+}
+```
+
+## Configuration
+In Order to configure DynamoDB as a saga repository, use the *AddMassTransit* container extension:
+
+```csharp
+builder.Services.AddMassTransit(cfg =>
+{
+    cfg.AddSagaStateMachine<OrderStateMachine, OrderState>()
+        .DynamoDbRepository(config =>
+        {
+            config.TableName = "Orders"; // required
+            config.ContextFactory(provider => new DynamoDBContext(dynamoDbClient)); // required. Refer to AWS SDK docs for how to create a context.
+        });
+});
+```
+
+

--- a/doc/content/3.documentation/2.configuration/4.persistence/dynamodb.md
+++ b/doc/content/3.documentation/2.configuration/4.persistence/dynamodb.md
@@ -35,4 +35,12 @@ builder.Services.AddMassTransit(cfg =>
 });
 ```
 
+The code above configures the repository to store saga instances in a table named `Orders`.
+A `DynamoDBContext` must be created from an existing `AmazonDynamoDBClient` instance.
+For example, if a local dynamodb instance is used, the code creating a client could look like this:
+
+```csharp
+var dynamoDbClient = new AmazonDynamoDBClient(new AmazonDynamoDBConfig { ServiceURL = "http://localhost:4566" });
+```
+
 


### PR DESCRIPTION
This PR improves the documentation by:

- Updating two sample code snippets in the Requests section to use primary constructors, making the examples more concise.
- Adding an example for configuring DynamoDB as a SagaRepository, replacing a previously empty page.

The updated snippets were tested in a sample project and should work as intended.