### PR TITLE
feat(rabbitmq-stream): add support for consumer reference name

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqStreamConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Configuration/IRabbitMqStreamConfigurator.cs
@@ -47,4 +47,10 @@ public interface IRabbitMqStreamConfigurator
     /// Begin consuming messages from the last message in the stream
     /// </summary>
     void FromLast();
+
+    /// <summary>
+    /// Consumer reference name.
+    /// Used to identify the consumer server side when storing the messages offset.
+    /// </summary>
+    string Reference { set; }
 }

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqStreamConfigurator.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqStreamConfigurator.cs
@@ -70,4 +70,9 @@ public class RabbitMqStreamConfigurator :
     {
         _settings.ConsumeArguments[Headers.XStreamOffset] = "last";
     }
+
+    public string Reference
+    {
+        set => _settings.ConsumeArguments["name"] = value;
+    }
 }


### PR DESCRIPTION
Introduced `Reference` property on `IRabbitMqStreamConfigurator` to allow specifying a consumer reference name used for server-side offset tracking. This value is applied to the "name" argument of the stream consumer.

## What I did to test
1. I made the code change to the MassTransit project
1. I ran this to get a new package
```sh
dotnet pack src/Transports/MassTransit.RabbitMqTransport/MassTransit.RabbitMqTransport.csproj -c Release -p:Version=8.0.1-nmummau
```
1. I created a local nuget feed at `C:\LocalFeed`, and copied over the `MassTransit.RabbitMQ.8.0.0-nmummau.nupkg` file to this directory
1.  I installed this pre-release package `MassTransit.RabbitMQ.8.0.0-nmummau` into a worker project that I'm building
1. I set the Reference in the StreamConfigurator
![image](https://github.com/user-attachments/assets/8e8044bc-4168-47d8-8f76-09b44db5678b)
1. At startup of my worker project, the consumer is created with the "name" consumer argument that is needed for offset tracking
![image](https://github.com/user-attachments/assets/0ebb3578-c8c4-424d-a9f2-84786f7918ce)

## Noteworthy
- I determined this was an option by inspecting how the RabbitMQ.Stream.Client creates stream consumers [here](https://github.com/rabbitmq/rabbitmq-stream-dotnet-client/blob/de1ecf5b5de1bad3f4349f8bf7a760e7891e6963/RabbitMQ.Stream.Client/RawConsumer.cs#L556). Specifically that client sets the "name" consumer property. MassTransit can do the same by specfying this as a ConsumeArgument.
- This is related to discussion #2788  