### PR TITLE
Bump Apache.NMS.AMQP to 2.4.0 to address CVE-2025-54539

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.1" />
-    <PackageVersion Include="Apache.NMS.AMQP" Version="2.2.0" />
+    <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.2.0" />
+    <PackageVersion Include="Apache.NMS.AMQP" Version="2.4.0" />
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.6.3" />
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.1.3" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.7.4" />


### PR DESCRIPTION
Bumping Apache.NMS.AMQP package from 2.2.0 -> 2.4.0 to address [CVE-2025-54539](https://nvd.nist.gov/vuln/detail/CVE-2025-54539).

The 2.3.0 and 2.4.0 releases contain the following changes:

* [2.3.0](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311201&version=12355896)
* [2.4.0](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311201&version=12356027)

[git diff between 2.2.0 and 2.4.0](https://github.com/apache/activemq-nms-amqp/compare/4f3b0dacab358c9cba5decea1ac2add17063c76b...f2cff6b2edf17fa73f55c06092ee63a7eeadf569)
