### PR TITLE
feat: Add configurable visibility timeout renewal

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsReceiveLockContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsReceiveLockContext.cs
@@ -121,7 +121,7 @@ public class AmazonSqsReceiveLockContext :
 
         var delay = CalculateDelay(visibilityTimeout);
 
-        visibilityTimeout = Math.Min(_settings.VisibilityTimeoutExtension, visibilityTimeout);
+        visibilityTimeout = Math.Min(_settings.MaxVisibilityTimeoutRenewal, visibilityTimeout);
 
         while (_locked && !_activeTokenSource.IsCancellationRequested)
         {

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
@@ -107,11 +107,11 @@ public class AmazonSqsReceiveEndpointConfiguration :
         if (_settings.MaxVisibilityTimeout < visibilityTimeout)
             yield return this.Failure("MaxVisibilityTimeout", "Must be greater than or equal to VisibilityTimeout");
         
-        if (_settings.VisibilityTimeoutExtension < 0)
-            yield return this.Failure("VisibilityTimeoutExtension", "must be >= 0 (values less than 60 will be set to 60)");
+        if (_settings.MaxVisibilityTimeoutRenewal < 0)
+            yield return this.Failure("MaxVisibilityTimeoutRenewal", "must be >= 0 (values less than 60 will be set to 60)");
 
-        if (_settings.VisibilityTimeoutExtension > 43200)
-            yield return this.Failure("VisibilityTimeoutExtension", "must be <= 43200 seconds (12 hours per AWS SQS limits)");
+        if (_settings.MaxVisibilityTimeoutRenewal > 43200)
+            yield return this.Failure("MaxVisibilityTimeoutRenewal", "must be <= 43200 seconds (12 hours per AWS SQS limits)");
 
         foreach (var result in base.Validate())
             yield return result.WithParentKey(queueName);
@@ -174,9 +174,9 @@ public class AmazonSqsReceiveEndpointConfiguration :
         set => _settings.MaxVisibilityTimeout = value > MaxAllowedVisibilityTimeout ? MaxAllowedVisibilityTimeout : value;
     }
 
-    public int VisibilityTimeoutExtension
+    public int MaxVisibilityTimeoutRenewal
     {
-        set => _settings.VisibilityTimeoutExtension = value < 60 ? 60 : value;
+        set => _settings.MaxVisibilityTimeoutRenewal = value < 60 ? 60 : value;
     }
 
     public void Subscribe<T>(Action<IAmazonSqsTopicSubscriptionConfigurator>? configure = null)

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/ReceiveSettings.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/ReceiveSettings.cs
@@ -56,7 +56,7 @@ public interface ReceiveSettings :
     /// Must be at least 60 seconds per AWS SQS API constraints.
     /// See <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html">ChangeMessageVisibility</see>.
     /// </summary>
-    int VisibilityTimeoutExtension { get; set; }
+    int MaxVisibilityTimeoutRenewal { get; set; }
 
     string? QueueUrl { get; set; }
 

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/QueueReceiveSettings.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/QueueReceiveSettings.cs
@@ -19,7 +19,7 @@ public class QueueReceiveSettings :
         VisibilityTimeout = 30;
         RedeliverVisibilityTimeout = 1;
         MaxVisibilityTimeout = TimeSpan.FromHours(12);
-        VisibilityTimeoutExtension = 60;
+        MaxVisibilityTimeoutRenewal = 60;
 
         ConcurrentDeliveryLimit = 1;
 
@@ -44,7 +44,7 @@ public class QueueReceiveSettings :
 
     public TimeSpan MaxVisibilityTimeout { get; set; }
 
-    public int VisibilityTimeoutExtension { get; set; }
+    public int MaxVisibilityTimeoutRenewal { get; set; }
 
     public string? QueueUrl { get; set; }
 

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsReceiveEndpointConfigurator.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/IAmazonSqsReceiveEndpointConfigurator.cs
@@ -38,7 +38,7 @@ public interface IAmazonSqsReceiveEndpointConfigurator :
     /// Defaults to 60 seconds.
     /// See <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html">ChangeMessageVisibility</see>.
     /// </summary>
-    int VisibilityTimeoutExtension { set; }
+    int MaxVisibilityTimeoutRenewal { set; }
 
     /// <summary>
     /// Bind an existing exchange for the message type to the receive endpoint by name


### PR DESCRIPTION
Made the visibility timeout extension configurable for Amazon SQS instead of the default 60 seconds. As there are use cases where in case of background task the compute is known to take more than 2 hours. In such cases if we use the default 60 seconds of extension when the default timeout of a message is set to 1 hour, 133 extra SQS api calls to complete this message operation, this can cause a significant AWS cost for message operations.

Having the capability to configure this make is more flexible.

I have tested this in my usecase, where the default timeout of the message is set to 1 hour and the message in average was taking nearly 2 hours to complete. After using this property to extend the visibility timeout for the message, I can see a significant reduction of the AWS SQS cost( used day to day comparison)

Points considered:
- If the value for the extension is set to a value less than 60, its better to have it set to 60
-  Considered the boundary values allowed by Amazon SQS