### PR TITLE
Fix BusOutboxDeliveryService infinite retry loop on send fault

### DIFF
--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/BusOutboxDeliveryService.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/BusOutboxDeliveryService.cs
@@ -172,11 +172,14 @@ namespace MassTransit.EntityFrameworkCoreIntegration
                         ? await executionStrategy.ExecuteAsync(() => Execute()).ConfigureAwait(false)
                         : await Execute().ConfigureAwait(false);
 
-                    if (executeResult < 0)
+                    // executeResult < 0: no outbox found (nothing to do)
+                    // executeResult == 0: outbox locked but no messages delivered (likely send fault or poison message).
+                    //   Break so the outer loop falls through to WaitForDelivery(QueryDelay), rather than re-locking
+                    //   the same outbox immediately and spinning on the same poison message.
+                    if (executeResult <= 0)
                         break;
 
-                    if (executeResult > 0)
-                        messageCount += executeResult;
+                    messageCount += executeResult;
                 }
 
                 return messageCount;
@@ -275,6 +278,17 @@ namespace MassTransit.EntityFrameworkCoreIntegration
                         sentSequenceNumber = message.SequenceNumber;
 
                         LogContext.Debug?.Log("Outbox Sent: {OutboxId} {SequenceNumber} {MessageId}", message.OutboxId, sentSequenceNumber, message.MessageId);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        LogContext.Warning?.Log(ex,
+                            "Outbox Send Timeout after {Timeout}: {OutboxId} {SequenceNumber} {MessageId}",
+                            _options.MessageDeliveryTimeout, message.OutboxId, message.SequenceNumber, message.MessageId);
+                        break;
                     }
                     catch (Exception ex)
                     {

--- a/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/BusOutboxDeliveryService.cs
+++ b/src/Persistence/MassTransit.EntityFrameworkCoreIntegration/EntityFrameworkCoreIntegration/BusOutboxDeliveryService.cs
@@ -139,7 +139,9 @@ namespace MassTransit.EntityFrameworkCoreIntegration
                         {
                             await RemoveOutbox(dbContext, outboxState, cancellationToken).ConfigureAwait(false);
 
-                            continueProcessing = 0;
+                            // cleanup counts as progress so the outer loop keeps draining delivered outboxes
+                            // without falling through to WaitForDelivery; distinct from a zero-progress send fault.
+                            continueProcessing = 1;
                         }
                         else
                             continueProcessing = await DeliverOutboxMessages(dbContext, outboxState, cancellationToken).ConfigureAwait(false);
@@ -173,9 +175,10 @@ namespace MassTransit.EntityFrameworkCoreIntegration
                         : await Execute().ConfigureAwait(false);
 
                     // executeResult < 0: no outbox found (nothing to do)
-                    // executeResult == 0: outbox locked but no messages delivered (likely send fault or poison message).
-                    //   Break so the outer loop falls through to WaitForDelivery(QueryDelay), rather than re-locking
-                    //   the same outbox immediately and spinning on the same poison message.
+                    // executeResult == 0: pending outbox locked but no messages delivered (send fault or poison
+                    //   message). Break so the outer loop falls through to WaitForDelivery(QueryDelay), rather than
+                    //   re-locking the same outbox immediately and spinning on the same poison message.
+                    // executeResult > 0: progress (messages delivered, or delivered-outbox cleanup). Continue.
                     if (executeResult <= 0)
                         break;
 

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/BusOutboxDeliveryService.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/BusOutboxDeliveryService.cs
@@ -274,6 +274,17 @@ namespace MassTransit.MongoDbIntegration
 
                         LogContext.Debug?.Log("Outbox Sent: {OutboxId} {SequenceNumber} {MessageId}", message.OutboxId, sentSequenceNumber, message.MessageId);
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        LogContext.Warning?.Log(ex,
+                            "Outbox Send Timeout after {Timeout}: {OutboxId} {SequenceNumber} {MessageId}",
+                            _options.MessageDeliveryTimeout, message.OutboxId, message.SequenceNumber, message.MessageId);
+                        break;
+                    }
                     catch (Exception ex)
                     {
                         LogContext.Warning?.Log(ex, "Outbox Send Fault: {OutboxId} {SequenceNumber} {MessageId}", message.OutboxId, message.SequenceNumber,
@@ -299,7 +310,7 @@ namespace MassTransit.MongoDbIntegration
                 LogContext.Debug?.Log("Outbox Delivered: {OutboxId} {Delivered}", outboxState.OutboxId, outboxState.Delivered);
             }
 
-            return true;
+            return sentSequenceNumber > 0;
         }
 
         static async Task AbortTransaction(MongoDbContext dbContext)

