### PR TITLE
fix: add prefix to instance name

### DIFF
--- a/src/MassTransit/Consumers/Configuration/InstanceEndpointDefinition.cs
+++ b/src/MassTransit/Consumers/Configuration/InstanceEndpointDefinition.cs
@@ -29,8 +29,9 @@ namespace MassTransit.Configuration
 
         public string GetEndpointName(IEndpointNameFormatter formatter)
         {
-            var sb = new StringBuilder(InstanceName.Length + 9);
+            var sb = new StringBuilder(InstanceName.Length + formatter.Prefix.Length + 9);
 
+            sb.Append(formatter.Prefix);
             sb.Append("Instance");
             sb.Append('_');
             sb.Append(InstanceName);

--- a/src/MassTransit/DependencyInjection/Configuration/JobServiceEndpointDefinition.cs
+++ b/src/MassTransit/DependencyInjection/Configuration/JobServiceEndpointDefinition.cs
@@ -38,8 +38,9 @@ namespace MassTransit.Configuration
 
         public string GetEndpointName(IEndpointNameFormatter formatter)
         {
-            var sb = new StringBuilder(InstanceName.Length + 9);
+            var sb = new StringBuilder(InstanceName.Length + formatter.Prefix.Length + 9);
 
+            sb.Append(formatter.Prefix);
             sb.Append("Instance");
             sb.Append('_');
             sb.Append(InstanceName);


### PR DESCRIPTION
At the moment, instances are created with the names: Instance_<id>, you are able to update the endpoint name formatter to kebab case for example to produce instance-<id>, however the prefix is not prepended, eg. prefix-instance-<id>.

This will now prepend the prefix name to the name of the instance and then format it to match the specified formatter