### PR TITLE
docs: fix multibus advanced type declaration

### DIFF
--- a/doc/content/3.documentation/2.configuration/multibus.md
+++ b/doc/content/3.documentation/2.configuration/multibus.md
@@ -150,7 +150,7 @@ public interface ISomeService
 ```
 
 ```csharp
-services.AddMassTransit<IThirdBus>(x =>
+services.AddMassTransit<IThirdBus, ThirdBus>(x =>
 {
     x.UsingRabbitMq((context, cfg) =>
     {


### PR DESCRIPTION
Adds a simple fix to the docs to show how a concrete instance of `IBus` can be configured.