### PR TITLE
fix: add prefix to instance name

### DIFF
--- a/src/MassTransit/Configuration/DefaultEndpointNameFormatter.cs
+++ b/src/MassTransit/Configuration/DefaultEndpointNameFormatter.cs
@@ -132,7 +132,7 @@ namespace MassTransit
 
         public virtual string SanitizeName(string name)
         {
-            return name;
+            return string.IsNullOrWhiteSpace(Prefix) ? name : Prefix + name;
         }
 
         public static string GetTemporaryQueueName(string tag)
@@ -287,7 +287,7 @@ namespace MassTransit
                 ? string.Join(JoinSeparator ?? "", TypeCache.GetShortName(type).Split(_removeChars))
                 : type.Name;
 
-            return string.IsNullOrWhiteSpace(Prefix) ? name : Prefix + name;
+            return name;
         }
     }
 }

--- a/src/MassTransit/Configuration/SnakeCaseEndpointNameFormatter.cs
+++ b/src/MassTransit/Configuration/SnakeCaseEndpointNameFormatter.cs
@@ -80,7 +80,8 @@ namespace MassTransit
 
         public override string SanitizeName(string name)
         {
-            return _pattern.Replace(name, m => _separator + m.Value).ToLowerInvariant();
+            var sanitizedName = _pattern.Replace(name, m => _separator + m.Value).ToLowerInvariant();
+            return string.IsNullOrWhiteSpace(Prefix) ? sanitizedName : Prefix + sanitizedName;
         }
     }
 }

--- a/src/MassTransit/Consumers/Configuration/InstanceEndpointDefinition.cs
+++ b/src/MassTransit/Consumers/Configuration/InstanceEndpointDefinition.cs
@@ -29,9 +29,8 @@ namespace MassTransit.Configuration
 
         public string GetEndpointName(IEndpointNameFormatter formatter)
         {
-            var sb = new StringBuilder(InstanceName.Length + formatter.Prefix.Length + 9);
+            var sb = new StringBuilder(InstanceName.Length + 9);
 
-            sb.Append(formatter.Prefix);
             sb.Append("Instance");
             sb.Append('_');
             sb.Append(InstanceName);


### PR DESCRIPTION
At the moment, instances are created with the names: Instance_, you are able to update the endpoint name formatter to kebab case for example to produce instance-, however the prefix is not prepended, eg. prefix-instance-.

This will now prepend the prefix name to the name of the instance and then format it to match the specified formatter