### PR TITLE
Add MongoDB driver handshake metadata (`LibraryInfo`)

### DIFF
--- a/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbConfigurator.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbConfigurator.cs
@@ -36,7 +36,7 @@ namespace MassTransit.Configuration
 
                 ClientFactory(_ =>
                 {
-                    var mongoClient = new MongoClient(mongoUrl);
+                    var mongoClient = MongoDbLibraryInfo.CreateClient(mongoUrl);
 
                     return mongoClient;
                 });

--- a/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbConfigurator.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/Configuration/Configuration/MongoDbConfigurator.cs
@@ -36,7 +36,7 @@ namespace MassTransit.Configuration
 
                 ClientFactory(_ =>
                 {
-                    var mongoClient = MongoDbLibraryInfo.CreateClient(mongoUrl);
+                    var mongoClient = new MongoClient(MongoClientSettings.FromUrl(mongoUrl).WithMassTransitLibraryInfo());
 
                     return mongoClient;
                 });

--- a/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="MassTransit.MongoDbIntegration.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MassTransit.MongoDbIntegration.csproj
@@ -25,8 +25,4 @@
     <ProjectReference Include="..\..\MassTransit\MassTransit.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="MassTransit.MongoDbIntegration.Tests" />
-  </ItemGroup>
-
 </Project>

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Audit/MongoDbAuditStore.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Audit/MongoDbAuditStore.cs
@@ -39,7 +39,7 @@ namespace MassTransit.MongoDbIntegration.Audit
         }
 
         public MongoDbAuditStore(string connectionString, string database, string collectionName)
-            : this(new MongoClient(connectionString).GetDatabase(database), collectionName)
+            : this(MongoDbLibraryInfo.CreateClient(connectionString).GetDatabase(database), collectionName)
         {
         }
 

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Audit/MongoDbAuditStore.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Audit/MongoDbAuditStore.cs
@@ -39,7 +39,7 @@ namespace MassTransit.MongoDbIntegration.Audit
         }
 
         public MongoDbAuditStore(string connectionString, string database, string collectionName)
-            : this(MongoDbLibraryInfo.CreateClient(connectionString).GetDatabase(database), collectionName)
+            : this(new MongoClient(MongoClientSettings.FromConnectionString(connectionString).WithMassTransitLibraryInfo()).GetDatabase(database), collectionName)
         {
         }
 

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/MessageData/MongoDbMessageDataRepository.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/MessageData/MongoDbMessageDataRepository.cs
@@ -17,7 +17,7 @@
         readonly IMessageDataResolver _resolver;
 
         public MongoDbMessageDataRepository(string connectionString, string database)
-            : this(new MessageDataResolver(), new GridFSBucket(new MongoClient(connectionString).GetDatabase(database)), new NewIdFileNameGenerator())
+            : this(new MessageDataResolver(), new GridFSBucket(MongoDbLibraryInfo.CreateClient(connectionString).GetDatabase(database)), new NewIdFileNameGenerator())
         {
         }
 

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/MessageData/MongoDbMessageDataRepository.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/MessageData/MongoDbMessageDataRepository.cs
@@ -17,7 +17,7 @@
         readonly IMessageDataResolver _resolver;
 
         public MongoDbMessageDataRepository(string connectionString, string database)
