### PR TITLE
Update the AWS packages to use AWS .NET SDK V4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,10 @@
   <ItemGroup>
     <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.1" />
     <PackageVersion Include="Apache.NMS.AMQP" Version="2.2.0" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.407.2" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.141" />
-    <PackageVersion Include="AWSSDK.S3" Version="3.7.416.17" />
-    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.141" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.0" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.0" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.0" />
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.10.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.12.1" />

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
@@ -164,7 +164,7 @@ namespace MassTransit.AmazonSqsTransport
 
             response.EnsureSuccessfulResponse();
 
-            return response.Messages;
+            return response.Messages ?? new List<Message>();
         }
 
         public Task<QueueInfo> GetQueueInfo(string queueName)

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsHeaderProvider.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsHeaderProvider.cs
@@ -23,7 +23,7 @@
 
         public bool TryGetHeader(string key, out object value)
         {
-            if (_message.MessageAttributes.TryGetValue(key, out var val))
+            if (_message.MessageAttributes != null && _message.MessageAttributes.TryGetValue(key, out var val))
             {
                 value = val.StringValue;
                 return value != null;
@@ -43,7 +43,7 @@
 
             if (MessageHeaders.TransportSentTime.Equals(key, StringComparison.OrdinalIgnoreCase))
             {
-                if (_message.Attributes.TryGetValue(MessageSystemAttributeName.SentTimestamp, out var sentTimestamp))
+                if (_message.Attributes != null && _message.Attributes.TryGetValue(MessageSystemAttributeName.SentTimestamp, out var sentTimestamp))
                 {
                     if (long.TryParse(sentTimestamp, out var milliseconds))
                     {
@@ -62,10 +62,13 @@
             if (!TryGetHeader(MessageHeaders.MessageId, out _))
                 yield return new KeyValuePair<string, object>(MessageHeaders.MessageId, _message.MessageId);
 
-            foreach (KeyValuePair<string, object> header in _message.MessageAttributes
-                         .Where(x => x.Value.StringValue != null)
-                         .Select(x => new KeyValuePair<string, object>(x.Key, x.Value.StringValue)))
-                yield return header;
+            if (_message.MessageAttributes != null)
+            {
+                foreach (KeyValuePair<string, object> header in _message.MessageAttributes
+                             .Where(x => x.Value.StringValue != null)
+                             .Select(x => new KeyValuePair<string, object>(x.Key, x.Value.StringValue)))
+                    yield return header;
+            }
         }
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsReceiveContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsReceiveContext.cs
@@ -20,6 +20,8 @@
             : base(redelivered, context, settings, clientContext, connectionContext)
         {
             TransportMessage = message;
+            TransportMessage.MessageAttributes ??= new Dictionary<string, MessageAttributeValue>();
+            TransportMessage.Attributes ??= new Dictionary<string, string>();
 
             var messageBody = new SqsMessageBody(message);
 
@@ -40,13 +42,16 @@
         {
             var properties = new Lazy<Dictionary<string, object>>(() => new Dictionary<string, object>());
 
-            if (TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var messageGroupId)
-                && !string.IsNullOrWhiteSpace(messageGroupId))
-                properties.Value[AmazonSqsTransportPropertyNames.GroupId] = messageGroupId;
+            if (TransportMessage.Attributes != null)
+            {
+                if (TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var messageGroupId)
+                    && !string.IsNullOrWhiteSpace(messageGroupId))
+                    properties.Value[AmazonSqsTransportPropertyNames.GroupId] = messageGroupId;
 
-            if (TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var messageDeduplicationId)
-                && !string.IsNullOrWhiteSpace(messageDeduplicationId))
-                properties.Value[AmazonSqsTransportPropertyNames.DeduplicationId] = messageDeduplicationId;
+                if (TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId, out var messageDeduplicationId)
+                    && !string.IsNullOrWhiteSpace(messageDeduplicationId))
+                    properties.Value[AmazonSqsTransportPropertyNames.DeduplicationId] = messageDeduplicationId;
+            }
 
             return properties.IsValueCreated ? properties.Value : null;
         }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsRegistrationBusFactory.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsRegistrationBusFactory.cs
@@ -4,6 +4,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration
     using System.Collections.Generic;
     using Amazon;
     using Amazon.Runtime;
+    using Amazon.Runtime.Credentials;
     using MassTransit.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Options;
@@ -50,7 +51,7 @@ namespace MassTransit.AmazonSqsTransport.Configuration
                         h.SecretKey(options.SecretKey);
                     }
                     else
