### PR TITLE
Handle RabbitMQ auth failures as transient errors

### DIFF
--- a/src/Transports/MassTransit.RabbitMqTransport/Exceptions/RabbitMqConnectionException.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/Exceptions/RabbitMqConnectionException.cs
@@ -37,7 +37,7 @@
             {
                 BrokerUnreachableException bue => bue.InnerException switch
                 {
-                    AuthenticationFailureException _ => false,
+                    AuthenticationFailureException _ => true,
                     _ => true
                 },
                 _ => true

--- a/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqHostConfiguration.cs
+++ b/src/Transports/MassTransit.RabbitMqTransport/RabbitMqTransport/Configuration/RabbitMqHostConfiguration.cs
@@ -44,8 +44,6 @@ namespace MassTransit.RabbitMqTransport.Configuration
                 x.Handle<OperationInterruptedException>(exception => exception.ChannelShouldBeClosed());
                 x.Handle<NotSupportedException>(exception => exception.Message.Contains("Pipelining of requests forbidden"));
 
-                x.Ignore<AuthenticationFailureException>();
-
                 x.Exponential(1000, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(3));
             });
 

--- a/tests/MassTransit.RabbitMqTransport.Tests/ReconnectBug_Specs.cs
+++ b/tests/MassTransit.RabbitMqTransport.Tests/ReconnectBug_Specs.cs
@@ -1,0 +1,46 @@
+namespace MassTransit.RabbitMqTransport.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using MassTransit.Internals;
+    using RabbitMQ.Client;
+    using TestFramework.Messages;
+
+    [TestFixture]
+    public class ReconnectBug_Specs :
+        RabbitMqTestFixture
+    {
+        [Test]
+        public async Task Should_refresh_credentials_and_reconnect()
+        {
+            var refreshed = new TaskCompletionSource<bool>();
+
+            _refreshCallback = factory =>
+            {
+                factory.Password = "guest";
+                refreshed.TrySetResult(true);
+                return Task.CompletedTask;
+            };
+
+            await Bus.Publish(new PingMessage());
+
+            await Task.Delay(500);
+
+            await BusControl.StopAsync(TestCancellationToken);
+
+            await BusControl.StartAsync(TestCancellationToken);
+
+            Assert.That(await refreshed.Task.OrTimeout(5000), Is.True, "Refresh callback called");
+        }
+
+        Func<ConnectionFactory, Task> _refreshCallback;
+
+        protected override void ConfigureRabbitMqHost(IRabbitMqHostConfigurator configurator)
+        {
+            configurator.OnRefreshConnectionFactory = factory => _refreshCallback?.Invoke(factory) ?? Task.CompletedTask;
+
+            base.ConfigureRabbitMqHost(configurator);
+        }
+    }
+}


### PR DESCRIPTION
AuthenticationFailureException is now treated as a transient error, allowing connection retries when authentication fails. Removed the ignore rule for this exception in host configuration. Added a test to verify that credentials can be refreshed and the bus will reconnect after an authentication failure.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