-            : this(new MessageDataResolver(), new GridFSBucket(MongoDbLibraryInfo.CreateClient(connectionString).GetDatabase(database)), new NewIdFileNameGenerator())
+            : this(new MessageDataResolver(), new GridFSBucket(new MongoClient(MongoClientSettings.FromConnectionString(connectionString).WithMassTransitLibraryInfo()).GetDatabase(database)), new NewIdFileNameGenerator())
         {
         }
 

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Saga/MongoDbSagaRepository.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Saga/MongoDbSagaRepository.cs
@@ -15,7 +15,7 @@ namespace MassTransit.MongoDbIntegration.Saga
 
         public static ISagaRepository<TSaga> Create(string connectionString, string database, string? collectionName = null)
         {
-            var mongoDatabase = new MongoClient(connectionString).GetDatabase(database);
+            var mongoDatabase = MongoDbLibraryInfo.CreateClient(connectionString).GetDatabase(database);
 
             return Create(mongoDatabase, collectionName);
         }

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Saga/MongoDbSagaRepository.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/Saga/MongoDbSagaRepository.cs
@@ -15,7 +15,7 @@ namespace MassTransit.MongoDbIntegration.Saga
 
         public static ISagaRepository<TSaga> Create(string connectionString, string database, string? collectionName = null)
         {
-            var mongoDatabase = MongoDbLibraryInfo.CreateClient(connectionString).GetDatabase(database);
+            var mongoDatabase = new MongoClient(MongoClientSettings.FromConnectionString(connectionString).WithMassTransitLibraryInfo()).GetDatabase(database);
 
             return Create(mongoDatabase, collectionName);
         }

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbLibraryInfo.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbLibraryInfo.cs
@@ -1,0 +1,28 @@
+namespace MassTransit.MongoDbIntegration
+{
+    using MongoDB.Driver;
+    using MongoDB.Driver.Core.Configuration;
+
+
+    static class MongoDbLibraryInfo
+    {
+        static readonly string _version =
+            typeof(MongoDbLibraryInfo).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+        static readonly LibraryInfo _libraryInfo = new LibraryInfo("MassTransit", _version);
+
+        internal static MongoClient CreateClient(string connectionString)
+        {
+            var settings = MongoClientSettings.FromConnectionString(connectionString);
+            settings.LibraryInfo = _libraryInfo;
+            return new MongoClient(settings);
+        }
+
+        internal static MongoClient CreateClient(MongoUrl mongoUrl)
+        {
+            var settings = MongoClientSettings.FromUrl(mongoUrl);
+            settings.LibraryInfo = _libraryInfo;
+            return new MongoClient(settings);
+        }
+    }
+}

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbLibraryInfo.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbLibraryInfo.cs
@@ -4,25 +4,17 @@ namespace MassTransit.MongoDbIntegration
     using MongoDB.Driver.Core.Configuration;
 
 
-    static class MongoDbLibraryInfo
+    public static class MongoClientSettingsExtensions
     {
         static readonly string _version =
-            typeof(MongoDbLibraryInfo).Assembly.GetName().Version?.ToString() ?? "unknown";
+            typeof(MongoClientSettingsExtensions).Assembly.GetName().Version?.ToString() ?? "unknown";
 
         static readonly LibraryInfo _libraryInfo = new LibraryInfo("MassTransit", _version);
 
-        internal static MongoClient CreateClient(string connectionString)
+        public static MongoClientSettings WithMassTransitLibraryInfo(this MongoClientSettings settings)
         {
-            var settings = MongoClientSettings.FromConnectionString(connectionString);
             settings.LibraryInfo = _libraryInfo;
-            return new MongoClient(settings);
-        }
-
-        internal static MongoClient CreateClient(MongoUrl mongoUrl)
-        {
-            var settings = MongoClientSettings.FromUrl(mongoUrl);
-            settings.LibraryInfo = _libraryInfo;
-            return new MongoClient(settings);
+            return settings;
         }
     }
 }

--- a/tests/MassTransit.MongoDbIntegration.Tests/MongoDbLibraryInfo_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/MongoDbLibraryInfo_Specs.cs
@@ -5,24 +5,34 @@ namespace MassTransit.MongoDbIntegration.Tests
 
 
     [TestFixture]
