### PR TITLE
Fix error queue naming convention in documentation

### DIFF
--- a/doc/content/3.documentation/1.concepts/4.exceptions.md
+++ b/doc/content/3.documentation/1.concepts/4.exceptions.md
@@ -17,7 +17,7 @@ public class SubmitOrderConsumer :
 }
 ```
 
-When a message is delivered to the consumer, the consumer throws an exception. With a default bus configuration, the exception is caught by middleware in the transport (the `ErrorTransportFilter` to be exact), and the message is moved to an _\_error_ queue (prefixed by the receive endpoint queue name). The exception details are stored as headers with the message for analysis and to assist in troubleshooting the exception.
+When a message is delivered to the consumer, the consumer throws an exception. With a default bus configuration, the exception is caught by middleware in the transport (the `ErrorTransportFilter` to be exact), and the message is moved to an _\_error_ queue (suffixed by the receive endpoint queue name). The exception details are stored as headers with the message for analysis and to assist in troubleshooting the exception.
 
 ::callout{type="info"}
 #summary


### PR DESCRIPTION
Corrected the description of the error queue naming convention.

**prefixed** -> **suffixed**
