### PR TITLE
SendMessageBatchAsync has changed to return a null value for response.Failed

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SendBatcher.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SendBatcher.cs
@@ -40,8 +40,11 @@ namespace MassTransit.AmazonSqsTransport
 
             Complete(batch, response.Successful.Select(x => x.Id));
 
-            foreach (var error in response.Failed)
-                Fail(batch, error.Id, error.Code, error.Message);
+            if (response.Failed != null)
+            {
+                foreach (var error in response.Failed)
+                    Fail(batch, error.Id, error.Code, error.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
- Adds a check to prevent an exception accessing response.Failed when there are no failed messages

response.Failed is null, which generates an exception.
![image](https://github.com/user-attachments/assets/d2a1a776-92bb-4c56-8b93-37f69bf7b255)

The response was successful. 
![image](https://github.com/user-attachments/assets/1997907c-6adc-4286-8e24-f207c312397f)

I believe the problem was introduced by the update to a new version of the AWS libraries and that they've modified the behavior from returning response.Failed as an empty array to returning response.Failed as a null if all messages were sent successfully.


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
