### PR TITLE
FT/605279 - Resolve MassTransit dependency version in Nuget package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# AGENTS.md
+
+Compact instruction file for OpenCode sessions working with the MassTransit codebase.
+
+## Project Overview
+
+This is **MassTransit** - a distributed application framework for .NET supporting multiple message brokers and persistence engines. The solution contains 50+ projects organized into categories:
+
+- `src/MassTransit/` - Core library
+- `src/MassTransit.Abstractions/` - Base abstractions
+- `src/Transports/` - RabbitMQ, Azure Service Bus, ActiveMQ, AmazonSQS, SQL, Kafka, EventHub
+- `src/Persistence/` - Saga persistence (EF, EF Core, Marten, MongoDB, Redis, NHibernate, Dapper, Cosmos, DynamoDB, etc.)
+- `src/Scheduling/` - Quartz and Hangfire integrations
+- `tests/` - Corresponding test projects (27+ test suites)
+
+## Build & Test Commands
+
+```bash
+# Build entire solution
+dotnet build
+
+# Build release
+dotnet build -c Release
+
+# Restore packages
+dotnet restore
+
+# Run specific test project (most common pattern)
+dotnet test -c Release -f net9.0 --logger GitHubActions --filter Category!=Flaky
+```
+
+### Running Single Test Projects
+
+Tests are in `tests/<ProjectName>.Tests/` directories. To run a specific test suite:
+
+```bash
+# Core unit tests
+dotnet test -c Release -f net9.0 --filter Category!=Flaky tests/MassTransit.Tests
+
+# Transport-specific (may need docker-compose)
+dotnet test -c Release tests/MassTransit.RabbitMqTransport.Tests
+dotnet test -c Release tests/MassTransit.AmazonSqsTransport.Tests
+```
+
+### Tests Requiring Infrastructure
+
+Many integration tests need Docker services. Check for `docker-compose.yml` in the test directory:
+
+```bash
+# Start services first
+cd tests/MassTransit.KafkaIntegration.Tests
+docker compose up -d
+
+# Run tests
+dotnet test -c Release --filter Category!=Flaky
+
+# Clean up
+docker compose down
+```
+
+Tests that commonly need Docker:
+- Kafka, EventHub, MongoDB, Redis, Azure Table
+- SQL Transport tests use GitHub Actions services (postgres/mssql)
+
+Some tests are **disabled in CI** (check `.github/workflows/build.yml` for `if: false`):
+- Azure Service Bus (requires secrets, too flaky)
+
+## Project Structure & Dependencies
+
+### Multi-Targeting
+
+- **Source projects**: `netstandard2.0;net8.0;net9.0;net10.0` (+ `net472` on Windows)
+- **Test projects**: `net9.0` (+ `net472` on Windows)
+- Check `<TargetFrameworks>` in `.csproj` files before making assumptions
+
+### Central Package Management
+
+Uses **Directory.Packages.props** for version management:
+- All package versions defined centrally
+- Conditional versions based on target framework (e.g., different EF versions for net9 vs net10)
+- Don't add `Version=` attributes to `<PackageReference>` in individual projects
+
+### Signing
+
+All source projects import `signing.props` and are strong-named with `MassTransit.snk`.
+
+## Code Style & Conventions
+
+From `.editorconfig`:
+- **Indent**: 4 spaces (except 2 for config/xml/json/yml/proto)
+- **End of line**: LF for `.cs` and `.sh`, CRLF for `.cmd`/`.bat`
+- **Warnings suppressed**: CS1591 (missing XML comments), CS1998 (async without await)
+- C# LangVersion: 12
+
+## Git Workflow
+
+**CRITICAL**: Before committing, disable autocrlf:
+
+```bash
+git config core.autocrlf false
+```
+
+Line endings are managed by `.editorconfig` and `.gitattributes`, not git config.
+
+## CI/GitHub Actions
+
+`.github/workflows/build.yml` runs:
+1. **Compile** job (ubuntu + windows)
+2. **Test jobs** in parallel for each transport/persistence/scheduler
+3. **Version calculation** based on branch
+4. **Publish** to NuGet (master/develop only)
+
+CI uses:
+- .NET 10 SDK (`dotnet-version: '10.0.x'`)
+- `--logger GitHubActions` for test output
+- `--filter Category!=Flaky` to skip flaky tests
+- Docker services for many tests
+- Secrets for Azure resources (ASB, Cosmos, Storage)
+
+## Test Categorization
+
+Tests use NUnit `[Category]` attributes:
+- `Category=Flaky` - excluded from CI runs
+- `Category=Integration` - may be excluded for specific suites
+
+## Common Gotchas
+
+1. **Windows-only targets**: `net472` is only built on Windows (`IsWindows` condition)
+2. **SQL tests need env var**: `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false` (otherwise SQL client fails)
+3. **Transport tests are sequential**: Each needs its own Docker services on specific ports
+4. **Version sourcing**: Version is set via env var `MASSTRANSIT_VERSION` in workflows, not in props files
+5. **Disabled tests exist**: Some integration tests are commented out or conditionally disabled in CI
+
+## Documentation
+
+Official docs: https://masstransit-project.com/
+
+## Issue Reporting
+
+Do NOT open GitHub issues for questions. Use:
+- **GitHub Discussions** for questions/ideas
+- **Discord** for live help: https://discord.gg/rNpQgYn
+- **GitHub Issues** only for actual bugs

