### PR TITLE
Improved clarity of warning on message loss

### DIFF
--- a/doc/content/3.documentation/2.configuration/2.transports/2.rabbitmq.md
+++ b/doc/content/3.documentation/2.configuration/2.transports/2.rabbitmq.md
@@ -90,7 +90,8 @@ With either address, RabbitMQ will route the message from the _order-events-list
 When a message is published, the message is sent to the _OrderSystem.Events:OrderSubmitted_ exchange. If the exchange does not exist, it will be created. RabbitMQ will route the message from the _OrderSystem.Events:OrderSubmitted_ exchange to the _order-events-listener_ exchange, and subsequently to the _order-events-listener_ queue. If other receive endpoints connected to the same virtual host include consumers that consume the _OrderSubmitted_ message, a copy of the message would be routed to each of those endpoints as well.
 
 ::alert{type="danger"}
-If a message is published before starting the bus, so that MassTransit can create the exchanges and queues, the exchange _OrderSystem.Events:OrderSubmitted_ will be created. However, until the bus has been started at least once, there won't be a queue bound to the exchange and any published messages will be lost. Once the bus has been started, the queue will remain bound to the exchange even when the bus is stopped.
+When an event is published, MassTransit creates the necessary exchange for it, such as _OrderSystem.Events:OrderSubmitted_. However, if the listener hasn't started the bus yet, there won't be a queue bound to that exchange, and any messages published will be lost.
+Once the listener starts the bus for the first time, it creates and binds the queue to the exchange. From that point on, even if the bus is stopped, the queue will remain bound to the exchange, ensuring that new messages are not lost.
 ::
 
 Durable exchanges and queues remain configured on the virtual host, so even if the bus is stopped messages will continue to be routed to the queue. When the bus is restarted, queued messages will be consumed.


### PR DESCRIPTION
The new text is less complex and distinguishes publishers and listeners.
