### PR TITLE
Updated documentation on configureError method in Error pipe

### DIFF
--- a/doc/content/3.documentation/1.concepts/4.exceptions.md
+++ b/doc/content/3.documentation/1.concepts/4.exceptions.md
@@ -343,7 +343,7 @@ cfg.ReceiveEndpoint("input-queue", ec =>
 });
 ```
 
-Beyond that built-in customization, the individual filters can be added/configured as well. Shown below are the default filters, as an example.
+Beyond that built-in customization, the individual filters can be added/configured as well. Shown below are the default filters, as an example. If you want to add custom filter on top of existing behaviour make sure to include default filters after your custom one.
 
 > This is by default, do _NOT_ configure this unless you have a reason to change the behavior.
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Updated documentation to explicitly tell that we need to include default filters in error pipe if we want to define custom filter on top of default behaviour.

Related to https://github.com/MassTransit/MassTransit/discussions/2945 and https://github.com/MassTransit/MassTransit/discussions/5352