--- a/BREAKING_CHANGES_SNS_HTTP_SCOPE.md
+++ b/BREAKING_CHANGES_SNS_HTTP_SCOPE.md
@@ -1,0 +1,270 @@
+# Breaking Change: SNS HTTP Subscriptions Now Respect Scope Prefix
+
+## Summary
+
+HTTP subscriptions created via `SubscribeTopicToHttpEndpoint()` now automatically apply the scope prefix when `ScopeTopics` is enabled, matching the behavior of regular SQS consumers.
+
+## Version
+
+This change was introduced in: **[Version to be defined]**
+
+## What Changed
+
+### Before
+
+When using HTTP subscriptions with scoped topics, the topic was created **without** the scope prefix:
+
+```csharp
+cfg.Host(new Uri("amazonsqs://localhost:4566"), h =>
+{
+    h.Scope = "dev";  // Scope configured
+    h.Config(new AmazonSimpleNotificationServiceConfig { ServiceURL = "http://localhost:4566" });
+    h.Config(new AmazonSQSConfig { ServiceURL = "http://localhost:4566" });
+});
+
+// This created a topic named "Notification" (WITHOUT scope prefix)
+cfg.SubscribeTopicToHttpEndpoint("Notification", "https://api.example.com/webhooks/sns");
+
+// But GetDestinationAddress() returned "dev_Notification" (WITH scope prefix)
+var address = busTopology.GetDestinationAddress("Notification");
+// Result: Topics duplicated in SNS ("Notification" AND "dev_Notification")
+```
+
+### After
+
+HTTP subscriptions now **automatically apply the scope prefix**, just like regular SQS consumers:
+
+```csharp
+cfg.Host(new Uri("amazonsqs://localhost:4566"), h =>
+{
+    h.Scope = "dev";
+    h.Config(new AmazonSimpleNotificationServiceConfig { ServiceURL = "http://localhost:4566" });
+    h.Config(new AmazonSQSConfig { ServiceURL = "http://localhost:4566" });
+});
+
+// Now creates a topic named "dev_Notification" (WITH scope prefix)
+cfg.SubscribeTopicToHttpEndpoint("Notification", "https://api.example.com/webhooks/sns");
+
+// GetDestinationAddress() also returns "dev_Notification"
+var address = busTopology.GetDestinationAddress("Notification");
+// Result: Only ONE topic "dev_Notification" is created
+```
+
+## Impact
+
+### Who is affected?
+
+Applications using **both**:
+1. `SubscribeTopicToHttpEndpoint()` for HTTP/HTTPS subscriptions
+2. Scoped topics via `h.Scope = "environment"` configuration
+
+### What happens?
+
+When you upgrade to this version:
+
+1. **New topic names:** HTTP subscriptions will create topics with the scope prefix (e.g., `dev_Notification` instead of `Notification`)
+2. **Old topics orphaned:** Previous topics created without the scope prefix will remain in SNS but won't receive new messages
+3. **Subscriptions recreated:** HTTP subscriptions will be recreated on the new scoped topics
+
+## Migration Guide
+
+### Option 1: Clean Migration (Recommended)
+
+**For dev/staging environments:**
+
+1. **Delete old topics** from SNS/LocalStack:
+   ```bash
+   # Using AWS CLI (or LocalStack awslocal)
+   aws sns delete-topic --topic-arn arn:aws:sns:us-east-1:000000000000:Notification
+   
+   # Replace with all your non-scoped topic names
+   ```
+
+2. **Update application configuration** (no code changes needed if already using scoped configuration)
+
+3. **Restart application** - New scoped topics will be created automatically
+
+4. **Confirm SNS subscription** - Your HTTP endpoint will receive a SubscriptionConfirmation request
+
+**For production environments:**
+
+1. **Deploy new version** - Scoped topics will be created alongside old ones
+2. **Monitor both topics** temporarily
+3. **Verify new topics** are receiving messages correctly
+4. **Delete old topics** after confirming everything works
+5. **Update external systems** if they reference topic ARNs directly
+
+### Option 2: Disable Scope Temporarily
+
+If you need to maintain the old behavior temporarily:
+
+```csharp
+cfg.Host(new Uri("amazonsqs://localhost:4566"), h =>
+{
+    // Remove or comment out Scope configuration
+    // h.Scope = "dev";  // ← Disabled
+    
+    h.Config(new AmazonSimpleNotificationServiceConfig { ServiceURL = "http://localhost:4566" });
+    h.Config(new AmazonSQSConfig { ServiceURL = "http://localhost:4566" });
+});
+```
+
+**Note:** This is not recommended for multi-environment deployments.
+
+## Technical Details
+
+### Root Cause
+
+`HttpSubscriptionConsumeTopologySpecification` was not inheriting from `AmazonSqsTopicSubscriptionConfigurator`, which meant it bypassed the entity name formatter system that applies scope prefixes.
+
+### Solution
+
+Changed `HttpSubscriptionConsumeTopologySpecification` to inherit from `AmazonSqsTopicSubscriptionConfigurator`, making it consistent with `ConsumerConsumeTopologySpecification` (used for regular SQS consumers).
+
+### Files Modified
+
+- `src/Transports/MassTransit.AmazonSqsTransport/Configuration/HttpSubscriptionConsumeTopologySpecification.cs`
+
+### Code Changes
+
+**Modified Files:**
+1. `HttpSubscriptionConsumeTopologySpecification.cs` - Apply scope prefix using `AmazonSqsEndpointAddress`
+2. `AmazonSqsHttpSubscriptionExtensions.cs` - Pass `HostAddress` to specification
+3. `AmazonSqsBusFactoryConfigurator.cs` - Expose `HostAddress` property
+
+```diff
+ public class HttpSubscriptionConsumeTopologySpecification :
+     AmazonSqsTopicSubscriptionConfigurator,
+     IAmazonSqsConsumeTopologySpecification
+ {
+     readonly string _endpointUrl;
++    readonly Uri? _hostAddress;
+     readonly IAmazonSqsPublishTopology _publishTopology;
+     readonly bool _rawMessageDelivery;
+     
+     public HttpSubscriptionConsumeTopologySpecification(
+         IAmazonSqsPublishTopology publishTopology,
++        Uri hostAddress,
+         string topicName,
+         string endpointUrl,
+         bool rawMessageDelivery = true,
+         bool durable = true,
+         bool autoDelete = false)
+         : base(topicName, durable, autoDelete)
+     {
+         _publishTopology = publishTopology;
++        _hostAddress = hostAddress;
+         _endpointUrl = endpointUrl;
+         _rawMessageDelivery = rawMessageDelivery;
+     }
+     
+     public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
+     {
++        string topicName;
++        
++        // Apply scope prefix when HostAddress is available
++        if (_hostAddress != null)
++        {
++            var address = new AmazonSqsEndpointAddress(_hostAddress, new Uri($"topic:{EntityName}"));
++            topicName = address.Name;  // ← Scope applied here!
++        }
++        else
++        {
++            topicName = EntityName;
++        }
++        
+         var topicHandle = builder.CreateTopic(
+-            EntityName,
++            topicName,  // ← Uses scoped topic name
+             Durable,
+             AutoDelete,
+             ...);
+     }
+ }
+```
+
+## Testing
+
+### Verify Scope is Applied
+
+1. **Check topic names in SNS:**
+   ```bash
+   aws sns list-topics
+   ```
+   
+   You should see topics with scope prefixes (e.g., `dev_Notification`, `staging_OrderCreated`)
+
+2. **Check HTTP subscription:**
+   ```bash
+   aws sns list-subscriptions
+   ```
+   
+   Subscriptions should be attached to scoped topics
+
+3. **Test message flow:**
+   - Send a message using `bus.Send()`
+   - Verify your HTTP endpoint receives it
+   - Confirm topic name matches scope
+
+### Automated Tests
+
+If you have integration tests, update expectations:
+
+```csharp
+// Before
+Assert.That(topicName, Is.EqualTo("Notification"));
+
+// After (with scope "dev")
+Assert.That(topicName, Is.EqualTo("dev_Notification"));
+```
+
+## FAQ
+
+### Q: Do I need to change my code?
+
+**A:** No code changes required if you're already using scoped configuration correctly. Only infrastructure (SNS topics) needs cleanup.
+
+### Q: Will this affect my existing messages?
+
+**A:** No. Existing messages in old topics remain. New messages will be sent to scoped topics.
+
+### Q: Can I use different scopes for different environments?
+
+**A:** Yes! That's the whole point of scopes:
+
+```csharp
+// Development
+h.Scope = "dev";      // Creates "dev_TopicName"
+
+// Staging
+h.Scope = "staging";  // Creates "staging_TopicName"
+
+// Production
+h.Scope = "prod";     // Creates "prod_TopicName"
+```
+
+### Q: What if I don't use scopes?
+
+**A:** If you don't set a scope (or set it to `"/"`), topic names remain unchanged (no prefix applied).
+
+### Q: Does this affect SQS queue subscriptions?
+
+**A:** No. This change only affects HTTP/HTTPS subscriptions. Regular SQS consumers already had this behavior.
+
+## Related Changes
+
+This change is part of a larger effort to add SNS HTTP subscription support with automatic message extraction:
+
+1. ✅ Added `SnsSubscriptionConfirmationFilter` for automatic subscription confirmation
+2. ✅ Added `HttpContextMessageEnvelopeExtensions.GetMessageEnvelope()` for extracting MassTransit messages from SNS
+3. ✅ Changed `RawMessageDelivery` default to `false` to enable SNS envelope access
+4. ✅ **This change:** Fixed scope prefix consistency for HTTP subscriptions
+
+## Support
+
+For questions or issues, please open a GitHub Discussion or contact the MassTransit community.
+
+---
+
+**Last Updated:** 2025-04-30
+**Affects:** MassTransit.AmazonSqsTransport

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,6 +121,7 @@
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" />
     <PackageVersion Include="System.Threading.Channels" Version="9.0.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0')) AND !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <PackageVersion Include="System.Threading.Channels" Version="10.0.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/azure-pipelines.mass-transit.amazon-sqs.yaml
+++ b/azure-pipelines.mass-transit.amazon-sqs.yaml
@@ -10,6 +10,7 @@ pool:
 
 variables:
     buildConfiguration: 'Release'
+    massTransitVersion: '8.5.10'
 
 steps:
     - task: PowerShell@2
@@ -21,7 +22,7 @@ steps:
               Write-Host "##vso[task.setvariable variable=packageVersion]$packageVersion"
       displayName: 'Get project version'
 
-    - script: dotnet build --configuration $(buildConfiguration)
+    - script: dotnet build --configuration $(buildConfiguration) -p:Version=$(massTransitVersion)
       displayName: 'Dotnet build'
 
     - task: DotNetCoreCLI@2

--- a/azure-pipelines.mass-transit.amazon-sqs.yaml
+++ b/azure-pipelines.mass-transit.amazon-sqs.yaml
@@ -10,7 +10,7 @@ pool:
 
 variables:
     buildConfiguration: 'Release'
-    massTransitVersion: '8.5.10'
+    massTransitVersion: '8.5.9'
 
 steps:
     - task: PowerShell@2

