### PR TITLE
fix(amazonsqs): use UTF-8 byte count for batch size calculation

### DIFF
--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/PublishBatcher.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/PublishBatcher.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 
@@ -27,8 +28,8 @@ public class PublishBatcher :
     {
         entry.Id = entryId;
 
-        return entry.Message.Length
-            + (entry.MessageAttributes?.Where(x => x.Value.DataType == "String").Sum(x => x.Key.Length + x.Value.StringValue.Length)).GetValueOrDefault();
+        return Encoding.UTF8.GetByteCount(entry.Message)
+            + (entry.MessageAttributes?.Where(x => x.Value.DataType == "String").Sum(x => Encoding.UTF8.GetByteCount(x.Key) + Encoding.UTF8.GetByteCount(x.Value.StringValue))).GetValueOrDefault();
     }
 
     protected override async Task SendBatch(IList<BatchEntry<PublishBatchRequestEntry>> batch)

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SendBatcher.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SendBatcher.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 
@@ -26,8 +27,8 @@ public class SendBatcher :
     {
         entry.Id = entryId;
 
-        return entry.MessageBody.Length
-            + entry.MessageAttributes.Where(x => x.Value.DataType == "String").Sum(x => x.Key.Length + x.Value.StringValue.Length);
+        return Encoding.UTF8.GetByteCount(entry.MessageBody)
+            + entry.MessageAttributes.Where(x => x.Value.DataType == "String").Sum(x => Encoding.UTF8.GetByteCount(x.Key) + Encoding.UTF8.GetByteCount(x.Value.StringValue));
     }
 
     protected override async Task SendBatch(IList<BatchEntry<SendMessageBatchRequestEntry>> batch)


### PR DESCRIPTION
## Description

Fixes batch size calculation in the Amazon SQS/SNS transport layer.

### Bug

`string.Length` returns UTF-16 code unit count, but AWS SQS/SNS measures message size in **UTF-8 bytes**. For non-ASCII content (Chinese, Japanese, emoji, accented characters), `string.Length` significantly underestimates the actual byte size — e.g. a single emoji character counts as 1 in `string.Length` but encodes to 4 bytes in UTF-8.

This causes `BatchRequestTooLongException` from AWS when batches contain non-ASCII messages, because the batcher thinks the total is under the 245,760-byte limit when it's actually over.

### Fix

Replaced `string.Length` with `System.Text.Encoding.UTF8.GetByteCount()` for:
- Message body sizing (SendBatcher + PublishBatcher)
- String attribute key and value sizing (SendBatcher + PublishBatcher)

### Testing

- Built successfully on `net9.0` — 0 warnings, 0 errors
- `CalculateEntryLength` now returns accurate UTF-8 byte counts matching AWS SQS/SNS expectations

### Checklist

- [x] Single logical change
- [x] Conventional commit message
- [x] Build verified
- [x] Follows existing code patterns
