### PR TITLE
docs: improve config guidance and clarify documentation

### DIFF
--- a/doc/content/3.documentation/2.configuration/5.scheduling.md
+++ b/doc/content/3.documentation/2.configuration/5.scheduling.md
@@ -303,13 +303,10 @@ await scheduler.CancelScheduledRecurringMessage("PollExternalSystem", null);
 
 ## Quartz.NET
 
-To host Quartz.NET with MassTransit, configure Quartz and MassTransit as shown below.
+To host Quartz.NET with MassTransit, configure Quartz and MassTransit as shown below. For advanced scenarios (e.g. clustering, persistent store, serializer settings), refer to the [Quartz integration sample](https://github.com/MassTransit/Sample-Quartz/blob/master/src/QuartzService/Startup.cs).
 
 ```csharp
-services.AddQuartz(q =>
-{
-    q.UseMicrosoftDependencyInjectionJobFactory();
-});
+services.AddQuartz();
 ```
 
 ```csharp
@@ -326,6 +323,15 @@ services.AddMassTransit(x =>
         cfg.ConfigureEndpoints(context);
     });
 });
+```
+
+Add to appsettings.json
+```json
+"quartz": {
+  "serializer": {
+    "type": "Quartz.Simpl.JsonObjectSerializer, Quartz.Serialization.Json"
+  }
+}
 ```
 
 ## Hangfire

--- a/doc/content/3.documentation/3.patterns/13.job-consumers.md
+++ b/doc/content/3.documentation/3.patterns/13.job-consumers.md
@@ -492,7 +492,7 @@ public async Task RunJobNow(IPublishEndpoint publishEndpoint)
 }
 ```
 
-On the job has completed, the job next job run will be scheduled using the previously supplied cron expression.
+Once the job has completed, the job's next job run will be scheduled using the previously supplied cron expression.
 
 ## Job Saga Endpoints
 
@@ -559,7 +559,7 @@ A job attempt can be in one of the following states:
 
 ### Job Type Saga States
 
-A job type has only two valid states
+A job type can be in one of the following states:
 
 1. Initial
 2. Final
@@ -657,6 +657,3 @@ x.AddConsumer<ConvertVideoConsumer>(c =>
 
 The properties should be set using environmental information, such as machine type, data center location, or whatever makes sense for the desired strategy.
 `JobProperties` apply to the job type and `InstanceProperties` apply to the job consumer bus instance (the bus instance containing the job consumer).
-
-
-

--- a/doc/content/4.support/3.samples.md
+++ b/doc/content/4.support/3.samples.md
@@ -113,7 +113,7 @@ Clone the sample: [GitHub Repository](https://github.com/MassTransit/Sample-Shop
 
 ### Courier
 
-Courier is MassTransit's routing-slip implementation, which makes it possible to orchestrate distributed services into a business transaction. This sample demonstrates how to create and execute a routing slip, record routing slip events, and track transaction state using [Automatonymous](https://github.com/MassTransit/Automatonymous).
+Courier is MassTransit's routing slip implementation, which makes it possible to orchestrate distributed services into a business transaction. This sample demonstrates how to create and execute a routing slip, record routing slip events, and track transaction state using [Automatonymous](https://github.com/MassTransit/Automatonymous).
 
 This sample includes multiple console applications, which can be started simultaneously, to observe how the services interact.
 


### PR DESCRIPTION
This PR updates the MassTransit job consumer documentation for clarity and correctness:

- Fixed grammar in job scheduling section
- Standardized use of “routing slip” (removed unnecessary hyphen)
- Clarified job type saga state list to resolve contradiction in listed states
- Updated `AddQuartz()` usage by removing deprecated `UseMicrosoftDependencyInjectionJobFactory()`
- Added guidance around full Quartz configuration (clustering, serializer, etc.)
- Included required `quartz.serializer.type` appsettings example for persistent store scenarios

The minimal example is preserved for simplicity, with notes pointing to the full sample repo for advanced use cases.
