### PR TITLE
fix MemoryMessageBody.GetString

### DIFF
--- a/src/MassTransit/Serialization/MemoryMessageBody.cs
+++ b/src/MassTransit/Serialization/MemoryMessageBody.cs
@@ -2,6 +2,7 @@ namespace MassTransit.Serialization
 {
     using System;
     using System.IO;
+    using System.Runtime.InteropServices;
 
 
     public class MemoryMessageBody :
@@ -16,6 +17,11 @@ namespace MassTransit.Serialization
             _memory = memory;
         }
 
+        public MemoryMessageBody(in string base64String)
+        {
+            _memory = Convert.FromBase64String(base64String);
+        }
+
         public long? Length => _memory.Length;
 
         public Stream GetStream()
@@ -25,12 +31,14 @@ namespace MassTransit.Serialization
 
         public byte[] GetBytes()
         {
-            return _bytes ??= _memory.ToArray();
+            return _bytes ??= MemoryMarshal.TryGetArray(_memory, out ArraySegment<byte> bytes)
+                ? bytes.Array
+                : _memory.ToArray();
         }
 
         public string GetString()
         {
-            return _string ??= _memory.ToString();
+            return _string ??= Convert.ToBase64String(_memory.Span);
         }
     }
 }

--- a/src/MassTransit/Serialization/MemoryMessageBody.cs
+++ b/src/MassTransit/Serialization/MemoryMessageBody.cs
@@ -17,11 +17,6 @@ namespace MassTransit.Serialization
             _memory = memory;
         }
 
-        public MemoryMessageBody(in string base64String)
-        {
-            _memory = Convert.FromBase64String(base64String);
-        }
-
         public long? Length => _memory.Length;
 
         public Stream GetStream()


### PR DESCRIPTION
- Use base64 conversion in MemoryMessageBody.GetString so it can be used with OutboxMessage
- Optimize memory to array conversion if possible

I don't think it's used anywhere in the main codebase explaning why it hasn't been detected yet.  
But I encountered it by implementing my own serializer.