--- a/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/BusOutboxDeliveryService.cs
+++ b/src/Persistence/MassTransit.MongoDbIntegration/MongoDbIntegration/BusOutboxDeliveryService.cs
@@ -66,9 +66,12 @@ namespace MassTransit.MongoDbIntegration
         {
             List<Guid> outboxIds = (await GetOutboxes(_options.QueryMessageLimit, cancellationToken).ConfigureAwait(false)).ToList();
 
-            await Task.WhenAll(outboxIds.Select(outboxId => DeliverOutbox(outboxId, cancellationToken))).ConfigureAwait(false);
+            // Count outboxes that actually made progress (messages sent or delivered-cleanup).
+            // Returning outboxIds.Count would treat a poison outbox as "work done" and keep the outer loop
+            // re-entering without honoring WaitForDelivery(QueryDelay).
+            bool[] results = await Task.WhenAll(outboxIds.Select(outboxId => DeliverOutbox(outboxId, cancellationToken))).ConfigureAwait(false);
 
-            return outboxIds.Count;
+            return results.Count(r => r);
         }
 
         async Task<IEnumerable<Guid>> GetOutboxes(int resultLimit, CancellationToken cancellationToken)
@@ -98,7 +101,7 @@ namespace MassTransit.MongoDbIntegration
             }
         }
 