-    public class MongoDbLibraryInfo_Specs
+    public class MongoClientSettingsExtensions_Specs
     {
         [Test]
-        public void Should_set_library_info_on_connection_string_client()
+        public void Should_set_library_info_from_connection_string()
         {
-            var client = MongoDbLibraryInfo.CreateClient("mongodb://127.0.0.1");
-            Assert.That(client.Settings.LibraryInfo, Is.Not.Null);
-            Assert.That(client.Settings.LibraryInfo.Name, Is.EqualTo("MassTransit"));
-            Assert.That(client.Settings.LibraryInfo.Version, Is.Not.Null.And.Not.Empty);
+            var settings = MongoClientSettings.FromConnectionString("mongodb://127.0.0.1")
+                .WithMassTransitLibraryInfo();
+            Assert.That(settings.LibraryInfo, Is.Not.Null);
+            Assert.That(settings.LibraryInfo.Name, Is.EqualTo("MassTransit"));
+            Assert.That(settings.LibraryInfo.Version, Is.Not.Null.And.Not.Empty);
         }
 
         [Test]
-        public void Should_set_library_info_on_mongo_url_client()
+        public void Should_set_library_info_from_mongo_url()
         {
-            var client = MongoDbLibraryInfo.CreateClient(new MongoUrl("mongodb://127.0.0.1"));
-            Assert.That(client.Settings.LibraryInfo, Is.Not.Null);
-            Assert.That(client.Settings.LibraryInfo.Name, Is.EqualTo("MassTransit"));
-            Assert.That(client.Settings.LibraryInfo.Version, Is.Not.Null.And.Not.Empty);
+            var settings = MongoClientSettings.FromUrl(new MongoUrl("mongodb://127.0.0.1"))
+                .WithMassTransitLibraryInfo();
+            Assert.That(settings.LibraryInfo, Is.Not.Null);
+            Assert.That(settings.LibraryInfo.Name, Is.EqualTo("MassTransit"));
+            Assert.That(settings.LibraryInfo.Version, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public void Should_return_same_settings_instance()
+        {
+            var settings = MongoClientSettings.FromConnectionString("mongodb://127.0.0.1");
+            var result = settings.WithMassTransitLibraryInfo();
+            Assert.That(result, Is.SameAs(settings));
         }
     }
 }

--- a/tests/MassTransit.MongoDbIntegration.Tests/MongoDbLibraryInfo_Specs.cs
+++ b/tests/MassTransit.MongoDbIntegration.Tests/MongoDbLibraryInfo_Specs.cs
@@ -1,0 +1,28 @@
+namespace MassTransit.MongoDbIntegration.Tests
+{
+    using MongoDB.Driver;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    public class MongoDbLibraryInfo_Specs
+    {
+        [Test]
+        public void Should_set_library_info_on_connection_string_client()
+        {
+            var client = MongoDbLibraryInfo.CreateClient("mongodb://127.0.0.1");
+            Assert.That(client.Settings.LibraryInfo, Is.Not.Null);
+            Assert.That(client.Settings.LibraryInfo.Name, Is.EqualTo("MassTransit"));
+            Assert.That(client.Settings.LibraryInfo.Version, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public void Should_set_library_info_on_mongo_url_client()
+        {
+            var client = MongoDbLibraryInfo.CreateClient(new MongoUrl("mongodb://127.0.0.1"));
+            Assert.That(client.Settings.LibraryInfo, Is.Not.Null);
+            Assert.That(client.Settings.LibraryInfo.Name, Is.EqualTo("MassTransit"));
+            Assert.That(client.Settings.LibraryInfo.Version, Is.Not.Null.And.Not.Empty);
+        }
+    }
+}


### PR DESCRIPTION
Incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification by setting `MongoClientSettings.LibraryInfo` on every `MongoClient` constructed by MassTransit, so MongoDB server-side telemetry can attribute traffic to MassTransit rather than showing it as a generic driver connection. 

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2024-01-27T23:10:40.108Z"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn16235","msg":"client                                                                                                    
  metadata","attr":{"remote":"127.0.0.1:1094","client":"conn16235","doc":{"driver":{"name":"mongo-csharp-driver|MassTransit","version":"3.7.1|8.5.9"},"platform":".NET                                          
  9.0","os":{"name":"linux","architecture":"x64","version":"5.15.133+","type":"Linux"}}}}   

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.

**Changes**

- Added `MongoDbLibraryInfo` (internal helper) that builds a `LibraryInfo("MassTransit", <assembly-version>)` and exposes two `CreateClient` factory methods — one for connection strings, one for `MongoUrl`.
- Updated the four call sites that construct `MongoClient` directly (`MongoDbAuditStore`, `MongoDbSagaRepository`, `MongoDbMessageDataRepository`, `MongoDbConfigurator`) to go through the helper.

**Verification**

Added two unit tests in `MongoDbLibraryInfo_Specs` that assert `client.Settings.LibraryInfo` is non-null, named `"MassTransit"`, and carries the assembly version. No live MongoDB instance required.

To verify end-to-end, connect to a MongoDB Atlas cluster with [MongoDB Compass](https://www.mongodb.com/products/tools/compass) or check the `currentOp` / `$currentOp` output — the `client.driver.name` field in the handshake will include `"MassTransit"`.