### PR TITLE
fix(TransactionalOutbox): DisableInboxCleanupService ignored for Mongo

### DIFF
--- a/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbOutboxConfigurator.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbOutboxConfigurator.cs
@@ -55,15 +55,15 @@ namespace MassTransit.Configuration
             if(_enableInboxCleanupService)
             {
                 _configurator.AddHostedService<InboxCleanupService>();
+
+                _configurator.AddOptions<InboxCleanupServiceOptions>().Configure(options =>
+                {
+                    options.DuplicateDetectionWindow = DuplicateDetectionWindow;
+                    options.QueryMessageLimit = QueryMessageLimit;
+                    options.QueryDelay = QueryDelay;
+                    options.QueryTimeout = QueryTimeout;
+                });
             }
-            
-            _configurator.AddOptions<InboxCleanupServiceOptions>().Configure(options =>
-            {
-                options.DuplicateDetectionWindow = DuplicateDetectionWindow;
-                options.QueryMessageLimit = QueryMessageLimit;
-                options.QueryDelay = QueryDelay;
-                options.QueryTimeout = QueryTimeout;
-            });
 
             RegisterClassMaps();
 

--- a/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbOutboxConfigurator.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbOutboxConfigurator.cs
@@ -44,8 +44,6 @@ namespace MassTransit.Configuration
 
         public virtual void Configure(Action<IMongoDbOutboxConfigurator>? configure)
         {
-            configure?.Invoke(this);
-
             if (ProviderClientFactory == null)
                 throw new ConfigurationException("ClientFactory must be specified");
 
@@ -68,6 +66,8 @@ namespace MassTransit.Configuration
 
             _configurator.TryAddSingleton(ProviderClientFactory);
             _configurator.TryAddScoped<MongoDbContext, TransactionMongoDbContext>();
+
+            configure?.Invoke(this);
         }
 
         void RegisterCollectionFactory<T>()


### PR DESCRIPTION
- Calling IMongoDbOutboxConfigurator.DisableInboxCleanupService inside the configure callback is ignored

```cs
x.AddMongoDbOutbox(o =>
{
    o.QueryDelay = TimeSpan.FromSeconds(1);

    o.ClientFactory(provider => provider.GetRequiredService<IMongoClient>());
    o.DatabaseFactory(provider => provider.GetRequiredService<IMongoDatabase>());

    o.UseBusOutbox();

    // this call is ignored because it removes a service that isn't already added
    o.DisableInboxCleanupService();
});

// Workaround to remove the service manually
x.RemoveHostedService<InboxCleanupService>();
```

I implemented the same solution as found in [EntityFrameworkOutboxConfigurator.Configure](https://github.com/MassTransit/MassTransit/blob/2d7ad75ed68ba4f3db79fb433b5bf124d56a008f/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/Configuration/Configuration/EntityFrameworkOutboxConfigurator.cs#L77)