### PR TITLE
Configure namespace for DefaultMessageNameFormatter

### DIFF
--- a/src/MassTransit.Abstractions/Topology/PrefixEntityNameFormatter.cs
+++ b/src/MassTransit.Abstractions/Topology/PrefixEntityNameFormatter.cs
@@ -5,23 +5,18 @@ namespace MassTransit
     {
         readonly IEntityNameFormatter _entityNameFormatter;
         readonly string _prefix;
-        readonly string _separator;
 
-        public PrefixEntityNameFormatter(
-            IEntityNameFormatter entityNameFormatter,
-            string prefix,
-            string separator = "")
+        public PrefixEntityNameFormatter(IEntityNameFormatter entityNameFormatter, string prefix)
         {
             _entityNameFormatter = entityNameFormatter;
             _prefix = prefix;
-            _separator = separator;
         }
 
         public string FormatEntityName<T>()
         {
             var name = _entityNameFormatter.FormatEntityName<T>();
 
-            return $"{_prefix}{_separator}{name}";
+            return $"{_prefix}{name}";
         }
     }
 }

--- a/src/MassTransit.Abstractions/Topology/PrefixEntityNameFormatter.cs
+++ b/src/MassTransit.Abstractions/Topology/PrefixEntityNameFormatter.cs
@@ -5,18 +5,23 @@ namespace MassTransit
     {
         readonly IEntityNameFormatter _entityNameFormatter;
         readonly string _prefix;
+        readonly string _separator;
 
-        public PrefixEntityNameFormatter(IEntityNameFormatter entityNameFormatter, string prefix)
+        public PrefixEntityNameFormatter(
+            IEntityNameFormatter entityNameFormatter,
+            string prefix,
+            string separator = "")
         {
             _entityNameFormatter = entityNameFormatter;
             _prefix = prefix;
+            _separator = separator;
         }
 
         public string FormatEntityName<T>()
         {
             var name = _entityNameFormatter.FormatEntityName<T>();
 
-            return $"{_prefix}{name}";
+            return $"{_prefix}{_separator}{name}";
         }
     }
 }

--- a/src/MassTransit/Transports/DefaultMessageNameFormatter.cs
+++ b/src/MassTransit/Transports/DefaultMessageNameFormatter.cs
@@ -13,14 +13,20 @@ namespace MassTransit.Transports
         readonly string _genericTypeSeparator;
         readonly string _namespaceSeparator;
         readonly string _nestedTypeSeparator;
+        readonly bool _includeNamespace;
 
-        public DefaultMessageNameFormatter(string genericArgumentSeparator, string genericTypeSeparator,
-            string namespaceSeparator, string nestedTypeSeparator)
+        public DefaultMessageNameFormatter(
+            string genericArgumentSeparator,
+            string genericTypeSeparator,
+            string namespaceSeparator,
+            string nestedTypeSeparator,
+            bool includeNamespace = true)
         {
             _genericArgumentSeparator = genericArgumentSeparator;
             _genericTypeSeparator = genericTypeSeparator;
             _namespaceSeparator = namespaceSeparator;
             _nestedTypeSeparator = nestedTypeSeparator;
+            _includeNamespace = includeNamespace;
 
             _cache = new ConcurrentDictionary<Type, string>();
         }
@@ -46,7 +52,7 @@ namespace MassTransit.Transports
                 return "";
 
             var ns = type.Namespace;
-            if (ns != null)
+            if (ns != null && _includeNamespace)
             {
                 if (!ns.Equals(scope))
                 {

--- a/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ServiceBusMessageNameFormatter.cs
+++ b/src/Transports/MassTransit.Azure.ServiceBus.Core/AzureServiceBusTransport/ServiceBusMessageNameFormatter.cs
@@ -9,11 +9,13 @@ namespace MassTransit.AzureServiceBusTransport
     {
         readonly IMessageNameFormatter _formatter;
 
-        public ServiceBusMessageNameFormatter(string namespaceSeparator = default)
+        public ServiceBusMessageNameFormatter(
+            string namespaceSeparator = null,
+            bool includeNamespace = true)
         {
             _formatter = string.IsNullOrWhiteSpace(namespaceSeparator)
-                ? new DefaultMessageNameFormatter("---", "--", "/", "-")
-                : new DefaultMessageNameFormatter("---", "--", namespaceSeparator, "-");
+                ? new DefaultMessageNameFormatter("---", "--", "/", "-", includeNamespace)
+                : new DefaultMessageNameFormatter("---", "--", namespaceSeparator, "-", includeNamespace);
         }
 
         public string GetMessageName(Type type)


### PR DESCRIPTION
This pull request introduces enhancements to entity and message name formatters to improve configurability and flexibility.

### Enhancements to message name formatting:
* `DefaultMessageNameFormatter` introduces a new `_includeNamespace` field and a corresponding constructor parameter (defaulting to `true`) to control whether namespaces are included in message names.
* `ServiceBusMessageNameFormatter` propagates the new `includeNamespace` option to `DefaultMessageNameFormatter`, allowing Azure Service Bus users to configure namespace inclusion.

### Supporting use-case

Configuration of `EndpointName` already supported
```csharp
cfg.ConfigureEndpoints(
   context,
   new KebabCaseEndpointNameFormatter(includeNamespace: false, prefix: "registration"));
```

Configuration of `EntityName` in this PR
```csharp
var formatter = new MessageNameFormatterEntityNameFormatter(
   new ServiceBusMessageNameFormatter(includeNamespace: false));

cfg.MessageTopology.SetEntityNameFormatter(
   new PrefixEntityNameFormatter(formatter, prefix: "registration-"));
```

Created Topics:
- `registration-fault`
- `registration-fault--sendemailcommand--`
- `registration-useronboardstarted`

Created Queues:
- `registration-send-email`
- `registration-send-email_error`

Thanks!