-                        h.Credentials(FallbackCredentialsFactory.GetCredentials());
+                        h.Credentials(DefaultAWSCredentialsIdentityResolver.GetCredentials());
                 });
             }
 

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/AmazonSqsMessageReceiver.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/AmazonSqsMessageReceiver.cs
@@ -106,7 +106,7 @@ namespace MassTransit.AmazonSqsTransport.Middleware
             if (IsStopping)
                 return;
 
-            var redelivered = message.Attributes.TryGetInt("ApproximateReceiveCount", out var receiveCount) && receiveCount > 1;
+            var redelivered = (message.Attributes != null && message.Attributes.TryGetInt("ApproximateReceiveCount", out var receiveCount) && receiveCount > 1);
 
             var context = new AmazonSqsReceiveContext(message, redelivered, _context, _client, _receiveSettings, _client.ConnectionContext);
             try
@@ -169,7 +169,7 @@ namespace MassTransit.AmazonSqsTransport.Middleware
 
             static byte[] MessageGroupIdProvider(Message message)
             {
-                return message.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var groupId) && !string.IsNullOrEmpty(groupId)
+                return message.Attributes != null && message.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var groupId) && !string.IsNullOrEmpty(groupId)
                     ? Encoding.UTF8.GetBytes(groupId)
                     : [];
             }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/AmazonSqsMessageReceiver.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/AmazonSqsMessageReceiver.cs
@@ -91,7 +91,7 @@ namespace MassTransit.AmazonSqsTransport.Middleware
 
             _receiveSettings.QueueUrl = queueInfo.Url;
 
