### PR TITLE
Fix deploy topology freeze

### DIFF
--- a/src/MassTransit/BusControlExtensions.cs
+++ b/src/MassTransit/BusControlExtensions.cs
@@ -91,7 +91,9 @@
             if (bus == null)
                 throw new ArgumentNullException(nameof(bus));
 
-            await bus.StartAsync(cancellationToken).ConfigureAwait(false);
+            var busHandle = await bus.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            await busHandle.Ready.ConfigureAwait(false);
 
             await bus.StopAsync(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
Fixed an issue when DeployAsync can cause to freeze because StopAsync called while bus is not ready after StartAsync call