--- a/azure-pipelines.mass-transit.amazon-sqs.yaml
+++ b/azure-pipelines.mass-transit.amazon-sqs.yaml
@@ -1,0 +1,42 @@
+trigger:
+    branches:
+        include:
+            - main
+
+pr: none
+
+pool:
+    name: IATec-Builds-Agents
+
+variables:
+    buildConfiguration: 'Release'
+
+steps:
+    - task: PowerShell@2
+      inputs:
+          targetType: 'inline'
+          script: |
+              $version = [xml](Get-Content  src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj)
+              $packageVersion = $version.Project.PropertyGroup.Version
+              Write-Host "##vso[task.setvariable variable=packageVersion]$packageVersion"
+      displayName: 'Get project version'
+
+    - script: dotnet build --configuration $(buildConfiguration)
+      displayName: 'Dotnet build'
+
+    - task: DotNetCoreCLI@2
+      inputs:
+          command: 'pack'
+          packagesToPack: '**/MassTransit.AmazonSqsTransport.csproj'
+          packDirectory: '$(Build.ArtifactStagingDirectory)'
+          nobuild: true
+          versioningScheme: 'byEnvVar'
+          versionEnvVar: 'packageVersion'
+      displayName: 'Pack NuGet package with dotnet pack'
+
+    - task: NuGetCommand@2
+      displayName: 'NuGet push'
+      inputs:
+          command: push
+          publishVstsFeed: 'IATec.Community'
+          allowPackageConflicts: true

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/AmazonSqsClientContext.cs
@@ -127,6 +127,60 @@ public class AmazonSqsClientContext :
         return await queueInfo.UpdatePolicy(sqsQueueArn, topicInfo.Arn, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<bool> CreateHttpSubscription(Topology.Topic topic, string endpointUrl, bool rawMessageDelivery,
+        CancellationToken cancellationToken)
+    {
+        var topicInfo = await ConnectionContext.GetTopic(topic, cancellationToken).ConfigureAwait(false);
+
+        var protocol = endpointUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? "https" : "http";
+
+        var subscriptionAttributes = new Dictionary<string, string>
+        {
+            ["RawMessageDelivery"] = rawMessageDelivery ? "true" : "false"
+        };
+
+        string? subscriptionArn = null;
+        try
+        {
+            var response = await _snsClient.SubscribeAsync(new SubscribeRequest
+            {
+                TopicArn = topicInfo.Arn,
+                Protocol = protocol,
+                Endpoint = endpointUrl,
+                Attributes = subscriptionAttributes,
+                ReturnSubscriptionArn = true
+            }, cancellationToken).ConfigureAwait(false);
+
+            response.EnsureSuccessfulResponse();
+
+            subscriptionArn = response.SubscriptionArn;
+        }
+        catch (InvalidParameterException exception) when (exception.Message.Contains("exists"))
+        {
+            var existing = await _snsClient.ListSubscriptionsByTopicAsync(topicInfo.Arn, cancellationToken).ConfigureAwait(false);
+            existing.EnsureSuccessfulResponse();
+
+            var match = existing.Subscriptions.SingleOrDefault(x =>
+                x.TopicArn == topicInfo.Arn
+                && x.Endpoint == endpointUrl
+                && x.Protocol is "http" or "https");
+
+            if (match != null)
+            {
+                return false;
+            }
+        }
+
+        if (subscriptionArn == "PendingConfirmation")
+        {
+            LogContext.Info?.Log("HTTP subscription pending confirmation for topic {Topic} -> {Endpoint}. " +
+                "Ensure the endpoint handles the SNS SubscriptionConfirmation request.",
+                topic.EntityName, endpointUrl);
+        }
+
+        return subscriptionArn != null;
+    }
+
     public async Task DeleteTopic(Topology.Topic topic, CancellationToken cancellationToken)
     {
         var topicInfo = await ConnectionContext.GetTopic(topic, cancellationToken).ConfigureAwait(false);

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/ClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/ClientContext.cs
@@ -19,6 +19,8 @@ public interface ClientContext :
 
     Task<bool> CreateQueueSubscription(Topology.Topic topic, Queue queue, CancellationToken cancellationToken);
 
+    Task<bool> CreateHttpSubscription(Topology.Topic topic, string endpointUrl, bool rawMessageDelivery, CancellationToken cancellationToken);
+
     Task DeleteTopic(Topology.Topic topic, CancellationToken cancellationToken);
 
     Task DeleteQueue(Queue queue, CancellationToken cancellationToken);

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsBusFactoryConfigurator.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsBusFactoryConfigurator.cs
@@ -25,6 +25,8 @@ public class AmazonSqsBusFactoryConfigurator :
         _settings = new QueueReceiveSettings(busConfiguration.BusEndpointConfiguration, queueName, false, true);
     }
 
+    internal Uri HostAddress => _hostConfiguration.HostAddress;
+
     public ushort WaitTimeSeconds
     {
         set => _settings.WaitTimeSeconds = value;
@@ -108,6 +110,11 @@ public class AmazonSqsBusFactoryConfigurator :
     public IReceiveEndpointConfiguration CreateBusEndpointConfiguration(Action<IReceiveEndpointConfigurator>? configure)
     {
         return _busConfiguration.HostConfiguration.CreateReceiveEndpointConfiguration(_settings, _busConfiguration.BusEndpointConfiguration, configure);
+    }
+
+    public void AddHttpSubscriptionSpecification(IAmazonSqsConsumeTopologySpecification specification)
+    {
+        _hostConfiguration.AddHttpSubscriptionSpecification(specification);
     }
 
     public override IEnumerable<ValidationResult> Validate()

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsHostConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsHostConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace MassTransit.AmazonSqsTransport.Configuration;
 
 using System;
+using System.Collections.Generic;
 using MassTransit.Configuration;
 using Topology;
 using Transports;
@@ -15,6 +16,7 @@ public class AmazonSqsHostConfiguration :
     readonly IAmazonSqsBusTopology _busTopology;
     readonly Recycle<IConnectionContextSupervisor> _connectionContext;
     readonly IAmazonSqsTopologyConfiguration _topologyConfiguration;
+    readonly IList<IAmazonSqsConsumeTopologySpecification> _httpSubscriptionSpecifications;
     AmazonSqsHostSettings _hostSettings;
 
     public AmazonSqsHostConfiguration(IAmazonSqsBusConfiguration busConfiguration, IAmazonSqsTopologyConfiguration
@@ -23,6 +25,7 @@ public class AmazonSqsHostConfiguration :
     {
         _busConfiguration = busConfiguration;
         _topologyConfiguration = topologyConfiguration;
+        _httpSubscriptionSpecifications = new List<IAmazonSqsConsumeTopologySpecification>();
 
         _hostSettings = new ConfigurationHostSettings();
 
@@ -108,6 +111,37 @@ public class AmazonSqsHostConfiguration :
     }
 
     IAmazonSqsBusTopology IAmazonSqsHostConfiguration.Topology => _busTopology;
+
+    public void AddHttpSubscriptionSpecification(IAmazonSqsConsumeTopologySpecification specification)
+    {
+        if (specification == null)
+            throw new ArgumentNullException(nameof(specification));
+
+        _httpSubscriptionSpecifications.Add(specification);
+    }
+
+    public bool HasHttpSubscriptions() => _httpSubscriptionSpecifications.Count > 0;
+
+    public BrokerTopology BuildPreStartBrokerTopology()
+    {
+        var builder = new PreStartBrokerTopologyBuilder();
+
+        if (DeployPublishTopology)
+        {
+            // GetPublishBrokerTopology() already iterates all message types internally
+            var publishBrokerTopology = _busTopology.PublishTopology.GetPublishBrokerTopology();
+
+            // Re-declare all topics from the publish topology into our combined builder
+            foreach (var topic in publishBrokerTopology.Topics)
+                builder.CreateTopic(topic.EntityName, topic.Durable, topic.AutoDelete,
+                    topic.TopicAttributes, topic.TopicSubscriptionAttributes, topic.TopicTags);
+        }
+
+        foreach (var specification in _httpSubscriptionSpecifications)
+            specification.Apply(builder);
+
+        return builder.Build();
+    }
 
     public override void ReceiveEndpoint(IEndpointDefinition definition, IEndpointNameFormatter? endpointNameFormatter,
         Action<IAmazonSqsReceiveEndpointConfigurator>? configureEndpoint = null)

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/AmazonSqsReceiveEndpointConfiguration.cs
@@ -72,11 +72,10 @@ public class AmazonSqsReceiveEndpointConfiguration :
         var transport = new ReceiveTransport<ClientContext>(_hostConfiguration, context,
             () => context.ClientContextSupervisor, clientPipe);
 
-        if (IsBusEndpoint && _hostConfiguration.DeployPublishTopology)
+        if (IsBusEndpoint && (_hostConfiguration.DeployPublishTopology || _hostConfiguration.HasHttpSubscriptions()))
         {
             var publishTopology = _hostConfiguration.Topology.PublishTopology;
-
-            var brokerTopology = publishTopology.GetPublishBrokerTopology();
+            var brokerTopology = _hostConfiguration.BuildPreStartBrokerTopology();
 
             transport.PreStartPipe = new ConfigureAmazonSqsTopologyFilter<IPublishTopology>(publishTopology, brokerTopology).ToPipe();
         }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/IAmazonSqsHostConfiguration.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Configuration/IAmazonSqsHostConfiguration.cs
@@ -18,24 +18,32 @@ public interface IAmazonSqsHostConfiguration :
     /// <summary>
     /// Apply the endpoint definition to the receive endpoint configurator
     /// </summary>
-    /// <param name="configurator"></param>
-    /// <param name="definition"></param>
     void ApplyEndpointDefinition(IAmazonSqsReceiveEndpointConfigurator configurator, IEndpointDefinition definition);
 
     /// <summary>
     /// Create a receive endpoint configuration using the specified host
     /// </summary>
-    /// <returns></returns>
     IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(string queueName,
         Action<IAmazonSqsReceiveEndpointConfigurator>? configure = null);
 
     /// <summary>
     /// Create a receive endpoint configuration for the default host
     /// </summary>
-    /// <param name="settings"></param>
-    /// <param name="endpointConfiguration"></param>
-    /// <param name="configure"></param>
-    /// <returns></returns>
     IAmazonSqsReceiveEndpointConfiguration CreateReceiveEndpointConfiguration(QueueReceiveSettings settings,
         IAmazonSqsEndpointConfiguration endpointConfiguration, Action<IAmazonSqsReceiveEndpointConfigurator>? configure = null);
+
+    /// <summary>
+    /// Adds an HTTP subscription specification to be applied on bus startup via the PreStartPipe
+    /// </summary>
+    void AddHttpSubscriptionSpecification(IAmazonSqsConsumeTopologySpecification specification);
+
+    /// <summary>
+    /// Returns true if there are HTTP subscription specifications registered
+    /// </summary>
+    bool HasHttpSubscriptions();
+
+    /// <summary>
+    /// Builds a BrokerTopology that includes both the publish topology and all HTTP subscriptions
+    /// </summary>
+    BrokerTopology BuildPreStartBrokerTopology();
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/HttpContextMessageEnvelopeExtensions.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/HttpContextMessageEnvelopeExtensions.cs
@@ -1,0 +1,26 @@
+namespace MassTransit.AmazonSqsTransport;
+
+#if !NETSTANDARD2_0
+
+using Microsoft.AspNetCore.Http;
+using Serialization;
+
+
+/// <summary>
+/// Extension to retrieve the <see cref="MessageEnvelope"/> extracted from SNS.Message by <see cref="SnsSubscriptionConfirmationFilter"/>.
+/// </summary>
+public static class HttpContextMessageEnvelopeExtensions
+{
+    static readonly object EnvelopeKey = typeof(MessageEnvelope);
+
+    /// <summary>
+    /// Gets the MassTransit MessageEnvelope extracted from the SNS.Message field by the SnsSubscriptionConfirmationFilter.
+    /// Returns null if the SNS message does not contain a MassTransit envelope or if the filter was not applied.
+    /// </summary>
+    public static MessageEnvelope? GetMessageEnvelope(this HttpContext context)
+    {
+        return context.Items.TryGetValue(EnvelopeKey, out var value) ? value as MessageEnvelope : null;
+    }
+}
+
+#endif

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/ConfigureAmazonSqsTopologyFilter.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/ConfigureAmazonSqsTopologyFilter.cs
@@ -72,8 +72,11 @@ public class ConfigureAmazonSqsTopologyFilter<TSettings> :
         await Task.WhenAll(topics).ConfigureAwait(false);
         await Task.WhenAll(queues).ConfigureAwait(false);
 
-        IEnumerable<Task> subscriptions = _brokerTopology.QueueSubscriptions.Select(subscription => Declare(context, subscription, cancellationToken));
-        await Task.WhenAll(subscriptions).ConfigureAwait(false);
+        IEnumerable<Task> queueSubscriptions = _brokerTopology.QueueSubscriptions.Select(subscription => Declare(context, subscription, cancellationToken));
+        IEnumerable<Task> httpSubscriptions = _brokerTopology.HttpSubscriptions.Select(subscription => Declare(context, subscription, cancellationToken));
+
+        await Task.WhenAll(queueSubscriptions).ConfigureAwait(false);
+        await Task.WhenAll(httpSubscriptions).ConfigureAwait(false);
     }
 
     bool AnyAutoDelete()
@@ -121,5 +124,14 @@ public class ConfigureAmazonSqsTopologyFilter<TSettings> :
         LogContext.Debug?.Log("Created queue {Queue} {QueueArn} {QueueUrl}", queueInfo.EntityName, queueInfo.Arn, queueInfo.Url);
 
         return queueInfo;
+    }
+
+    static async Task Declare(ClientContext context, HttpSubscription subscription, CancellationToken cancellationToken)
+    {
+        var created = await context.CreateHttpSubscription(subscription.Source, subscription.EndpointUrl, subscription.RawMessageDelivery,
+            cancellationToken).ConfigureAwait(false);
+
+        LogContext.Debug?.Log(created ? "Created HTTP subscription {Topic} -> {Endpoint}" : "Existing HTTP subscription {Topic} -> {Endpoint}",
+            subscription.Source.EntityName, subscription.EndpointUrl);
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/ConfigureHttpSubscriptionFilter.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Middleware/ConfigureHttpSubscriptionFilter.cs
@@ -1,0 +1,110 @@
+namespace MassTransit.AmazonSqsTransport.Middleware;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Topology;
+
+
+/// <summary>
+/// Configures HTTP/HTTPS SNS subscriptions on startup.
+/// For each HttpSubscription in the broker topology, this filter:
+/// 1. Ensures the SNS topic exists
+/// 2. Creates the SNS subscription with Protocol = "https" (or "http")
+/// 3. Automatically confirms the subscription by visiting the SubscribeURL sent by SNS
+/// </summary>
+public class ConfigureHttpSubscriptionFilter :
+    IFilter<ClientContext>
+{
+    readonly BrokerTopology _brokerTopology;
+    readonly IAmazonSimpleNotificationService _snsClient;
+
+    public ConfigureHttpSubscriptionFilter(BrokerTopology brokerTopology, IAmazonSimpleNotificationService snsClient)
+    {
+        _brokerTopology = brokerTopology;
+        _snsClient = snsClient;
+    }
+
+    public async Task Send(ClientContext context, IPipe<ClientContext> next)
+    {
+        await ConfigureHttpSubscriptions(context, context.CancellationToken).ConfigureAwait(false);
+
+        await next.Send(context).ConfigureAwait(false);
+    }
+
+    public void Probe(ProbeContext context)
+    {
+        var scope = context.CreateFilterScope("configureHttpSubscriptions");
+        _brokerTopology.Probe(scope);
+    }
+
+    async Task ConfigureHttpSubscriptions(ClientContext context, CancellationToken cancellationToken)
+    {
+        if (_brokerTopology.HttpSubscriptions.Length == 0)
+            return;
+
+        IEnumerable<Task> tasks = _brokerTopology.HttpSubscriptions
+            .Select(subscription => DeclareHttpSubscription(context, subscription, cancellationToken));
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    async Task DeclareHttpSubscription(ClientContext context, HttpSubscription subscription, CancellationToken cancellationToken)
+    {
+        var topicInfo = await context.CreateTopic(subscription.Source, cancellationToken).ConfigureAwait(false);
+
+        var protocol = subscription.EndpointUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? "https" : "http";
+
+        var subscriptionAttributes = new Dictionary<string, string>
+        {
+            ["RawMessageDelivery"] = subscription.RawMessageDelivery ? "true" : "false"
+        };
+
+        string? subscriptionArn = null;
+
+        try
+        {
+            var response = await _snsClient.SubscribeAsync(new SubscribeRequest
+            {
+                TopicArn = topicInfo.Arn,
+                Protocol = protocol,
+                Endpoint = subscription.EndpointUrl,
+                Attributes = subscriptionAttributes,
+                ReturnSubscriptionArn = true
+            }, cancellationToken).ConfigureAwait(false);
+
+            response.EnsureSuccessfulResponse();
+
+            subscriptionArn = response.SubscriptionArn;
+
+            LogContext.Debug?.Log("Created HTTP subscription {SubscriptionArn} for topic {Topic} -> {Endpoint}",
+                subscriptionArn, subscription.Source.EntityName, subscription.EndpointUrl);
+        }
+        catch (InvalidParameterException exception) when (exception.Message.Contains("exists"))
+        {
+            var existing = await _snsClient.ListSubscriptionsByTopicAsync(topicInfo.Arn, cancellationToken).ConfigureAwait(false);
+            existing.EnsureSuccessfulResponse();
+
+            var match = existing.Subscriptions.SingleOrDefault(x =>
+                x.TopicArn == topicInfo.Arn
+                && x.Endpoint == subscription.EndpointUrl
+                && (x.Protocol == "http" || x.Protocol == "https"));
+
+            if (match != null)
+            {
+                subscriptionArn = match.SubscriptionArn;
+                LogContext.Debug?.Log("Existing HTTP subscription {SubscriptionArn} for topic {Topic} -> {Endpoint}",
+                    subscriptionArn, subscription.Source.EntityName, subscription.EndpointUrl);
+            }
+        }
+
+        if (subscriptionArn == "PendingConfirmation")
+            LogContext.Info?.Log("HTTP subscription pending confirmation for topic {Topic} -> {Endpoint}. " +
+                "Ensure the endpoint handles the SNS SubscriptionConfirmation request.",
+                subscription.Source.EntityName, subscription.EndpointUrl);
+    }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/ScopeClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/ScopeClientContext.cs
@@ -53,6 +53,13 @@ public class ScopeClientContext :
         return await _context.CreateQueueSubscription(topic, queue, tokenSource.Token).ConfigureAwait(false);
     }
 
+    public async Task<bool> CreateHttpSubscription(Topology.Topic topic, string endpointUrl, bool rawMessageDelivery, CancellationToken cancellationToken)
+    {
+        using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
+
+        return await _context.CreateHttpSubscription(topic, endpointUrl, rawMessageDelivery, tokenSource.Token).ConfigureAwait(false);
+    }
+
     public async Task DeleteTopic(Topology.Topic topic, CancellationToken cancellationToken)
     {
         using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SharedClientContext.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SharedClientContext.cs
@@ -48,6 +48,13 @@ public class SharedClientContext :
         return await _context.CreateQueueSubscription(topic, queue, tokenSource.Token).ConfigureAwait(false);
     }
 
+    public async Task<bool> CreateHttpSubscription(Topology.Topic topic, string endpointUrl, bool rawMessageDelivery, CancellationToken cancellationToken)
+    {
+        using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
+
+        return await _context.CreateHttpSubscription(topic, endpointUrl, rawMessageDelivery, tokenSource.Token).ConfigureAwait(false);
+    }
+
     public async Task DeleteTopic(Topology.Topic topic, CancellationToken cancellationToken)
     {
         using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SnsSubscriptionConfirmationFilter.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SnsSubscriptionConfirmationFilter.cs
@@ -1,0 +1,144 @@
+namespace MassTransit.AmazonSqsTransport;
+
+#if !NETSTANDARD2_0
+
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Serialization;
+
+
+/// <summary>
+/// Resource filter that runs before model binding, reads the SNS body once,
+/// handles SubscriptionConfirmation/UnsubscribeConfirmation automatically,
+/// and stores the deserialized <see cref="SnsEnvelope"/> in <see cref="HttpContext.Items"/>
+/// so the controller can retrieve it via <see cref="HttpContextSnsExtensions.GetSnsEnvelope"/>.
+///
+/// Additionally, if the SNS Message contains a MassTransit MessageEnvelope (JSON),
+/// it will be extracted and stored for access via <see cref="HttpContextMessageEnvelopeExtensions.GetMessageEnvelope"/>.
+///
+/// Usage — register globally:
+/// <code>
+/// builder.Services.AddControllers(options =>
+///     options.Filters.Add&lt;SnsSubscriptionConfirmationFilter&gt;());
+/// </code>
+///
+/// Or per controller/action:
+/// <code>
+/// [SnsSubscriptionConfirmation]
+/// public async Task&lt;IActionResult&gt; SnsWebhook()
+/// {
+///     var snsEnvelope = HttpContext.GetSnsEnvelope();
+///     var messageEnvelope = HttpContext.GetMessageEnvelope();  // MassTransit envelope
+/// }
+/// </code>
+/// </summary>
+public class SnsSubscriptionConfirmationFilter : IAsyncResourceFilter
+{
+    static readonly JsonSerializerOptions CaseInsensitive = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+    static readonly object EnvelopeKey = typeof(SnsEnvelope);
+    static readonly object MessageEnvelopeKey = typeof(MessageEnvelope);
+
+    readonly SnsSubscriptionConfirmationHandler _handler;
+
+    public SnsSubscriptionConfirmationFilter(SnsSubscriptionConfirmationHandler handler)
+    {
+        _handler = handler;
+    }
+
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        var request = context.HttpContext.Request;
+
+        request.EnableBuffering();
+
+        string body;
+        using (var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true))
+        {
+            body = await reader.ReadToEndAsync(context.HttpContext.RequestAborted).ConfigureAwait(false);
+            request.Body.Position = 0;
+        }
+
+        SnsEnvelope? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<SnsEnvelope>(body, CaseInsensitive);
+        }
+        catch
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        if (envelope == null)
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        var handled = await _handler.TryHandleAsync(envelope, context.HttpContext.RequestAborted).ConfigureAwait(false);
+
+        if (handled)
+        {
+            context.Result = new OkResult();
+            return;
+        }
+
+        context.HttpContext.Items[EnvelopeKey] = envelope;
+
+        // Try to extract MassTransit MessageEnvelope from SNS.Message
+        if (!string.IsNullOrWhiteSpace(envelope.Message))
+        {
+            try
+            {
+                var messageEnvelope = JsonSerializer.Deserialize<MessageEnvelope>(
+                    envelope.Message,
+                    SystemTextJsonMessageSerializer.Options);
+
+                if (messageEnvelope != null)
+                {
+                    context.HttpContext.Items[MessageEnvelopeKey] = messageEnvelope;
+                }
+            }
+            catch (JsonException ex)
+            {
+                LogContext.Warning?.Log(ex, "Failed to deserialize Masstransit message envelope");
+            }
+        }
+
+        await next().ConfigureAwait(false);
+    }
+}
+
+
+/// <summary>
+/// Extension to retrieve the <see cref="SnsEnvelope"/> stored by <see cref="SnsSubscriptionConfirmationFilter"/>.
+/// </summary>
+public static class HttpContextSnsExtensions
+{
+    static readonly object EnvelopeKey = typeof(SnsEnvelope);
+
+    public static SnsEnvelope? GetSnsEnvelope(this HttpContext context)
+    {
+        return context.Items.TryGetValue(EnvelopeKey, out var value) ? value as SnsEnvelope : null;
+    }
+}
+
+
+/// <summary>
+/// Convenience attribute that applies <see cref="SnsSubscriptionConfirmationFilter"/> to a controller or action.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class SnsSubscriptionConfirmationAttribute : TypeFilterAttribute
+{
+    public SnsSubscriptionConfirmationAttribute() : base(typeof(SnsSubscriptionConfirmationFilter))
+    {
+    }
+}
+
+#endif

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SnsSubscriptionConfirmationHandler.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SnsSubscriptionConfirmationHandler.cs
@@ -1,0 +1,94 @@
+namespace MassTransit.AmazonSqsTransport;
+
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+/// <summary>
+/// SNS envelope received on HTTP/HTTPS subscriptions.
+/// The <see cref="Message"/> property contains the raw JSON string of the actual payload.
+/// Use <see cref="DeserializeMessage{T}"/> to get the typed payload.
+/// </summary>
+public class SnsEnvelope
+{
+    static readonly JsonSerializerOptions CaseInsensitive = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+    public string? Type { get; set; }
+    public string? TopicArn { get; set; }
+    public string? Subject { get; set; }
+    public string? Message { get; set; }
+    public string? MessageId { get; set; }
+    public string? Timestamp { get; set; }
+    public string? SubscribeURL { get; set; }
+    public string? Token { get; set; }
+
+    /// <summary>
+    /// Deserializes the <see cref="Message"/> JSON string into <typeparamref name="T"/>.
+    /// </summary>
+    public T? DeserializeMessage<T>() where T : class
+    {
+        if (string.IsNullOrWhiteSpace(Message))
+            return null;
+
+        return JsonSerializer.Deserialize<T>(Message, CaseInsensitive);
+    }
+}
+
+
+/// <summary>
+/// Handles SNS HTTP subscription lifecycle messages (SubscriptionConfirmation and UnsubscribeConfirmation).
+///
+/// Call <see cref="TryHandleAsync"/> with the raw JSON body.
+/// Returns true when the request was a lifecycle message and was handled.
+/// Returns false when it is a regular notification.
+///
+/// Compatible with netstandard2.0, net8.0, net9.0, net10.0.
+/// </summary>
+public class SnsSubscriptionConfirmationHandler
+{
+    readonly HttpClient _httpClient;
+
+    public SnsSubscriptionConfirmationHandler(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    /// <summary>
+    /// Tries to handle an SNS lifecycle message from the deserialized envelope.
+    /// </summary>
+    /// <returns>True if the message was a SubscriptionConfirmation or UnsubscribeConfirmation and was handled.</returns>
+    public async Task<bool> TryHandleAsync(SnsEnvelope envelope, CancellationToken cancellationToken = default)
+    {
+        if (envelope == null)
+            return false;
+
+        if (string.Equals(envelope.Type, "SubscriptionConfirmation", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(envelope.Type, "UnsubscribeConfirmation", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(envelope.SubscribeURL))
+            {
+                LogContext.Warning?.Log("SNS {Type} received but SubscribeURL is missing", envelope.Type);
+                return true;
+            }
+
+            try
+            {
+                var response = await _httpClient.GetAsync(envelope.SubscribeURL, cancellationToken).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+
+                LogContext.Info?.Log("SNS {Type} confirmed for topic {TopicArn}", envelope.Type, envelope.TopicArn);
+            }
+            catch (Exception ex)
+            {
+                LogContext.Warning?.Log(ex, "Failed to confirm SNS {Type} for topic {TopicArn}", envelope.Type, envelope.TopicArn);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SnsSubscriptionConfirmationServiceCollectionExtensions.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/SnsSubscriptionConfirmationServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+namespace MassTransit.AmazonSqsTransport;
+
+#if !NETSTANDARD2_0
+
+using Microsoft.Extensions.DependencyInjection;
+
+
+public static class SnsSubscriptionConfirmationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="SnsSubscriptionConfirmationHandler"/> and <see cref="SnsSubscriptionConfirmationFilter"/>
+    /// in the DI container, required when using the <see cref="SnsSubscriptionConfirmationAttribute"/>.
+    /// </summary>
+    public static IServiceCollection AddSnsSubscriptionConfirmation(this IServiceCollection services)
+    {
+        services.AddHttpClient<SnsSubscriptionConfirmationHandler>();
+        services.AddScoped<SnsSubscriptionConfirmationFilter>();
+        return services;
+    }
+}
+
+#endif

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/AmazonSqsBrokerTopology.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/AmazonSqsBrokerTopology.cs
@@ -8,18 +8,20 @@ public class AmazonSqsBrokerTopology :
     BrokerTopology
 {
     public AmazonSqsBrokerTopology(IEnumerable<Topic> exchanges, IEnumerable<Queue> queues, IEnumerable<QueueSubscription> queueSubscriptions,
-        IEnumerable<TopicSubscription> topicSubscriptions)
+        IEnumerable<TopicSubscription> topicSubscriptions, IEnumerable<HttpSubscription>? httpSubscriptions = null)
     {
         Topics = exchanges.ToArray();
         Queues = queues.ToArray();
         QueueSubscriptions = queueSubscriptions.ToArray();
         TopicSubscriptions = topicSubscriptions.ToArray();
+        HttpSubscriptions = httpSubscriptions?.ToArray() ?? [];
     }
 
     public Topic[] Topics { get; }
     public Queue[] Queues { get; }
     public QueueSubscription[] QueueSubscriptions { get; }
     public TopicSubscription[] TopicSubscriptions { get; }
+    public HttpSubscription[] HttpSubscriptions { get; }
 
     void IProbeSite.Probe(ProbeContext context)
     {
@@ -62,6 +64,17 @@ public class AmazonSqsBrokerTopology :
             {
                 Source = subscription.Source.EntityName,
                 Destination = subscription.Destination.EntityName
+            });
+        }
+
+        foreach (var subscription in HttpSubscriptions)
+        {
+            var subscriptionScope = context.CreateScope("httpSubscription");
+            subscriptionScope.Set(new
+            {
+                Source = subscription.Source.EntityName,
+                subscription.EndpointUrl,
+                subscription.RawMessageDelivery
             });
         }
     }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/AmazonSqsConsumeTopology.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/AmazonSqsConsumeTopology.cs
@@ -58,6 +58,23 @@ public class AmazonSqsConsumeTopology :
         _specifications.Add(specification);
     }
 
+    public void BindHttp(string topicName, string endpointUrl, Action<IHttpTopicSubscriptionConfigurator>? configure = null)
+    {
+        var configurator = new HttpTopicSubscriptionConfigurator(topicName, endpointUrl);
+
+        configure?.Invoke(configurator);
+
+        var specification = new HttpSubscriptionConsumeTopologySpecification(
+            _publishTopology,
+            configurator.TopicName,
+            configurator.EndpointUrl,
+            configurator.RawMessageDelivery,
+            configurator.Durable,
+            configurator.AutoDelete);
+
+        _specifications.Add(specification);
+    }
+
     public override IEnumerable<ValidationResult> Validate()
     {
         return base.Validate().Concat(_specifications.SelectMany(x => x.Validate()));

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/BrokerTopology.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/BrokerTopology.cs
@@ -7,4 +7,5 @@ public interface BrokerTopology :
     Queue[] Queues { get; }
     QueueSubscription[] QueueSubscriptions { get; }
     TopicSubscription[] TopicSubscriptions { get; }
+    HttpSubscription[] HttpSubscriptions { get; }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/BrokerTopologyBuilder.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/BrokerTopologyBuilder.cs
@@ -11,6 +11,7 @@ public abstract class BrokerTopologyBuilder
     protected readonly NamedEntityCollection<QueueSubscriptionEntity, QueueSubscriptionHandle> QueueSubscriptions;
     protected readonly NamedEntityCollection<TopicEntity, TopicHandle> Topics;
     protected readonly NamedEntityCollection<TopicSubscriptionEntity, TopicSubscriptionHandle> TopicSubscriptions;
+    protected readonly NamedEntityCollection<HttpSubscriptionEntity, HttpSubscriptionHandle> HttpSubscriptions;
     long _nextId;
 
     protected BrokerTopologyBuilder()
@@ -23,6 +24,9 @@ public abstract class BrokerTopologyBuilder
         TopicSubscriptions =
             new NamedEntityCollection<TopicSubscriptionEntity, TopicSubscriptionHandle>(TopicSubscriptionEntity.EntityComparer,
                 TopicSubscriptionEntity.NameComparer);
+        HttpSubscriptions =
+            new NamedEntityCollection<HttpSubscriptionEntity, HttpSubscriptionHandle>(HttpSubscriptionEntity.EntityComparer,
+                HttpSubscriptionEntity.NameComparer);
     }
 
     long GetNextId()
@@ -74,5 +78,16 @@ public abstract class BrokerTopologyBuilder
         var binding = new TopicSubscriptionEntity(id, sourceEntity, destinationEntity);
 
         return TopicSubscriptions.GetOrAdd(binding);
+    }
+
+    public HttpSubscriptionHandle CreateHttpSubscription(TopicHandle topic, string endpointUrl, bool rawMessageDelivery = true)
+    {
+        var id = GetNextId();
+
+        var topicEntity = Topics.Get(topic);
+
+        var subscription = new HttpSubscriptionEntity(id, topicEntity, endpointUrl, rawMessageDelivery);
+
+        return HttpSubscriptions.GetOrAdd(subscription);
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/Entities/HttpSubscription.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/Entities/HttpSubscription.cs
@@ -1,0 +1,23 @@
+namespace MassTransit.AmazonSqsTransport.Topology;
+
+
+/// <summary>
+/// Represents an SNS topic subscription with HTTP/HTTPS protocol
+/// </summary>
+public interface HttpSubscription
+{
+    /// <summary>
+    /// The SNS topic source
+    /// </summary>
+    Topic Source { get; }
+
+    /// <summary>
+    /// The HTTP/HTTPS endpoint URL that will receive the messages
+    /// </summary>
+    string EndpointUrl { get; }
+
+    /// <summary>
+    /// When true, SNS delivers the raw message body without the JSON wrapper
+    /// </summary>
+    bool RawMessageDelivery { get; }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/Entities/HttpSubscriptionEntity.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/Entities/HttpSubscriptionEntity.cs
@@ -1,0 +1,87 @@
+namespace MassTransit.AmazonSqsTransport.Topology;
+
+using System.Collections.Generic;
+using System.Linq;
+
+
+public class HttpSubscriptionEntity :
+    HttpSubscription,
+    HttpSubscriptionHandle
+{
+    readonly string _endpointUrl;
+    readonly TopicEntity _topic;
+
+    public HttpSubscriptionEntity(long id, TopicEntity topic, string endpointUrl, bool rawMessageDelivery)
+    {
+        Id = id;
+        _topic = topic;
+        _endpointUrl = endpointUrl;
+        RawMessageDelivery = rawMessageDelivery;
+    }
+
+    public static IEqualityComparer<HttpSubscriptionEntity> EntityComparer { get; } = new HttpSubscriptionEntityEqualityComparer();
+    public static IEqualityComparer<HttpSubscriptionEntity> NameComparer { get; } = new NameEqualityComparer();
+
+    public long Id { get; }
+    public HttpSubscription HttpSubscription => this;
+
+    public Topic Source => _topic.Topic;
+    public string EndpointUrl => _endpointUrl;
+    public bool RawMessageDelivery { get; }
+
+    public override string ToString()
+    {
+        return string.Join(", ",
+            new[] { $"source: {Source.EntityName}", $"endpoint: {_endpointUrl}" }.Where(x => !string.IsNullOrWhiteSpace(x)));
+    }
+
+
+    sealed class HttpSubscriptionEntityEqualityComparer : IEqualityComparer<HttpSubscriptionEntity>
+    {
+        public bool Equals(HttpSubscriptionEntity? x, HttpSubscriptionEntity? y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                return false;
+            if (x.GetType() != y.GetType())
+                return false;
+
+            return x._topic.Equals(y._topic) && x._endpointUrl == y._endpointUrl;
+        }
+
+        public int GetHashCode(HttpSubscriptionEntity obj)
+        {
+            unchecked
+            {
+                var hashCode = obj._topic.GetHashCode();
+                hashCode = (hashCode * 397) ^ obj._endpointUrl.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+
+
+    sealed class NameEqualityComparer : IEqualityComparer<HttpSubscriptionEntity>
+    {
+        public bool Equals(HttpSubscriptionEntity? x, HttpSubscriptionEntity? y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                return false;
+            if (x.GetType() != y.GetType())
+                return false;
+
+            return string.Equals(x._topic.EntityName, y._topic.EntityName) && x._endpointUrl == y._endpointUrl;
+        }
+
+        public int GetHashCode(HttpSubscriptionEntity obj)
+        {
+            unchecked
+            {
+                return (obj._topic.EntityName.GetHashCode() * 397) ^ obj._endpointUrl.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/Entities/HttpSubscriptionHandle.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/Entities/HttpSubscriptionHandle.cs
@@ -1,0 +1,9 @@
+namespace MassTransit.AmazonSqsTransport.Topology;
+
+using MassTransit.Topology;
+
+
+public interface HttpSubscriptionHandle : EntityHandle
+{
+    HttpSubscription HttpSubscription { get; }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/IBrokerTopologyBuilder.cs
@@ -46,4 +46,13 @@ public interface IBrokerTopologyBuilder
     /// <param name="destination"></param>
     /// <returns></returns>
     TopicSubscriptionHandle CreateTopicSubscription(TopicHandle source, TopicHandle destination);
+
+    /// <summary>
+    /// Create an HTTP/HTTPS subscription on a topic
+    /// </summary>
+    /// <param name="topic">The source topic handle</param>
+    /// <param name="endpointUrl">The HTTP/HTTPS endpoint URL</param>
+    /// <param name="rawMessageDelivery">When true, SNS delivers the raw message body</param>
+    /// <returns></returns>
+    HttpSubscriptionHandle CreateHttpSubscription(TopicHandle topic, string endpointUrl, bool rawMessageDelivery = true);
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/PreStartBrokerTopologyBuilder.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/PreStartBrokerTopologyBuilder.cs
@@ -1,0 +1,20 @@
+namespace MassTransit.AmazonSqsTransport.Topology;
+
+
+/// <summary>
+/// Builds a broker topology that combines publish topology entries and HTTP subscription entries.
+/// Used in the PreStartPipe to apply both in a single pass.
+/// </summary>
+public class PreStartBrokerTopologyBuilder :
+    BrokerTopologyBuilder,
+    IPublishEndpointBrokerTopologyBuilder,
+    IReceiveEndpointBrokerTopologyBuilder
+{
+    public TopicHandle? Topic { get; set; }
+    public QueueHandle? Queue { get; set; }
+
+    public BrokerTopology Build()
+    {
+        return new AmazonSqsBrokerTopology(Topics, Queues, QueueSubscriptions, TopicSubscriptions, HttpSubscriptions);
+    }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/PublishEndpointBrokerTopologyBuilder.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/PublishEndpointBrokerTopologyBuilder.cs
@@ -11,6 +11,6 @@ public class PublishEndpointBrokerTopologyBuilder :
 
     public BrokerTopology BuildBrokerTopology()
     {
-        return new AmazonSqsBrokerTopology(Topics, Queues, QueueSubscriptions, TopicSubscriptions);
+        return new AmazonSqsBrokerTopology(Topics, Queues, QueueSubscriptions, TopicSubscriptions, HttpSubscriptions);
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/ReceiveEndpointBrokerTopologyBuilder.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/ReceiveEndpointBrokerTopologyBuilder.cs
@@ -8,6 +8,6 @@ public class ReceiveEndpointBrokerTopologyBuilder :
 
     public BrokerTopology BuildTopologyLayout()
     {
-        return new AmazonSqsBrokerTopology(Topics, Queues, QueueSubscriptions, TopicSubscriptions);
+        return new AmazonSqsBrokerTopology(Topics, Queues, QueueSubscriptions, TopicSubscriptions, HttpSubscriptions);
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/SendEndpointBrokerTopologyBuilder.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/AmazonSqsTransport/Topology/SendEndpointBrokerTopologyBuilder.cs
@@ -11,6 +11,6 @@ public class SendEndpointBrokerTopologyBuilder :
 
     public BrokerTopology BuildBrokerTopology()
     {
-        return new AmazonSqsBrokerTopology(Topics, Queues, QueueSubscriptions, TopicSubscriptions);
+        return new AmazonSqsBrokerTopology(Topics, Queues, QueueSubscriptions, TopicSubscriptions, HttpSubscriptions);
     }
 }

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsHttpSubscriptionExtensions.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/AmazonSqsHttpSubscriptionExtensions.cs
@@ -1,0 +1,61 @@
+namespace MassTransit;
+
+using System;
+using AmazonSqsTransport.Configuration;
+
+
+public static class AmazonSqsHttpSubscriptionExtensions
+{
+    /// <summary>
+    /// Adds an SNS HTTP/HTTPS subscription for the specified topic name.
+    /// SNS will POST messages to the given endpoint URL.
+    /// The endpoint must handle the SNS SubscriptionConfirmation request — use
+    /// <see cref="AmazonSqsTransport.SnsSubscriptionConfirmationHandler"/> in your HTTP handler.
+    /// </summary>
+    public static void SubscribeTopicToHttpEndpoint(
+        this IAmazonSqsBusFactoryConfigurator configurator,
+        string topicName,
+        string endpointUrl,
+        Action<IHttpTopicSubscriptionConfigurator>? configure = null)
+    {
+        if (configurator == null)
+            throw new ArgumentNullException(nameof(configurator));
+        if (string.IsNullOrWhiteSpace(topicName))
+            throw new ArgumentNullException(nameof(topicName));
+        if (string.IsNullOrWhiteSpace(endpointUrl))
+            throw new ArgumentNullException(nameof(endpointUrl));
+
+        if (configurator is not AmazonSqsBusFactoryConfigurator busConfigurator)
+            throw new InvalidOperationException(
+                $"SubscribeTopicToHttpEndpoint requires {nameof(AmazonSqsBusFactoryConfigurator)}");
+
+        var subscriptionConfigurator = new HttpTopicSubscriptionConfigurator(topicName, endpointUrl);
+        configure?.Invoke(subscriptionConfigurator);
+
+        var specification = new HttpSubscriptionConsumeTopologySpecification(
+            configurator.PublishTopology,
+            busConfigurator.HostAddress,
+            subscriptionConfigurator.TopicName,
+            subscriptionConfigurator.EndpointUrl,
+            subscriptionConfigurator.RawMessageDelivery,
+            subscriptionConfigurator.Durable,
+            subscriptionConfigurator.AutoDelete);
+
+        busConfigurator.AddHttpSubscriptionSpecification(specification);
+    }
+
+    /// <summary>
+    /// Adds an SNS HTTP/HTTPS subscription for the message type <typeparamref name="T"/>.
+    /// The topic name is derived from the message type using the default naming convention.
+    /// </summary>
+    public static void SubscribeTopicToHttpEndpoint<T>(
+        this IAmazonSqsBusFactoryConfigurator configurator,
+        string endpointUrl,
+        Action<IHttpTopicSubscriptionConfigurator>? configure = null)
+        where T : class
+    {
+        var topicName = configurator.PublishTopology.GetMessageTopology<T>().Topic.EntityName;
+
+        configurator.SubscribeTopicToHttpEndpoint(topicName, endpointUrl, configure);
+    }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/HttpSubscriptionConsumeTopologySpecification.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/HttpSubscriptionConsumeTopologySpecification.cs
@@ -1,0 +1,95 @@
+namespace MassTransit;
+
+using System;
+using System.Collections.Generic;
+using AmazonSqsTransport.Configuration;
+using Internals;
+using MassTransit.AmazonSqsTransport.Topology;
+
+
+/// <summary>
+/// Applies an SNS HTTP/HTTPS subscription to the broker topology builder.
+/// This creates the SNS topic (if needed) and registers the HTTP subscription.
+/// Topic names respect the scope prefix when ScopeTopics is enabled.
+/// </summary>
+public class HttpSubscriptionConsumeTopologySpecification :
+    AmazonSqsTopicSubscriptionConfigurator,
+    IAmazonSqsConsumeTopologySpecification
+{
+    readonly string _endpointUrl;
+    readonly Uri? _hostAddress;
+    readonly IAmazonSqsPublishTopology _publishTopology;
+    readonly bool _rawMessageDelivery;
+
+    public HttpSubscriptionConsumeTopologySpecification(
+        IAmazonSqsPublishTopology publishTopology,
+        Uri hostAddress,
+        string topicName,
+        string endpointUrl,
+        bool rawMessageDelivery = true,
+        bool durable = true,
+        bool autoDelete = false)
+        : base(topicName, durable, autoDelete)
+    {
+        _publishTopology = publishTopology;
+        _hostAddress = hostAddress;
+        _endpointUrl = endpointUrl;
+        _rawMessageDelivery = rawMessageDelivery;
+    }
+
+    // Constructor for backward compatibility (when HostAddress is not available)
+    public HttpSubscriptionConsumeTopologySpecification(
+        IAmazonSqsPublishTopology publishTopology,
+        string topicName,
+        string endpointUrl,
+        bool rawMessageDelivery = true,
+        bool durable = true,
+        bool autoDelete = false)
+        : base(topicName, durable, autoDelete)
+    {
+        _publishTopology = publishTopology;
+        _hostAddress = null;
+        _endpointUrl = endpointUrl;
+        _rawMessageDelivery = rawMessageDelivery;
+    }
+
+    public IEnumerable<ValidationResult> Validate()
+    {
+        if (string.IsNullOrWhiteSpace(EntityName))
+            yield return this.Failure("TopicName", "must not be empty");
+
+        if (string.IsNullOrWhiteSpace(_endpointUrl))
+            yield return this.Failure("EndpointUrl", "must not be empty");
+
+        if (!string.IsNullOrWhiteSpace(_endpointUrl)
+            && !_endpointUrl.StartsWith("http://", System.StringComparison.OrdinalIgnoreCase)
+            && !_endpointUrl.StartsWith("https://", System.StringComparison.OrdinalIgnoreCase))
+            yield return this.Failure("EndpointUrl", "must start with http:// or https://");
+    }
+
+    public void Apply(IReceiveEndpointBrokerTopologyBuilder builder)
+    {
+        string topicName;
+        
+        // Apply scope prefix when HostAddress is available (using the same logic as GetDestinationAddress)
+        if (_hostAddress != null)
+        {
+            var address = new AmazonSqsEndpointAddress(_hostAddress, new Uri($"topic:{EntityName}"));
+            topicName = address.Name;
+        }
+        else
+        {
+            topicName = EntityName;
+        }
+
+        var topicHandle = builder.CreateTopic(
+            topicName,
+            Durable,
+            AutoDelete,
+            _publishTopology.TopicAttributes.MergeLeft(TopicAttributes),
+            _publishTopology.TopicSubscriptionAttributes.MergeLeft(TopicSubscriptionAttributes),
+            _publishTopology.TopicTags.MergeLeft(Tags));
+
+        builder.CreateHttpSubscription(topicHandle, _endpointUrl, _rawMessageDelivery);
+    }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/HttpTopicSubscriptionConfigurator.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/HttpTopicSubscriptionConfigurator.cs
@@ -1,0 +1,21 @@
+namespace MassTransit;
+
+
+public class HttpTopicSubscriptionConfigurator :
+    IHttpTopicSubscriptionConfigurator
+{
+    public HttpTopicSubscriptionConfigurator(string topicName, string endpointUrl, bool durable = true, bool autoDelete = false)
+    {
+        TopicName = topicName;
+        EndpointUrl = endpointUrl;
+        Durable = durable;
+        AutoDelete = autoDelete;
+        RawMessageDelivery = false;
+    }
+
+    public string TopicName { get; }
+    public string EndpointUrl { get; set; }
+    public bool RawMessageDelivery { get; set; }
+    public bool Durable { get; set; }
+    public bool AutoDelete { get; set; }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/Configuration/IHttpTopicSubscriptionConfigurator.cs
+++ b/src/Transports/MassTransit.AmazonSqsTransport/Configuration/IHttpTopicSubscriptionConfigurator.cs
@@ -1,0 +1,32 @@
+namespace MassTransit;
+
+
+public interface IHttpTopicSubscriptionConfigurator
+{
+    /// <summary>
+    /// The SNS topic name to subscribe to
+    /// </summary>
+    string TopicName { get; }
+
+    /// <summary>
+    /// The HTTP/HTTPS endpoint URL that will receive the messages
+    /// </summary>
+    string EndpointUrl { get; set; }
+
+    /// <summary>
+    /// When true, SNS delivers the raw message body without the JSON wrapper.
+    /// When false (default), SNS delivers the full envelope with Type, MessageId, TopicArn, and Message fields.
+    /// Defaults to false.
+    /// </summary>
+    bool RawMessageDelivery { get; set; }
+
+    /// <summary>
+    /// Whether the topic is durable (survives broker restart). Defaults to true.
+    /// </summary>
+    bool Durable { get; set; }
+
+    /// <summary>
+    /// Whether the topic is auto-deleted when the connection is closed. Defaults to false.
+    /// </summary>
+    bool AutoDelete { get; set; }
+}

--- a/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -19,7 +19,7 @@
     <Title>IATEc Shared EventBus Amazon SQS</Title>
     <Description>This project is a fork of MassTransit, updated to accelerate development for IATec teams. It is based on version 8.5.9.</Description>
     <Copyright>@IATec Solutions</Copyright>
-    <Version>0.1.0-RC1</Version>
+    <Version>0.1.0-RC2</Version>
     <PackageIconUrl>https://assets-services-dev.sdasystems.org/images/icons/standard.library.icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/iatecbr/IATec.Shared.Net.EventBus</PackageProjectUrl>
     <RepositoryUrl>https://github.com/iatecbr/IATec.Shared.Net.EventBus</RepositoryUrl>

--- a/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -10,20 +10,32 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RootNamespace>MassTransit</RootNamespace>
+    <RootNamespace>IATec.Shared.Net.EventBus.AmazonSQS</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>MassTransit.AmazonSQS</PackageId>
-    <Title>MassTransit.AmazonSQS</Title>
+    <PackageId>IATec.Shared.Net.EventBus.AmazonSQS</PackageId>
+    <Title>IATEc Shared EventBus Amazon SQS</Title>
+    <Description>This project is a fork of MassTransit, updated to accelerate development for IATec teams. It is based on version 8.5.9.</Description>
+    <Copyright>@IATec Solutions</Copyright>
+    <Version>0.1.0-RC1</Version>
+    <PackageIconUrl>https://assets-services-dev.sdasystems.org/images/icons/standard.library.icon.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/iatecbr/IATec.Shared.Net.EventBus</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/iatecbr/IATec.Shared.Net.EventBus</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>net</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>MassTransit;AmazonSQS</PackageTags>
-    <Description>MassTransit Amazon SQS transport support; $(Description)</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleNotificationService" />
     <PackageReference Include="AWSSDK.SQS" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
+++ b/src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj
@@ -5,9 +5,9 @@
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(IsWindows)' == 'true' ">
-    <TargetFrameworks>$(TargetFrameworks);net472</TargetFrameworks>
-  </PropertyGroup>
+<!--  <PropertyGroup Condition=" '$(IsWindows)' == 'true' ">-->
+<!--    <TargetFrameworks>$(TargetFrameworks);net472</TargetFrameworks>-->
+<!--  </PropertyGroup>-->
 
   <PropertyGroup>
     <RootNamespace>IATec.Shared.Net.EventBus.AmazonSQS</RootNamespace>


### PR DESCRIPTION
## fix: resolve MassTransit dependency version in NuGet package and bump to RC2

### Problem
The `IATec.Shared.Net.EventBus.AmazonSQS` package was declaring a dependency on
`MassTransit 0.1.0-RC1` in the generated `.nuspec`. Since that version doesn't exist
on any public or internal feed, NuGet was resolving the oldest available version:
`MassTransit 2.0.0` — causing build failures.

### Root Cause
The Azure Pipelines `dotnet build` step had no `-p:Version` argument. When the SDK
converts a `ProjectReference` to a `PackageReference` in the `.nuspec`, it uses the
same `Version` that was passed to the build — which defaulted to `0.1.0-RC1` (the
package's own version), producing an invalid transitive dependency.

### Changes

**`azure-pipelines.mass-transit.amazon-sqs.yaml`**
- Added `massTransitVersion: '8.5.10'` to the `variables` block
- Passed `-p:Version=$(massTransitVersion)` to `dotnet build` so the `ProjectReference`
  to `MassTransit` is correctly declared as `8.5.10` in the generated `.nuspec`
- The published package ID remains controlled by `packageVersion` (read from the `.csproj`)

**`src/Transports/MassTransit.AmazonSqsTransport/MassTransit.AmazonSqsTransport.csproj`**
- Bumped package version from `0.1.0-RC1` → `0.1.0-RC2`

### Result
| | Before | After |
|---|---|---|
| Published package ID | `0.1.0-RC1` | `0.1.0-RC2` |
| Declared MassTransit dependency | `0.1.0-RC1` ❌ | `8.5.9` ✅ |
| Local build | unaffected | unaffected |