-            if (queueInfo.Attributes.TryGetValue(QueueAttributeName.VisibilityTimeout, out var value)
+            if (queueInfo.Attributes != null && queueInfo.Attributes.TryGetValue(QueueAttributeName.VisibilityTimeout, out var value)
                 && int.TryParse(value, out var visibilityTimeout)
                 && visibilityTimeout != _receiveSettings.VisibilityTimeout)
             {

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/PublishBatcher.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/PublishBatcher.cs
@@ -28,7 +28,7 @@ namespace MassTransit.AmazonSqsTransport
             entry.Id = entryId;
 
             return entry.Message.Length
-                + entry.MessageAttributes.Where(x => x.Value.DataType == "String").Sum(x => x.Key.Length + x.Value.StringValue.Length);
+                + (entry.MessageAttributes?.Where(x => x.Value.DataType == "String").Sum(x => x.Key.Length + x.Value.StringValue.Length)).GetValueOrDefault();
         }
 
         protected override async Task SendBatch(IList<BatchEntry<PublishBatchRequestEntry>> batch)

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/QueueCache.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/QueueCache.cs
@@ -112,7 +112,7 @@ namespace MassTransit.AmazonSqsTransport
 
             attributesResponse.EnsureSuccessfulResponse();
 
-            var missingQueue = new QueueInfo(queue.EntityName, createResponse.QueueUrl, attributesResponse.Attributes, _client, _cancellationToken, false);
+            var missingQueue = new QueueInfo(queue.EntityName, createResponse.QueueUrl, attributesResponse.Attributes ?? new Dictionary<string, string>(), _client, _cancellationToken, false);
 
             if (queue.Durable && queue.AutoDelete == false)
             {
@@ -133,7 +133,7 @@ namespace MassTransit.AmazonSqsTransport
 
             attributesResponse.EnsureSuccessfulResponse();
 
-            return new QueueInfo(queueName, urlResponse.QueueUrl, attributesResponse.Attributes, _client, _cancellationToken, true);
+            return new QueueInfo(queueName, urlResponse.QueueUrl, attributesResponse.Attributes ?? new Dictionary<string, string>(), _client, _cancellationToken, true);
         }
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/QueueSendTransportContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/QueueSendTransportContext.cs
@@ -78,7 +78,7 @@ namespace MassTransit.AmazonSqsTransport
 
             sendContext.CancellationToken.ThrowIfCancellationRequested();
 
-            var message = new SendMessageBatchRequestEntry("", context.Body.GetString()) { Id = sendContext.MessageId.ToString() };
+            var message = new SendMessageBatchRequestEntry("", context.Body.GetString()) { Id = sendContext.MessageId.ToString(), MessageAttributes = new Dictionary<string, MessageAttributeValue>() };
 
             _headerAdapter.Set(message.MessageAttributes, context.Headers);
             _headerAdapter.Set(message.MessageAttributes, MessageHeaders.ContentType, context.ContentType.ToString());

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SqsMoveTransport.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SqsMoveTransport.cs
@@ -32,19 +32,22 @@
 
             OneTimeContext<ConfigureTopologyContext<TSettings>> oneTimeContext = await _topologyFilter.Configure(clientContext).ConfigureAwait(false);
 
-            var message = new SendMessageBatchRequestEntry("", Encoding.UTF8.GetString(context.GetBody()));
+            var message = new SendMessageBatchRequestEntry("", Encoding.UTF8.GetString(context.GetBody())) { MessageAttributes = new Dictionary<string, MessageAttributeValue>() };
 
             if (context.TryGetPayload(out AmazonSqsMessageContext receiveContext))
             {
                 if (_isFifo)
                 {
-                    if (receiveContext.TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var messageGroupId)
-                        && !string.IsNullOrWhiteSpace(messageGroupId))
-                        message.MessageGroupId = messageGroupId;
-                    if (receiveContext.TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId,
-                            out var messageDeduplicationId)
-                        && !string.IsNullOrWhiteSpace(messageDeduplicationId))
-                        message.MessageDeduplicationId = messageDeduplicationId;
+                    if (receiveContext.TransportMessage.Attributes != null)
+                    {
+                        if (receiveContext.TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageGroupId, out var messageGroupId)
+                            && !string.IsNullOrWhiteSpace(messageGroupId))
+                            message.MessageGroupId = messageGroupId;
+                        if (receiveContext.TransportMessage.Attributes.TryGetValue(MessageSystemAttributeName.MessageDeduplicationId,
+                                out var messageDeduplicationId)
+                            && !string.IsNullOrWhiteSpace(messageDeduplicationId))
+                            message.MessageDeduplicationId = messageDeduplicationId;
+                    }
                 }
 
                 CopyReceivedMessageHeaders(receiveContext, message.MessageAttributes);

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicSendTransportContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/TopicSendTransportContext.cs
@@ -78,7 +78,7 @@ namespace MassTransit.AmazonSqsTransport
 
             sendContext.CancellationToken.ThrowIfCancellationRequested();
 
-            var request = new PublishBatchRequestEntry { Message = context.Body.GetString() };
+            var request = new PublishBatchRequestEntry { Message = context.Body.GetString(), MessageAttributes = new Dictionary<string, MessageAttributeValue>() };
 
             _headerAdapter.Set(request.MessageAttributes, context.Headers);
             _headerAdapter.Set(request.MessageAttributes, MessageHeaders.ContentType, context.ContentType.ToString());

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsBusFactoryConfiguratorExtensions.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsBusFactoryConfiguratorExtensions.cs
@@ -4,6 +4,7 @@ namespace MassTransit
     using System;
     using Amazon;
     using Amazon.Runtime;
+    using Amazon.Runtime.Credentials;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
     using AmazonSqsTransport.Configuration;
@@ -67,7 +68,7 @@ namespace MassTransit
         {
             configurator.Host(endpoint.SystemName, h =>
             {
-                h.Credentials(FallbackCredentialsFactory.GetCredentials());
+                h.Credentials(DefaultAWSCredentialsIdentityResolver.GetCredentials());
 
                 configure?.Invoke(h);
             });


### PR DESCRIPTION
We GA V4 of the AWS SDK for .NET: https://aws.amazon.com/blogs/developer/general-availability-of-aws-sdk-for-net-v4-0/

The PR updates the SDK dependencies to V4 and address any compilation and obsolete warnings triggered by the update. V4 does have a runtime behavior change where collection properties for types used to make requests like `MessageAttributes` on `Message` default to `null` unlike V3 which defaulted to empty string. I Looked through the usage of the SDK calls and added null checks.

I wasn't sure how I should run the tests locally. I see it uses Localstack which I'm not very familiar with. Hoping maybe a GitHub workflow will kick them off but otherwise are there steps I should follow to run the tests?