-        async Task DeliverOutbox(Guid outboxId, CancellationToken cancellationToken)
+        async Task<bool> DeliverOutbox(Guid outboxId, CancellationToken cancellationToken)
         {
             var scope = _provider.CreateAsyncScope();
 
@@ -109,6 +112,8 @@ namespace MassTransit.MongoDbIntegration
 
             FilterDefinitionBuilder<OutboxState> builder = Builders<OutboxState>.Filter;
             FilterDefinition<OutboxState> filter = builder.Eq(x => x.OutboxId, outboxId);
+
+            var madeProgress = false;
 
             try
             {
@@ -144,11 +149,17 @@ namespace MassTransit.MongoDbIntegration
                             {
                                 await RemoveOutbox(messageCollection, stateCollection, outboxState, cancellationToken).ConfigureAwait(false);
 
+                                // cleanup counts as progress so ProcessOutboxes doesn't treat this sweep as idle
+                                madeProgress = true;
                                 continueProcessing = false;
                             }
                             else
                             {
                                 continueProcessing = await DeliverOutboxMessages(messageCollection, outboxState, cancellationToken).ConfigureAwait(false);
+
+                                // continueProcessing reflects sentSequenceNumber > 0 so it doubles as a progress signal
+                                if (continueProcessing)
+                                    madeProgress = true;
 
                                 outboxState.Version++;
 
@@ -194,6 +205,8 @@ namespace MassTransit.MongoDbIntegration
             {
                 await scope.DisposeAsync().ConfigureAwait(false);
             }
+
+            return madeProgress;
         }
 
         static async Task RemoveOutbox(MongoDbCollectionContext<OutboxMessage> messageCollection, MongoDbCollectionContext<OutboxState> stateCollection,

--- a/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/BusOutbox_Specs.cs
+++ b/tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/BusOutbox_Specs.cs
@@ -340,6 +340,76 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
         }
 
         [Test]
+        public async Task Should_not_spin_when_send_repeatedly_fails()
+        {
+            // Regression test for https://github.com/MassTransit/MassTransit/discussions/5768
+            // Before the fix, a send that always threw caused DeliverOutbox to spin at maximum speed:
+            // the inner while-loop had no exit path for executeResult == 0, so the worker re-locked the
+            // same outbox and retried the same poison message until process restart. After the fix the
+            // worker breaks out of the inner loop on zero-progress and backs off via WaitForDelivery(QueryDelay).
+            var failingFilter = new FailingSendFilter();
+
+            await using var provider = new ServiceCollection()
+                .AddBusOutboxServices()
+                .AddTelemetryListener()
+                .AddMassTransitTestHarness(x =>
+                {
+                    x.SetTestTimeouts(testInactivityTimeout: TimeSpan.FromSeconds(10));
+
+                    x.AddEntityFrameworkOutbox<ReliableDbContext>(o =>
+                    {
+                        o.QueryDelay = TimeSpan.FromMilliseconds(500);
+
+                        o.UseBusOutbox(bo =>
+                        {
+                            bo.MessageDeliveryLimit = 10;
+                        });
+                    });
+
+                    x.AddConsumer<PingConsumer>();
+
+                    x.UsingInMemory((context, cfg) =>
+                    {
+                        cfg.ConfigureSend(s => s.UseFilter(failingFilter));
+                        cfg.ConfigureEndpoints(context);
+                    });
+                })
+                .BuildServiceProvider(true);
+
+            var harness = provider.GetTestHarness();
+            await harness.Start();
+
+            try
+            {
+                {
+                    await using var dbContext = harness.Scope.ServiceProvider.GetRequiredService<ReliableDbContext>();
+
+                    var publishEndpoint = harness.Scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
+
+                    await publishEndpoint.Publish(new PingMessage());
+
+                    await dbContext.SaveChangesAsync(harness.CancellationToken);
+                }
+
+                // Two seconds of wall clock: with the fix the worker wakes at most once per QueryDelay (500ms)
+                // plus startup, so the filter should be invoked on the order of 4-6 times. Without the fix,
+                // the inner DeliverOutbox while-loop spins as fast as the DB can service transactions and
+                // produces dozens-to-hundreds of attempts in the same window.
+                await Task.Delay(TimeSpan.FromSeconds(2), harness.CancellationToken);
+
+                var attempts = failingFilter.AttemptCount;
+
+                Assert.That(attempts, Is.GreaterThan(0), "The outbox delivery service never attempted to send");
+                Assert.That(attempts, Is.LessThan(30),
+                    $"BusOutboxDeliveryService attempted send {attempts} times in 2s — indicates infinite retry loop (see discussion #5768)");
+            }
+            finally
+            {
+                await harness.Stop();
+            }
+        }
+
+        [Test]
         [Explicit]
         public async Task Fill_up_the_outbox()
         {
@@ -539,6 +609,25 @@ namespace MassTransit.EntityFrameworkCoreIntegration.Tests.ReliableMessaging
             public Task Consume(ConsumeContext<PingMessage> context)
             {
                 return Task.CompletedTask;
+            }
+        }
+
+
+        class FailingSendFilter :
+            IFilter<SendContext>
+        {
+            int _count;
+
+            public int AttemptCount => Volatile.Read(ref _count);
+
+            public Task Send(SendContext context, IPipe<SendContext> next)
+            {
+                Interlocked.Increment(ref _count);
+                throw new InvalidOperationException("Simulated send failure for BusOutboxDeliveryService regression test");
+            }
+
+            public void Probe(ProbeContext context)
+            {
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes an infinite retry loop in the persistent bus outbox (`BusOutboxDeliveryService`) where a single un-sendable message pins the background worker at 100% CPU and prevents every other outbox from shipping — until the host process is restarted. Affects both the EF Core and MongoDB persistence implementations; both are fixed here.

## Related community reports

These threads describe symptoms of the same underlying bug (log spam from `"Outbox Send Fault"` / `TaskCanceledException`, messages permanently stuck in the `OutboxMessage` table, CPU burn that requires a process restart):

- [Discussion #5768 — Infinite retry persistent outbox with azure service bus](https://github.com/MassTransit/MassTransit/discussions/5768) — the canonical report; `BusOutboxDeliveryService` throws `OperationCanceledException` every ~30 s and never recovers.
- [Discussion #3507 — Outbox Send Fault at SQL server](https://github.com/MassTransit/MassTransit/discussions/3507) — `TaskCanceledException` during send; current workaround is `AutoStart = true` to front-load the ASB connection and avoid the first-connect timeout. This PR fixes the underlying loop so the workaround is no longer load-bearing.
- [Discussion #3567 — Outbox Message table doesn't clean up](https://github.com/MassTransit/MassTransit/discussions/3567) — messages stuck in the `OutboxMessage` table when delivery fails intermittently. Same mechanism: failed sends exit without advancing `LastSequenceNumber` and the worker spins instead of backing off.
- [Issue #3508 — Outbox not Publishing via Azure Service Bus](https://github.com/MassTransit/MassTransit/issues/3508) — older, closed issue about outbox/ASB compatibility. Listed for historical context; this PR addresses a distinct but adjacent failure mode.

## Root cause

`DeliverOutboxMessages` catches exceptions from `endpoint.Send(...)` — including the `OperationCanceledException` triggered by the `MessageDeliveryTimeout` CTS — logs `"Outbox Send Fault"`, and `break`s the per-message loop with `sentSequenceNumber == 0`.

The enclosing loop in `DeliverOutbox` has no exit path for that outcome:

- **EF Core** — `while (messageCount < resultLimit)` only exits on `< 0` (no outbox) or `> 0` (progress); `== 0` falls through with no increment, looping forever and re-locking the same outbox.
- **MongoDB** — `DeliverOutboxMessages` unconditionally `return true`, so `while (continueProcessing)` loops forever on any poison send.

Each iteration re-takes the outbox lock, reloads the same messages, and fails on the same first-in-queue message — producing the continuous log spam and CPU pegging users report.

## Fix

- `BusOutboxDeliveryService<TDbContext>` — break the inner loop on `executeResult <= 0` so the caller falls through to `WaitForDelivery(QueryDelay)` instead of re-locking immediately.
- `BusOutboxDeliveryService` (Mongo) — `DeliverOutboxMessages` now returns `sentSequenceNumber > 0`, matching the EF semantics.
- Both services — split the per-message catch into three cases:
  1. `OperationCanceledException` caused by the outer `cancellationToken` (shutdown) → rethrow.
  2. `OperationCanceledException` caused by the per-send timeout CTS → log `"Outbox Send Timeout after {Timeout}…"` with the configured value so operators can tune.
  3. Any other send exception → log `"Outbox Send Fault"` (existing behaviour).

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Send succeeds | Message removed, loop advances | Unchanged |
| First message fails once, transient cause | Loops infinitely until it recovers | Breaks inner loop, waits `QueryDelay`, retries on next sweep |
| First message is genuinely poisoned | Hot loop forever; host must be restarted | One attempt per `QueryDelay` with a clear log per attempt |
| Shutdown during send | OCE caught and silently swallowed | OCE from `cancellationToken` rethrown cleanly |

## What this PR does NOT change

- No public API or configuration surface changes.
- No default option values changed.
- Per-outbox ordering guarantees preserved. A genuinely-poisoned first message still blocks later messages in the same outbox — automatic dead-lettering after N attempts would be a separate, schema-changing enhancement, not in scope here.
- Happy-path throughput unchanged (`WaitForDelivery` still respects same-process `Delivered()` notifications).

## Tests

Adds `Should_not_spin_when_send_repeatedly_fails` to `tests/MassTransit.EntityFrameworkCoreIntegration.Tests/ReliableMessaging/BusOutbox_Specs.cs`.

The test wires an `IFilter<SendContext>` that throws on every call, publishes one message via the bus outbox, waits 2 s with `QueryDelay = 500 ms`, and asserts the filter was invoked fewer than 30 times (post-fix: ~4–6; pre-fix: dozens-to-hundreds as the inner loop spins at DB round-trip speed).

Requires SQL Server LocalDb, consistent with the other tests in that file.

No MongoDB-equivalent test is included to keep the PR small; the fix is symmetric and the EF test exercises the shared bug class.

## Verification

- Both persistence projects build clean (0 warnings, 0 errors).
- Reverting the production change causes the new test to fail the "< 30 attempts" assertion — confirming it genuinely catches the regression rather than just compiling green.
- Log message enrichment (`Outbox Send Timeout after {Timeout}`) gives operators a way to distinguish timeout-induced cancellation from shutdown and real send faults, which was previously ambiguous in production logs.

## Commits

1. `Fix BusOutboxDeliveryService infinite retry loop on send fault`
2. `Add regression test for outbox delivery spin on send failure`

Refs: #5768, #3507, #3567, #3508