### PR TITLE
Fix ActiveMQ connection string creation for failover

### DIFF
--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/AmqpHostSettings.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/AmqpHostSettings.cs
@@ -18,5 +18,7 @@ namespace MassTransit.ActiveMqTransport.Configuration
         public override string Scheme => HostScheme;
 
         public override string NmsScheme => "amqp";
+
+        public override string FailoverConnectionSettingPrefix => "failover.";
     }
 }

--- a/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/OpenWireHostSettings.cs
+++ b/src/Transports/MassTransit.ActiveMqTransport/ActiveMqTransport/Configuration/OpenWireHostSettings.cs
@@ -19,5 +19,7 @@ namespace MassTransit.ActiveMqTransport.Configuration
         public override string FailoverScheme => $"{NmsScheme}:failover";
 
         public override string Scheme => $"{NmsScheme}:{HostScheme}";
+
+        public override string FailoverConnectionSettingPrefix => "transport.";
     }
 }

--- a/tests/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
+++ b/tests/MassTransit.ActiveMqTransport.Tests/Configure_Specs.cs
@@ -122,10 +122,12 @@ namespace MassTransit.ActiveMqTransport.Tests
                 FailoverHosts = new[] { "failover1", "failover2" },
             };
             settings.TransportOptions.Add("reconnectAttempts", "-1");
+            settings.TransportOptions.Add("transport.maxReconnectAttempts", "5");
+            settings.TransportOptions.Add("transport.sendBufferSize", "10");
 
             Assert.That(settings.BrokerAddress,
                 Is.EqualTo(new Uri(
-                    "activemq:failover:(tcp://failover1:61616/?wireFormat.tightEncodingEnabled=true,tcp://failover2:61616/?wireFormat.tightEncodingEnabled=true)?transport.reconnectAttempts=-1")));
+                    "activemq:failover:(tcp://failover1:61616/?wireFormat.tightEncodingEnabled=true&transport.sendBufferSize=10,tcp://failover2:61616/?wireFormat.tightEncodingEnabled=true&transport.sendBufferSize=10)?transport.reconnectAttempts=-1&transport.maxReconnectAttempts=5")));
         }
 
         [Test]
@@ -137,9 +139,12 @@ namespace MassTransit.ActiveMqTransport.Tests
                 FailoverHosts = new[] { "failover1", "failover2" },
             };
             settings.TransportOptions.Add("reconnectAttempts", "-1");
+            settings.TransportOptions.Add("failover.maxReconnectAttempts", "5");
+            settings.TransportOptions.Add("transport.sendBufferSize", "10");
+            
 
             Assert.That(settings.BrokerAddress,
-                Is.EqualTo(new Uri("failover:(amqp://failover1:61616/?,amqp://failover2:61616/?)?transport.reconnectAttempts=-1")));
+                Is.EqualTo(new Uri("failover:(amqp://failover1:61616/?transport.sendBufferSize=10,amqp://failover2:61616/?transport.sendBufferSize=10)?failover.reconnectAttempts=-1&failover.maxReconnectAttempts=5")));
         }
 
         [Test]


### PR DESCRIPTION
This is fix for #6044 

The root of problem is in creating connection string for ActiveMQ. In AMQP settings for failover need prefix failover. In OpenWire it is transport. I also added condition to accept settings with prefix and put them to correct part of connection string.